### PR TITLE
Feature/90 camera triangulation

### DIFF
--- a/src/architecture/msgPayloadDefC/CameraLocalizationMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/CameraLocalizationMsgPayload.h
@@ -1,0 +1,32 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef CAMERA_LOCALIZATION_MSG_H
+#define CAMERA_LOCALIZATION_MSG_H
+
+/*! @brief This structure includes the estimated camera location obtained from triangulation given a point cloud*/
+typedef struct {
+    bool valid; //!< [-] Quality of measurement
+    int64_t cameraID; //!< [-] ID of the camera
+    uint64_t timeTag; //!< [ns] vehicle time-tag when images where taken
+    double sigma_BN[3]; //!< [-] MRP orientation of spacecraft when images where taken
+    double cameraPos_N[3]; //!< [m] Camera location in inertial frame */
+}CameraLocalizationMsgPayload;
+
+#endif

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/_UnitTest/test_cameraTriangulation.py
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/_UnitTest/test_cameraTriangulation.py
@@ -1,0 +1,232 @@
+# 
+#  ISC License
+# 
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+# 
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+# 
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# 
+#
+
+import itertools
+
+import numpy as np
+import pytest
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import cameraTriangulation
+from Basilisk.utilities import RigidBodyKinematics
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import orbitalMotion
+
+# parameters
+trueAnomalies = [0., 10., 350.]
+cameraPositions = np.array([[1., 3., 4.], [0., 0., 0.]])
+scRotation = [0., 5., 70.]
+
+paramArray = [trueAnomalies, cameraPositions, scRotation]
+# create list with all combinations of parameters
+paramList = list(itertools.product(*paramArray))
+
+@pytest.mark.parametrize("accuracy", [1e-4])
+@pytest.mark.parametrize("p1_f, p2_cam, p3_scRot", paramList)
+
+def test_cameraTriangulation(show_plots, p1_f, p2_cam, p3_scRot, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This test checks if the camera triangulation module works correctly for different spacecraft positions, camera
+    positions (w.r.t. the spacecraft) and spacecraft orientations.
+
+    **Test Parameters**
+
+    Args:
+        :param show_plots: flag if plots should be shown
+        :param p1_f: spacecraft true anomaly
+        :param p2_cam: camera position
+        :param p3_scRot: spacecraft principal rotation angle, around a fixed vector
+        :param accuracy: accuracy of the test
+
+    **Description of Variables Being Tested**
+
+    The content of the CameraLocalizationMsg output message is compared with the true values.
+    """
+    cameraTriangulationTestFunction(show_plots, p1_f, p2_cam, p3_scRot, accuracy)
+
+
+def cameraTriangulationTestFunction(show_plots, p1_f, p2_cam, p3_scRot, accuracy):
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProcessRate = macros.sec2nano(100)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # set up the transfer orbit using classical orbit elements
+    mu = 3.986004418e14
+    oe = orbitalMotion.ClassicElements()
+    r = 10000. * 1.e3  # meters
+    oe.a = r
+    oe.e = 0.01
+    oe.i = 5. * macros.D2R
+    oe.Omega = 25. * macros.D2R
+    oe.omega = 30. * macros.D2R
+    oe.f = p1_f * macros.D2R
+    r_BN_N, v_BN_N = orbitalMotion.elem2rv(mu, oe)
+
+    time = macros.sec2nano(500)
+    ID = 0
+    fov = 20. * macros.D2R
+    res = np.array([1000, 800])
+    r_CB_B = p2_cam
+    dcm_CB = np.array([[0., 1., 0.], [0., 0., -1.], [-1., 0., 0.]])  # make sure camera z-axis points out of image plane
+    rotAxis = np.array([1., 0.3, 0.5])
+    prv_BN = p3_scRot * macros.D2R * rotAxis/np.linalg.norm(rotAxis)
+    sigma_BN = RigidBodyKinematics.PRV2MRP(prv_BN)
+    numberOfPoints = 100
+
+    sigma_CB = RigidBodyKinematics.C2MRP(dcm_CB)
+    dcm_BN = RigidBodyKinematics.MRP2C(sigma_BN)
+    dcm_CN = np.dot(dcm_CB, dcm_BN)
+
+    r_CN_N = r_BN_N + np.dot(dcm_BN, r_CB_B)
+
+    # camera parameters
+    alpha = 0.
+    resX = res[0]
+    resY = res[1]
+    pX = 2.*np.tan(fov*resX/resY/2.0)
+    pY = 2.*np.tan(fov/2.0)
+    dX = resX/pX
+    dY = resY/pY
+    up = resX/2.
+    vp = resY/2.
+    # build camera calibration matrix (not the inverse of it)
+    K = np.array([[dX, alpha, up], [0., dY, vp], [0., 0., 1.]])
+
+    # generate point cloud
+    pointCloud = createCircularPointCloud(1000. * 1.e3, numberOfPoints)
+    # reshape point cloud from Nx3 to 1x3*N stacked vector
+    pointCloudStacked = np.reshape(np.array(pointCloud), 3*numberOfPoints)
+
+    # generate images (keyPoints in pixel space)
+    keyPoints = createImages(pointCloud, r_CN_N, dcm_CN, K)
+    # reshape key points from Nx2 to 1x2*N stacked vector
+    keyPointsStacked = np.reshape(np.array(keyPoints), 2*numberOfPoints)
+
+    # setup module to be tested
+    module = cameraTriangulation.CameraTriangulation()
+    module.ModelTag = "cameraTriangulation"
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # Configure input messages
+    pointCloudInMsgData = messaging.PointCloudMsgPayload()
+    pointCloudInMsgData.timeTag = time
+    pointCloudInMsgData.valid = True
+    pointCloudInMsgData.numberOfPoints = numberOfPoints
+    pointCloudInMsgData.points = pointCloudStacked
+    pointCloudInMsg = messaging.PointCloudMsg().write(pointCloudInMsgData)
+
+    keyPointsInMsgData = messaging.PairedKeyPointsMsgPayload()
+    keyPointsInMsgData.valid = True
+    keyPointsInMsgData.cameraID = ID
+    keyPointsInMsgData.timeTag_secondImage = time
+    keyPointsInMsgData.keyPoints_secondImage = keyPointsStacked
+    keyPointsInMsgData.sigma_BN_secondImage = sigma_BN
+    keyPointsInMsgData.keyPointsFound = numberOfPoints
+    keyPointsInMsg = messaging.PairedKeyPointsMsg().write(keyPointsInMsgData)
+
+    cameraConfigInMsgData = messaging.CameraConfigMsgPayload()
+    cameraConfigInMsgData.cameraID = ID
+    cameraConfigInMsgData.fieldOfView = fov
+    cameraConfigInMsgData.resolution = res
+    cameraConfigInMsgData.cameraPos_B = r_CB_B
+    cameraConfigInMsgData.sigma_CB = sigma_CB
+    cameraConfigInMsg = messaging.CameraConfigMsg().write(cameraConfigInMsgData)
+
+    # subscribe input messages to module
+    module.pointCloudInMsg.subscribeTo(pointCloudInMsg)
+    module.keyPointsInMsg.subscribeTo(keyPointsInMsg)
+    module.cameraConfigInMsg.subscribeTo(cameraConfigInMsg)
+
+    # setup output message recorder objects
+    cameraLocationOutMsgRec = module.cameraLocationOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, cameraLocationOutMsgRec)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.TotalSim.SingleStepProcesses()
+
+    # pull module data
+    cameraLocation = cameraLocationOutMsgRec.cameraPos_N[0]
+    valid = cameraLocationOutMsgRec.valid[0]
+
+    # true data
+    cameraLocationTrue = r_CN_N
+    if (pointCloudInMsgData.valid and
+    keyPointsInMsgData.valid and
+    keyPointsInMsgData.cameraID == cameraConfigInMsgData.cameraID and
+    pointCloudInMsgData.timeTag == keyPointsInMsgData.timeTag_secondImage and
+    pointCloudInMsgData.numberOfPoints == keyPointsInMsgData.keyPointsFound):
+        validTrue = True
+    else:
+        validTrue = False
+
+    # make sure module output data is correct
+    paramsString = ' for true anomaly={}, camera position={}, SC rotation={}, accuracy={}'.format(
+        str(p1_f),
+        str(p2_cam),
+        str(p3_scRot),
+        str(accuracy))
+
+    np.testing.assert_allclose(cameraLocation,
+                               cameraLocationTrue,
+                               rtol=0,
+                               atol=accuracy,
+                               err_msg=('Variable: cameraLocation,' + paramsString),
+                               verbose=True)
+
+    np.testing.assert_equal(valid,
+                            validTrue,
+                            err_msg=('Variable: valid flag,' + paramsString),
+                            verbose=True)
+
+
+def createCircularPointCloud(radius, numberOfPoints):
+    phi = np.linspace(0., 2*np.pi, numberOfPoints)
+
+    # generate circular point cloud
+    points = []
+    for angle in phi:
+        rPoint_N = np.array([0., radius*np.cos(angle), radius*np.sin(angle)]).transpose()
+        points.append(rPoint_N)
+
+    return np.array(points)
+
+
+def createImages(pointCloud, cameraLocation, dcm_CN, cameraCalibrationMatrix):
+    r_CN_N = cameraLocation
+    K = cameraCalibrationMatrix
+    images = []
+    for r_PN_N in pointCloud:
+        r_PC_N = r_PN_N - r_CN_N
+        r_PC_C = np.dot(dcm_CN, r_PC_N)
+        xBar = r_PC_C/r_PC_C[2]
+        uBar = np.dot(K, xBar)
+        u = uBar[0:2]
+        images.append(u)
+
+    return np.array(images)
+
+
+if __name__ == "__main__":
+    test_cameraTriangulation(False, trueAnomalies[0], cameraPositions[0], scRotation[0], 1e-4)

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.cpp
@@ -1,0 +1,232 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#include "fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.h"
+#include <cmath>
+
+/*! This is the constructor for the module class.  It sets default variable
+    values and initializes the various parts of the model */
+CameraTriangulation::CameraTriangulation() = default;
+
+/*! Module Destructor */
+CameraTriangulation::~CameraTriangulation() = default;
+
+/*! This method is used to reset the module and checks that required input messages are connected.
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void CameraTriangulation::Reset(uint64_t currentSimNanos)
+{
+    // check that required input messages are connected
+    if (!this->pointCloudInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "cameraTriangulation.pointCloudInMsg was not linked.");
+    }
+    if (!this->keyPointsInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "cameraTriangulation.keyPointsInMsg was not linked.");
+    }
+    if (!this->cameraConfigInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "cameraTriangulation.cameraConfigInMsg was not linked.");
+    }
+}
+
+/*! This is the main method that gets called every time the module is updated.
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void CameraTriangulation::UpdateState(uint64_t currentSimNanos)
+{
+    // read messages
+    this->readMessages();
+
+    if (this->validInputs == 1) {
+        this->estimatedCameraLocation = this->triangulation(
+                this->pointCloud,
+                this->keyPoints,
+                this->cameraCalibrationMatrixInverse,
+                std::vector<Eigen::Matrix3d>{this->dcm_CN}
+        );
+    }
+
+    // write messages
+    this->writeMessages(currentSimNanos);
+}
+
+/*! This method reads the input messages each call of updateState.
+    It also checks if the message contents are valid for this module.
+    @return void
+*/
+void CameraTriangulation::readMessages()
+{
+    PointCloudMsgPayload pointCloudInMsgBuffer = this->pointCloudInMsg();
+    PairedKeyPointsMsgPayload keyPointsInMsgBuffer = this->keyPointsInMsg();
+    CameraConfigMsgPayload cameraConfigInMsgBuffer = this->cameraConfigInMsg();
+
+    /* point cloud message */
+    bool validPointCloud = pointCloudInMsgBuffer.valid;
+    int pointCloudSize = pointCloudInMsgBuffer.numberOfPoints;
+    // stacked vector with all feature locations of point cloud
+    Eigen::VectorXd pointCloudStacked(POINT_DIM*pointCloudSize);
+    pointCloudStacked = cArray2EigenMatrixXd(pointCloudInMsgBuffer.points, POINT_DIM*pointCloudSize, 1);
+    // convert to std vector that includes all point cloud feature locations
+    this->pointCloud.clear();
+    for (int c=0; c < pointCloudSize; c++) {
+        // point of point cloud
+        this->pointCloud.emplace_back(pointCloudStacked.segment(POINT_DIM*c, POINT_DIM));
+    }
+    uint64_t timeTagPointCloud = pointCloudInMsgBuffer.timeTag;
+
+    /* key points message */
+    bool validKeyPoints = keyPointsInMsgBuffer.valid;
+    int numberKeyPoints = keyPointsInMsgBuffer.keyPointsFound;
+    int cameraIDkeyPoints = keyPointsInMsgBuffer.cameraID;
+    // stacked vector with all pixel locations of key points
+    Eigen::VectorXd keyPointsStacked(2*numberKeyPoints);
+    keyPointsStacked = cArray2EigenMatrixXd(keyPointsInMsgBuffer.keyPoints_secondImage, 2*numberKeyPoints, 1);
+    // convert to std vector that includes all key point pixel locations
+    this->keyPoints.clear();
+    for (int c=0; c < numberKeyPoints; c++) {
+        // 2D pixel location
+        this->keyPoints.emplace_back(keyPointsStacked.segment(2*c, 2));
+    }
+    uint64_t timeTagKeyPoints = keyPointsInMsgBuffer.timeTag_secondImage;
+    // dcm from inertial frame N to body frame B
+    this->sigma_BN = cArray2EigenMRPd(keyPointsInMsgBuffer.sigma_BN_secondImage);
+    Eigen::Matrix3d dcm_BN = this->sigma_BN.toRotationMatrix().transpose();
+
+    /* camera config message */
+    int cameraIDconfig = cameraConfigInMsgBuffer.cameraID;
+    // dcm from body frame B to camera frame C
+    Eigen::MRPd sigma_CB = cArray2EigenMRPd(cameraConfigInMsgBuffer.sigma_CB);
+    Eigen::Matrix3d dcm_CB = sigma_CB.toRotationMatrix().transpose();
+    // camera parameters
+    double alpha = 0;
+    double fieldOfView = cameraConfigInMsgBuffer.fieldOfView;
+    double resolutionX = cameraConfigInMsgBuffer.resolution[0];
+    double resolutionY = cameraConfigInMsgBuffer.resolution[1];
+    double pX = 2.*tan(fieldOfView*resolutionX/resolutionY/2.0);
+    double pY = 2.*tan(fieldOfView/2.0);
+    double dX = resolutionX/pX;
+    double dY = resolutionY/pY;
+    double up = resolutionX/2;
+    double vp = resolutionY/2;
+    // build inverse K^-1 of camera calibration matrix K
+    this->cameraCalibrationMatrixInverse << 1./dX, -alpha/(dX*dY), (alpha*vp - dY*up)/(dX*dY),
+                                            0., 1./dY, -vp/dY,
+                                            0., 0., 1.;
+
+    // dcm from inertial frame N to camera frame C
+    this->dcm_CN = dcm_CB*dcm_BN;
+
+    this->validInputs = false;
+    if (validPointCloud && validKeyPoints) {
+        this->validInputs = true;
+    }
+
+    // check if cameraIDs, time tags, and number of features are equal
+    if (cameraIDkeyPoints == cameraIDconfig) {
+        this->cameraID = cameraIDkeyPoints;
+    } else {
+        bskLogger.bskLog(BSK_ERROR, "cameraTriangulation: camera IDs from keyPointsInMsg and "
+                                    "cameraConfigInMsg are different, but should be equal.");
+        this->validInputs = false;
+    }
+    if (timeTagPointCloud == timeTagKeyPoints) {
+        this->timeTag = timeTagPointCloud;
+    } else {
+        bskLogger.bskLog(BSK_ERROR, "cameraTriangulation: time tags from pointCloudInMsg and "
+                                    "keyPointsInMsg (timeTag_secondImage) are different, but should be equal.");
+        this->validInputs = false;
+    }
+    if (pointCloudSize != numberKeyPoints) {
+        bskLogger.bskLog(BSK_ERROR, "cameraTriangulation: number of features from pointCloudInMsg "
+                                    "(pointCloudSize) and keyPointsInMsg (numberKeyPoints) are different, "
+                                    "but should be equal.");
+        this->validInputs = false;
+    }
+}
+
+/*! This method writes the output messages each call of updateState
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void CameraTriangulation::writeMessages(uint64_t currentSimNanos)
+{
+    CameraLocalizationMsgPayload cameraLocationOutMsgBuffer;
+    cameraLocationOutMsgBuffer = this->cameraLocationOutMsg.zeroMsgPayload;
+
+    cameraLocationOutMsgBuffer.valid = this->validInputs;
+    cameraLocationOutMsgBuffer.cameraID = this->cameraID;
+    cameraLocationOutMsgBuffer.timeTag = this->timeTag;
+    Eigen::Vector3d sig_BN = eigenMRPd2Vector3d(this->sigma_BN);
+    eigenVector3d2CArray(sig_BN, cameraLocationOutMsgBuffer.sigma_BN);
+    eigenVector3d2CArray(this->estimatedCameraLocation, cameraLocationOutMsgBuffer.cameraPos_N);
+
+    this->cameraLocationOutMsg.write(&cameraLocationOutMsgBuffer, this->moduleID, currentSimNanos);
+}
+
+/*! This method performs the triangulation to estimate the unknown location given the known locations and images
+    @param knownLocations known positions (point cloud points)
+    @param imagePoints location of key points in pixel space
+    @param cameraCalibrationInverse inverse of camera calibration matrix K
+    @param dcmCamera dcm from frame of interest F to camera frame C
+    @return Eigen::Vector3d
+*/
+Eigen::Vector3d CameraTriangulation::triangulation(std::vector<Eigen::Vector3d> knownLocations,
+                                                       std::vector<Eigen::Vector2d> imagePoints,
+                                                       const Eigen::Matrix3d& cameraCalibrationInverse,
+                                                       std::vector<Eigen::Matrix3d> dcmCamera) const
+{
+    unsigned long numLocations = knownLocations.size();
+    unsigned long numImagePoints = imagePoints.size();
+    unsigned long numDCM = dcmCamera.size();
+
+    // make sure number of provided locations is equal to number of image points.
+    // number of DCMs must be either 1 or also equal to number of image points
+    assert(numLocations == numImagePoints && (numDCM == 1 || numDCM == numImagePoints));
+
+    Eigen::Matrix3d dcm_CF = dcmCamera.at(0); // dcm from frame of interest F to camera frame C
+
+    Eigen::MatrixXd A(3*numLocations, 3);
+    Eigen::VectorXd y(3*numLocations);
+
+    for (int c = 0; c < numLocations; ++c) {
+        // update dcm in case they are different for each image point
+        if (dcmCamera.size() != 1) {
+            dcm_CF = dcmCamera.at(c);
+        }
+
+        // 2D pixel location
+        Eigen::Vector2d u = imagePoints.at(c);
+        // 3D pixel location
+        Eigen::Vector3d uBar;
+        uBar << u,
+                1.;
+        // transform from pixel space to [m] space
+        Eigen::Vector3d xBar = cameraCalibrationInverse*uBar;
+        // known point
+        Eigen::Vector3d p = knownLocations.at(c);
+        // fill in A matrix and measurements y
+        A.block(3*c, 0, 3, 3) = eigenTilde(xBar)*dcm_CF;
+        y.segment(3*c, 3) = eigenTilde(xBar)*dcm_CF*p;
+    }
+    // solve linear least squares to find unknown location r
+    Eigen::Vector3d r = A.colPivHouseholderQr().solve(y);
+
+    return r;
+}

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.h
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.h
@@ -1,0 +1,73 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#ifndef CAMERATRIANGULATION_H
+#define CAMERATRIANGULATION_H
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/msgPayloadDefCpp/PointCloudMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h"
+#include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+#include "architecture/msgPayloadDefC/CameraLocalizationMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include <vector>
+#include <array>
+
+
+/*! @brief This module triangulates a camera position from a point cloud
+ */
+class CameraTriangulation: public SysModel {
+public:
+    CameraTriangulation();
+    ~CameraTriangulation();
+
+    void Reset(uint64_t currentSimNanos) override;
+    void UpdateState(uint64_t currentSimNanos) override;
+
+    ReadFunctor<PointCloudMsgPayload> pointCloudInMsg; //!< point cloud input message
+    ReadFunctor<PairedKeyPointsMsgPayload> keyPointsInMsg; //!< key (feature) points input message
+    ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg; //!< camera configuration input message
+    Message<CameraLocalizationMsgPayload> cameraLocationOutMsg; //!< estimated camera location output message
+
+    BSKLogger bskLogger; //!< -- BSK Logging
+
+private:
+    void readMessages();
+    void writeMessages(uint64_t currentSimNanos);
+    Eigen::Vector3d triangulation(std::vector<Eigen::Vector3d> knownLocations,
+                                  std::vector<Eigen::Vector2d> imagePoints,
+                                  const Eigen::Matrix3d& cameraCalibrationInverse,
+                                  std::vector<Eigen::Matrix3d> dcmCamera) const;
+
+    std::vector<Eigen::Vector3d> pointCloud{}; //!< [-] point cloud
+    std::vector<Eigen::Vector2d> keyPoints; //!< [-] key point pixel coordinates
+    Eigen::Matrix3d cameraCalibrationMatrixInverse; //!< [-] inverse of camera calibration matrix
+    Eigen::Matrix3d dcm_CN; //!< [-] direction cosine matrix (DCM) from inertial frame N to camera frame C
+    Eigen::MRPd sigma_BN; //!< [-] MRP orientation of spacecraft body B w.r.t. inertial frame N when images where taken
+    int64_t cameraID{}; //!< [-] ID of the camera that took the images
+    uint64_t timeTag{}; //!< [ns] vehicle time-tag associated with images
+    bool validInputs; //!< [-] validity flag for triangulation (true if information from input messages is as expected)
+    Eigen::Vector3d estimatedCameraLocation; //!< [m] triangulated camera location in inertial frame
+};
+
+#endif

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.i
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.i
@@ -1,0 +1,46 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+%module cameraTriangulation
+%{
+    #include "cameraTriangulation.h"
+%}
+
+%pythoncode %{
+    from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "std_vector.i"
+%include "swig_eigen.i"
+%include "sys_model.h"
+
+%include "cameraTriangulation.h"
+
+%include "architecture/msgPayloadDefCpp/PointCloudMsgPayload.h"
+%include "architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h"
+%include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+struct CameraConfigMsg_C;
+%include "architecture/msgPayloadDefC/CameraLocalizationMsgPayload.h"
+struct CameraLocalizationMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.rst
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.rst
@@ -1,0 +1,84 @@
+Executive Summary
+-----------------
+This module estimates the position of a camera using triangulation. Given a point cloud of feature locations (such as
+boulders on an asteroid), and the pixel coordinates of these features (key points) obtained from an image that the
+camera took, the camera location is estimated by triangulation. The triangulation algorithm is based on
+`this paper by S. Henry and J. A. Christian <https://doi.org/10.2514/1.G006989>`__ (Equation 20).
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.
+The module msg connection is set by the user from python.
+The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - pointCloudInMsg
+      - :ref:`PointCloudMsgPayload`
+      - point cloud input message
+    * - keyPointsInMsg
+      - :ref:`PairedKeyPointsMsgPayload`
+      - key points (features) input message
+    * - cameraConfigInMsg
+      - :ref:`CameraConfigMsgPayload`
+      - camera configuration input message
+    * - cameraLocationOutMsg
+      - :ref:`CameraLocalizationMsgPayload`
+      - camera location output message
+
+Module Assumptions and Limitations
+----------------------------------
+The module assumes the number of features in the provided point cloud and the number of key points from the camera
+image are equal, and that the features and corresponding key points are in the same order. The module also assumes that
+all key points come from a single camera, so the camera calibration matrix :math:`[K]` and the direction cosine matrix
+(DCM) :math:`[CN]` that maps from the inertial frame N to the camera frame C is the same for all key points.
+
+Algorithm
+---------
+The unknown camera location :math:`{}^N\mathbf{r}`, expressed in the inertial frame N, is estimated by solving the
+linear least squares problem
+
+.. math::
+    :label: eq:LLS
+
+    \begin{bmatrix}
+        [\tilde{\bar{\mathbf{x}}_1}][CN_1] \\
+        [\tilde{\bar{\mathbf{x}}_2}][CN_2] \\
+        \vdots \\
+        [\tilde{\bar{\mathbf{x}}_n}][CN_n]
+    \end{bmatrix} {}^N\mathbf{r} =
+    \begin{bmatrix}
+        [\tilde{\bar{\mathbf{x}}_1}][CN_1] {}^N\mathbf{p}_1 \\
+        [\tilde{\bar{\mathbf{x}}_2}][CN_2] {}^N\mathbf{p}_2 \\
+        \vdots \\
+        [\tilde{\bar{\mathbf{x}}_n}][CN_n] {}^N\mathbf{p}_n
+    \end{bmatrix}
+
+where :math:`{}^N\mathbf{p}_i` are the known points (point cloud), :math:`\bar{\mathbf{x}}_i = [K_i] \bar{\mathbf{u}}_i`
+with :math:`\bar{\mathbf{u}}_i = [\mathbf{u}_i, 1]^T` and image point in pixel space :math:`\mathbf{u}_i`. The tilde
+:math:`[\tilde{\mathbf{x}}]` indicates the skew-symmetric matrix that is equivalent to the cross product
+:math:`\mathbf{x} \times`.
+
+User Guide
+----------
+The module is first initialized as follows:
+
+.. code-block:: python
+
+    module = cameraTriangulation.CameraTriangulation()
+    module.ModelTag = "cameraTriangulation"
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+The input messages are then connected:
+
+.. code-block:: python
+
+    module.pointCloudInMsg.subscribeTo(pointCloudInMsg)
+    module.keyPointsInMsg.subscribeTo(keyPointsInMsg)
+    module.cameraConfigInMsg.subscribeTo(cameraConfigInMsg)


### PR DESCRIPTION
* **Tickets addressed:** Confluence 90
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
A module was created that estimates the location of a camera by triangulation and given a point cloud and corresponding images. The commits are organized as follows:

- Commits 1-2: Update and create necessary message definitions
- Commit 3: Create module
- Commit 4: UnitTest
- Commit 5: Documentation

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
A UnitTest was created that compares the estimated camera location with the true camera location.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
This is a new module. An RST documentation was added.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The triangulation() method of the module will eventually be moved from the module to an external utilities library. Thus, it is kept general here: Even though this module assumes that all images come from the same camera, the triangulation() method is set up such that the camera calibration matrix and camera direction cosine matrix (DCM) could be different for each image. 
