### PR TITLE
Refactor/97 thrusterPlatformReference refactor

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -28,6 +28,7 @@
 #include "cMsgCInterface/CmdTorqueBodyMsg_C.h"
 #include "cMsgCInterface/HingedRigidBodyMsg_C.h"
 #include "cMsgCInterface/BodyHeadingMsg_C.h"
+#include "cMsgCInterface/THRConfigMsg_C.h"
 
 
 enum momentumDumping{
@@ -42,8 +43,6 @@ typedef struct {
     double sigma_MB[3];                                   //!< orientation of the M frame w.r.t. the B frame
     double r_BM_M[3];                                     //!< position of B frame origin w.r.t. M frame origin, in M frame coordinates
     double r_FM_F[3];                                     //!< position of F frame origin w.r.t. M frame origin, in F frame coordinates
-    double r_TF_F[3];                                     //!< position of the thrust application point w.r.t. F frame origin, in F frame coordinates
-    double T_F[3];                                        //!< thrust vector in F frame coordinates
 
     double K;                                             //!< momentum dumping time constant [1/s]
 
@@ -52,13 +51,15 @@ typedef struct {
     int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
 
     /* declare module IO interfaces */
-    VehicleConfigMsg_C        vehConfigInMsg;             //!< input msg vehicle configuration msg (needed for CM location)
+    VehicleConfigMsg_C        vehConfigInMsg;            //!< input msg vehicle configuration msg (needed for CM location)
+    THRConfigMsg_C            thrusterConfigFInMsg;        //!< input thruster configuration msg
     RWSpeedMsg_C              rwSpeedsInMsg;              //!< input reaction wheel speeds message
     RWArrayConfigMsg_C        rwConfigDataInMsg;          //!< input RWA configuration message
     HingedRigidBodyMsg_C      hingedRigidBodyRef1OutMsg;  //!< output msg containing theta1 reference and thetaDot1 reference
     HingedRigidBodyMsg_C      hingedRigidBodyRef2OutMsg;  //!< output msg containing theta2 reference and thetaDot2 reference
     BodyHeadingMsg_C          bodyHeadingOutMsg;          //!< output msg containing the thrust heading in body frame coordinates
     CmdTorqueBodyMsg_C        thrusterTorqueOutMsg;       //!< output msg containing the opposite of the thruster torque to be compensated by RW's
+    THRConfigMsg_C            thrusterConfigBOutMsg;      //!< output msg containing the thruster configuration infor in B-frame
 
     BSKLogger *bskLogger;                                 //!< BSK Logging
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.i
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.i
@@ -33,6 +33,8 @@
 
 %include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
 struct VehicleConfigMsg_C;
+%include "architecture/msgPayloadDefC/THRConfigMsgPayload.h"
+struct THRConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
 struct RWArrayConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -18,6 +18,9 @@ provides information on what this message is used for.
     * - vehConfigInMsg
       - :ref:`VehicleConfigMsgPayload`
       - Input vehicle configuration message containing the position of the center of mass of the system.
+    * - thrusterConfigFInMsg
+      - :ref:`THRConfigMsgPayload`
+      - Input thruster configuration message containing the thrust direction vector and magnitude in **platform frame coordinates**. The entry ``rThrust_B`` here is the position of the thrust application point, with respect to the origin of the platform frame, in platform-frame coordinates (:math:`{}^\mathcal{F}\boldsymbol{r}_{T/F}`).
     * - rwConfigDataInMsg
       - :ref:`RWArrayConfigMsgPayload`
       - Input message containing the number of reaction wheels, relative inertias and orientations with respect to the body frame.
@@ -36,6 +39,9 @@ provides information on what this message is used for.
     * - thrusterTorqueOutMsg
       - :ref:`CmdTorqueBodyMsgPayload`
       - Output message containing the opposite of the net torque produced by the thruster on the system.
+    * - thrusterConfigBOutMsg
+      - :ref:`THRConfigMsgPayload`
+      - Output thruster configuration message containing the thrust direction vector and magnitude in **reference body frame coordinates**. The entry ``rThrust_B`` here is the position of the thrust application point, with respect to the origin of the body frame, in body-frame coordinates (:math:`{}^\mathcal{B}\boldsymbol{r}_{T/B}`).
 
 
 Detailed Module Description
@@ -75,8 +81,6 @@ The required module configuration is::
     platformConfig.sigma_MB = sigma_MB
     platformConfig.r_BM_M = r_BM_M
     platformConfig.r_FM_F = r_FM_F
-    platformConfig.r_TF_F = r_TF_F
-    platformConfig.T_F    = T_F
     platformConfig.K      = K
     scSim.AddModelToTaskAddModelToTask(simTaskName, platformWrap, platformConfig)
  	
@@ -98,12 +102,6 @@ The module is configurable with the following parameters:
     * - ``r_FM_F``
       - [0, 0, 0]
       - relative position of point :math:`F` with respect to point :math:`M`, in :math:`\mathcal{F}`-frame coordinates
-    * - ``r_TF_F``
-      - [0, 0, 0]
-      - relative position of point :math:`T` with respect to point :math:`F`, in :math:`\mathcal{F}`-frame coordinates
-    * - ``T_F``
-      - [0, 0, 0]
-      - thrust vector in :math:`\mathcal{F}`-frame coordinates
     * - ``K``
       - 0
       - proportional gain of the momentum dumping control loop


### PR DESCRIPTION
* **Tickets addressed:** #97 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This refactor consists in providing the thrusterPlatformReference module with an input thruster configuration msg containing the configuration information of the thruster with respect to the platform frame. A similar module is provided as an output, containing the reference thruster configuration info in body-frame coordinates. Commit 1 implements these changes in the module. Commits 2 and 3 update the documentation and unit test, respectively.

## Verification
Unit test is updated to test the correctness of input and output messages.

## Documentation
Documentation is updated to reflect the changes.

## Future work
No future work anticipated at this stage.
