### PR TITLE
Feature/106 sep point

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -44,6 +44,9 @@ Version |release|
 - Corrected an error with :ref:`magnetometer` where the RNG seed was passed to the Gauss-Markov noise model within the
   constructor and could therefore not be modified after creating the object. Furthermore, the noise model is now only
   used if all three components of the standard deviation parameter are initialized to a positive value.
+- Corrected an error with :ref:`magnetometer` where the RNG seed was passed to the Gauss-Markov noise model within the
+  constructor and could therefore not be modified after creating the object. Furthermore, the noise model is now only
+  used if all three components of the standard deviation parameter are initialized to a positive value.
 - Removed fswAuto and associated documenation, as the tool was outdated.
 - Changed how C modules are wrapped as C++ classes. This makes handling C modules the same as C++ modules,
   removing the need for "Config" and "Wrap" objects. Updated all scenarios and test files for this new syntax.
@@ -65,6 +68,9 @@ Version |release|
 - Added :ref:`scenario_LambertGuidance` BSK-Sim scenario to illustrate the Lambert modules in different flight modes
 - Added :ref:`scenario_ClosedLoopManeuver` BSK-Sim scenario to illustrate how a Delta-V maneuver can be performed using
   thrusters
+- Created :ref:`sepPoint` to compute the reference attitude during SEP Point thrusting, with thruster alignment as
+  first constraint, and interchangeable second and third constraint consisting in maximum sunlight incidence on the
+  solar arrays, and keep-in constraint of a body-fixed direction around the Sun direction.
 
 Version 2.2.0 (June 28, 2023)
 -----------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -554,7 +554,7 @@ find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/vehicleConfigData" VEH_C
 
 generate_package_targets("${ATT_CONTROL_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${ATT_DET_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")
-generate_package_targets("${ATT_GUID_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")
+generate_package_targets("${ATT_GUID_TARGETS}" "attGuidanceLib;${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${DV_GUID_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${EFF_INTERFACES_TARGETS}" "effectorInterfacesLib;${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${FORM_FLYING_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")

