### PR TITLE
Increment ubuntu version, add gtk2, and null ffmpeg in opencv build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-linux:
     name: Build Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9"]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,9 +45,12 @@ jobs:
       - name: "Install swig and cmake"
         run: sudo apt-get update && sudo apt-get install build-essential swig cmake -y
       - name: "Install python packages"
-        run: sudo apt-get install python3-setuptools python3-tk python3.9-venv
+        run: sudo apt-get install python3-setuptools python3-tk
       - name: "Create virtual Environment"
-        run: python3 -m venv .venv
+        run: |
+          python${{ matrix.python-version }} -m venv .venv
+          source .venv/bin/activate
+          echo "VIRTUAL ENV:" $VIRTUAL_ENV
       - name: "Install wheel and conan package"
         run: source .venv/bin/activate && pip3 install wheel conan==1.59.0 pytest datashader holoviews pytest-xdist
       - name: "Build basilisk"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: "Install swig and cmake"
-        run: sudo apt-get update && sudo apt-get install build-essential swig cmake -y
+        run: sudo apt-get update && sudo apt-get install build-essential cmake gtk2.0 libgtk2.0-dev ninja-build swig -y
       - name: "Install python packages"
         run: sudo apt-get install python3-setuptools python3-tk
       - name: "Create virtual Environment"

--- a/conanfile.py
+++ b/conanfile.py
@@ -189,6 +189,7 @@ class BasiliskConan(ConanFile):
         if self.options.opNav:
             self.requires.add("pcre/8.45")
             self.requires.add("opencv/4.1.2")
+            self.options['opencv'].with_ffmpeg = False
             self.requires.add("zlib/1.2.13")
             self.requires.add("xz_utils/5.4.0")
 


### PR DESCRIPTION
* **Tickets addressed:** resolves #61 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In recent years, the opnav module builds have only been maintained as working on mac os. After investigation it is discovered that the following changes will yield a building basilisk with opnav modules.
- Increment from Ubuntu 20.04 to 22.04 
- apt install the gtk2.0 package for Ubuntu 22.04 as gtk3.0 is the default and conan doesn't grab the old package when installing dependencies.
- Disable the ffmpeg option in the opencv build. This is a known issue and reported in many places for a few of the latest conan recipes. Rather than work up a custom conan recipie build for opencv, a more maintainable option is to simply disable the ffmpeg option. When the recipe works again, we can decide if we want to remove this toggle. Two of the multiple issue reporting this bug are recorded below in Additional Context.

## Verification
Opnav modules build and test run.

## Documentation
No invalidated documentation. No new documentation needed.

## Future work
It might be worth further configuring the opencv build toggles. Removing aspects of opencv that we know we will never need will reduce build times (prior to conan caching).
