### PR TITLE
Feature/219 optical flow improvements

### DIFF
--- a/src/architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h
@@ -33,13 +33,15 @@ PairedKeyPointsMsgPayload
 {
     bool valid; //!< --  Quality of measurement
     int64_t cameraID; //!< -- [-]   ID of the camera that took the images
-    uint64_t timeTagImageOld; //!< --[ns]   Current vehicle time-tag associated with old image
-    uint64_t timeTagImageNew; //!< --[ns]   Current vehicle time-tag associated with new image
-    double keyPointsImageOld[MAX_KEY_POINTS]; //!< -- [-]   Paired features in old image
-    double keyPointsImageNew[MAX_KEY_POINTS]; //!< -- [-]   Paired features in new image
-    double sigmaBNImageOld[3]; //!< -- [-]   Attitude associated with old image
-    double sigmaBNImageNew[3]; //!< -- [-]  Attitude associated with new image
-    double keyPointsFound; //!< -- [-] Number of paired features
+    uint64_t timeTag_firstImage; //!< --[ns]   Current vehicle time-tag associated with first image
+    uint64_t timeTag_secondImage; //!< --[ns]   Current vehicle time-tag associated with second image
+    double keyPoints_firstImage[2*MAX_KEY_POINTS]; //!< -- [-]   Paired features in first image
+    double keyPoints_secondImage[2*MAX_KEY_POINTS]; //!< -- [-]   Paired features in second image
+    double sigma_BN_firstImage[3]; //!< -- [-]   Spacecraft body frame attitude associated with first image
+    double sigma_BN_secondImage[3]; //!< -- [-]  Spacecraft body frame attitude associated with second image
+    double sigma_TN_firstImage[3]; //!< -- [-]   Target frame wrt inertial at time of first image
+    double sigma_TN_secondImage[3]; //!< -- [-]  Target frame wrt inertial at time of second image
+    int keyPointsFound; //!< -- [-] Number of paired features
 }PairedKeyPointsMsgPayload;
 
 #endif /* KEYPOINTSMSG_H */

--- a/src/fswAlgorithms/imageProcessing/opticalFlow/opticalFlow.h
+++ b/src/fswAlgorithms/imageProcessing/opticalFlow/opticalFlow.h
@@ -30,6 +30,7 @@
 
 #include "architecture/msgPayloadDefC/CameraImageMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h"
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
@@ -50,14 +51,15 @@ public:
     void makeMask(cv::Mat const & inputBWImage, cv::Mat mask) const;
 
 private:
-    cv::Mat oldImage;
-    cv::Mat newImage;
-    bool oldImagePresent = false;
-    bool newImagePresent = false;
-    double oldAttitude[3];
-    uint64_t oldTimeTag;
-    std::vector<cv::Vec2f> newFeatures;
-    std::vector<cv::Vec2f> oldFeatures;
+    cv::Mat firstImage;
+    cv::Mat secondImage;
+    bool firstImagePresent = false;
+    bool secondImagePresent = false;
+    double firstSpacecraftAttitude[3];
+    double firstTargetEphemAttitude[3];
+    uint64_t firstTimeTag;
+    std::vector<cv::Vec2f> secondFeatures;
+    std::vector<cv::Vec2f> firstFeatures;
 
 public:
     std::string filename = "";  //!< Filename for module to read an image directly
@@ -65,6 +67,7 @@ public:
     Message<PairedKeyPointsMsgPayload> keyPointsMsg;  //!< The name of the output message containing key points
     ReadFunctor<CameraImageMsgPayload> imageInMsg;  //!< The name of the camera output message containing images
     ReadFunctor<NavAttMsgPayload> attitudeMsg;  //!< The name of the input attitude information
+    ReadFunctor<EphemerisMsgPayload> ephemerisMsg;  //!< The name of the input central target ephemeris data
     uint64_t sensorTimeTag; //!< [ns] Current time tag for sensor out
 
     double minTimeBetweenPairs = 1; //!< [s] Minimum time between pairs of images

--- a/src/fswAlgorithms/imageProcessing/opticalFlow/opticalFlow.i
+++ b/src/fswAlgorithms/imageProcessing/opticalFlow/opticalFlow.i
@@ -39,6 +39,8 @@ from Basilisk.architecture.swig_common_model import *
 struct CameraImageMsg_C;
 %include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 struct OpNavLimbMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
 
 %include "architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h"
 

--- a/src/fswAlgorithms/imageProcessing/opticalFlow/opticalFlow.rst
+++ b/src/fswAlgorithms/imageProcessing/opticalFlow/opticalFlow.rst
@@ -38,6 +38,9 @@ provides information on what this message is used for.
     * - attitudeMsg
       - :ref:`NavAttMsgPayload`
       - Input Spacecraft body to inertial attitude
+    * - ephemerisMsg
+      - :ref:`EphemerisMsgPayload`
+      - Input Target body to inertial attitude
 
 Module Description
 -------------------------------
@@ -98,4 +101,5 @@ feature tracking. For example::
 
     module.imageInMsg.subscribeTo(imageInMsg)
     module.attitudeMsg.subscribeTo(attInMsg)
+    module.ephemerisMsg.subscribeTo(ephemInMsg)
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-219
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
This PR contains additions to the Paired Keypoint message and the relevant modules that write it (optical flow). The message now has improved nomenclature from old/new to first/second in regard to the first and second images of the stereo pairs. Updates are added to the module and test as well. Next, the message has added fields: the frame of the target body with respect to inertial that the times when the two images are read. This is necessary for downstream modules.

## Verification
The test is enhanced to update the nomenclature and to test the proper reading and writing of the ephemeris message.

## Documentation
Documentation is updated to reflect the new input message

## Future work
None