--- a/src/fswAlgorithms/attGuidance/_GeneralModuleFiles/attitudePointingLibrary.cpp
+++ b/src/fswAlgorithms/attGuidance/_GeneralModuleFiles/attitudePointingLibrary.cpp
@@ -1,0 +1,297 @@
+/*
+ ISC License
+
+ Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "attitudePointingLibrary.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#endif
+#include <math.h>
+
+/*! This constructor initializes an SolutionSpace class for the solution
+    of the second order inequality (At^2+Bt+C)/(1+t^2) >= 0 */
+SolutionSpace::SolutionSpace(double A, double B, double C, double tol)
+{
+    double Delta = B*B - 4*A*C;
+    // A is nonzero
+    if (fabs(A) > tol) {
+        if ((Delta > 0) && (fabs(Delta) > tol)) {
+            this->emptySet = false;
+            double t1 = (-B - sqrt(Delta)) / (2*A);
+            double t2 = (-B + sqrt(Delta)) / (2*A);
+            if (A > 0) {
+                this->inf = 2 * atan(t2);
+                this->sup = 2 * (atan(t1) + M_PI);
+            }
+            else {
+                this->inf = 2 * atan(t2);
+                this->sup = 2 * atan(t1);
+            }
+            this->zero[0] = this->inf;
+            this->zero[1] = this->sup;
+            this->zeros = 2;
+        }
+        else if ((Delta < 0) && (fabs(Delta) > tol)) {
+            if (A > 0) {
+                this->emptySet = false;
+                this->inf = -M_PI;
+                this->sup =  M_PI;
+            }
+            else {
+                this->emptySet = true;
+            }
+            this->zeros = 0;
+        }
+        else {
+            this->emptySet = false;
+            if (A > 0) {
+                this->inf = -M_PI;
+                this->sup =  M_PI;
+            }
+            else {
+                this->inf = 2 * atan(-B / (2*A));
+                this->sup = 2 * atan(-B / (2*A));
+            }
+            this->zero[0] = 2 * atan(-B / (2*A));
+            this->zero[1] = 2 * atan(-B / (2*A));
+        }
+    }
+    // A is zero
+    else {
+        // B is nonzero
+        if (fabs(B) > tol) {
+            this->emptySet = false;
+            if (B > 0) {
+                this->inf = 2 * atan(-C / B);
+                this->sup = M_PI;
+            }
+            else {
+                this->inf = -M_PI;
+                this->sup = 2 * atan(-C / B);
+            }
+            this->zero[0] = this->inf;
+            this->zero[1] = this->sup;
+            this->zeros = 2;
+        }
+        // B is zero
+        else {
+            if (C > 0) {
+                this->emptySet = false;
+                this->inf = -M_PI;
+                this->sup =  M_PI;
+            }
+            else {
+                this->emptySet = true;
+            }
+            this->zeros = 0;
+        }
+    }
+    // compute max and min of the function
+    double psi1;    // PRA #1
+    double psi2;    // PRA #2
+    double y1;      // fcn value #1
+    double y2;      // fcn value #2
+    if (fabs(B) > tol) {
+        double q = (A - C) / B;
+        double t1 = q - sqrt(q*q + 1);
+        double t2 = q + sqrt(q*q + 1);
+        y1 = (A*t1*t1 + B*t1 + C) / (1+t1*t1);
+        y2 = (A*t2*t2 + B*t2 + C) / (1+t2*t2);
+        psi1 = 2 * atan(t1);
+        psi2 = 2 * atan(t2);
+    }
+    else {
+        psi1 = 0;
+        psi2 = M_PI;
+        y1 = C;
+        y2 = A;
+    }
+    if (y1 < y2) {
+        this->psiMin = psi1;
+        this->psiMax = psi2;
+        this->yMin = y1;
+        this->yMax = y2;
+    }
+    else {
+        this->psiMin = psi2;
+        this->psiMax = psi1;
+        this->yMin = y2;
+        this->yMax = y1;
+    }
+}
+
+/*! Generic destructor */
+SolutionSpace::~SolutionSpace() = default;
+
+/*! Define this method that returns the number of zeros method */
+bool SolutionSpace::isEmpty() {return this->emptySet;}
+
+/*! Define this method that returns the number of zeros method */
+int SolutionSpace::numberOfZeros() {return this->zeros;}
+
+/*! Define this method that returns the absolute minimum of the function method */
+double SolutionSpace::returnAbsMin(int idx)
+{
+    if ((idx < 1) || (idx > 2)) {
+        return 0;
+    }
+
+    switch (this->zeros) {
+
+        case 2 :
+            return this->zero[idx-1];
+
+        case 1 :
+            return this->zero[0];
+
+        case 0 :
+            if (fabs(this->yMin) < fabs(this->yMax)) {
+                return this->psiMin;
+            }
+            else {
+                return this->psiMax;
+            }
+
+        default :
+            return 0;
+    }
+}
+
+/*! Define this method that returns whether the input is contained in the solution space */
+bool SolutionSpace::contains(double psi)
+{
+    if (this->emptySet) {
+        return false;
+    }
+    if (psi < this->inf && psi+2*M_PI > this->sup) {
+        return false;
+    }
+    if (psi > this->sup) {
+        return false;
+    }
+    return true;
+}
+
+/*! Define this method the closest value in the solution space to the input */
+double SolutionSpace::passThrough(double psi)
+{
+    if (!this->emptySet) {
+        if (psi > this->sup) {
+            return this->sup;
+        }
+        else if (psi < this->inf && psi + 2 * M_PI > this->sup) {
+            double dt1 = this->inf - psi;
+            double dt2 = psi + 2 * M_PI - this->sup;
+            if (dt1 < dt2) {
+                return this->inf;
+            } else {
+                return this->sup;
+            }
+        }
+        else {
+            return psi;
+        }
+    }
+    else {
+        return this->returnAbsMin(1);
+    }
+}
+
+/*! This function computes the DCM DB that aligns direction hRefHat to a requested direction hReqHat */
+void boresightAlignment(double hRefHat[3], double hReqHat[3], double tol, double DB[3][3])
+{
+    /*! compute principal rotation angle (phi) and vector (e_phi) */
+    double phi = acos( fmin( fmax( v3Dot(hRefHat, hReqHat), -1 ), 1 ) );
+    double e_phi[3];
+    v3Cross(hRefHat, hReqHat, e_phi);
+    // If phi = PI, e_phi can be any vector perpendicular to hRefHat_B
+    if (fabs(phi-M_PI) < tol) {
+        phi = M_PI;
+        v3Perpendicular(hRefHat, e_phi);
+    }
+    else if (fabs(phi) < tol) {
+        phi = 0;
+    }
+    // normalize e_phi
+    v3Normalize(e_phi, e_phi);
+
+    /*! define first rotation R1B */
+    double PRV_phi[3];
+    v3Scale(phi, e_phi, PRV_phi);
+    PRV2C(PRV_phi, DB);
+}
+
+/*! This function implements second-order finite differences to compute reference angular
+    rates and accelerations */
+void finiteDifferencesRatesAndAcc(double sigma_RN[3], double sigma_RN_1[3], double sigma_RN_2[3],
+                                  uint64_t callTime, uint64_t T1Nanos, uint64_t T2Nanos, int callCount,
+                                  double omega_RN_R[3], double omegaDot_RN_R[3])
+{
+    // switch sigma_RN_1 and sigma_RN_2 if needed
+    double delSigma[3];
+    v3Subtract(sigma_RN, sigma_RN_1, delSigma);
+    if (v3Norm(delSigma) > 1) {
+        MRPshadow(sigma_RN_1, sigma_RN_1);
+    }
+    v3Subtract(sigma_RN_1, sigma_RN_2, delSigma);
+    if (v3Norm(delSigma) > 1) {
+        MRPshadow(sigma_RN_2, sigma_RN_2);
+    }
+    // if first update call, derivatives are set to zero
+    double T1Seconds;
+    double T2Seconds;
+    double sigmaDot_RN[3];
+    double sigmaDDot_RN[3];
+    if (callCount == 0) {
+        v3SetZero(sigmaDot_RN);
+        v3SetZero(sigmaDDot_RN);
+        // store information for next time step
+    }
+    // if second update call, derivatives are computed with first order finite differences
+    else if (callCount == 1) {
+        T1Seconds = (T1Nanos - callTime) * NANO2SEC;
+        for (int j = 0; j < 3; j++) {
+            sigmaDot_RN[j] = (sigma_RN_1[j] - sigma_RN[j]) / T1Seconds;
+        }
+        v3SetZero(sigmaDDot_RN);
+        // store information for next time step
+        T2Nanos = T1Nanos;
+        T1Nanos = callTime;
+        v3Copy(sigma_RN_1, sigma_RN_2);
+        v3Copy(sigma_RN, sigma_RN_1);
+    }
+    // if third update call or higher, derivatives are computed with second order finite differences
+    else {
+        T1Seconds = (T1Nanos - callTime) * NANO2SEC;
+        T2Seconds = (T2Nanos - callTime) * NANO2SEC;
+        for (int j = 0; j < 3; j++) {
+            sigmaDot_RN[j] = ((sigma_RN_1[j]*T2Seconds*T2Seconds - sigma_RN_2[j]*T1Seconds*T1Seconds) / (T2Seconds - T1Seconds) - sigma_RN[j] * (T2Seconds + T1Seconds)) / T1Seconds / T2Seconds;
+            sigmaDDot_RN[j] = 2 * ((sigma_RN_1[j]*T2Seconds - sigma_RN_2[j]*T1Seconds) / (T1Seconds - T2Seconds) + sigma_RN[j]) / T1Seconds / T2Seconds;
+        }
+        // store information for next time step
+        T2Nanos = T1Nanos;
+        T1Nanos = callTime;
+        v3Copy(sigma_RN_1, sigma_RN_2);
+        v3Copy(sigma_RN, sigma_RN_1);
+    }
+    callCount += 1;
+    dMRP2Omega(sigma_RN, sigmaDot_RN, omega_RN_R);
+    ddMRP2dOmega(sigma_RN, sigmaDot_RN, sigmaDDot_RN, omegaDot_RN_R);
+}

