### PR TITLE
Feature/88 point cloud triangulation

### DIFF
--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/_UnitTest/test_pointCloudTriangulation.py
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/_UnitTest/test_pointCloudTriangulation.py
@@ -1,0 +1,315 @@
+# 
+#  ISC License
+# 
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+# 
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+# 
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# 
+#
+
+import copy
+import itertools
+
+import numpy as np
+import pytest
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import pointCloudTriangulation
+from Basilisk.utilities import RigidBodyKinematics
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import orbitalMotion
+
+# parameters
+numInitialSteps = [0, 2, 3]
+cameraPositions = np.array([[1., 3., 4.], [0., 0., 0.]])
+scRotation = [0., 70.]
+
+paramArray = [numInitialSteps, cameraPositions, scRotation]
+# create list with all combinations of parameters
+paramList = list(itertools.product(*paramArray))
+
+@pytest.mark.parametrize("accuracy", [1e-4])
+@pytest.mark.parametrize("p1_n, p2_cam, p3_scRot", paramList)
+
+def test_pointCloudTriangulation(show_plots, p1_n, p2_cam, p3_scRot, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This test checks if the point cloud triangulation module works correctly for different camera
+    positions (w.r.t. the spacecraft) and spacecraft orientations.
+
+    **Test Parameters**
+
+    Args:
+        :param show_plots: flag if plots should be shown
+        :param p1_n: number of initial steps
+        :param p2_cam: camera position
+        :param p3_scRot: spacecraft principal rotation angle, around a fixed vector
+        :param accuracy: accuracy of the test
+
+    **Description of Variables Being Tested**
+
+    The content of the PointCloudMsg output message is compared with the true values.
+    """
+    pointCloudTriangulationTestFunction(show_plots, p1_n, p2_cam, p3_scRot, accuracy)
+
+
+def pointCloudTriangulationTestFunction(show_plots, p1_n, p2_cam, p3_scRot, accuracy):
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProcessRate = macros.sec2nano(10)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # setup module to be tested
+    module = pointCloudTriangulation.PointCloudTriangulation()
+    module.ModelTag = "pointCloudTriangulation"
+    module.numberTimeStepsInitialPhase = p1_n
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # set up the transfer orbit using classical orbit elements
+    mu = 3.986004418e14
+    oe = orbitalMotion.ClassicElements()
+    r = 10000. * 1.e3  # meters
+    oe.a = r
+    oe.e = 0.01
+    oe.i = 5. * macros.D2R
+    oe.Omega = 25. * macros.D2R
+    oe.omega = 30. * macros.D2R
+    oe.f = 40.
+
+    time = macros.sec2nano(0)
+    dt = testProcessRate * macros.NANO2SEC
+    ID = 0
+    fov = 20. * macros.D2R
+    res = np.array([1000, 800])
+    r_CB_B = p2_cam
+    dcm_CB = np.array([[0., 1., 0.], [0., 0., -1.], [-1., 0., 0.]])  # make sure camera z-axis points out of image plane
+    rotAxis = np.array([1., 0.3, 0.5])
+    omega_BN_hat = rotAxis/np.linalg.norm(rotAxis)
+    omega_BN_mag = 0.01
+    omega_BN = omega_BN_mag * omega_BN_hat
+    numberOfPoints = 20
+
+    # generate point cloud
+    pointCloudReference = createCircularPointCloud(1000. * 1.e3, numberOfPoints)
+    # reshape point cloud from Nx3 to 1x3*N stacked vector
+    pointCloudReferenceStacked = np.reshape(np.array(pointCloudReference), 3*numberOfPoints)
+
+    # camera parameters
+    alpha = 0.
+    resX = res[0]
+    resY = res[1]
+    pX = 2.*np.tan(fov*resX/resY/2.0)
+    pY = 2.*np.tan(fov/2.0)
+    dX = resX/pX
+    dY = resY/pY
+    up = resX/2.
+    vp = resY/2.
+    # build camera calibration matrix (not the inverse of it)
+    K = np.array([[dX, alpha, up], [0., dY, vp], [0., 0., 1.]])
+
+    sigma_CB = RigidBodyKinematics.C2MRP(dcm_CB)
+
+    # Configure input messages
+    ephemerisInMsgData = messaging.EphemerisMsgPayload()
+    ephemerisInMsg = messaging.EphemerisMsg().write(ephemerisInMsgData)
+
+    navTransInMsgData = messaging.NavTransMsgPayload()
+    navTransInMsg = messaging.NavTransMsg().write(navTransInMsgData)
+
+    directionOfMotionInMsgData = messaging.DirectionOfMotionMsgPayload()
+    directionOfMotionInMsg = messaging.DirectionOfMotionMsg().write(directionOfMotionInMsgData)
+
+    keyPointsInMsgData = messaging.PairedKeyPointsMsgPayload()
+    keyPointsInMsg = messaging.PairedKeyPointsMsg().write(keyPointsInMsgData)
+
+    cameraConfigInMsgData = messaging.CameraConfigMsgPayload()
+    cameraConfigInMsg = messaging.CameraConfigMsg().write(cameraConfigInMsgData)
+
+    # subscribe input messages to module
+    module.ephemerisInMsg.subscribeTo(ephemerisInMsg)
+    module.navTransInMsg.subscribeTo(navTransInMsg)
+    module.directionOfMotionInMsg.subscribeTo(directionOfMotionInMsg)
+    module.keyPointsInMsg.subscribeTo(keyPointsInMsg)
+    module.cameraConfigInMsg.subscribeTo(cameraConfigInMsg)
+
+    # setup output message recorder objects
+    pointCloudOutMsgRec = module.pointCloudOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, pointCloudOutMsgRec)
+
+    unitTestSim.InitializeSimulation()
+
+    # run simulation for several time steps
+    numTimeSteps = p1_n + 2
+    pointCloud = np.zeros([numTimeSteps, 3*numberOfPoints])
+    for i in range(0, numTimeSteps):
+        time1 = time + macros.sec2nano(dt*(i))
+        time2 = time + macros.sec2nano(dt*(i+1))
+
+        # SC state at time1
+        oeNew = copy.deepcopy(oe)
+        M0 = orbitalMotion.E2M(orbitalMotion.f2E(oe.f, oeNew.e), oeNew.e)
+        n = np.sqrt(mu / (oeNew.a) ** 3)
+        M1 = M0 + n*(time1-time)*macros.NANO2SEC
+        oeNew.f = orbitalMotion.E2f(orbitalMotion.M2E(M1, oeNew.e), oeNew.e)
+        r_BN_N, v_BN_N = orbitalMotion.elem2rv(mu, oeNew)
+
+        prv_B1N = (p3_scRot + omega_BN_mag*dt*(i)) * macros.D2R * rotAxis/np.linalg.norm(rotAxis)
+        prv_B2N = (p3_scRot + omega_BN_mag*dt*(i+1)) * macros.D2R * rotAxis/np.linalg.norm(rotAxis)
+        sigma_B1N = RigidBodyKinematics.PRV2MRP(prv_B1N)
+        sigma_B2N = RigidBodyKinematics.PRV2MRP(prv_B2N)
+
+        dcm_B1N = RigidBodyKinematics.MRP2C(sigma_B1N)
+        dcm_C1N = np.dot(dcm_CB, dcm_B1N)
+        dcm_B2N = RigidBodyKinematics.MRP2C(sigma_B2N)
+        dcm_C2N = np.dot(dcm_CB, dcm_B2N)
+
+        # First position vector follows orbital motion such that velocity also changes over time.
+        # Second position vector is obtained using linear motion since this is assumed inside the module
+        r_C1B_N = np.dot(dcm_B1N, r_CB_B)
+        r_C1N_N = r_BN_N + r_C1B_N
+        v_C1N_N = v_BN_N + np.cross(omega_BN, r_C1B_N)
+        vScale = np.linalg.norm(v_C1N_N)
+        v_N_hat = v_C1N_N / np.linalg.norm(v_C1N_N)
+        v_C_hat = np.dot(dcm_C1N, v_N_hat)
+        r_C2N_N = r_C1N_N + vScale * dt * v_N_hat  # use linear motion for unit test
+
+        # generate images (keyPoints in pixel space)
+        keyPoints1 = createImages(pointCloudReference, r_C1N_N, dcm_C1N, K)
+        keyPoints2 = createImages(pointCloudReference, r_C2N_N, dcm_C2N, K)
+        # reshape key points from Nx2 to 1x2*N stacked vector
+        keyPoints1Stacked = np.reshape(np.array(keyPoints1), 2*numberOfPoints)
+        keyPoints2Stacked = np.reshape(np.array(keyPoints2), 2*numberOfPoints)
+
+        # Update input messages
+
+        # For first p1_n time steps, ephemeris message should be used.
+        # For all subsequent time steps, navigation message should be used.
+        # Thus, set the message that shouldn't be used to zero (would cause unit test to fail if that message was
+        # accidentally used by the module
+        if i < p1_n:
+            ephemerisInMsgData.v_BdyZero_N = v_C1N_N  # use v_C1_N instead of v_BN_N for accurate unit test
+            ephemerisInMsgData.timeTag = time1 * macros.NANO2SEC
+            ephemerisInMsg.write(ephemerisInMsgData, unitTestSim.TotalSim.CurrentNanos)
+
+            navTransInMsgData.v_BN_N = np.array([0., 0., 0.])
+            navTransInMsgData.timeTag = 0.
+            navTransInMsg.write(navTransInMsgData, unitTestSim.TotalSim.CurrentNanos)
+        else:
+            ephemerisInMsgData.v_BdyZero_N = np.array([0., 0., 0.])
+            ephemerisInMsgData.timeTag = 0.
+            ephemerisInMsg.write(ephemerisInMsgData, unitTestSim.TotalSim.CurrentNanos)
+
+            navTransInMsgData.v_BN_N = v_C1N_N  # use v_C1_N instead of v_BN_N for accurate unit test
+            navTransInMsgData.timeTag = time1 * macros.NANO2SEC
+            navTransInMsg.write(navTransInMsgData, unitTestSim.TotalSim.CurrentNanos)
+
+        directionOfMotionInMsgData.valid = True
+        directionOfMotionInMsgData.cameraID = ID
+        directionOfMotionInMsgData.timeOfDirectionEstimate = time1
+        directionOfMotionInMsgData.v_C_hat = v_C_hat
+        directionOfMotionInMsg.write(directionOfMotionInMsgData, unitTestSim.TotalSim.CurrentNanos)
+
+        keyPointsInMsgData.valid = True
+        keyPointsInMsgData.cameraID = ID
+        keyPointsInMsgData.timeTag_firstImage = time1
+        keyPointsInMsgData.keyPoints_firstImage = keyPoints1Stacked
+        keyPointsInMsgData.sigma_BN_firstImage = sigma_B1N
+        keyPointsInMsgData.timeTag_secondImage = time2
+        keyPointsInMsgData.keyPoints_secondImage = keyPoints2Stacked
+        keyPointsInMsgData.sigma_BN_secondImage = sigma_B2N
+        keyPointsInMsgData.keyPointsFound = numberOfPoints
+        keyPointsInMsg.write(keyPointsInMsgData, unitTestSim.TotalSim.CurrentNanos)
+
+        cameraConfigInMsgData.cameraID = ID
+        cameraConfigInMsgData.fieldOfView = fov
+        cameraConfigInMsgData.resolution = res
+        cameraConfigInMsgData.cameraPos_B = r_CB_B
+        cameraConfigInMsgData.sigma_CB = sigma_CB
+        cameraConfigInMsg.write(cameraConfigInMsgData, unitTestSim.TotalSim.CurrentNanos)
+
+        unitTestSim.ConfigureStopTime(i * testProcessRate)
+        unitTestSim.ExecuteSimulation()
+
+        # pull module data
+        pointCloudMeasuredStacked = pointCloudOutMsgRec.points[i]
+        pointCloudMeasuredSize = pointCloudOutMsgRec.numberOfPoints[i]
+        pointCloudMeasured = np.reshape(np.array(pointCloudMeasuredStacked[0:3*pointCloudMeasuredSize]), (pointCloudMeasuredSize, 3))
+
+        # convert point cloud: module output is w.r.t. first camera location expressed in camera frame
+        # convert to be w.r.t. inertial frame, expressed in inertial frame
+        pointCloudConverted = convertPointCloud(pointCloudMeasured, dcm_C1N, r_C1N_N)
+        pointCloudConvertedStacked = np.reshape(np.array(pointCloudConverted), 3*numberOfPoints)
+
+        pointCloud[i, :] = pointCloudConvertedStacked
+
+    # true data
+    pointCloudTrue = np.tile(pointCloudReferenceStacked, [numTimeSteps, 1])
+
+    # make sure module output data is correct
+    paramsString = ' for number initial steps={}, camera position={}, SC rotation={}, accuracy={}'.format(
+        str(p1_n),
+        str(p2_cam),
+        str(p3_scRot),
+        str(accuracy))
+
+    np.testing.assert_allclose(pointCloud,
+                               pointCloudTrue,
+                               rtol=0,
+                               atol=accuracy,
+                               err_msg=('Variable: point cloud,' + paramsString),
+                               verbose=True)
+
+
+def createCircularPointCloud(radius, numberOfPoints):
+    phi = np.linspace(0., 2*np.pi, numberOfPoints)
+
+    # generate circular point cloud
+    points = []
+    for angle in phi:
+        rPoint_N = np.array([0., radius*np.cos(angle), radius*np.sin(angle)]).transpose()
+        points.append(rPoint_N)
+
+    return np.array(points)
+
+
+def createImages(pointCloud, cameraLocation, dcm_CN, cameraCalibrationMatrix):
+    r_CN_N = cameraLocation
+    K = cameraCalibrationMatrix
+    images = []
+    for r_PN_N in pointCloud:
+        r_PC_N = r_PN_N - r_CN_N
+        r_PC_C = np.dot(dcm_CN, r_PC_N)
+        xBar = r_PC_C/r_PC_C[2]
+        uBar = np.dot(K, xBar)
+        u = uBar[0:2]
+        images.append(u)
+
+    return np.array(images)
+
+
+def convertPointCloud(pointCloudIn, dcm_CN, r_CN_N):
+    pointCloudOut = []
+    for r_PC_C in pointCloudIn:
+        r_PC_N = np.dot(dcm_CN.transpose(), r_PC_C)
+        r_PN_N = r_PC_N + r_CN_N
+        pointCloudOut.append(r_PN_N)
+
+    return np.array(pointCloudOut)
+
+
+if __name__ == "__main__":
+    test_pointCloudTriangulation(False, numInitialSteps[0], cameraPositions[1], scRotation[0], 1e-4)

--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.cpp
@@ -1,0 +1,275 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#include "fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.h"
+#include <cmath>
+
+/*! This is the constructor for the module class.  It sets default variable
+    values and initializes the various parts of the model */
+PointCloudTriangulation::PointCloudTriangulation()
+{
+    this->numberTimesCalled = 0;
+    this->initialPhase = true;
+}
+
+/*! Module Destructor */
+PointCloudTriangulation::~PointCloudTriangulation() = default;
+
+/*! This method is used to reset the module and checks that required input messages are connected.
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void PointCloudTriangulation::Reset(uint64_t currentSimNanos)
+{
+    // check that required input messages are connected
+    if (!this->directionOfMotionInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "pointCloudTriangulation.directionOfMotionInMsg was not linked.");
+    }
+    if (!this->keyPointsInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "pointCloudTriangulation.keyPointsInMsg was not linked.");
+    }
+    if (!this->cameraConfigInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "pointCloudTriangulation.cameraConfigInMsg was not linked.");
+    }
+}
+
+/*! This is the main method that gets called every time the module is updated.
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void PointCloudTriangulation::UpdateState(uint64_t currentSimNanos)
+{
+    if (this->numberTimesCalled >= this->numberTimeStepsInitialPhase) {
+        this->initialPhase = false;
+    }
+
+    // read messages
+    this->readMessages();
+
+    if (this->valid) {
+        Eigen::Vector3d p1_C1 = Eigen::Vector3d::Zero();
+        double dt = (this->timeTag2 - this->timeTag1)*NANO2SEC;
+        Eigen::Vector3d p2_C1 = this->vScaleFactor*dt*this->v_C1_hat;
+
+        std::vector<Eigen::Vector3d> cameraLocations = {p1_C1, p2_C1};
+
+        std::vector<Eigen::Matrix3d> dcmCamera = {Eigen::Matrix3d::Identity(), this->dcm_C2C1};
+
+        this->measuredPointCloud.clear();
+        for (int c = 0; c < this->numberKeyPoints; ++c) {
+            std::vector<Eigen::Vector2d> imagePoints = {this->keyPoints1.at(c), this->keyPoints2.at(c)};
+            Eigen::Vector3d featureLocation = this->triangulation(
+                    cameraLocations,
+                    imagePoints,
+                    this->cameraCalibrationMatrixInverse,
+                    dcmCamera
+            );
+            this->measuredPointCloud.emplace_back(featureLocation);
+        }
+        this->pointCloudSize = this->numberKeyPoints;
+    }
+
+    // write messages
+    this->writeMessages(currentSimNanos);
+
+    this->numberTimesCalled += 1;
+}
+
+/*! This method reads the input messages each call of updateState.
+    It also checks if the message contents are valid for this module.
+    @return void
+*/
+void PointCloudTriangulation::readMessages()
+{
+    EphemerisMsgPayload ephemerisInMsgBuffer = this->ephemerisInMsg();
+    NavTransMsgPayload navTransInMsgBuffer = this->navTransInMsg();
+    DirectionOfMotionMsgPayload directionOfMotionInMsgBuffer = this->directionOfMotionInMsg();
+    PairedKeyPointsMsgPayload keyPointsInMsgBuffer = this->keyPointsInMsg();
+    CameraConfigMsgPayload cameraConfigInMsgBuffer = this->cameraConfigInMsg();
+
+    /* velocity information either from ephemeris message or nav message */
+    uint64_t timeTagVelocityInfo{};
+    if (this->initialPhase) {
+        this->vScaleFactor = cArray2EigenVector3d(ephemerisInMsgBuffer.v_BdyZero_N).norm();
+        timeTagVelocityInfo = ephemerisInMsgBuffer.timeTag * SEC2NANO;
+    } else {
+        this->vScaleFactor = cArray2EigenVector3d(navTransInMsgBuffer.v_BN_N).norm();
+        timeTagVelocityInfo = navTransInMsgBuffer.timeTag * SEC2NANO;
+    }
+
+    /* direction of motion message */
+    bool validDOM = directionOfMotionInMsgBuffer.valid;
+    uint64_t timeTagDOM = directionOfMotionInMsgBuffer.timeOfDirectionEstimate;
+    this->v_C1_hat = cArray2EigenVector3d(directionOfMotionInMsgBuffer.v_C_hat);
+
+    /* key points message */
+    bool validKeyPoints = keyPointsInMsgBuffer.valid;
+    this->numberKeyPoints = keyPointsInMsgBuffer.keyPointsFound;
+    int64_t cameraIDkeyPoints = keyPointsInMsgBuffer.cameraID;
+
+    // stacked vector with all pixel locations of key points for 1st camera location
+    Eigen::VectorXd keyPointsStacked1(2*this->numberKeyPoints);
+    keyPointsStacked1 = cArray2EigenMatrixXd(keyPointsInMsgBuffer.keyPoints_firstImage,
+                                             2*this->numberKeyPoints,
+                                             1);
+    // convert to std vector that includes all key point pixel locations
+    this->keyPoints1.clear();
+    for (int c=0; c < this->numberKeyPoints; c++) {
+        // 2D pixel location
+        this->keyPoints1.emplace_back(keyPointsStacked1.segment(2*c, 2));
+    }
+    this->timeTag1 = keyPointsInMsgBuffer.timeTag_firstImage;
+    // dcm from inertial frame N to body frame B
+    Eigen::MRPd sigma_B1N = cArray2EigenMRPd(keyPointsInMsgBuffer.sigma_BN_firstImage);
+    Eigen::Matrix3d dcm_B1N = sigma_B1N.toRotationMatrix().transpose();
+
+    // stacked vector with all pixel locations of key points for 2nd camera location
+    Eigen::VectorXd keyPointsStacked2(2*this->numberKeyPoints);
+    keyPointsStacked2 = cArray2EigenMatrixXd(keyPointsInMsgBuffer.keyPoints_secondImage,
+                                             2*this->numberKeyPoints,
+                                             1);
+    // convert to std vector that includes all key point pixel locations
+    this->keyPoints2.clear();
+    for (int c=0; c < this->numberKeyPoints; c++) {
+        // 2D pixel location
+        this->keyPoints2.emplace_back(keyPointsStacked2.segment(2*c, 2));
+    }
+    this->timeTag2 = keyPointsInMsgBuffer.timeTag_secondImage;
+    // dcm from inertial frame N to body frame B
+    Eigen::MRPd sigma_B2N = cArray2EigenMRPd(keyPointsInMsgBuffer.sigma_BN_secondImage);
+    Eigen::Matrix3d dcm_B2N = sigma_B2N.toRotationMatrix().transpose();
+
+    /* camera config message */
+    int64_t cameraIDconfig = cameraConfigInMsgBuffer.cameraID;
+    // dcm from body frame B to camera frame C
+    Eigen::MRPd sigma_CB = cArray2EigenMRPd(cameraConfigInMsgBuffer.sigma_CB);
+    Eigen::Matrix3d dcm_CB = sigma_CB.toRotationMatrix().transpose();
+    // camera parameters
+    double alpha = 0;
+    double fieldOfView = cameraConfigInMsgBuffer.fieldOfView;
+    double resolutionX = cameraConfigInMsgBuffer.resolution[0];
+    double resolutionY = cameraConfigInMsgBuffer.resolution[1];
+    double pX = 2.*tan(fieldOfView*resolutionX/resolutionY/2.0);
+    double pY = 2.*tan(fieldOfView/2.0);
+    double dX = resolutionX/pX;
+    double dY = resolutionY/pY;
+    double up = resolutionX/2;
+    double vp = resolutionY/2;
+    // build inverse K^-1 of camera calibration matrix K
+    this->cameraCalibrationMatrixInverse << 1./dX, -alpha/(dX*dY), (alpha*vp - dY*up)/(dX*dY),
+                                            0., 1./dY, -vp/dY,
+                                            0., 0., 1.;
+
+    // dcm from first image camera frame C1 to second image camera frame C2
+    Eigen::Matrix3d dcm_C1N = dcm_CB*dcm_B1N;
+    Eigen::Matrix3d dcm_C2N= dcm_CB*dcm_B2N;
+    this->dcm_C2C1 = dcm_C2N*dcm_C1N.transpose();
+
+    this->valid = false;
+    if (validDOM && validKeyPoints) {
+        this->valid = true;
+    }
+
+    // check if cameraIDs and time tags are equal
+    if (cameraIDkeyPoints != cameraIDconfig) {
+        bskLogger.bskLog(BSK_ERROR, "pointCloudTriangulation: camera IDs from keyPointsInMsg and "
+                                    "cameraConfigInMsg are different, but should be equal.");
+        this->valid = false;
+    }
+    if (!(timeTagVelocityInfo == timeTagDOM && timeTagDOM == this->timeTag1)) {
+        bskLogger.bskLog(BSK_ERROR, "pointCloudTriangulation: time tags from ephemerisInMsg, "
+                                    "navTransInMsg, directionOfMotionInMsg and the time tag of the first image from "
+                                    "keyPointsInMsg (timeTag_firstImage) are different, but should be equal.");
+        this->valid = false;
+    }
+}
+
+/*! This method writes the output messages each call of updateState
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void PointCloudTriangulation::writeMessages(uint64_t currentSimNanos)
+{
+    PointCloudMsgPayload pointCloudOutMsgBuffer;
+    pointCloudOutMsgBuffer = this->pointCloudOutMsg.zeroMsgPayload;
+
+    pointCloudOutMsgBuffer.timeTag = this->timeTag2;
+    pointCloudOutMsgBuffer.valid = this->valid;
+    pointCloudOutMsgBuffer.numberOfPoints = this->pointCloudSize;
+
+    // stacked vector with all feature locations of point cloud
+    Eigen::VectorXd pointCloudStacked(POINT_DIM*this->pointCloudSize);
+    for (int c=0; c < this->pointCloudSize; c++) {
+        pointCloudStacked.segment(POINT_DIM*c, POINT_DIM) = this->measuredPointCloud.at(c);
+    }
+    eigenMatrixXd2CArray(pointCloudStacked, pointCloudOutMsgBuffer.points);
+
+    this->pointCloudOutMsg.write(&pointCloudOutMsgBuffer, this->moduleID, currentSimNanos);
+}
+
+/*! This method performs the triangulation to estimate the unknown location given the known locations and images
+    @param knownLocations known positions (point cloud points)
+    @param imagePoints location of key points in pixel space
+    @param cameraCalibrationInverse inverse of camera calibration matrix K
+    @param dcmCamera dcm from frame of interest F to camera frame C
+    @return Eigen::Vector3d
+*/
+Eigen::Vector3d PointCloudTriangulation::triangulation(std::vector<Eigen::Vector3d> knownLocations,
+                                                   std::vector<Eigen::Vector2d> imagePoints,
+                                                   const Eigen::Matrix3d& cameraCalibrationInverse,
+                                                   std::vector<Eigen::Matrix3d> dcmCamera) const
+{
+    unsigned long numLocations = knownLocations.size();
+    unsigned long numImagePoints = imagePoints.size();
+    unsigned long numDCM = dcmCamera.size();
+
+    // make sure number of provided locations is equal to number of image points.
+    // number of DCMs must be either 1 or also equal to number of image points
+    assert(numLocations == numImagePoints && (numDCM == 1 || numDCM == numImagePoints));
+
+    Eigen::Matrix3d dcm_CF = dcmCamera.at(0); // dcm from frame of interest F to camera frame C
+
+    Eigen::MatrixXd A(3*numLocations, 3);
+    Eigen::VectorXd y(3*numLocations);
+
+    for (int c = 0; c < numLocations; ++c) {
+        // update dcm in case they are different for each image point
+        if (dcmCamera.size() != 1) {
+            dcm_CF = dcmCamera.at(c);
+        }
+
+        // 2D pixel location
+        Eigen::Vector2d u = imagePoints.at(c);
+        // 3D pixel location
+        Eigen::Vector3d uBar;
+        uBar << u,
+                1.;
+        // transform from pixel space to [m] space
+        Eigen::Vector3d xBar = cameraCalibrationInverse*uBar;
+        // known point
+        Eigen::Vector3d p = knownLocations.at(c);
+        // fill in A matrix and measurements y
+        A.block(3*c, 0, 3, 3) = eigenTilde(xBar)*dcm_CF;
+        y.segment(3*c, 3) = eigenTilde(xBar)*dcm_CF*p;
+    }
+    // solve linear least squares to find unknown location r
+    Eigen::Vector3d r = A.colPivHouseholderQr().solve(y);
+
+    return r;
+}

--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.h
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.h
@@ -1,0 +1,85 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#ifndef POINTCLOUDTRIANGULATION_H
+#define POINTCLOUDTRIANGULATION_H
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/DirectionOfMotionMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h"
+#include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/PointCloudMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include <vector>
+#include <array>
+
+
+/*! @brief This module triangulates a camera position from a point cloud
+ */
+class PointCloudTriangulation: public SysModel {
+public:
+    PointCloudTriangulation();
+    ~PointCloudTriangulation();
+
+    void Reset(uint64_t currentSimNanos) override;
+    void UpdateState(uint64_t currentSimNanos) override;
+
+    ReadFunctor<EphemerisMsgPayload> ephemerisInMsg; //!< ephemeris input message
+    ReadFunctor<NavTransMsgPayload> navTransInMsg; //!< translational navigation input message
+    ReadFunctor<DirectionOfMotionMsgPayload> directionOfMotionInMsg; //!< direction of motion input message
+    ReadFunctor<PairedKeyPointsMsgPayload> keyPointsInMsg; //!< key (feature) points input message
+    ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg; //!< camera configuration input message
+    Message<PointCloudMsgPayload> pointCloudOutMsg; //!< point cloud output message
+
+    BSKLogger bskLogger; //!< -- BSK Logging
+
+    //!< number of times (time steps) the module should use the ephemeris message before using the navigation message
+    int numberTimeStepsInitialPhase = 5;
+
+private:
+    void readMessages();
+    void writeMessages(uint64_t currentSimNanos);
+    Eigen::Vector3d triangulation(std::vector<Eigen::Vector3d> knownLocations,
+                                  std::vector<Eigen::Vector2d> imagePoints,
+                                  const Eigen::Matrix3d& cameraCalibrationInverse,
+                                  std::vector<Eigen::Matrix3d> dcmCamera) const;
+
+    int numberTimesCalled{}; //!< number of times (time steps) the module has been called
+    bool initialPhase{}; //!< indicates if the module is still in the initial phase (using ephemeris message)
+    double vScaleFactor{}; //!< velocity scale factor to be applied to direction of motion
+    Eigen::Vector3d v_C1_hat; //!< [-] camera direction of motion
+    int numberKeyPoints{}; //!< [-] number of key points (features)
+    std::vector<Eigen::Vector2d> keyPoints1; //!< [-] key point pixel coordinates for 1st camera position
+    uint64_t timeTag1{}; //!< [ns] vehicle time-tag associated with images for 1st camera position
+    std::vector<Eigen::Vector2d> keyPoints2; //!< [-] key point pixel coordinates for 2nd camera position
+    uint64_t timeTag2{}; //!< [ns] vehicle time-tag associated with images for 2nd camera position
+    Eigen::Matrix3d cameraCalibrationMatrixInverse; //!< [-] inverse of camera calibration matrix
+    Eigen::Matrix3d dcm_C2C1; //!< [-] direction cosine matrix (DCM) from camera frame C1 to camera frame C2
+    bool valid; //!< [-] validity flag for point cloud triangulation
+    int pointCloudSize{}; //!< [-] number of points in point cloud
+    std::vector<Eigen::Vector3d> measuredPointCloud{}; //!< [-] measured point cloud
+};
+
+#endif

--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.i
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.i
@@ -1,0 +1,49 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+%module pointCloudTriangulation
+%{
+    #include "pointCloudTriangulation.h"
+%}
+
+%pythoncode %{
+    from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "std_vector.i"
+%include "swig_eigen.i"
+%include "sys_model.h"
+
+%include "pointCloudTriangulation.h"
+
+%include "architecture/msgPayloadDefCpp/PointCloudMsgPayload.h"
+%include "architecture/msgPayloadDefCpp/PairedKeyPointsMsgPayload.h"
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+struct NavTransMsg_C;
+%include "architecture/msgPayloadDefCpp/DirectionOfMotionMsgPayload.h"
+%include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+struct CameraConfigMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.rst
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.rst
@@ -1,0 +1,96 @@
+Executive Summary
+-----------------
+This module creates a point cloud using triangulation. Given the pixel coordinates of features (key points, such as
+boulders on an asteroid) obtained from two images that the camera took at two known camera locations, the point cloud is
+estimated by triangulation. The triangulation algorithm is based on
+`this paper by S. Henry and J. A. Christian <https://doi.org/10.2514/1.G006989>`__ (Equation 20).
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.
+The module msg connection is set by the user from python.
+The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+
+    * - ephemerisInMsg
+      - :ref:`EphemerisMsgPayload`
+      - ephemeris input message
+    * - navTransInMsg
+      - :ref:`NavTransMsgPayload`
+      - translational navigation input message
+    * - directionOfMotionInMsg
+      - :ref:`DirectionOfMotionMsgPayload`
+      - direction of motion input message
+    * - keyPointsInMsg
+      - :ref:`PairedKeyPointsMsgPayload`
+      - key points (features) input message
+    * - cameraConfigInMsg
+      - :ref:`CameraConfigMsgPayload`
+      - camera configuration input message
+    * - pointCloudOutMsg
+      - :ref:`PointCloudMsgPayload`
+      - point cloud output message
+
+Module Assumptions and Limitations
+----------------------------------
+The module assumes the number of key points (features) in both "images" (at camera location 1 and 2) of the
+:ref:`PairedKeyPointsMsgPayload` are equal, and that the key points are in the same order in both images.
+The module also assumes that all key points come from a single camera, so the camera calibration matrix :math:`[K]` is
+the same for all key points.
+
+Algorithm
+---------
+The unknown feature location (point of point cloud) :math:`{}^N\mathbf{r}`, expressed in the inertial frame N, is
+estimated by solving the linear least squares problem
+
+.. math::
+    :label: eq:LLS
+
+    \begin{bmatrix}
+        [\tilde{\bar{\mathbf{x}}_1}][CN_1] \\
+        [\tilde{\bar{\mathbf{x}}_2}][CN_2] \\
+        \vdots \\
+        [\tilde{\bar{\mathbf{x}}_n}][CN_n]
+    \end{bmatrix} {}^N\mathbf{r} =
+    \begin{bmatrix}
+        [\tilde{\bar{\mathbf{x}}_1}][CN_1] {}^N\mathbf{p}_1 \\
+        [\tilde{\bar{\mathbf{x}}_2}][CN_2] {}^N\mathbf{p}_2 \\
+        \vdots \\
+        [\tilde{\bar{\mathbf{x}}_n}][CN_n] {}^N\mathbf{p}_n
+    \end{bmatrix}
+
+where :math:`{}^N\mathbf{p}_i` are the known camera locations, :math:`\bar{\mathbf{x}}_i = [K_i] \bar{\mathbf{u}}_i`
+with :math:`\bar{\mathbf{u}}_i = [\mathbf{u}_i, 1]^T` and image point in pixel space :math:`\mathbf{u}_i`. The tilde
+:math:`[\tilde{\mathbf{x}}]` indicates the skew-symmetric matrix that is equivalent to the cross product
+:math:`\mathbf{x} \times`.
+
+The module solves this least squares problem in a loop for all points of the point cloud.
+
+User Guide
+----------
+The module is first initialized as follows:
+
+.. code-block:: python
+
+    module = pointCloudTriangulation.PointCloudTriangulation()
+    module.ModelTag = "pointCloudTriangulation"
+    module.numberTimeStepsInitialPhase = 3  # optional (defaults to 5)
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+The input messages are then connected:
+
+.. code-block:: python
+
+    module.ephemerisInMsg.subscribeTo(ephemerisInMsg)
+    module.navTransInMsg.subscribeTo(navTransInMsg)
+    module.directionOfMotionInMsg.subscribeTo(directionOfMotionInMsg)
+    module.keyPointsInMsg.subscribeTo(keyPointsInMsg)
+    module.cameraConfigInMsg.subscribeTo(cameraConfigInMsg)


### PR DESCRIPTION
* **Tickets addressed:** Confluence 88
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
A module was created that estimates the location of features (creates a point cloud) by triangulation, given a two camera locations and corresponding images. The commits are organized as follows:

- Commit 1: Create necessary message definitions
- Commit 2: Create module
- Commit 3: UnitTest
- Commit 4: Documentation

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
A UnitTest was created that compares the generated point cloud with the true point cloud.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
This is a new module. An RST documentation was added.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The triangulation() method of the module will eventually be moved from the module to an external utilities library. Thus, it is kept general here: Even though this module assumes that all images come from the same camera, the triangulation() method is set up such that the camera calibration matrix and camera direction cosine matrix (DCM) could be different for each image.
