### PR TITLE
Feature/281 triangulation covariance

### DIFF
--- a/src/architecture/msgPayloadDefC/CameraLocalizationMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/CameraLocalizationMsgPayload.h
@@ -27,6 +27,7 @@ typedef struct {
     uint64_t timeTag; //!< [ns] vehicle time-tag when images where taken
     double sigma_BN[3]; //!< [-] MRP orientation of spacecraft when images where taken
     double cameraPos_N[3]; //!< [m] Camera location in inertial frame */
+    double covariance_N[3*3]; //!< [m^2] covariance of estimated camera location in inertial frame
 }CameraLocalizationMsgPayload;
 
 #endif

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.h
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.h
@@ -51,23 +51,28 @@ public:
 
     BSKLogger bskLogger; //!< -- BSK Logging
 
+    double uncertaintyImageMeasurement = 0.; //!< [pixel] standard deviation of image point errors (about 1/4 to 1/2 px)
+
 private:
     void readMessages();
     void writeMessages(uint64_t currentSimNanos);
-    Eigen::Vector3d triangulation(Eigen::MatrixXd knownLocations,
-                                  std::vector<Eigen::Vector2d> imagePoints,
-                                  const Eigen::Matrix3d& cameraCalibrationInverse,
-                                  std::vector<Eigen::Matrix3d> dcmCamera) const;
+    std::pair<Eigen::Vector3d, Eigen::Matrix3d> triangulation(Eigen::MatrixXd knownLocations,
+                                                              std::vector<Eigen::Vector2d> imagePoints,
+                                                              const Eigen::Matrix3d& cameraCalibrationInverse,
+                                                              std::vector<Eigen::Matrix3d> dcmCamera) const;
 
     Eigen::MatrixXd pointCloud{}; //!< [-] point cloud
     std::vector<Eigen::Vector2d> keyPoints{}; //!< [-] key point pixel coordinates
     Eigen::Matrix3d cameraCalibrationMatrixInverse{}; //!< [-] inverse of camera calibration matrix
+    Eigen::Matrix2d Ru{}; //!< [-] measurement covariance matrix of pixel coordinate u
+    Eigen::Matrix3d Rx{}; //!< [-] measurement covariance matrix of image point x
     Eigen::Matrix3d dcm_CN{}; //!< [-] direction cosine matrix (DCM) from inertial frame N to camera frame C
     Eigen::MRPd sigma_BN{}; //!< [-] MRP orientation of spacecraft body B w.r.t. inertial frame N when images where taken
     int64_t cameraID{}; //!< [-] ID of the camera that took the images
     uint64_t timeTag{}; //!< [ns] vehicle time-tag associated with images
     bool validInputs; //!< [-] validity flag for triangulation (true if information from input messages is as expected)
     Eigen::Vector3d estimatedCameraLocation{}; //!< [m] triangulated camera location in inertial frame
+    Eigen::Matrix3d triangulationCovariance{}; //!< [m^2] covariance of triangulation result
 };
 
 #endif

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.rst
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.rst
@@ -3,7 +3,8 @@ Executive Summary
 This module estimates the position of a camera using triangulation. Given a point cloud of feature locations (such as
 boulders on an asteroid), and the pixel coordinates of these features (key points) obtained from an image that the
 camera took, the camera location is estimated by triangulation. The triangulation algorithm is based on
-`this paper by S. Henry and J. A. Christian <https://doi.org/10.2514/1.G006989>`__ (Equation 20).
+`this paper by S. Henry and J. A. Christian <https://doi.org/10.2514/1.G006989>`__ (Equation 20). The covariance matrix
+of the estimated camera location is also computed according to Equation A5 in the appendix of the paper.
 
 Message Connection Descriptions
 -------------------------------
@@ -36,8 +37,7 @@ Module Assumptions and Limitations
 ----------------------------------
 The module assumes the number of features in the provided point cloud and the number of key points from the camera
 image are equal, and that the features and corresponding key points are in the same order. The module also assumes that
-all key points come from a single camera, so the camera calibration matrix :math:`[K]` and the direction cosine matrix
-(DCM) :math:`[CN]` that maps from the inertial frame N to the camera frame C is the same for all key points.
+all key points come from a single camera, so the camera calibration matrix :math:`[K]` is the same for all key points.
 
 Algorithm
 ---------
@@ -73,6 +73,7 @@ The module is first initialized as follows:
 
     module = cameraTriangulation.CameraTriangulation()
     module.ModelTag = "cameraTriangulation"
+    module.uncertaintyImageMeasurement = 0.25   # optional, default = 0.
     unitTestSim.AddModelToTask(unitTaskName, module)
 
 The input messages are then connected:


### PR DESCRIPTION
* **Tickets addressed:** Confluence 281
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The computation of the triangulation covariance matrix was added to the triangulation() method of the cameraTriangulation module. This module now computes the covariance matrix and writes it to the cameraLocalizationMsg. The commits are organized as follows:

- Commit 1: Update necessary message definitions
- Commit 2: Update module
- Commit 3: Update UnitTest
- Commit 4: Update Documentation

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
The UnitTest of the cameraTriangulation module was updated to check if the covariance matrix is computed accurately.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
The documentation of the cameraTriangulation module was updated to mention that the covariance is also computed by the module.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The triangulation() method may be moved to a library outside the module.