### PR TITLE
Feature/bsk 28 flyby point

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -54,6 +54,7 @@ Version |release|
 - Created :ref:`lambertValidator` module to check if the solution from the :ref:`lambertSolver` module violates any
   constraints before a Delta-V is commanded.
 - Added :ref:`scenarioLambertSolver` scenario to illustrate the Lambert solver module package
+- Created :ref:`flybyPoint` to provide hill point reference during a flyby, and a related :ref:`scenarioFlybyPoint`.
 
 Version 2.1.7 (March 24, 2023)
 ------------------------------

--- a/examples/_default.rst
+++ b/examples/_default.rst
@@ -60,6 +60,7 @@ Attitude Guidance
 
    Hill Frame Pointing on Elliptic Orbit <scenarioAttitudeGuidance>
    Velocity Frame Pointing on Hyperbolic Orbit <scenarioAttGuideHyperbolic>
+   Hill Frame Pointing on Hyperbolic Orbit <scenarioFlybyPoint>
    Pointing at Earth Location <scenarioAttLocPoint>
    Prescribing the spacecraft orientation <scenarioAttitudePrescribed>
    Layered spiral attitude guidance <scenarioInertialSpiral>

--- a/examples/scenarioFlybyPoint.py
+++ b/examples/scenarioFlybyPoint.py
@@ -1,0 +1,425 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+r"""
+Overview
+--------
+
+This script shows how to set up the :ref:`flybyPoint` to compute a guidance reference frame that allows to track the
+direction of the celestial object being flown by. In this scenario, an Earth flyby is simulated. Effectively,
+:ref:`flybyPoint` computes a Hill reference frame, which is however referred to a body that is not the spacecraft's
+primary gravity body. To align a specific body-frame direction with the direction of the body, for example the direction
+ of a camera that needs to take pictures of an asteroid, the user needst to specify the ``sigma_R0R'' parameter in the
+ :ref:`attTrackingError`: this allows to introduce an offset rotation that aligns the desired axis with the celestial
+ body, rather than the  body's :math:`x` axis. The script is run with the following input arguments:
+
+The script is found in the folder ``basilisk/examples`` and executed by using::
+
+      python3 scenarioFlybyPoint.py
+
+Illustration of Simulation Results
+----------------------------------
+
+The scenario is run assuming to not neglect Earth's gravity. The relative position and velocity of the spacecraft w.r.t.
+Earth are updated every 10 minutes. The following figures show the reference attitude, angular rates and angular
+accelerations required to track Earth during the flyby, according to the rectilinear flyby model outlined in
+:ref:`flybyPoint`.
+
+.. image:: /_images/Scenarios/scenarioFlybyPoint3.svg
+   :align: center
+
+.. image:: /_images/Scenarios/scenarioFlybyPoint4.svg
+   :align: center
+
+.. image:: /_images/Scenarios/scenarioFlybyPoint5.svg
+   :align: center
+
+Lastly, the following plot shows the error angles between the camera location, along the body axis :math:`[0,1,0]`, and
+the desired out-of-plane body axis :math:`[1,0,0]`. It can be observed that both angle errors drop to zero soon after
+the initial transient. Additionally, errors are observed around 175 minutes, when the spacecraft reaches its closes
+approach to Earth. The errors grow due to the inaccuracy of the model of :ref:`flybyPoint`, which does not account for
+the effects of Earth's gravity on the motion of the spacecraft.
+
+.. image:: /_images/Scenarios/scenarioFlybyPoint6.svg
+   :align: center
+
+"""
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import (flybyPoint, attTrackingError, mrpFeedback, rwMotorTorque)
+from Basilisk.simulation import (simpleNav, spacecraft, reactionWheelStateEffector, planetEphemeris)
+from Basilisk.utilities import (SimulationBaseClass, simIncludeRW, macros, unitTestSupport, orbitalMotion,
+                                simIncludeGravBody)
+from Basilisk.utilities import RigidBodyKinematics as rbk
+
+bskPath = __path__[0]
+fileName = os.path.basename(os.path.splitext(__file__)[0])
+
+
+
+
+def run(show_plots, zeroEarthGravity, dtFilterData):
+
+    # Create simulation variable names
+    simTaskName = "simTask"
+    simProcessName = "simProcess"
+
+    #  Create a sim module as an empty container
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    # Shows the simulation progress bar in the terminal
+    scSim.SetProgressBar(True)
+
+    # set the simulation time variable used later on
+    simulationTime = macros.hour2nano(6.)
+
+    #
+    #  create the simulation process
+    #
+    dynProcess = scSim.CreateNewProcess(simProcessName)
+
+    # create the dynamics task and specify the integration update time
+    simulationTimeStep = macros.sec2nano(0.5)
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
+
+    # # Specify orbital parameters of the asteroid
+    timeInitString = "2011 January 1 0:00:00.0"
+    G = 6.67408 * (10 ** -11)  # m^3 / kg*s^2
+    massBennu = 7.329 * (10 ** 10)  # kg
+    muBennu = G * massBennu  # Bennu grav. parameter, m^3/s^2011
+
+    # Create additional gravitational bodies
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    gravFactory.createBodies(["earth", "sun"])
+    earth = gravFactory.gravBodies["earth"]
+    earth.isCentralBody = True  # ensures the asteroid is the central gravitational body
+
+    # Create and configure the default SPICE support module. The first step is to store
+    # the date and time of the start of the simulation.
+    gravFactory.createSpiceInterface(bskPath + '/supportData/EphemerisData/',
+                                     timeInitString,
+                                     epochInMsg=True)
+    gravFactory.spiceObject.zeroBase = "earth"
+
+    # Add the SPICE object to the simulation task list
+    scSim.AddModelToTask(simTaskName, gravFactory.spiceObject)
+
+    # set Earth's gravity to zero to show rectilinear flyby
+    if zeroEarthGravity:
+        earth.mu = 0
+
+    #
+    #   setup the simulation tasks/objects
+    #
+
+    # initialize spacecraft object and set properties
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "bsk-Sat"
+
+    # Connect all gravitational bodies to the spacecraft
+    scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))
+
+    # define the simulation inertia
+    I = [900., 0., 0.,
+         0., 800., 0.,
+         0., 0., 600.]
+    scObject.hub.mHub = 750.0  # kg - spacecraft mass
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
+    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.r_CN_NInit = [-2.08e8, 15e6, 0]  # m   - r_CN_N
+    scObject.hub.v_CN_NInit = [2e4, 0, 0]  # m/s - v_CN_N
+    scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]  # sigma_CN_B
+    scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]  # rad/s - omega_CN_B
+
+    # add spacecraft object to the simulation process
+    scSim.AddModelToTask(simTaskName, scObject)
+
+    #
+    # add RW devices
+    #
+    # Make a fresh RW factory instance, this is critical to run multiple times
+    rwFactory = simIncludeRW.rwFactory()
+
+    # create each RW by specifying the RW type, the spin axis gsHat, plus optional arguments
+    RW1 = rwFactory.create('Honeywell_HR16', [1, 0, 0], maxMomentum=50., Omega=100.)
+    RW2 = rwFactory.create('Honeywell_HR16', [0, 1, 0], maxMomentum=50., Omega=200.)
+    RW3 = rwFactory.create('Honeywell_HR16', [0, 0, 1], maxMomentum=50., Omega=300.)
+
+    numRW = rwFactory.getNumOfDevices()
+
+    # create RW object container and tie to spacecraft object
+    rwStateEffector = reactionWheelStateEffector.ReactionWheelStateEffector()
+    rwStateEffector.ModelTag = "RW_cluster"
+    rwFactory.addToSpacecraft(scObject.ModelTag, rwStateEffector, scObject)
+
+    # add RW object array to the simulation process.  This is required for the UpdateState() method
+    # to be called which logs the RW states
+    scSim.AddModelToTask(simTaskName, rwStateEffector, None, 2)
+
+    # add the simple Navigation sensor module.  This sets the SC attitude, rate, position
+    # velocity navigation message
+    sNavObject = simpleNav.SimpleNav()
+    sNavObject.ModelTag = "SimpleNavigation"
+    scSim.AddModelToTask(simTaskName, sNavObject)
+
+    #
+    #   setup the FSW algorithm tasks
+    #
+
+    # se tup flybyPoint guidance module
+    flybyGuid = flybyPoint.FlybyPoint()
+    flybyGuid.ModelTag = "flybyPoint"
+    flybyGuid.dtFilterData = dtFilterData
+    scSim.AddModelToTask(simTaskName, flybyGuid)
+
+    cameraAxis_B = np.array([0, 1, 0])
+    outOfPlaneAxis_B = np.array([1, 0, 0])
+    crossProductAxis_B = np.cross(cameraAxis_B, outOfPlaneAxis_B)
+    R0R = np.array([-cameraAxis_B,
+                    crossProductAxis_B,
+                    np.cross(crossProductAxis_B, cameraAxis_B)])
+
+    # set up the attitude tracking error evaluation module
+    attErrorConfig = attTrackingError.attTrackingErrorConfig()
+    attErrorWrap = scSim.setModelDataWrap(attErrorConfig)
+    attErrorWrap.ModelTag = "attErrorInertial3D"
+    attErrorConfig.sigma_R0R = rbk.C2MRP(R0R)
+    scSim.AddModelToTask(simTaskName, attErrorWrap, attErrorConfig)
+
+    # setup the MRP Feedback control module
+    mrpControlConfig = mrpFeedback.mrpFeedbackConfig()
+    mrpControlWrap = scSim.setModelDataWrap(mrpControlConfig)
+    mrpControlWrap.ModelTag = "mrpFeedback"
+    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig)
+    mrpControlConfig.K = 3.5
+    mrpControlConfig.Ki = -1  # make value negative to turn off integral feedback
+    mrpControlConfig.P = 30.0
+    mrpControlConfig.integralLimit = 2. / mrpControlConfig.Ki * 0.1
+
+    # add module that maps the Lr control torque into the RW motor torques
+    rwMotorTorqueConfig = rwMotorTorque.rwMotorTorqueConfig()
+    rwMotorTorqueWrap = scSim.setModelDataWrap(rwMotorTorqueConfig)
+    rwMotorTorqueWrap.ModelTag = "rwMotorTorque"
+    scSim.AddModelToTask(simTaskName, rwMotorTorqueWrap, rwMotorTorqueConfig)
+
+    # Make the RW control all three body axes
+    controlAxes_B = [
+        1, 0, 0, 0, 1, 0, 0, 0, 1
+    ]
+    rwMotorTorqueConfig.controlAxes_B = controlAxes_B
+
+    #
+    #   Setup data logging before the simulation is initialized
+    #
+    numDataPoints = 1000
+    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    snTransLog = sNavObject.transOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, snTransLog)
+    snAttLog = sNavObject.attOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, snAttLog)
+    attRefLog = flybyGuid.attRefOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, attRefLog)
+    attGuidLog = attErrorConfig.attGuidOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, attGuidLog)
+    torqueLog = mrpControlConfig.cmdTorqueOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, torqueLog)
+
+    # create the FSW vehicle configuration message
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
+    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
+
+    # If the exact same RW configuration states are to be used by the simulation and fsw, then the following helper
+    # function is convenient to extract the fsw RW configuration message from the rwFactory setup earlier.
+    fswRwParamMsg = rwFactory.getConfigMessage()
+
+    #
+    # create simulation messages
+    #
+
+    # link messages
+    sNavObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
+    flybyGuid.filterInMsg.subscribeTo(sNavObject.transOutMsg)
+    attErrorConfig.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
+    attErrorConfig.attRefInMsg.subscribeTo(flybyGuid.attRefOutMsg)
+    mrpControlConfig.guidInMsg.subscribeTo(attErrorConfig.attGuidOutMsg)
+    mrpControlConfig.vehConfigInMsg.subscribeTo(vcMsg)
+    mrpControlConfig.rwParamsInMsg.subscribeTo(fswRwParamMsg)
+    mrpControlConfig.rwSpeedsInMsg.subscribeTo(rwStateEffector.rwSpeedOutMsg)
+    rwMotorTorqueConfig.rwParamsInMsg.subscribeTo(fswRwParamMsg)
+    rwMotorTorqueConfig.vehControlInMsg.subscribeTo(mrpControlConfig.cmdTorqueOutMsg)
+    rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueConfig.rwMotorTorqueOutMsg)
+
+    #
+    #   initialize Simulation
+    #
+    scSim.InitializeSimulation()
+
+    #
+    #   configure a simulation stop time and execute the simulation run
+    #
+    scSim.ConfigureStopTime(simulationTime)
+    scSim.ExecuteSimulation()
+
+    #
+    #   retrieve the logged data
+    #
+    dataPos = snTransLog.r_BN_N
+    dataVel = snTransLog.v_BN_N
+    att = snAttLog.sigma_BN
+    refAtt = attRefLog.sigma_RN
+    refRate = attRefLog.omega_RN_N
+    refAcc = attRefLog.domega_RN_N
+    guidAtt = attGuidLog.sigma_BR
+    cmdTorque = torqueLog.torqueRequestBody
+
+    cameraAxis_N = []
+    outOfPlaneAxis_N = []
+    pointingErrorCamera = []
+    pointingErrorOutOfPlane = []
+    for i in range(len(dataPos)):
+        ur = dataPos[i] / np.linalg.norm(dataPos[i])
+        uh = np.cross(dataPos[i], dataVel[i]) / np.linalg.norm(np.cross(dataPos[i], dataVel[i]))
+        BN = rbk.MRP2C(att[i])
+        NB = BN.transpose()
+        cameraAxis_N.append(np.matmul(NB, cameraAxis_B))
+        outOfPlaneAxis_N.append(np.matmul(NB, outOfPlaneAxis_B))
+        pointingErrorCamera.append(np.arccos(min(max(-np.dot(ur, cameraAxis_N[i]), -1), 1)))
+        pointingErrorOutOfPlane.append(np.arccos(min(max(np.dot(uh, outOfPlaneAxis_N[i]), -1), 1)))
+
+
+    #
+    #   plot the results
+    #
+    timeData = snTransLog.times() * macros.NANO2MIN
+    plt.close("all")  # clears out plots from earlier test runs
+
+    figureList = {}
+
+    plot_position(timeData, dataPos)
+    pltName = fileName + "1"
+    figureList[pltName] = plt.figure(1)
+
+    plot_velocity(timeData, dataVel)
+    pltName = fileName + "2"
+    figureList[pltName] = plt.figure(2)
+
+    plot_ref_attitude(timeData, refAtt)
+    pltName = fileName + "3"
+    figureList[pltName] = plt.figure(3)
+
+    plot_ref_rates(timeData, refRate)
+    pltName = fileName + "4"
+    figureList[pltName] = plt.figure(4)
+
+    plot_ref_accelerations(timeData, refAcc)
+    pltName = fileName + "5"
+    figureList[pltName] = plt.figure(5)
+
+    plot_angular_errors(timeData, pointingErrorCamera, pointingErrorOutOfPlane)
+    pltName = fileName + "6"
+    figureList[pltName] = plt.figure(6)
+
+    if show_plots:
+        plt.show()
+
+    # close the plots being saved off to avoid over-writing old and new figures
+    plt.close("all")
+
+    return figureList
+
+# Plotting functions
+def plot_position(timeData, dataPos):
+    """Plot the attitude errors."""
+    plt.figure(1)
+    for idx in range(3):
+        plt.plot(timeData, dataPos[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$r_{BN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Inertial Position [m]')
+
+def plot_velocity(timeData, dataVel):
+    """Plot the attitude errors."""
+    plt.figure(2)
+    for idx in range(3):
+        plt.plot(timeData, dataVel[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$v_{BN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Inertial Velocity [m/s]')
+
+def plot_ref_attitude(timeData, sigma_RN):
+    """Plot the attitude errors."""
+    plt.figure(3)
+    for idx in range(3):
+        plt.plot(timeData, sigma_RN[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\sigma_{RN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Reference attitude')
+
+def plot_ref_rates(timeData, omega_RN):
+    """Plot the attitude errors."""
+    plt.figure(4)
+    for idx in range(3):
+        plt.plot(timeData, omega_RN[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\omega_{RN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Ref. rates [rad/s]')
+
+def plot_ref_accelerations(timeData, omegaDot_RN):
+    """Plot the attitude errors."""
+    plt.figure(5)
+    for idx in range(3):
+        plt.plot(timeData, omegaDot_RN[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\dot{\omega}_{RN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Ref. accelerations [rad/s^2]')
+
+def plot_angular_errors(timeData, errCamera, errOutOfPlane):
+    """Plot the attitude errors."""
+    plt.figure(6)
+    plt.plot(timeData, errCamera, label=r'$\Delta \theta_{camera}$')
+    plt.plot(timeData, errOutOfPlane, label=r'$\Delta \theta_{out of plane}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Angular errors [rad]')
+
+#
+# This statement below ensures that the unit test scrip can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    run(
+        True,  # show_plots
+        False, # zeroEarthGravity
+        600,   # dtFilterData
+    )

--- a/src/fswAlgorithms/attGuidance/flybyPoint/_UnitTest/test_flybyPoint.py
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/_UnitTest/test_flybyPoint.py
@@ -1,0 +1,270 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+#
+#   Unit Test Script
+#   Module Name:        flybyPoint
+#   Author:             Riccardo Calaon
+#   Creation Date:      May 26, 2023
+#
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import flybyPoint
+from Basilisk.utilities import SimulationBaseClass, macros, unitTestSupport
+from Basilisk.utilities import RigidBodyKinematics as rbk
+
+bskPath = __path__[0]
+fileName = os.path.basename(os.path.splitext(__file__)[0])
+
+
+@pytest.mark.parametrize("initPos", [[-5e7, 7.5e6, 5e5]])  # m - r_CN_N
+@pytest.mark.parametrize("initVel", [[2e4, 0, 0]])  # m/s - v_CN_N
+@pytest.mark.parametrize("dTsim", [10, 100])  # s
+@pytest.mark.parametrize("dTfilter", [0, 60, 600])  # s
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_flybyPoint(show_plots, initPos, initVel, dTsim, dTfilter, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`flybyPoint` in a scenario
+    where the rectilinear flyby assumption is valid.
+
+    **Test Parameters**
+
+    In this test, there is no gravity body, and the spacecraft is put onto a rectilinear trajectory about the origin.
+    With no gravity, the linear momentum of the spacecraft does not change, which means that the spacecraft proceeds
+    along a rectilinear trajectory. The input message to the :ref:`flybyPoint` is the relative position and velocity
+    of the spacecraft with respect to the body/asteroid, which coincides with the origin and is assumed to be static.
+    Correctness is tested assessing whether the computed hill frame moves according to the motion of the spacecraft.
+
+    Args:
+        initPos[3] (m): initial position of the spacecraft w.r.t. the body/origin
+        initVel[3] (m): initial velocity of the spacecraft w.r.t. the body/origin
+        dTsim (s): simulation time step
+        dTfilter (s): time between two consecutive reads of the input message
+        accuracy: tolerance on the result.
+
+    **Description of Variables Being Tested**
+
+    The referene attitude :math:`\sigma_\mathcal{R/N}`, reference angular rates :math:`\omega_\mathcal{R/N}` and
+    angular accelerations :math:`\dot{\omega}_\mathcal{R/N}` are tested. These are compared to the analytical results
+    expected from the rectilinear motion described in the documentation of :ref:`flybyPoint`.
+    The reference attitude is mapped to the corresponding reference frame, and each axis of the reference frame is
+    tested for correctness. The angular rate and acceleration vectors are tested against the analytical result,
+    expressed in R-frame coordinates.
+    """
+    # each test method requires a single assert method to be called
+    flybyPointTestFunction(show_plots, initPos, initVel, dTsim, dTfilter, accuracy)
+
+
+def flybyPointTestFunction(show_plots, initPos, initVel, dTsim, dTfilter, accuracy):
+    testFailCount = 0                       # zero unit test result counter
+    testMessages = []                       # create empty array to store test log messages
+    unitTaskName = "unitTask"               # arbitrary name (don't change)
+    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(dTsim)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create simulation variable names
+    unitTaskName = "unitTask"
+    unitProcessName = "unitProcess"
+
+    #  Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    #  create the simulation process
+    testProcess = unitTestSim.CreateNewProcess(unitProcessName)
+
+    # create the dynamics task and specify the integration update time
+    simulationTimeStep = macros.sec2nano(dTsim)
+    testProcess.addTask(unitTestSim.CreateNewTask(unitTaskName, simulationTimeStep))
+
+    #   setup the FSW algorithm tasks
+
+    # setup flybyPoint guidance module
+    flybyGuid = flybyPoint.FlybyPoint()
+    flybyGuid.ModelTag = "flybyPoint"
+    flybyGuid.dtFilterData = dTfilter
+    unitTestSim.AddModelToTask(unitTaskName, flybyGuid)
+
+    inputData = messaging.NavTransMsgPayload()
+    inputData.v_BN_N = np.array(initVel)
+    filterInMsg = messaging.NavTransMsg()
+    flybyGuid.filterInMsg.subscribeTo(filterInMsg)
+
+    #
+    #   Setup data logging before the simulation is initialized
+    #
+    attRefLog = flybyGuid.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, attRefLog)
+
+    unitTestSim.InitializeSimulation()
+    dataPos = []
+    dataVel = []
+    for i in range(round(9*600/dTsim)):
+        dataPos.append(np.array(initPos) + np.array(initVel) * (i * dTsim))
+        dataVel.append(np.array(initVel))
+        inputData.timeTag = macros.sec2nano(i * dTsim)
+        inputData.r_BN_N = dataPos[i]
+        filterInMsg.write(inputData, unitTestSim.TotalSim.CurrentNanos)
+        unitTestSim.ConfigureStopTime(macros.sec2nano((i + 1) * dTsim) - 1)
+        unitTestSim.ExecuteSimulation()
+
+    #   retrieve the logged data
+    refAtt = attRefLog.sigma_RN
+    refRate = attRefLog.omega_RN_N
+    refAcc = attRefLog.domega_RN_N
+    timeData = attRefLog.times() * macros.NANO2MIN
+
+    ur_output = []
+    ut_output = []
+    uh_output = []
+    for i in range(len(refAtt)):
+        RN = rbk.MRP2C(refAtt[i])
+        ur_output.append(np.matmul(RN.transpose(), [1, 0, 0]))
+        ut_output.append(np.matmul(RN.transpose(), [0, 1, 0]))
+        uh_output.append(np.matmul(RN.transpose(), [0, 0, 1]))
+
+    ur = initPos / np.linalg.norm(initPos)
+    uh = np.cross(initPos, initVel) / np.linalg.norm(np.cross(initPos, initVel))
+    ut = np.cross(uh, ur)
+    f0 = np.linalg.norm(initVel) / np.linalg.norm(initPos)
+    gamma0 = np.arctan(np.dot(initVel, ur) / np.dot(initVel, ut))
+    for i in range(len(refAtt)):
+        # check a vector values
+        ur = dataPos[i] / np.linalg.norm(dataPos[i])
+        uh = np.cross(dataPos[i], dataVel[i]) / np.linalg.norm(np.cross(dataPos[i], dataVel[i]))
+        ut = np.cross(uh, ur)
+        dt = timeData[i]*60
+        den = ((f0*dt)**2 + 2*f0*np.sin(gamma0)*dt + 1)
+        omega = uh * f0 * np.cos(gamma0) / den
+        omegaDot = uh * (-2*f0*f0 * np.cos(gamma0)) * (f0*dt + np.sin(gamma0)) / den / den
+
+        # test correctness of frame, angular rate and acceleration
+        np.testing.assert_allclose(ur_output[i], ur, rtol=0, atol=accuracy, verbose=True)
+        np.testing.assert_allclose(ut_output[i], ut, rtol=0, atol=accuracy, verbose=True)
+        np.testing.assert_allclose(uh_output[i], uh, rtol=0, atol=accuracy, verbose=True)
+        np.testing.assert_allclose(refRate[i], omega, rtol=0, atol=accuracy, verbose=True)
+        np.testing.assert_allclose(refAcc[i], omegaDot, rtol=0, atol=accuracy, verbose=True)
+
+    # plot the results
+    plt.close("all")  # clears out plots from earlier test runs
+    dataPos = np.array(dataPos)
+    dataVel = np.array(dataVel)
+    plot_position(timeData, dataPos)
+    plot_velocity(timeData, dataVel)
+    plot_ref_attitude(timeData, refAtt)
+    plot_ref_rates(timeData, refRate)
+    plot_ref_accelerations(timeData, refAcc)
+
+    if show_plots:
+        plt.show()
+
+    # close the plots being saved off to avoid over-writing old and new figures
+    plt.close("all")
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    # return [testFailCount, ''.join(testMessages)]
+    return
+
+
+def plot_position(timeData, dataPos):
+    """Plot the attitude errors."""
+    plt.figure(1)
+    for idx in range(3):
+        plt.plot(timeData, dataPos[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$r_{BN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Inertial Position [m]')
+
+
+def plot_velocity(timeData, dataVel):
+    """Plot the attitude errors."""
+    plt.figure(2)
+    for idx in range(3):
+        plt.plot(timeData, dataVel[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$v_{BN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Inertial Velocity [m/s]')
+
+
+def plot_ref_attitude(timeData, sigma_RN):
+    """Plot the attitude errors."""
+    plt.figure(3)
+    for idx in range(3):
+        plt.plot(timeData, sigma_RN[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\sigma_{RN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Reference attitude')
+
+
+def plot_ref_rates(timeData, omega_RN):
+    """Plot the attitude errors."""
+    plt.figure(4)
+    for idx in range(3):
+        plt.plot(timeData, omega_RN[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\omega_{RN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Reference rates')
+
+
+def plot_ref_accelerations(timeData, omegaDot_RN):
+    """Plot the attitude errors."""
+    plt.figure(5)
+    for idx in range(3):
+        plt.plot(timeData, omegaDot_RN[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\dot{\omega}_{RN,' + str(idx+1) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Reference accelerations')
+
+
+#
+# This statement below ensures that the unit test scrip can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_flybyPoint(
+        True,                # show_plots
+        [-5e7, 7.5e6, 5e5],  # initPos
+        [2e4, 0, 0],         # initVel
+        60,                  # dTsim
+        60,                  # dTfilter
+        1e-12                # accuracy
+    )

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
@@ -1,0 +1,58 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "fswAlgorithms/attGuidance/flybyPoint/flybyPoint.h"
+#include <cmath>
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/macroDefinitions.h"
+
+/*! Module constructor */
+FlybyPoint::FlybyPoint() = default;
+
+
+/*! Module destructor */
+FlybyPoint::~FlybyPoint() = default;
+
+
+/*! Initialize C-wrapped output messages */
+void FlybyPoint::SelfInit(){
+    AttRefMsg_C_init(&this->attRefOutMsgC);
+}
+
+
+/*! This method is used to reset the module.
+ @return void
+ */
+void FlybyPoint::Reset(uint64_t CurrentSimNanos)
+{
+
+}
+
+
+/*! This method is the main carrier for the boresight calculation routine.  If it detects
+ that it needs to re-init (direction change maybe) it will re-init itself.
+ Then it will compute the angles away that the boresight is from the celestial target.
+ @return void
+ @param CurrentSimNanos The current simulation time for system
+ */
+void FlybyPoint::UpdateState(uint64_t CurrentSimNanos)
+{
+
+}

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
@@ -42,7 +42,15 @@ void FlybyPoint::SelfInit(){
  */
 void FlybyPoint::Reset(uint64_t CurrentSimNanos)
 {
+    if (!this->filterInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".filterInMsg wasn't connected.");
+    }
+    if (this->flybyModel == cwEquations && !this->asteroidEphemerisInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".asteroidEphemerisInMsg wasn't connected.");
+    }
 
+    this->lastFilterReadTime = 0;
+    this->firstRead = true;
 }
 
 

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
@@ -62,5 +62,75 @@ void FlybyPoint::Reset(uint64_t CurrentSimNanos)
  */
 void FlybyPoint::UpdateState(uint64_t CurrentSimNanos)
 {
+    /*! create and zero the output message */
+    AttRefMsgPayload attMsgBuffer = this->attRefOutMsg.zeroMsgPayload;
 
+    /*! compute dt from current time and last filter read time [s] */
+    double dt = (CurrentSimNanos - this->lastFilterReadTime)*NANO2SEC;
+
+    if ((dt >= this->dtFilterData) || this->firstRead) {
+        /*! set firstRead to false if this was the first read after a reset */
+        if (this->firstRead) {
+            this->firstRead = false;
+        }
+
+        /*! read and allocate the attitude navigation message */
+        NavTransMsgPayload relativeState = this->filterInMsg();
+
+        /*! compute radial (ur_N), along-track (ut_N) and out-of-plane (uh_N) unit direction vectors at time of read */
+        double ur_N[3];
+        v3Normalize(relativeState.r_BN_N, ur_N);
+        double uh_N[3];
+        v3Cross(relativeState.r_BN_N, relativeState.v_BN_N, uh_N);
+        v3Normalize(uh_N, uh_N);
+        double ut_N[3];
+        v3Cross(uh_N, ur_N, ut_N);
+
+        /*! compute inertial-to-reference DCM at time of read */
+        for (int i=0; i<3; i++) {
+            this->R0N[0][i] = ur_N[i];
+            this->R0N[1][i] = ut_N[i];
+            this->R0N[2][i] = uh_N[i];
+        }
+
+        /*! compute velocity/radius ratio at time of read */
+        this->f0 = v3Norm(relativeState.v_BN_N) / v3Norm(relativeState.r_BN_N);
+
+        /*! compute flight path angle at time of read */
+        this->gamma0 = atan(v3Dot(relativeState.v_BN_N, ur_N) / v3Dot(relativeState.v_BN_N, ut_N));
+
+        /*! update lastFilterReadTime to current time and dt to zero */
+        this->lastFilterReadTime = CurrentSimNanos;
+        dt = 0;
+    }
+
+    /*! compute rotation angle of reference frame from last read time */
+    double theta = atan(tan(this->gamma0) + this->f0 / cos(this->gamma0) * dt) -this->gamma0;
+
+    /*! compute DCM (RtR0) of reference frame from last read time */
+    double PRV_theta[3] = {0, 0, theta};
+    double RtR0[3][3];
+    PRV2C(PRV_theta, RtR0);
+
+    /*! compute DCM of reference frame at time t_0 + dt with respect to inertial frame */
+    double RtN[3][3];
+    m33MultM33(RtR0, this->R0N, RtN);
+
+    /*! compute scalar angular rate and acceleration of the reference frame in R-frame coordinates */
+    double den = (this->f0*this->f0*dt*dt + 2*this->f0*sin(this->gamma0)*dt + 1);
+    double thetaDot = this->f0 * cos(this->gamma0) / den;
+    double thetaDDot = -2*this->f0*this->f0*cos(this->gamma0) * (this->f0*dt + sin(this->gamma0)) / (den*den);
+    double omega_RN_R[3] = {0, 0, thetaDot};
+    double omegaDot_RN_R[3] = {0, 0, thetaDDot};
+
+    /*! populate attRefOut with reference frame information */
+    C2MRP(RtN, attMsgBuffer.sigma_RN);
+    m33tMultV3(RtN, omega_RN_R, attMsgBuffer.omega_RN_N);
+    m33tMultV3(RtN, omegaDot_RN_R, attMsgBuffer.domega_RN_N);
+
+    /* Write the output messages */
+    this->attRefOutMsg.write(&attMsgBuffer, this->moduleID, CurrentSimNanos);
+
+    /* Write the C-wrapped output messages */
+    AttRefMsg_C_write(&attMsgBuffer, &this->attRefOutMsgC, this->moduleID, CurrentSimNanos);
 }

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.h
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.h
@@ -1,0 +1,66 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef FLYBY_POINT_H
+#define FLYBY_POINT_H
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+#include "cMsgCInterface/AttRefMsg_C.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/utilities/bskLogging.h"
+
+
+typedef enum flybyModel{
+    rectilinear = 0,
+    cwEquations = 1
+} FlybyModel;
+
+
+/*! @brief A class to perform flyby pointing */
+class FlybyPoint: public SysModel {
+public:
+    FlybyPoint();
+    ~FlybyPoint();
+    void SelfInit();                   //!< Self initialization for C-wrapped messages
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+    
+    double     dtFilterData = 0;       //!< time between two subsequent reads of the filter information
+    FlybyModel flybyModel;             //!< flag to indicate which flyby model is being used
+
+    ReadFunctor<NavTransMsgPayload>  filterInMsg;               //!< input msg relative position w.r.t. asteroid
+    ReadFunctor<EphemerisMsgPayload> asteroidEphemerisInMsg;    //!< input asteroid ephemeris msg
+    Message<AttRefMsgPayload> attRefOutMsg;                     //!< Attitude reference output message
+    AttRefMsg_C attRefOutMsgC = {};                             //!< C-wrapped attitude reference output message
+
+private:
+    bool     firstRead;
+    double   f0;                       //!< ratio between relative velocity and position norms at time of read [Hz]
+    double   gamma0;                   //!< flight path angle of the spacecraft at time of read [rad]
+    double   R0N[3][3];                //!< inertial-to-reference DCM at time of read
+    uint64_t lastFilterReadTime;       //!< time of last filter read
+
+    BSKLogger bskLogger;               //!< BSK Logging
+};
+
+
+#endif

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.i
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.i
@@ -1,0 +1,46 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module flybyPoint
+%{
+   #include "flybyPoint.h"
+%}
+
+%include "std_string.i"
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "swig_conly_data.i"
+
+%include "sys_model.h"
+%include "flybyPoint.h"
+
+%include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+struct NavTransMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+struct AttRefMsg_C;
+
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}
+

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.rst
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.rst
@@ -1,0 +1,82 @@
+Executive Summary
+-----------------
+This module computes a reference attitude frame for a spacecraft in relative motion about a small body. The implicit assumption is that the small body's mass does not perturb the motion of the spacecraft significantly. Conceptually, this module is equivalent to :ref:`hillPoint`, but for the relative motion of a spacecraft about a body that is not the main center of gravity.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages. The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - transNavInMsg
+      - :ref:`NavTransMsgPayload`
+      - Input message containing the relative position and velocity of the spacecraft with respect to the small body, estimated from a filter.
+    * - ephemerisInMsg
+      - :ref:`EphemerisMsgPayload`
+      - Input message containing the inertial position of the small body. This is needed only when the flyby is modeled using the Clohessy-Wiltshire equations.
+    * - attRefOutMsg
+      - :ref:`AttRefMsgPayload`
+      - Output attitude reference message containing reference attitude, reference angular rates and accelerations.
+
+
+Detailed Module Description
+---------------------------
+The relative position and velocity vector of the spacecraft with respect to the small body are obtained as noisy estimates. Therefore the desire is, for this module, to only read the filter message every so often. The input parameter ``dtFilterData`` allows the user to specify the desired time interval between two subsequent reads of the filter output. For every call of this module that happens between two consecutive filter reads, the reference attitude needs to be propagated from the last filter read according to a dynamic model of the flyby.
+
+Rectilinear Motion Model
+........................
+In this case the flyby is modeled as rectilinear motion of the spacecraft, i.e., the spacecraft moves with a constant velocity. At every filter read, the relative position and velocity vectors :math:`\boldsymbol{r}_0` and :math:`\boldsymbol{v}_0` of the spacecraft with respect to the small body are provided. The following coefficients are defined: the flight path angle :math:`\gamma_0` of the spacecraft, and the ratio between velocity and radius magnitudes :math:`f_0 = \frac{v_0}{r_0}`. From these quantities, the rotation of the reference frame is given by the following equations:
+
+.. math::
+    \theta(t) = \arctan \left( \tan \gamma_0 + \frac{f_0}{\cos \gamma_0} t \right) - \gamma_0
+.. math::
+    \dot{\theta}(t) = \frac{f_0 \cos \gamma_0}{f_0^2 t^2 + 2 f_0 \sin \gamma_0 t + 1}
+.. math::
+    \ddot{\theta}(t) = -2 f_0^2 \cos \gamma_0 \frac{f_0t + \sin \gamma_0}{(f_0^2 t^2 + 2 f_0 \sin \gamma_0 t + 1)^2}
+
+where :math:`t` is the time passes since the last filter read. Note that using the flight path angle :math:`gamma_0` makes these equation always nonsingular. :math:`\theta(t)` is used to compute the additional frame rotation from the Hill frame computed at the read time. Such rotation happens about the angular momentum direction vector. :math:`\dot{\theta}(t)` and :math:`\ddot{\theta}(t)` projected onto the angular momentum direction vector give the angular rate and acceleration vectors of the reference frame.
+
+
+Clohessy-Wiltshire Equations Model
+..................................
+T.B.D.
+
+
+Module Assumptions and Limitations
+----------------------------------
+The limitations of this module are inherent to the geometry of the problem, which determines whether or not all the constraints can be satisfied. For example, as shown in  in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints," In preparation for Journal of Spacecraft and Rockets, depending on the relative orientation of :math:`{}^\mathcal{B}h` and :math:`{}^\mathcal{B}a_1`, it may not be possible to  achieve perfect incidence angle on the solar arrays. Only when perfect incidence is obtained, it is possible to solve for the solution that also drives the body-fixed direction :math:`{}^\mathcal{B}a_2` close to the Sun. When perfect incidence is achievable, two solutions exist. If :math:`{}^\mathcal{B}a_2` is provided as input, this is used to determine which solution to pick. If this input is not provided, one of the two solution is chosen arbitrarily.
+
+Due to the difficulty in developing an analytical formulation for the reference angular rate and angular acceleration vectors, these are computed via second-order finite differences. At every time step, the current reference attitude and time stamp are stored in a module variable and used in the following time updates to compute angular rates and accelerations via finite differences.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    flybyGuid = flybyPoint.FlybyPoint()
+    flybyWrap.ModelTag = "flybyPoint"
+    flybyGuid.dtFilterData = 60
+    unitTestSim.AddModelToTask(unitTaskName, flybyGuid)
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``dtFilterData``
+     - 0
+     - time between two consecutive filter reads. If defaulted to zero, the filter information is read at every update call
+   * - ``flybyModel``
+     - 0
+     - 0 for rectilinear flyby model, 1 for Clohessy-Wiltshire model
+

--- a/src/tests/test_scenarioFlybyPoint.py
+++ b/src/tests/test_scenarioFlybyPoint.py
@@ -1,0 +1,83 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+# Basilisk Scenario Script and Integrated Test
+#
+# Purpose:  Integrated test of the attitude Hill point guidance of a spacecraft during a flyby.
+# Author:   Riccardo Calaon
+# Creation Date:  May 22, 2023
+#
+
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import unitTestSupport
+
+# Get current file path
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+sys.path.append(path + '/../../examples')
+import scenarioFlybyPoint
+
+
+# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
+# @pytest.mark.skipif(conditionstring)
+# uncomment this line if this test has an expected failure, adjust message as needed
+# @pytest.mark.xfail(True)
+
+# The following 'parameterize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.
+
+
+@pytest.mark.scenarioTest
+
+# provide a unique test method name, starting with test_
+def test_bskFlybyPoint(show_plots):
+    """This function is called by the py.test environment."""
+    # each test method requires a single assert method to be called
+
+    testFailCount = 0  # zero unit test result counter
+    testMessages = []  # create empty array to store test log messages
+
+    try:
+        figureList = scenarioFlybyPoint.run(show_plots, True, 1200)
+        # save the figures to the Doxygen scenario images folder
+        for pltName, plt in list(figureList.items()):
+            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+
+    except OSError as err:
+        testFailCount += 1
+        testMessages.append("scenarioFlybyPoint tests have failed.")
+
+    #   print out success message if no error were found
+    if testFailCount == 0:
+        print("PASSED ")
+    else:
+        print(testFailCount)
+        print(testMessages)
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    assert testFailCount < 1, testMessages
+


### PR DESCRIPTION
* **Tickets addressed:** bsk-028
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module computes the reference frame, reference angular rates and accelerations for a spacecraft flying by an asteroid. The module assumes a rectilinear flyby of the spacecraft with respect to the asteroid. The equations of motion are based on the relative position and velocity of the spacecraft with respect to the asteroid. Commit 1 generates the module files. Commit 2 populates the Reset method which reads in the input messages. Commit 3 populates the Update method. Commit 4 contains the Unit Test. Commit 5 contains the integrated scenario. Commit 6 contains the .rst documentation for the module and the updated release notes and index file.

## Verification
A unit test and an integrated scenario to show performance are provided.

## Documentation
Documentation is provided to describe the flyby model used in the code.

## Future work
A more refined model will involve Clohessy-Wiltshire equations to describe the relative motion of the spacecraft with respect to the asteroid.
