### PR TITLE
hotfix - Add centerOfBrightness to the list of excluded targets

### DIFF
--- a/src/cmake/bskTargetExcludeBuildOptions.cmake
+++ b/src/cmake/bskTargetExcludeBuildOptions.cmake
@@ -5,5 +5,5 @@ endif()
 
 option(BUILD_OPNAV "Build OpNav Modules" OFF)
 if(NOT BUILD_OPNAV)
-  list(APPEND EXCLUDED_BSK_TARGETS "limbFinding" "centerRadiusCNN" "houghCircles" "camera")
+  list(APPEND EXCLUDED_BSK_TARGETS "limbFinding" "centerRadiusCNN" "houghCircles" "camera" "centerOfBrightness")
 endif()


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description
Hot fix on a forgotten cmake modification in order to exclude the center of brightness module from the build when opnav mode is off.

## Verification
Build on the CI has opnav mode (hence why it wasn't caught in the first place), so this build needs to be tested by reviewers.

## Documentation
None

## Future work
None