--- a/src/fswAlgorithms/attGuidance/_GeneralModuleFiles/attitudePointingLibrary.h
+++ b/src/fswAlgorithms/attGuidance/_GeneralModuleFiles/attitudePointingLibrary.h
@@ -1,0 +1,59 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#include "architecture/utilities/macroDefinitions.h"
+#include <stdint.h>
+
+//! @brief The SolutionSpace class contains the solutions of the nonlinear inequality
+//! |Ax^2 + Bx + C| / (1+x^2) >= 0
+class SolutionSpace {
+public:
+    SolutionSpace(double A, double B, double C, double tol);
+    ~SolutionSpace();
+
+    bool   isEmpty();                //!< returns whether the solution set is empty or not
+    int    numberOfZeros();          //!< returns the number of zeros of the associated equation
+    double returnAbsMin(int idx);    //!< return the minimum value of f(x) = |Ax^2 + Bx + C| / (1+x^2)
+    bool   contains(double psi);     //!< determines whether psi is contained in the solution space
+    double passThrough(double psi);  //!< "passes" psi through the solution space
+
+private:
+    bool   emptySet{};          //!< determines whether the solution space is empty
+    double inf{};               //!< inferior end of the solution space
+    double sup{};               //!< superior end of the solution space
+    double zero[2]{};           //!< zero(s) of the associated equation
+    int    zeros{};             //!< number of distinct solutions of the associated equation
+    double psiMin{};            //!< psi = 2*atan(x) for which y = |Ax^2 + Bx + C| / (1+x^2) is minimum
+    double psiMax{};            //!< psi = 2*atan(x) for which y = |Ax^2 + Bx + C| / (1+x^2) is maximum
+    double yMin{};              //!< minimum value of y = |Ax^2 + Bx + C| / (1+x^2)
+    double yMax{};              //!< maximum vaule of y = |Ax^2 + Bx + C| / (1+x^2)
+};
+
+void boresightAlignment(double hRefHat[3], double hReqHat[3], double tol, double DB[3][3]);
+
+void finiteDifferencesRatesAndAcc(double sigma_RN[3],
+                                  double sigma_RN_1[3],
+                                  double sigma_RN_2[3],
+                                  uint64_t TNanos,
+                                  uint64_t T1Nanos,
+                                  uint64_t T2Nanos,
+                                  int callCount,
+                                  double omega_RN_R[3],
+                                  double omegaDot_RN_R[3]);

