### PR TITLE
Feature/309 simple nav ephem msg

### DIFF
--- a/src/simulation/navigation/simpleNav/simpleNav.cpp
+++ b/src/simulation/navigation/simpleNav/simpleNav.cpp
@@ -35,6 +35,7 @@ SimpleNav::SimpleNav()
     this->trueAttState = this->attOutMsg.zeroMsgPayload;
     this->estTransState = this->transOutMsg.zeroMsgPayload;
     this->trueTransState = this->transOutMsg.zeroMsgPayload;
+    this->spacecraftEphemerisState = this->scEphemOutMsg.zeroMsgPayload;
     this->PMatrix.resize(18,18);
     this->PMatrix.fill(0.0);
     this->walkBounds.resize(18);
@@ -113,9 +114,11 @@ void SimpleNav::writeOutputMessages(uint64_t Clock)
     /* time tage the output message */
     this->estAttState.timeTag = (double) Clock * NANO2SEC;
     this->estTransState.timeTag = (double) Clock * NANO2SEC;
-    
+    this->spacecraftEphemerisState.timeTag = (double) Clock * NANO2SEC;
+
     this->attOutMsg.write(&this->estAttState, this->moduleID, Clock);
     this->transOutMsg.write(&this->estTransState, this->moduleID, Clock);
+    this->scEphemOutMsg.write(&this->spacecraftEphemerisState, this->moduleID, Clock);
 }
 
 void SimpleNav::applyErrors()
@@ -125,6 +128,14 @@ void SimpleNav::applyErrors()
     v3Add(this->trueTransState.v_BN_N, &(this->navErrors.data()[3]), this->estTransState.v_BN_N);
     addMRP(this->trueAttState.sigma_BN, &(this->navErrors.data()[6]), this->estAttState.sigma_BN);
     v3Add(this->trueAttState.omega_BN_B, &(this->navErrors.data()[9]), this->estAttState.omega_BN_B);
+    v3Add(this->spacecraftEphemerisState.r_BdyZero_N, &(this->navErrors.data()[0]),
+          this->spacecraftEphemerisState.r_BdyZero_N);
+    v3Add(this->spacecraftEphemerisState.v_BdyZero_N, &(this->navErrors.data()[3]),
+          this->spacecraftEphemerisState.v_BdyZero_N);
+    addMRP(this->spacecraftEphemerisState.sigma_BN, &(this->navErrors.data()[6]),
+           this->spacecraftEphemerisState.sigma_BN);
+    v3Add(this->spacecraftEphemerisState.omega_BN_B, &(this->navErrors.data()[9]),
+          this->spacecraftEphemerisState.omega_BN_B);
     v3Add(this->trueTransState.vehAccumDV, &(this->navErrors.data()[15]), this->estTransState.vehAccumDV);
     //! - Add errors to  sun-pointing
     if(this->sunStateInMsg.isLinked()){
@@ -150,6 +161,12 @@ void SimpleNav::computeTrueOutput(uint64_t Clock)
     v3Copy(this->inertialState.sigma_BN, this->trueAttState.sigma_BN);
     v3Copy(this->inertialState.omega_BN_B, this->trueAttState.omega_BN_B);
     v3Copy(this->inertialState.TotalAccumDVBdy, this->trueTransState.vehAccumDV);
+
+    //! - Set ephemeris state to truth data
+    v3Copy(this->inertialState.r_BN_N, this->spacecraftEphemerisState.r_BdyZero_N);
+    v3Copy(this->inertialState.v_BN_N, this->spacecraftEphemerisState.v_BdyZero_N);
+    v3Copy(this->inertialState.sigma_BN, this->spacecraftEphemerisState.sigma_BN);
+    v3Copy(this->inertialState.omega_BN_B, this->spacecraftEphemerisState.omega_BN_B);
 
     //! - For the sun pointing output, compute the spacecraft to sun vector, normalize, and trans 2 body.
     if(this->sunStateInMsg.isLinked()){

--- a/src/simulation/navigation/simpleNav/simpleNav.cpp
+++ b/src/simulation/navigation/simpleNav/simpleNav.cpp
@@ -142,6 +142,7 @@ void SimpleNav::applyErrors()
         double dcm_OT[3][3];       /* dcm, body T to body O */
         MRP2C(&(this->navErrors.data()[12]), dcm_OT);
         m33MultV3(dcm_OT, this->trueAttState.vehSunPntBdy, this->estAttState.vehSunPntBdy);
+        v3Normalize(this->estAttState.vehSunPntBdy, this->estAttState.vehSunPntBdy);
     } else {
         v3SetZero(this->estAttState.vehSunPntBdy);
     }
@@ -176,6 +177,7 @@ void SimpleNav::computeTrueOutput(uint64_t Clock)
         v3Normalize(sc2SunInrtl, sc2SunInrtl);
         MRP2C(this->inertialState.sigma_BN, dcm_BN);
         m33MultV3(dcm_BN, sc2SunInrtl, this->trueAttState.vehSunPntBdy);
+        v3Normalize(this->trueAttState.vehSunPntBdy, this->trueAttState.vehSunPntBdy);
     } else {
         v3SetZero(this->trueAttState.vehSunPntBdy);
     }

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -27,6 +27,7 @@
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 #include <Eigen/Dense>
 #include "architecture/messaging/messaging.h"
