### PR TITLE
Use ubuntu focal (20.04) instead of jammy (22.04)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-linux:
     name: Build Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.9"]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,14 @@ list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/conan")
 
 include(bskTargetExcludeBuildOptions)
 
+# This was set because when executing on a github runner the runner
+# has 4 compiler versions on it and conan finds version 9 and Cmake find 11.3.
+# I didn't manage to find a robust way of accommodating this dynamically setting
+# the conan compiler to the same as what Cmake finds. But I did find
+# some discussion on this setting and it seems that if we are not looking to
+# support a wide range of versions of then the compiler needs of our conan
+# dependencies will often be met with the compiler that CMake ends up finding.
+set(CONAN_DISABLE_CHECK_COMPILER TRUE CACHE BOOL "" FORCE )
 
 # ! create_symlinks : create symlinks to support files in source rather than keeping them in dist The function takes one
 # required argument and N optional arguments. \argn: a list of supporting file paths


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
There are some changes that are coming from upstream Basilisk that fail tests when using an Ubuntu 22.04 runner. I'm unable to figure it out (at the moment) and we need to be able to bring in the upstream changes. So this PR steps us back to Ubuntu 20.04 (same as upstream basilisk) and side steps the conan to CMake compiler disagreement.

## Verification
CI runs successfully

## Documentation
None needed, none invalidated.

## Future work
Work out how we and community Basilisk can move to Ubuntu 22.04 CI runners.