--- a/src/fswAlgorithms/attGuidance/sepPoint/_UnitTest/test_sepPoint0.py
+++ b/src/fswAlgorithms/attGuidance/sepPoint/_UnitTest/test_sepPoint0.py
@@ -1,0 +1,217 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import pytest
+import os
+import inspect
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.fswAlgorithms import sepPoint
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+def computeGamma(alpha, delta):
+
+    if alpha >= 0 and alpha <= np.pi/2:
+        if delta < np.pi/2 - alpha:
+            gamma = np.pi/2 - alpha - delta
+        elif delta > alpha + np.pi/2:
+            gamma = - np.pi/2 - alpha + delta
+        else:
+            gamma = 0
+    else:
+        if delta < alpha - np.pi/2:
+            gamma = - np.pi/2 + alpha - delta 
+        elif delta > 3/2*np.pi - alpha:
+            gamma = alpha + delta - 3/2*np.pi
+        else:
+            gamma = 0
+
+    return gamma
+
+
+# The 'ang' array spans the interval from 0 to pi.  pi is excluded because
+# the code is less accurate around this point;
+ang = np.linspace(0, np.pi, 10, endpoint=False)
+ang = list(ang)
+
+
+@pytest.mark.parametrize("alpha", ang)
+@pytest.mark.parametrize("delta", ang)
+@pytest.mark.parametrize("alignmentPriority", [0])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_(show_plots, alpha, delta, alignmentPriority, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`sepPoint`.
+    The correctness of the output is determined based on whether the reference attitude causes the solar array drive
+    axis :math:`\hat{a}_1` to be at an angle :math:`\gamma` from the Sun direction :math:`\hat{r}_{S/B}`.
+
+    **Test Parameters**
+
+    This test generates an array ``ang`` of linearly-spaced points between 0 and :math:`\pi`. Values of
+    :math:`\alpha` and :math:`\delta` are drawn from all possible combinations of such linearly spaced values.
+    In the test, values of :math:`\alpha` and :math:`\delta` are used to set the angular distance between the vectors
+    :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`, and :math:`{}^\mathcal{B}\hat{h}_1`
+    and :math:`{}^\mathcal{B}\hat{a}_1`.
+
+    Args:
+        alpha (rad): angle between :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`
+        delta (rad): angle between :math:`{}^\mathcal{B}\hat{h}_1` and :math:`{}^\mathcal{B}\hat{a}_1`
+        alignmentPriority (int): 0 to prioritize body heading alignment and incidence on solar arrays.
+
+    **Description of Variables Being Tested**
+
+    The angle :math:`\gamma` is a function of the angles :math:`\alpha` and :math:`\delta`, where :math:`\alpha` is the
+    angle between the Sun direction :math:`{}^\mathcal{N}\hat{r}_{S/B}` and the reference inertial heading
+    :math:`{}^\mathcal{N}\hat{h}_\text{ref}`, whereas :math:`\delta` is the angle between the body-frame heading
+    :math:`{}^\mathcal{B}\hat{h}_1` and the solar array axis drive :math:`{}^\mathcal{B}\hat{a}_1`.
+    The angle :math:`\gamma` is computed from the output reference attitude and compared with the results of a
+    python function that computes the correct output based on the geometry of the problem. For a description of how
+    such correct result is obtained, see R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft
+    with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
+
+    **General Documentation Comments**
+
+    This unit test verifies the correctness of the generated reference attitude. It does not test the correctness of the
+    reference angular rates and accelerations contained in the ``attRefOutMsg``, because this would require to run the
+    module for multiple update calls. To ensure fast execution of the unit test, this is avoided.
+    """
+
+    gamma_true = computeGamma(alpha, delta)
+
+    rHat_SB_N = np.array([1, -2, 3])                            # Sun direction in inertial coordinates
+    rHat_SB_N = rHat_SB_N / np.linalg.norm(rHat_SB_N)
+    a1Hat_B = np.array([-9, 8, 7])                            # array axis direction in body frame
+    a1Hat_B = a1Hat_B / np.linalg.norm(a1Hat_B)
+
+    a = np.cross(rHat_SB_N, [4, 5, -6])
+    a = a / np.linalg.norm(a)
+    
+    d = np.cross(a1Hat_B, [6, -5, 4])
+    d = d / np.linalg.norm(d)
+    
+    DCM1 = rbk.PRV2C(a * alpha)
+    DCM2 = rbk.PRV2C(d * delta)
+
+    hHat_N = np.matmul(DCM1, rHat_SB_N)             # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+    hHat_B = np.matmul(DCM2, a1Hat_B)               # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+
+    unitTaskName = "unitTask"                                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"                          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    attGuid = sepPoint.SepPoint()
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.alignmentPriority = alignmentPriority
+    attGuid.ModelTag = "sepPoint"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, attGuid)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+
+    # Create input navigation message
+    sigma_BN = np.array([0, 0, 0])
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rHat_SB_N)
+    NavAttMessageData = messaging.NavAttMsgPayload()     
+    NavAttMessageData.sigma_BN = sigma_BN
+    NavAttMessageData.vehSunPntBdy = rS_B
+    NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
+    attGuid.attNavInMsg.subscribeTo(NavAttMsg)
+
+    # Create input bodyHeadingMsg
+    bodyHeadingData = messaging.BodyHeadingMsgPayload()
+    bodyHeadingData.rHat_XB_B = hHat_B
+    bodyHeadingMsg = messaging.BodyHeadingMsg().write(bodyHeadingData)
+    attGuid.bodyHeadingInMsg.subscribeTo(bodyHeadingMsg)
+
+    # Create input inertialHeadingMsg
+    inertialHeadingData = messaging.InertialHeadingMsgPayload()
+    inertialHeadingData.rHat_XN_N = hHat_N
+    inertialHeadingMsg = messaging.InertialHeadingMsg().write(inertialHeadingData)
+    attGuid.inertialHeadingInMsg.subscribeTo(inertialHeadingMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = attGuid.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    dataLogC = attGuid.attRefOutMsgC.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogC)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    moduleOutput = dataLog.sigma_RN
+    sigma_RN = moduleOutput[0]
+    RN = rbk.MRP2C(sigma_RN)
+    NR = RN.transpose()
+    a1Hat_N = np.matmul(NR, a1Hat_B)
+    gamma_sim = np.arcsin( abs( np.clip( np.dot(rHat_SB_N, a1Hat_N), -1, 1 ) ) )
+
+    # set the filtered output truth states
+    np.testing.assert_allclose(gamma_sim, gamma_true, rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(hHat_B, np.matmul(RN, hHat_N), rtol=0, atol=accuracy, verbose=True)
+
+    return
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_(
+                 False,
+                 0.62831,    # alpha
+                 0.79586,    # delta
+                 0,          # priorityFlag
+                 1e-12       # accuracy
+               )

--- a/src/fswAlgorithms/attGuidance/sepPoint/_UnitTest/test_sepPoint1.py
+++ b/src/fswAlgorithms/attGuidance/sepPoint/_UnitTest/test_sepPoint1.py
@@ -1,0 +1,193 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import pytest
+import os
+import inspect
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.fswAlgorithms import sepPoint
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+# The 'ang' array spans the interval from 0 to pi.  pi is excluded because
+# the code is less accurate around this point;
+ang = np.linspace(0, np.pi, 50, endpoint=False)
+ang = list(ang)
+
+
+@pytest.mark.parametrize("alpha", ang)
+@pytest.mark.parametrize("alignmentPriority", [1])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_(show_plots, alpha, alignmentPriority, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`sepPoint`.
+    The correctness of the output is determined based on whether the reference attitude causes the Sun-constrained
+    axis :math:`\hat{a}_2` to be within an angle :math:`\beta` from the Sun direction :math:`\hat{r}_{S/B}`.
+
+    **Test Parameters**
+
+    This test generates an array ``ang`` of linearly-spaced points between 0 and :math:`\pi`. Values of
+    :math:`\alpha` are drawn from all possible combinations of such linearly spaced values.
+    In the test, values of :math:`\alpha` are used to set the angular distance between the vectors
+    :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`.
+
+    Args:
+        alpha (rad): angle between :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`
+        alignmentPriority (int): 1 to prioritize body heading alignment and Sun-constrained body-frame axis.
+
+    **Description of Variables Being Tested**
+
+    In this unit test, the module computes a solution that is compliant with the keep-in condition on the
+    Sun-constrained body-frame axis. The correctness of the solution is assessed verifying whether the angle between
+    such axis and the Sun direction is smaller or equal than the maximum allowed value :math:`\beta`. Within the range
+    of admissible solutions, the module also chooses the one that maximizes the incidence of sunlight on the solar
+    arrays. See R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft
+    with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
+
+    **General Documentation Comments**
+
+    This module only tests the case :math:`\beta = \pi/2`, which is known to always have a compliant solution. When
+    :math:`\beta < \pi/2`, it is not in general possible to guarantee that the solution is compliant with the
+    requirements on the Sun-constrained direction, which makes testing difficult. The user can input smaller values for
+    :math:`\beta` to verify that it will cause some instantiations of the test to fail. This unit test verifies the
+    correctness of the generated reference attitude. It does not test the correctness of the reference angular rates
+    and accelerations contained in the ``attRefOutMsg``, because this would require to run the module for multiple
+    update calls. To ensure fast execution of the unit test, this is avoided.
+    """
+
+    rHat_SB_N = np.array([1, -2, 3])                            # Sun direction in inertial coordinates
+    rHat_SB_N = rHat_SB_N / np.linalg.norm(rHat_SB_N)
+
+    a = np.cross(rHat_SB_N, [4, 5, -6])
+    a = a / np.linalg.norm(a)
+
+    DCM1 = rbk.PRV2C(a * alpha)
+
+    hHat_N = np.matmul(DCM1, rHat_SB_N)             # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+
+    hHat_B  = [0, 0, 1]
+    a1Hat_B = [1, 0, 0]
+    a2Hat_B = [0, 1, 0]
+    beta = np.pi/2
+
+    unitTaskName = "unitTask"                                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"                          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    attGuid = sepPoint.SepPoint()
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.a2Hat_B = a2Hat_B
+    attGuid.beta = beta
+    attGuid.alignmentPriority = alignmentPriority
+    attGuid.ModelTag = "sepPoint"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, attGuid)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+
+    # Create input navigation message
+    sigma_BN = np.array([0, 0, 0])
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rHat_SB_N)
+    NavAttMessageData = messaging.NavAttMsgPayload()     
+    NavAttMessageData.sigma_BN = sigma_BN
+    NavAttMessageData.vehSunPntBdy = rS_B
+    NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
+    attGuid.attNavInMsg.subscribeTo(NavAttMsg)
+
+    # Create input bodyHeadingMsg
+    bodyHeadingData = messaging.BodyHeadingMsgPayload()
+    bodyHeadingData.rHat_XB_B = hHat_B
+    bodyHeadingMsg = messaging.BodyHeadingMsg().write(bodyHeadingData)
+    attGuid.bodyHeadingInMsg.subscribeTo(bodyHeadingMsg)
+
+    # Create input inertialHeadingMsg
+    inertialHeadingData = messaging.InertialHeadingMsgPayload()
+    inertialHeadingData.rHat_XN_N = hHat_N
+    inertialHeadingMsg = messaging.InertialHeadingMsg().write(inertialHeadingData)
+    attGuid.inertialHeadingInMsg.subscribeTo(inertialHeadingMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = attGuid.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    dataLogC = attGuid.attRefOutMsgC.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogC)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    moduleOutput = dataLog.sigma_RN
+    sigma_RN = moduleOutput[0]
+    RN = rbk.MRP2C(sigma_RN)
+    NR = RN.transpose()
+    a1Hat_N = np.matmul(NR, a1Hat_B)
+    gamma_sim = np.arcsin( abs( np.clip( np.dot(rHat_SB_N, a1Hat_N), -1, 1 ) ) )
+
+    # set the filtered output truth states
+    np.testing.assert_allclose(hHat_B, np.matmul(RN, hHat_N), rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_array_less(np.cos(beta), np.dot(a2Hat_B, np.matmul(RN, rHat_SB_N)) + accuracy, verbose=True)
+
+    return
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_(
+                 False,
+                 0.62831,    # alpha
+                 1,          # priorityFlag
+                 1e-12       # accuracy
+               )

--- a/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.cpp
@@ -1,0 +1,61 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#include "sepPoint.h"
+#include <math.h>
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "fswAlgorithms/attGuidance/_GeneralModuleFiles/attitudePointingLibrary.h"
+
+const double epsilon = 1e-12;                           // module tolerance for zero
+
+/*! Module constructor */
+SepPoint::SepPoint() = default;
+
+
+/*! Module destructor */
+SepPoint::~SepPoint() = default;
+
+
+/*! Initialize C-wrapped output messages */
+void SepPoint::SelfInit(){
+    AttRefMsg_C_init(&this->attRefOutMsgC);
+}
+
+/*! This method is used to reset the module.
+ @return void
+ */
+void SepPoint::Reset(uint64_t CurrentSimNanos)
+{
+
+}
+
+
+/*! This method is the main carrier for the boresight calculation routine.  If it detects
+ that it needs to re-init (direction change maybe) it will re-init itself.
+ Then it will compute the angles away that the boresight is from the celestial target.
+ @return void
+ @param CurrentSimNanos The current simulation time for system
+ */
+void SepPoint::UpdateState(uint64_t CurrentSimNanos)
+{
+    
+}
+

--- a/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.cpp
@@ -65,6 +65,159 @@ void SepPoint::Reset(uint64_t CurrentSimNanos)
  */
 void SepPoint::UpdateState(uint64_t CurrentSimNanos)
 {
+    /*! create and zero the output message */
+    AttRefMsgPayload attRefOut = this->attRefOutMsg.zeroMsgPayload;
 
+    /*! read and allocate the input attitude navigation message */
+    NavAttMsgPayload attNavIn = this->attNavInMsg();
+
+    /*! read and allocate the input inertial heading message */
+    BodyHeadingMsgPayload bodyHeadingIn = this->bodyHeadingInMsg();
+    double hRefHat_B[3];
+    v3Normalize(bodyHeadingIn.rHat_XB_B, hRefHat_B);
+
+    /*! read and allocate the input inertial heading message */
+    InertialHeadingMsgPayload inertialHeadingIn = this->inertialHeadingInMsg();
+    double hReqHat_N[3];
+    v3Normalize(inertialHeadingIn.rHat_XN_N, hReqHat_N);
+
+    /*! define the body frame orientation DCM BN */
+    double BN[3][3];
+    MRP2C(attNavIn.sigma_BN, BN);
+
+    /*! get the solar array drive direction in body frame coordinates */
+    double a1Hat_B[3];
+    v3Normalize(this->a1Hat_B, a1Hat_B);
+
+    /*! get the Sun-constrained axis in body frame coordinates */
+    double a2Hat_B[3];
+    v3Normalize(this->a2Hat_B, a2Hat_B);
+
+    /*! read Sun direction in B frame from the attNav message */
+    double rHat_SB_B[3];
+    v3Copy(attNavIn.vehSunPntBdy, rHat_SB_B);
+
+    /*! map requested heading into B frame */
+    double hReqHat_B[3];
+    m33MultV3(BN, hReqHat_N, hReqHat_B);
+
+    /*! compute intermediate rotation DB to align the boresight */
+    double DB[3][3];
+    boresightAlignment(hRefHat_B, hReqHat_B, epsilon, DB);
+
+    /*! map Sun direction vector to intermediate frame */
+    double rHat_SB_D[3];
+    m33MultV3(DB, rHat_SB_B, rHat_SB_D);
+
+    /*! define the coefficients of the quadratic equation A, B, and C for the solar array drive axis */
+    double e_psi[3];
+    v3Copy(hRefHat_B, e_psi);
+    double b3[3];
+    v3Cross(rHat_SB_D, e_psi, b3);
+    double A = 2 * v3Dot(rHat_SB_D, e_psi) * v3Dot(e_psi, a1Hat_B) - v3Dot(a1Hat_B, rHat_SB_D);
+    double B = 2 * v3Dot(a1Hat_B, b3);
+    double C = v3Dot(a1Hat_B, rHat_SB_D);
+
+    /*! define the coefficients of the quadratic equation D, E, and F for the Sun-constrained axis */
+    double D = 2 * v3Dot(rHat_SB_D, e_psi) * v3Dot(e_psi, a2Hat_B) - v3Dot(a2Hat_B, rHat_SB_D);
+    double E = 2 * v3Dot(a2Hat_B, b3);
+    double F = v3Dot(a2Hat_B, rHat_SB_D);
+
+    /*! compute the solution(s) to the optimized solar array alignment problem */
+    SolutionSpace solarArraySolutions(A, B, C, epsilon);
+
+    double PRV_psi[3];
+    switch (this->alignmentPriority) {
+
+        case solarArrayAlign :
+            if (solarArraySolutions.numberOfZeros() == 2) {
+                double psi1 = solarArraySolutions.returnAbsMin(1);
+                double psi2 = solarArraySolutions.returnAbsMin(2);
+                double PRV_psi1[3];
+                v3Scale(psi1, e_psi, PRV_psi1);
+                double PRV_psi2[3];
+                v3Scale(psi2, e_psi, PRV_psi2);
+                double P1D[3][3];
+                PRV2C(PRV_psi1, P1D);
+                double P2D[3][3];
+                PRV2C(PRV_psi2, P2D);
+                double rHat_SB_P1[3];
+                m33MultV3(P1D, rHat_SB_D, rHat_SB_P1);
+                double rHat_SB_P2[3];
+                m33MultV3(P2D, rHat_SB_D, rHat_SB_P2);
+                if (fabs(v3Dot(a2Hat_B, rHat_SB_P2) - v3Dot(a2Hat_B, rHat_SB_P1)) > 0) {
+                    v3Scale(psi2, e_psi, PRV_psi);
+                }
+                else {
+                    v3Scale(psi1, e_psi, PRV_psi);
+                }
+            }
+            else {
+                double psi = solarArraySolutions.returnAbsMin(1);
+                v3Scale(psi, e_psi, PRV_psi);
+            }
+            break;
+
+        case sunConstrAxisAlign :
+            double k = cos(this->beta);
+            SolutionSpace sunConstAxisSolutions(D-k, E, F-k, epsilon);
+            if (sunConstAxisSolutions.isEmpty()) {
+                double psi = sunConstAxisSolutions.returnAbsMin(1);
+                v3Scale(psi, e_psi, PRV_psi);
+            }
+            else if (solarArraySolutions.numberOfZeros() == 2) {
+                double psi1 = solarArraySolutions.returnAbsMin(1);
+                double psi2 = solarArraySolutions.returnAbsMin(2);
+                double deltaPsi1 = psi1 - sunConstAxisSolutions.passThrough(psi1);
+                double deltaPsi2 = psi2 - sunConstAxisSolutions.passThrough(psi2);
+                if (fabs(deltaPsi2 - deltaPsi1) > 0) {
+                    v3Scale(psi1, e_psi, PRV_psi);
+                } else {
+                    v3Scale(psi2, e_psi, PRV_psi);
+                }
+            }
+            else {
+                double psi = solarArraySolutions.returnAbsMin(1);
+                psi = sunConstAxisSolutions.passThrough(psi);
+                v3Scale(psi, e_psi, PRV_psi);
+            }
+            break;
+    }
+
+    /*! map PRV to RD direction cosine matrix */
+    double RD[3][3];
+    PRV2C(PRV_psi, RD);
+    double RB[3][3];
+    m33MultM33(RD, DB, RB);
+    double RN[3][3];
+    m33MultM33(RB, BN, RN);
+
+    /*! compute reference MRP */
+    double sigma_RN[3];
+    C2MRP(RN, sigma_RN);
+    v3Copy(sigma_RN, attRefOut.sigma_RN);
+
+    /*! compute reference angular rates and accelerations via finite differences */
+    double omega_RN_R[3];
+    double omegaDot_RN_R[3];
+    finiteDifferencesRatesAndAcc(sigma_RN,
+                                 this->sigma_RN_1,
+                                 this->sigma_RN_2,
+                                 CurrentSimNanos,
+                                 this->T1NanoSeconds,
+                                 this->T2NanoSeconds,
+                                 this->callCount,
+                                 omega_RN_R,
+                                 omegaDot_RN_R);
+
+    /*! compute angular rates and accelerations in N frame and store in buffer msg */
+    m33tMultV3(RN, omega_RN_R, attRefOut.omega_RN_N);
+    m33tMultV3(RN, omegaDot_RN_R, attRefOut.domega_RN_N);
+
+    /*! Write the output messages */
+    this->attRefOutMsg.write(&attRefOut, this->moduleID, CurrentSimNanos);
+
+    /*! Write the C-wrapped output messages */
+    AttRefMsg_C_write(&attRefOut, &this->attRefOutMsgC, this->moduleID, CurrentSimNanos);
 }
 

--- a/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.cpp
@@ -44,7 +44,16 @@ void SepPoint::SelfInit(){
  */
 void SepPoint::Reset(uint64_t CurrentSimNanos)
 {
-
+    if (!this->attNavInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".attNavInMsg wasn't connected.");
+    }
+    if (!this->bodyHeadingInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".bodyHeadingInMsg wasn't connected.");
+    }
+    if (!this->inertialHeadingInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".inertialHeadingInMsg wasn't connected.");
+    }
+    this->callCount = 0;
 }
 
 