@@ -51,12 +52,14 @@ public:
     Eigen::VectorXd navErrors;        //!< -- Current navigation errors applied to truth
     Message<NavAttMsgPayload> attOutMsg;        //!< attitude navigation output msg
     Message<NavTransMsgPayload> transOutMsg;    //!< translation navigation output msg
+    Message<EphemerisMsgPayload> scEphemOutMsg;    //!< translation navigation output msg
     bool crossTrans;                  //!< -- Have position error depend on velocity
     bool crossAtt;                    //!< -- Have attitude depend on attitude rate
     NavAttMsgPayload trueAttState;        //!< -- attitude nav state without errors
     NavAttMsgPayload estAttState;         //!< -- attitude nav state including errors
     NavTransMsgPayload trueTransState;    //!< -- translation nav state without errors
     NavTransMsgPayload estTransState;     //!< -- translation nav state including errors
+    EphemerisMsgPayload spacecraftEphemerisState;    //!< -- full spacecraft ephemeris state without errors
     SCStatesMsgPayload inertialState; //!< -- input inertial state from Star Tracker
     SpicePlanetStateMsgPayload sunState;  //!< -- input Sun state
     BSKLogger bskLogger;              //!< -- BSK Logging

--- a/src/simulation/navigation/simpleNav/simpleNav.i
+++ b/src/simulation/navigation/simpleNav/simpleNav.i
@@ -39,6 +39,8 @@ struct NavAttMsg_C;
 struct NavTransMsg_C;
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 struct SpicePlanetStateMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/simulation/navigation/simpleNav/simpleNav.rst
+++ b/src/simulation/navigation/simpleNav/simpleNav.rst
@@ -18,6 +18,10 @@ The following table lists all the module input and output messages.  The module 
 user from python.  The msg type contains a link to the message structure definition, while the description
 provides information on what this message is used for.
 
+The ephemeris message emulates the fsw process that would read a spice file for trajectory or attitude.
+It can contain stochastic errors although it represents the best understanding of the spacecraft states and does
+not come from a noisy sensor but from a ground-based estimation process.
+
 .. list-table:: Module I/O Messages
     :widths: 25 25 50
     :header-rows: 1
@@ -31,6 +35,9 @@ provides information on what this message is used for.
     * - transOutMsg
       - :ref:`NavTransMsgPayload`
       - translation navigation output msg
+    * - scEphemOutMsg
+      - :ref:`EphemerisMsgPayload`
+      - spacecraft ephemeris output msg
     * - scStateInMsg
       - :ref:`SCStatesMsgPayload`
       - spacecraft state input msg


### PR DESCRIPTION
* **Tickets addressed:** bsk-309
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
Add an ephemeris message to the simple nav outputs in order to simulate a spacecraft ephemeris message. 
This message could be generated via a table, but a secondary method is needed for simplicity.

## Verification
The test of simple nav was outdated and refactored entirely in this PR. This was done so that there could be a clear delineation between the purposes of subtests and the addition of the ephemeris message check could be easy and legible.
All previous test functionality was maintained. 

## Documentation
The documentation was updated accordingly

## Future work
None
