### PR TITLE
Feature/271 lambert surface relative velocity

### DIFF
--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/_UnitTest/test_lambertSurfaceRelativeVelocity.py
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/_UnitTest/test_lambertSurfaceRelativeVelocity.py
@@ -1,0 +1,170 @@
+# 
+#  ISC License
+# 
+#  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+# 
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+# 
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# 
+#
+import itertools
+
+import numpy as np
+import pytest
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import lambertSurfaceRelativeVelocity
+from Basilisk.utilities import RigidBodyKinematics
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import orbitalMotion
+
+# parameters
+relativeVelocities = np.array([[0., 0., 0.], [100., -300., 200.]])
+time_maneuver = [1.e3, 2.e3]
+trueAnomalies = [0., 70.]
+rotAngles = [0., 230.]
+angularVelocities = np.array([[0., 0., 0.], [1., -3., 2.]])
+
+paramArray = [relativeVelocities, time_maneuver, trueAnomalies, rotAngles, angularVelocities]
+# create list with all combinations of parameters
+paramList = list(itertools.product(*paramArray))
+
+@pytest.mark.parametrize("accuracy", [1e-4])
+@pytest.mark.parametrize("p1_vr, p2_tm, p3_f, p4_rot, p5_omega", paramList)
+
+def test_lambertSurfaceRelativeVelocity(show_plots, p1_vr, p2_tm, p3_f, p4_rot, p5_omega, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This test checks if the Lambert Surface Relative Velocity module works correctly for different relative velocity
+    vectors, maneuver times, true anomalies, planet rotation angles, and planet angular velocity vectors.
+
+    **Test Parameters**
+
+    Args:
+        :param show_plots: flag if plots should be shown
+        :param p1_vr: desired relative velocity
+        :param p2_tm: maneuver time
+        :param p3_f: true anomaly
+        :param p4_rot: rotation angle of planet
+        :param p5_omega: angular velocity vector of planet
+        :param accuracy: accuracy of the test
+
+    **Description of Variables Being Tested**
+
+    The content of the DesiredVelocityMsg output message (velocity vector and maneuver time) is compared with the true
+    values.
+    """
+    lambertSurfaceRelativeVelocityTestFunction(show_plots, p1_vr, p2_tm, p3_f, p4_rot, p5_omega, accuracy)
+
+
+def lambertSurfaceRelativeVelocityTestFunction(show_plots, p1_vr, p2_tm, p3_f, p4_rot, p5_omega, accuracy):
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProcessRate = macros.sec2nano(100)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    muBody = 3.986004418e14
+    ecc = 0.1
+    vRelativeDesired_S = p1_vr
+    tm = p2_tm
+
+    omega_PN_N = p5_omega
+    omegaHat_PN_N = omega_PN_N/np.linalg.norm(omega_PN_N)
+    prv_PN = p4_rot * macros.D2R * omegaHat_PN_N
+    sigma_PN = RigidBodyKinematics.PRV2MRP(prv_PN)
+    dcm_PN = RigidBodyKinematics.MRP2C(sigma_PN)
+    omega_PN_P = np.dot(dcm_PN, omega_PN_N)
+
+    # set up orbit using classical orbit elements
+    oe0 = orbitalMotion.ClassicElements()
+    r = 10000. * 1000  # meters
+    oe0.a = r
+    oe0.e = ecc
+    oe0.i = 10. * macros.D2R
+    oe0.Omega = 20. * macros.D2R
+    oe0.omega = 30. * macros.D2R
+    oe0.f = p3_f * macros.D2R
+    # spacecraft state at initial time
+    r0_BN_N, v0_BN_N = orbitalMotion.elem2rv_parab(muBody, oe0)
+
+    # setup module to be tested
+    module = lambertSurfaceRelativeVelocity.LambertSurfaceRelativeVelocity()
+    module.ModelTag = "lambertSurfaceRelativeVelocity"
+    module.vRelativeDesired_S = vRelativeDesired_S
+    module.time = tm
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # Configure input messages
+    ephemerisInMsgData = messaging.EphemerisMsgPayload()
+    ephemerisInMsgData.sigma_BN = sigma_PN
+    ephemerisInMsgData.omega_BN_B = omega_PN_P
+    ephemerisInMsg = messaging.EphemerisMsg().write(ephemerisInMsgData)
+
+    lambertProblemInMsgData = messaging.LambertProblemMsgPayload()
+    lambertProblemInMsgData.r2vec = r0_BN_N  # only info of LambertProblemMsg needed by module
+    lambertProblemInMsg = messaging.LambertProblemMsg().write(lambertProblemInMsgData)
+
+    # subscribe input messages to module
+    module.lambertProblemInMsg.subscribeTo(lambertProblemInMsg)
+    module.ephemerisInMsg.subscribeTo(ephemerisInMsg)
+
+    # setup output message recorder objects
+    desiredVelocityOutMsgRec = module.desiredVelocityOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, desiredVelocityOutMsgRec)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.TotalSim.SingleStepProcesses()
+
+    # pull module data
+    vDesired = desiredVelocityOutMsgRec.vDesired_N[0]
+    time = desiredVelocityOutMsgRec.maneuverTime[0]
+
+    # true values
+    s1Hat = np.cross(omega_PN_N, r0_BN_N)/np.linalg.norm(np.cross(omega_PN_N, r0_BN_N))
+    s3Hat = r0_BN_N/np.linalg.norm(r0_BN_N)
+    s2Hat = np.cross(s3Hat, s1Hat)/np.linalg.norm(np.cross(s3Hat, s1Hat))
+    dcm_SN = np.array([s1Hat, s2Hat, s3Hat])
+    vDesiredTrue = np.cross(omega_PN_N, r0_BN_N) + np.dot(dcm_SN.T, vRelativeDesired_S)
+    timeTrue = tm
+
+    # make sure module output data is correct
+    paramsString = ' for desired relative velocity={}, maneuver time={}, true anomaly={}, rotation angle={}, ' \
+                   'angular velocity={}, accuracy={}'.format(
+        str(p1_vr),
+        str(p2_tm),
+        str(p3_f),
+        str(p4_rot),
+        str(p5_omega),
+        str(accuracy))
+
+    np.testing.assert_allclose(vDesired,
+                               vDesiredTrue,
+                               rtol=0,
+                               atol=accuracy,
+                               err_msg=('Variable: desired velocity,' + paramsString),
+                               verbose=True)
+
+    np.testing.assert_allclose(time,
+                               timeTrue,
+                               rtol=0,
+                               atol=accuracy,
+                               err_msg=('Variable: maneuver time,' + paramsString),
+                               verbose=True)
+
+
+if __name__ == "__main__":
+    test_lambertSurfaceRelativeVelocity(False, relativeVelocities[1], time_maneuver[0], trueAnomalies[0], rotAngles[0],
+                                        angularVelocities[0], 1e-4)

--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.cpp
@@ -1,0 +1,98 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#include "fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include <cmath>
+
+/*! This is the constructor for the module class.  It sets default variable
+    values and initializes the various parts of the model */
+LambertSurfaceRelativeVelocity::LambertSurfaceRelativeVelocity() = default;
+
+/*! Module Destructor */
+LambertSurfaceRelativeVelocity::~LambertSurfaceRelativeVelocity() = default;
+
+/*! This method is used to reset the module and checks that required input messages are connected.
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void LambertSurfaceRelativeVelocity::Reset(uint64_t currentSimNanos)
+{
+    // check that required input messages are connected
+    if (!this->lambertProblemInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "lambertSurfaceRelativeVelocity.lambertProblemInMsg was not linked.");
+    }
+    if (!this->ephemerisInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "lambertSurfaceRelativeVelocity.ephemerisInMsg was not linked.");
+    }
+}
+
+/*! This is the main method that gets called every time the module is updated.
+    It computes the solution of Lambert's problem.
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void LambertSurfaceRelativeVelocity::UpdateState(uint64_t currentSimNanos)
+{
+    // read messages
+    this->readMessages();
+
+    // surface frame: s1 in east direction, s2 in north direction, s3 in up direction
+    Eigen::Vector3d s1Hat_N = (this->omega_PN_N.cross(this->r_BN_N)).normalized();
+    Eigen::Vector3d s3Hat_N = this->r_BN_N.normalized();
+    Eigen::Vector3d s2Hat_N = (s3Hat_N.cross(s1Hat_N)).normalized();
+    // DCM from inertial frame N to surface frame S
+    Eigen::Matrix3d dcm_SN;
+    dcm_SN << s1Hat_N.transpose(), s2Hat_N.transpose(), s3Hat_N.transpose();
+
+    this->v_BN_N = this->omega_PN_N.cross(this->r_BN_N) + dcm_SN.transpose()*this->vRelativeDesired_S;
+
+    // write messages
+    this->writeMessages(currentSimNanos);
+}
+
+/*! This method reads the input messages each call of updateState.
+    @return void
+*/
+void LambertSurfaceRelativeVelocity::readMessages(){
+    LambertProblemMsgPayload lambertProblemInMsgBuffer = this->lambertProblemInMsg();
+    EphemerisMsgPayload ephemerisInMsgBuffer = this->ephemerisInMsg();
+
+    this->r_BN_N = cArray2EigenVector3d(lambertProblemInMsgBuffer.r2vec);
+
+    Eigen::MRPd sigma_PN = cArray2EigenMRPd(ephemerisInMsgBuffer.sigma_BN);
+    this->dcm_PN = sigma_PN.toRotationMatrix().transpose();
+    Eigen::Vector3d omega_PN_P = cArray2EigenVector3d(ephemerisInMsgBuffer.omega_BN_B);
+    this->omega_PN_N = this->dcm_PN.transpose()*omega_PN_P;
+}
+
+/*! This method writes the output messages each call of updateState
+    @param currentSimNanos current simulation time in nano-seconds
+    @return void
+*/
+void LambertSurfaceRelativeVelocity::writeMessages(uint64_t currentSimNanos){
+    DesiredVelocityMsgPayload desiredVelocityOutMsgBuffer;
+    desiredVelocityOutMsgBuffer = this->desiredVelocityOutMsg.zeroMsgPayload;
+
+    eigenVector3d2CArray(this->v_BN_N, desiredVelocityOutMsgBuffer.vDesired_N);
+    desiredVelocityOutMsgBuffer.maneuverTime = this->time;
+
+    // Write to the output messages
+    this->desiredVelocityOutMsg.write(&desiredVelocityOutMsgBuffer, this->moduleID, currentSimNanos);
+}

--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.h
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.h
@@ -1,0 +1,65 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+
+#ifndef LAMBERTSURFACERELATIVEVELOCITY_H
+#define LAMBERTSURFACERELATIVEVELOCITY_H
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/msgPayloadDefC/LambertProblemMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/DesiredVelocityMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/astroConstants.h"
+#include <vector>
+#include <array>
+
+/*! @brief This module computes the inertial velocity corresponding to a given position and relative velocity to the
+    celestial body surface
+ */
+class LambertSurfaceRelativeVelocity: public SysModel {
+public:
+    LambertSurfaceRelativeVelocity();
+    ~LambertSurfaceRelativeVelocity();
+
+    void Reset(uint64_t currentSimNanos) override;
+    void UpdateState(uint64_t currentSimNanos) override;
+
+    ReadFunctor<LambertProblemMsgPayload> lambertProblemInMsg;          //!< lambert problem input message
+    ReadFunctor<EphemerisMsgPayload> ephemerisInMsg;                    //!< ephemeris input message
+    Message<DesiredVelocityMsgPayload> desiredVelocityOutMsg;           //!< desired inertial velocity output message
+
+    BSKLogger bskLogger;                                                //!< -- BSK Logging
+
+    Eigen::Vector3d vRelativeDesired_S; //!< [m/s] desired relative velocity, in surface frame S (East-North-Up)
+    double time{}; //!< [s] time for the desired velocity of the spacecraft
+
+private:
+    void readMessages();
+    void writeMessages(uint64_t currentSimNanos);
+
+    Eigen::Vector3d r_BN_N; //!< position of spacecraft, expressed in inertial frame N
+    Eigen::Vector3d v_BN_N; //!< velocity of spacecraft, expressed in inertial frame N
+    Eigen::Matrix3d dcm_PN; //!< DCM of the orbital body fixed frame relative to inertial
+    Eigen::Vector3d omega_PN_N; //!< [r/s] angular velocity of the orbital body relative to inertial
+};
+
+#endif

--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.i
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.i
@@ -1,0 +1,47 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+%module lambertSurfaceRelativeVelocity
+%{
+    #include "lambertSurfaceRelativeVelocity.h"
+%}
+
+%pythoncode %{
+    from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "std_vector.i"
+%include "swig_eigen.i"
+
+%include "sys_model.h"
+%include "lambertSurfaceRelativeVelocity.h"
+
+%include "architecture/msgPayloadDefC/LambertProblemMsgPayload.h"
+struct LambertProblemMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/DesiredVelocityMsgPayload.h"
+struct DesiredVelocityMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}
+

--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.rst
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.rst
@@ -1,0 +1,69 @@
+Executive Summary
+-----------------
+This module computes the required inertial spacecraft velocity :math:`{}^N\mathbf{v}_{B/N}` to satisfy the desired
+relative velocity to the surface :math:`{}^S\mathbf{v}_{rel,des}` at position :math:`{}^N\mathbf{r}_{B/N}` and
+(maneuver) time :math:`t`. The module takes into account the rotation and orientation of the celestial body, provided
+by the :ref:`EphemerisMsgPayload`. The spacecraft position :math:`{}^N\mathbf{r}_{B/N}` is provided by the second
+position vector :math:`{}^N\mathbf{r}_{2} in `:ref:`LambertProblemMsgPayload`, as this module is designed to be used at
+the end of a Lambert problem transfer arc. The surface frame S, in which the desired relative velocity vector is
+expressed in, is an East-North-Up frame (third unit vector is in the radial direction, first unit vector is
+perpendicular to the angular velocity vector of the celestial body and the radial direction, and the second unit vector
+completes the right-handed coordinate frame). The computed required inertial spacecraft velocity and maneuver time are
+written to the :ref:`DesiredVelocityMsgPayload` output message.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.
+The module msg connection is set by the user from python.
+The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - lambertProblemInMsg
+      - :ref:`lambertProblemMsgPayload`
+      - lambert problem setup input message
+    * - ephemerisInMsg
+      - :ref:`EphemerisMsgPayload`
+      - ephemeris input message
+    * - desiredVelocityOutMsg
+      - :ref:`DesiredVelocityMsgPayload`
+      - Desired velocity output message
+
+
+Algorithm
+---------
+The required inertial spacecraft velocity is computed by:
+
+.. math::
+    :label: eq:vInertial
+
+    \mathbf{v}_{B/N} = \mathbf{\omega}_{P/N} \times \mathbf{r}_{B/N} + \mathbf{v}_{rel,des}
+
+where :math:`\mathbf{\omega}_{P/N}` is the angular velocity of the planet fixed frame P w.r.t. the inertial frame N.
+
+
+User Guide
+----------
+The module is first initialized as follows:
+
+.. code-block:: python
+
+    module = lambertSurfaceRelativeVelocity.LambertSurfaceRelativeVelocity()
+    module.ModelTag = "lambertSurfaceRelativeVelocity"
+    module.vRelativeDesired_S = np.array([0., 0., 10.])  # in surface frame (East-North-Up)
+    module.time = 1000.
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+The input messages are then connected:
+
+.. code-block:: python
+
+    module.lambertProblemInMsg.subscribeTo(lambertProblemInMsg)
+    module.ephemerisInMsg.subscribeTo(ephemerisInMsg)


### PR DESCRIPTION
* **Tickets addressed:** Confluence 271
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
A module was created that computes the inertial velocity required to achieve a desired velocity relative to the surface of a celestial body at the end of a Lambert problem transfer arc (at the second position vector of Lambert problem). The computed inertial velocity can then be used by the module in #109 to obtain the Delta-V that should be performed at the end of the Lambert problem transfer arc. The commits are organized as follows:

- Commit 1: Create necessary message definitions (from PR #109)
- Commit 2: Create module
- Commit 3: UnitTest
- Commit 4: Documentation

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
A UnitTest was created that compares the computed Delta-V with the true value.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
This is a new module. An RST documentation was added.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None at this point.