@@ -56,6 +65,6 @@ void SepPoint::Reset(uint64_t CurrentSimNanos)
  */
 void SepPoint::UpdateState(uint64_t CurrentSimNanos)
 {
-    
+
 }
 

--- a/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.h
+++ b/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.h
@@ -1,0 +1,69 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _SEP_POINT_
+#define _SEP_POINT_
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/BodyHeadingMsgPayload.h"
+#include "architecture/msgPayloadDefC/InertialHeadingMsgPayload.h"
+#include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+#include "cMsgCInterface/AttRefMsg_C.h"
+
+
+typedef enum alignmentPriority{
+    solarArrayAlign = 0,
+    sunConstrAxisAlign = 1
+} AlignmentPriority;
+
+
+/*! @brief A class to perform EMA SEP pointing */
+class SepPoint: public SysModel {
+public:
+    SepPoint();
+    ~SepPoint();
+    void SelfInit();                                               //!< Self initialization for C-wrapped messages
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+
+    AlignmentPriority alignmentPriority;                           //!< flag to indicate which flyby model is being used
+    double            a1Hat_B[3];                                  //!< solar array drive axis in B-frame coordinates
+    double            a2Hat_B[3];                                  //!< Sun-constrained axis in B-frame coordinates
+    double            beta;                                        //!< Sun-constraint half-cone angle
+
+    ReadFunctor<NavAttMsgPayload>          attNavInMsg;            //!< input msg measured attitude
+    ReadFunctor<BodyHeadingMsgPayload>     bodyHeadingInMsg;       //!< input body heading msg
+    ReadFunctor<InertialHeadingMsgPayload> inertialHeadingInMsg;   //!< input inertial heading msg
+    Message<AttRefMsgPayload>              attRefOutMsg;           //!< Attitude reference output message
+    AttRefMsg_C                            attRefOutMsgC = {};     //!< C-wrapped attitude reference output message
+
+private:
+    int               callCount;                                   //!< count variable used in the finite difference logic
+    uint64_t          T1NanoSeconds;                               //!< callTime one update step prior
+    uint64_t          T2NanoSeconds;                               //!< callTime two update steps prior
+    double            sigma_RN_1[3];                               //!< reference attitude one update step prior
+    double            sigma_RN_2[3];                               //!< reference attitude two update steps prior
+    BSKLogger                              bskLogger;              //!< BSK Logging
+};
+
+
+#endif

