### PR TITLE
Return conan dependencies to previous values

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,69 +64,69 @@ jobs:
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
-  build-windows:
-    name: Build Windows
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    env:
-      MPLBACKEND: agg
-    steps:
-      - name: Checkout code
-        uses: nschloe/action-checkout-with-lfs-cache@v1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/bskPkgRequired.txt'
-      - name: Choco help
-        uses: crazy-max/ghaction-chocolatey@v2
-        with:
-          args: -h
-      - name: "Install swig and cmake"
-        shell: pwsh
-        run: choco install swig cmake -y
-      - name: "Create python virtual env"
-        shell: pwsh
-        run: python -m venv venv
-      - name: "Install wheel and conan package"
-        shell: pwsh
-        run: |
-            venv\Scripts\activate
-            pip install wheel conan==1.59.0 parse six pytest-xdist
-      - name: "Add basilisk and cmake path to env path"
-        shell: pwsh
-        run: |
-          $oldpath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
-          $newpath = “$oldpath;${{ env.GITHUB_WORKSPACE }}\dist3\Basilisk;C:\Program Files\CMake\bin”
-          Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
-      - name: "Build basilisk"
-        shell: pwsh
-        run: |
-          venv\Scripts\activate
-          python conanfile.py --opNav True
-      - name: "Test Simulation"
-        shell: pwsh
-        run: |
-          Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name MPLBACKEND -Value ${MPLBACKEND}
-          venv\Scripts\activate
-          cd src\simulation
-          (Get-ChildItem -Directory).FullName | ForEach-Object { cd $_; pytest -n 2 -m "not scenarioTest"; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}
-      - name: "Test Architecture"
-        shell: pwsh
-        run: |
-          venv\Scripts\activate
-          cd src\architecture
-          (Get-ChildItem -Directory).FullName | ForEach-Object { cd $_; pytest -n 2; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}
-      - name: "Test fswAlgorithms"
-        shell: pwsh
-        run: |
-          venv\Scripts\activate
-          cd src\fswAlgorithms
-          (Get-ChildItem -Directory).FullName | ForEach-Object { cd $_; pytest -n 2; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}
+#  build-windows:
+#    name: Build Windows
+#    runs-on: windows-2019
+#    strategy:
+#      matrix:
+#        python-version: ["3.9"]
+#    permissions:
+#      actions: read
+#      contents: read
+#      security-events: write
+#    env:
+#      MPLBACKEND: agg
+#    steps:
+#      - name: Checkout code
+#        uses: nschloe/action-checkout-with-lfs-cache@v1
+#      - name: Set up Python ${{ matrix.python-version }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#          cache: 'pip'
+#          cache-dependency-path: '**/bskPkgRequired.txt'
+#      - name: Choco help
+#        uses: crazy-max/ghaction-chocolatey@v2
+#        with:
+#          args: -h
+#      - name: "Install swig and cmake"
+#        shell: pwsh
+#        run: choco install swig cmake -y
+#      - name: "Create python virtual env"
+#        shell: pwsh
+#        run: python -m venv venv
+#      - name: "Install wheel and conan package"
+#        shell: pwsh
+#        run: |
+#            venv\Scripts\activate
+#            pip install wheel conan==1.59.0 parse six pytest-xdist
+#      - name: "Add basilisk and cmake path to env path"
+#        shell: pwsh
+#        run: |
+#          $oldpath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
+#          $newpath = “$oldpath;${{ env.GITHUB_WORKSPACE }}\dist3\Basilisk;C:\Program Files\CMake\bin”
+#          Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+#      - name: "Build basilisk"
+#        shell: pwsh
+#        run: |
+#          venv\Scripts\activate
+#          python conanfile.py --opNav True
+#      - name: "Test Simulation"
+#        shell: pwsh
+#        run: |
+#          Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name MPLBACKEND -Value ${MPLBACKEND}
+#          venv\Scripts\activate
+#          cd src\simulation
+#          (Get-ChildItem -Directory).FullName | ForEach-Object { cd $_; pytest -n 2 -m "not scenarioTest"; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}
+#      - name: "Test Architecture"
+#        shell: pwsh
+#        run: |
+#          venv\Scripts\activate
+#          cd src\architecture
+#          (Get-ChildItem -Directory).FullName | ForEach-Object { cd $_; pytest -n 2; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}
+#      - name: "Test fswAlgorithms"
+#        shell: pwsh
+#        run: |
+#          venv\Scripts\activate
+#          cd src\fswAlgorithms
+#          (Get-ChildItem -Directory).FullName | ForEach-Object { cd $_; pytest -n 2; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}

--- a/conanfile.py
+++ b/conanfile.py
@@ -176,14 +176,15 @@ class BasiliskConan(ConanFile):
 
     def requirements(self):
         if self.options.opNav:
-            self.requires.add("pcre/8.45@#563d050c69aaa0a61be46bb09ba5c23c")
-            self.requires.add("opencv/4.5.0@#ca322b38d4ce8d07965c13707c7c788f")
-            self.requires.add("zlib/1.2.13@#13c96f538b52e1600c40b88994de240f")
+            self.requires.add("pcre/8.45")
+            self.requires.add("opencv/4.1.2")
+            self.requires.add("zlib/1.2.13")
+            self.requires.add("xz_utils/5.4.0")
 
         if self.options.vizInterface or self.options.opNav:
-            self.requires.add("libsodium/1.0.18@#9e310e52ed60084484c5f640ab88883a")
-            self.requires.add("protobuf/3.21.9@#e998066606a66775c0fd370649e031fd")
-            self.requires.add("cppzmq/4.9.0@#a51a906f0a5abe1f6c0b4dd47ba5ff66")
+            self.requires.add("libsodium/1.0.18")
+            self.requires.add("protobuf/3.17.1")
+            self.requires.add("cppzmq/4.5.0")
 
     def configure(self):
         if self.options.clean:

--- a/conanfile.py
+++ b/conanfile.py
@@ -337,9 +337,15 @@ if __name__ == "__main__":
     # run conan install
     conanCmdString = list()
     if is_running_virtual_env() or platform.system() == "Windows":
-        conanCmdString.append('python -m conans.conan install . --build=missing')
+        conanCmdString.append('python -m conans.conan install . '
+                              '--build=missing '
+                              '-c tools.system.package_manager:mode=install '
+                              '-c tools.system.package_manager:sudo=True')
     else:
-        conanCmdString.append('python3 -m conans.conan install . --build=missing')
+        conanCmdString.append('python3 -m conans.conan install . '
+                              '--build=missing '
+                              '-c tools.system.package_manager:mode=install '
+                              '-c tools.system.package_manager:sudo=True')
     conanCmdString.append(' -s build_type=' + str(args.buildType))
     conanCmdString.append(' -if ' + buildFolderName)
     if args.generator:


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
I accidentally pushed some test conan dependency updates to develop prior to setting branch protections. This PR reverts those.

## Verification
CI system needs to run.

## Documentation
NA

## Future work
We will want to pin the package ids of the dependencies, but it should be done in a separate/focused PR.