--- a/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.i
+++ b/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.i
@@ -1,0 +1,46 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module sepPoint
+%{
+   #include "sepPoint.h"
+%}
+
+%include "std_string.i"
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "swig_conly_data.i"
+
+%include "sys_model.h"
+%include "sepPoint.h"
+
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/BodyHeadingMsgPayload.h"
+struct BodyHeadingMsg_C;
+%include "architecture/msgPayloadDefC/InertialHeadingMsgPayload.h"
+struct InertialHeadingMsg_C;
+%include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+struct AttRefMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.rst
+++ b/src/fswAlgorithms/attGuidance/sepPoint/sepPoint.rst
@@ -1,0 +1,83 @@
+Executive Summary
+-----------------
+This module computes a reference attitude frame that simultaneously satisfies multiple pointing constraints. The first constraint consists of aligning a body-frame direction :math:`{}^\mathcal{B}\hat{h}_1` with a certain inertial reference direction :math:`{}^\mathcal{N}\hat{h}_\text{ref}`. This locks two out of three degrees of freedom that characterize a rigid body rotation. The second constraint consists in achieving maximum power generation on the solar arrays, assuming that the solar arrays can rotate about their drive axis. This condition is obtained ensuring that the body-fixed solar array drive direction :math:`{}^\mathcal{B}\hat{a}_1` is as close to perpendicular as possible to the Sun direction. The third constraint consists in keeping a certain body-fixed, Sun-constrained direction, :math:`{}^\mathcal{B}\hat{a}_2`, within an angle :math:`beta` from the Sun direction.
+
+The second and third constraint can be switched in priority. When solar array incidence is prioritized, there is no guarantee that the Sun-constrained axis can be kept within a certain angular distance from the Sun. Conversely, when the Sun-constrained direction is prioritized, the algorithm searches the space of compliant solutions for the solution that also maximizes Sun incidence on the solar arrays.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages. The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - attNavInMsg
+      - :ref:`NavAttMsgPayload`
+      - Input message containing current attitude and Sun direction in body-frame coordinates. Note that, for the Sun direction to appear in the message, the :ref:`SpicePlanetStateMsgPayload` must be provided as input msg to :ref:`simpleNav`, otherwise the Sun direction is zeroed by default.
+    * - bodyHeadingInMsg
+      - :ref:`BodyHeadingMsgPayload`
+      - Input message containing the body-frame direction :math:`{}^\mathcal{B}\hat{h}`.
+    * - inertialHeadingInMsg
+      - :ref:`InertialHeadingMsgPayload`
+      - Input message containing the inertial-frame direction :math:`{}^\mathcal{N}\hat{h}_\text{ref}`.
+    * - attRefOutMsg
+      - :ref:`AttRefMsgPayload`
+      - Output attitude reference message containing reference attitude, reference angular rates and accelerations.
+
+
+Detailed Module Description
+---------------------------
+A detailed mathematical derivation of the equations applied by this module can be found in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
+
+The input parameter ``alignmentPriority`` allows to choose which between the second and the third constraint are being prioritized. Regardless of the chosen ``alignmentPriority``, the reference attitude aligns the body-frame and the inertial-frame headings contained in the message before any other constraint.
+
+When ``alignmentPriority = 0``, the reference attitude makes it such that the solar array drive axis :math:`{}^\mathcal{B}\hat{a}_1` is as perpendicular as possible to the Sun direction. When perfectly perpendicular, two compliant solution exist, therefore the module picks the one that keeps the Sun-constrained direction :math:`{}^\mathcal{B}\hat{a}_2` closer to the Sun.
+
+When ``alignmentPriority = 0``, the reference attitude makes it such that the Sun-constrained vector :math:`{}^\mathcal{B}\hat{a}_2` is never more than :math:`\beta` degrees apart from the Sun direction. Within this range of admissible solutions, the module picks the one that also result in maximum incidence on the solar arrays, i.e., the one that drives the solar array drive axis :math:`{}^\mathcal{B}\hat{a}_1` as perpendicular as possible to sunlight.
+
+
+Module Assumptions and Limitations
+----------------------------------
+The limitations of this module are inherent to the geometry of the problem, which determines which of the constraints can be satisfied. For example, as shown in  in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints," In preparation for Journal of Spacecraft and Rockets, depending on the relative orientation of :math:`{}^\mathcal{B}h` and :math:`{}^\mathcal{B}a_1`, it may not be possible to  achieve perfect incidence angle on the solar arrays. Only when perfect incidence is obtained, it is possible to solve for the solution that also drives the body-fixed direction :math:`{}^\mathcal{B}a_2` close to the Sun. When perfect incidence is achievable, two solutions exist. If :math:`{}^\mathcal{B}a_2` is provided as input, this is used to determine which solution to pick. If this input is not provided, one of the two solution is chosen arbitrarily.
+
+Due to the difficulty in developing an analytical formulation for the reference angular rate and angular acceleration vectors, these are computed via second-order finite differences. At every time step, the current reference attitude and time stamp are stored in a module variable and used in the following time updates to compute angular rates and accelerations via finite differences.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    attGuid = sepPoint.SepPoint()
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.a2Hat_B = a2Hat_B
+    attGuid.beta = beta
+    attGuid.alignmentPriority = alignmentPriority
+    attGuid.ModelTag = "sepPoint"
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``a1Hat_B``
+     - [0, 0, 0]
+     - solar array drive direction in body-frame coordinates
+   * - ``a2Hat_B`` (optional)
+     - [0, 0, 0]
+     - Sun-constrained direction in body frame coordinates
+   * - ``beta`` (optional)
+     - [0, 0, 0]
+     - half-cone angle of the keep-in Sun constraint
+   * - ``alignmentPriority``
+     - 0
+     - 0 to prioritize incidence on the arrays, 1 to prioritize Sun-constrained direction.


### PR DESCRIPTION
* **Tickets addressed:** bsk-106
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This branch delivers a module sepPoint that is a refactored version of the already existing oneAxisSolarArrayPoint. This new version focuses on a single flight mode and univocally defines the input messages and input parameters to the module. The new module incorporates a new feature that enables the user to choose which pointing requirements to prioritize, after the main thruster pointing requirement is met. In the first commit, a library of utility function is created inside the attGuidance folder, which contains functions used in this module and in similar future modules. Commit 2 initializes the module files. Commit 3 populates the Reset function to check that all the inputs are connected correctly. Commit 4 contains the bulk of the module, where the Update function is populated, and the output message is computed and written. Commits 5 and 6 contain the unit tests and the documentation, respectively.

## Verification
Two unit tests are provided, to test the correct functionality of the module with the two different sets of priorities.

## Documentation
Documentation is provided to describe how to use the module.

## Future work
Future work will involve the development of more similar modules that use similar math, but satisfy the pointing requirements for different flight modes.
