### PR TITLE
Feature/335 initialize icp

### DIFF
--- a/src/architecture/msgPayloadDefCpp/SICPMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/SICPMsgPayload.h
@@ -32,7 +32,9 @@ typedef struct
 SICPMsgPayload
 //@endcond
 {
+    bool valid; //!< --[-] Message was purposefully populated
     uint64_t numberOfIteration; //!< --[-] Number of iterations used for SICP convergence
+    uint64_t timeTag; //!< --[-] Time at which these iterations were computed
     double scaleFactor[MAX_ITERATIONS]; //!< -- [-] Array of scale factors
     double rotationMatrix[POINT_DIM*POINT_DIM*MAX_ITERATIONS]; //!< -- [-]  Array of rotation matrices
     double translation[POINT_DIM*MAX_ITERATIONS]; //!< -- [-] Array of translation vectors

--- a/src/fswAlgorithms/pointCloudProcessing/SICP/_UnitTest/testFunctions.py
+++ b/src/fswAlgorithms/pointCloudProcessing/SICP/_UnitTest/testFunctions.py
@@ -183,6 +183,7 @@ def runModule(data, reference, numberPoints, iters = 100):
     # Create the input messages.
     inputPointCloud = messaging.PointCloudMsgPayload()
     referencePointCloud = messaging.PointCloudMsgPayload()
+    icpInitialCondition = messaging.SICPMsgPayload()
 
     inputPointCloud.points = data.flatten().tolist()
     inputPointCloud.numberOfPoints = numberPoints
@@ -190,6 +191,10 @@ def runModule(data, reference, numberPoints, iters = 100):
     inputPointCloud.valid = True
     inputPointCloudMsg = messaging.PointCloudMsg().write(inputPointCloud)
     sicp.measuredPointCloud.subscribeTo(inputPointCloudMsg)
+
+    icpInitialCondition.valid = False
+    initialConditionMsg = messaging.SICPMsg().write(icpInitialCondition)
+    sicp.initialCondition.subscribeTo(initialConditionMsg)
 
     referencePointCloud.points = reference.flatten().tolist()
     referencePointCloud.numberOfPoints = numberPoints

--- a/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.cpp
@@ -254,7 +254,7 @@ void ScalingIterativeClosestPoint::UpdateState(uint64_t CurrentSimNanos)
             //! - Center point clouds about average point
             this->centerCloud(measuredPoints);
 
-            for (int iterRS = 0; iterRS < this->maxInteralIterations; iterRS++) {
+            for (int iterRS = 0; iterRS < this->maxInternalIterations; iterRS++) {
                 //! - Eq 14-17 to find R
                 R_k = this->computeRk(s_kmin1, R_kmin1);
 

--- a/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.h
+++ b/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.h
@@ -39,11 +39,12 @@ public:
     ScalingIterativeClosestPoint();
     ~ScalingIterativeClosestPoint();
     
-    void UpdateState(uint64_t CurrentSimNanos);
-    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos) override;
+    void Reset(uint64_t CurrentSimNanos) override;
 
     Message<PointCloudMsgPayload> outputPointCloud;  //!< The output fitted point cloud
     Message<SICPMsgPayload> outputSICPData;  //!< The output algorithm data
+    ReadFunctor<SICPMsgPayload> initialCondition;          //!< The input measured data
     ReadFunctor<PointCloudMsgPayload> measuredPointCloud;          //!< The input measured data
     ReadFunctor<PointCloudMsgPayload> referencePointCloud;          //!< The input reference data
     BSKLogger bskLogger;                //!< -- BSK Logging
@@ -70,6 +71,7 @@ private:
     PointCloudMsgPayload outputCloudBuffer;
     PointCloudMsgPayload measuredCloudBuffer;
     PointCloudMsgPayload referenceCloudBuffer;
+    SICPMsgPayload initialConditionBuffer;
     SICPMsgPayload sicpBuffer;
 
     Eigen::MatrixXd correspondingPoints;

--- a/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.h
+++ b/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.h
@@ -79,7 +79,7 @@ private:
     Eigen::MatrixXd n;
 
     int Np = 0; //!< Number of detected points
-    int maxInteralIterations = 10; //!< Maximum iterations in the inner loop for scale factor and rotation
+    int maxInternalIterations = 10; //!< Maximum iterations in the inner loop for scale factor and rotation
 
 };
 

--- a/src/fswAlgorithms/pointCloudProcessing/SICP/sicpDefinitions.h
+++ b/src/fswAlgorithms/pointCloudProcessing/SICP/sicpDefinitions.h
@@ -19,4 +19,4 @@
 
 #define MAX_POINTS 5000
 #define POINT_DIM 3
-#define MAX_ITERATIONS 100
+#define MAX_ITERATIONS 250

--- a/src/fswAlgorithms/pointCloudProcessing/initializeICP/_UnitTest/test_initICP.py
+++ b/src/fswAlgorithms/pointCloudProcessing/initializeICP/_UnitTest/test_initICP.py
@@ -1,0 +1,187 @@
+# ISC License
+#
+# Copyright (c) 2023, Laboratory for Atmospheric Space Physics, University of Colorado Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import inspect
+import numpy as np
+import os
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import SimulationBaseClass, macros
+
+from Basilisk.fswAlgorithms import initializeICP
+from Basilisk.architecture import messaging
+
+
+def test_all_valid():
+    """
+    Unit test with valid ICP message and valid point cloud
+    """
+    icp_init_sim(validICP = True, validCloud = True, normalize = True)
+
+def test_all_valid_no_normalization():
+    """
+    Unit test with valid ICP message and valid point cloud without normalization
+    """
+    icp_init_sim(validICP = True, validCloud = True, normalize = False)
+
+def test_valid_cloud():
+    """
+    Unit test with valid ICP message and valid point cloud
+    """
+    icp_init_sim(validICP = False, validCloud = True, normalize = True)
+
+def test_valid_ICP():
+    """
+    Unit test with valid ICP message and valid point cloud
+    """
+    icp_init_sim(validICP = True, validCloud = False, normalize = True)
+
+
+def icp_init_sim(validICP = True, validCloud = True, normalize = True):
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
+
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
+    process_rate = macros.sec2nano(0.5)
+    test_process = unit_test_sim.CreateNewProcess(unit_process_name)
+    test_process.addTask(unit_test_sim.CreateNewTask(unit_task_name, process_rate))
+
+    # setup module to be tested
+    module = initializeICP.InitializeICP()
+    # module.ModelTag = 'initializationICP'
+    module.normalizeMeasuredCloud = normalize
+    unit_test_sim.AddModelToTask(unit_task_name, module)
+
+    ephemeris_input_msg_buffer = messaging.EphemerisMsgPayload()
+    ephemeris_input_msg_buffer.r_BdyZero_N = [100, 1, 0]  # use v_C1_N instead of v_BN_N for accurate unit test
+    ephemeris_input_msg_buffer.sigma_BN = [0.1, 0., 1]  # use v_C1_N instead of v_BN_N for accurate unit test
+    ephemeris_input_msg_buffer.timeTag = 1 * 1E9
+    ephemeris_input_msg = messaging.EphemerisMsg().write(ephemeris_input_msg_buffer)
+    module.ephemerisInMsg.subscribeTo(ephemeris_input_msg)
+
+    camera_input_msg_buffer = messaging.CameraConfigMsgPayload()
+    camera_input_msg_buffer.cameraID = 1
+    camera_input_msg_buffer.sigma_CB = [0.1, 0.2, 0.3]
+    camera_input_msg = messaging.CameraConfigMsg().write(camera_input_msg_buffer)
+    module.cameraConfigInMsg.subscribeTo(camera_input_msg)
+
+    input_points = np.array([[1, 1, 1], [2, 2, 2], [5, 1, 3], [0, 2, 0], [0, 0, 1], [0, 0, -1]])
+    pointcloud_input_msg_buffer = messaging.PointCloudMsgPayload()
+    pointcloud_input_msg_buffer.points = input_points.flatten().tolist()
+    pointcloud_input_msg_buffer.numberOfPoints = len(input_points)
+    pointcloud_input_msg_buffer.timeTag = 1
+    pointcloud_input_msg_buffer.valid = validCloud
+    pointcloud_input_msg = messaging.PointCloudMsg().write(pointcloud_input_msg_buffer)
+    module.inputMeasuredPointCloud.subscribeTo(pointcloud_input_msg)
+
+    icp_input_msg_buffer = messaging.SICPMsgPayload()
+    icp_input_msg_buffer.rotationMatrix = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    icp_input_msg_buffer.translation = [1, 0, 0]
+    icp_input_msg_buffer.scaleFactor = [1.05]
+    icp_input_msg_buffer.numberOfIteration = 1
+    icp_input_msg_buffer.valid = validICP
+    icp_input_msg_buffer.timeTag = 500
+    icp_input_msg = messaging.SICPMsg().write(icp_input_msg_buffer)
+    module.inputSICPData.subscribeTo(icp_input_msg)
+
+    icp_msg_log = module.initializeSICPMsg.recorder()
+    unit_test_sim.AddModelToTask(unit_task_name, icp_msg_log)
+    cloud_msg_log = module.measuredPointCloud.recorder()
+    unit_test_sim.AddModelToTask(unit_task_name, cloud_msg_log)
+
+    unit_test_sim.InitializeSimulation()
+    unit_test_sim.ConfigureStopTime(process_rate)
+    unit_test_sim.ExecuteSimulation()
+
+    output_iterations = icp_msg_log.numberOfIteration[-1] + 1
+    output_Ss = icp_msg_log.scaleFactor[-1][:output_iterations]
+    output_Rs = icp_msg_log.rotationMatrix[-1][:9*output_iterations]
+    output_Ts = icp_msg_log.translation[-1][:3*output_iterations]
+
+    output_cloud_valid = cloud_msg_log.valid[-1]
+    output_cloud_timetag = cloud_msg_log.timeTag[-1]
+    output_cloud_numberpoints = cloud_msg_log.numberOfPoints[-1]
+    output_pointcloud = cloud_msg_log.points[-1][:3*output_cloud_numberpoints]
+
+    point_cloud_module = np.array(output_pointcloud).reshape([output_cloud_numberpoints, 3])
+
+    accuracy = 1E-10
+    if module.normalizeMeasuredCloud:
+        avg = np.mean(np.linalg.norm(input_points, axis=1))
+    else:
+        avg = 1
+    if validCloud and validICP:
+        np.testing.assert_allclose(point_cloud_module,
+                                   input_points/avg,
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Normalized point cloud vs expected'),
+                                   verbose=True)
+        np.testing.assert_allclose(output_Ss,
+                                   icp_input_msg_buffer.scaleFactor[0:1],
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Scale: ICP parameters vs expected'),
+                                   verbose=True)
+        np.testing.assert_allclose(output_Ts,
+                                   icp_input_msg_buffer.translation[0:3],
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Translation: ICP parameters vs expected'),
+                                   verbose=True)
+        np.testing.assert_allclose(output_Rs,
+                                   icp_input_msg_buffer.rotationMatrix[0:9],
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Rotation: ICP parameters vs expected'),
+                                   verbose=True)
+    if not validCloud:
+        np.testing.assert_allclose(point_cloud_module,
+                                   np.zeros(np.shape(point_cloud_module)),
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Normalized point cloud vs expected'),
+                                   verbose=True)
+    if not validICP and validCloud:
+        np.testing.assert_allclose(output_Ss,
+                                   [1],
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Invalid ICP: ICP parameters vs expected'),
+                                   verbose=True)
+        np.testing.assert_allclose(output_Ts,
+                                   np.array(ephemeris_input_msg_buffer.r_BdyZero_N),
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Invalid ICP: ICP parameters vs expected'),
+                                   verbose=True)
+        BN = rbk.MRP2C(ephemeris_input_msg_buffer.sigma_BN)
+        CB = rbk.MRP2C(camera_input_msg_buffer.sigma_CB)
+        np.testing.assert_allclose(np.array(output_Rs).reshape([3, 3]),
+                                   np.dot(CB, BN),
+                                   rtol=0,
+                                   atol=accuracy,
+                                   err_msg=('Invalid ICP: ICP parameters vs expected'),
+                                   verbose=True)
+
+
+if __name__ == "__main__":
+    icp_init_sim()

--- a/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.cpp
@@ -1,0 +1,165 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#include "initializeICP.h"
+
+InitializeICP::InitializeICP() = default;
+
+InitializeICP::~InitializeICP() = default;
+
+/*! This method performs a complete reset of the module.  Local module variables that retain time varying states
+ * between function calls are reset to their default values.
+ @return void
+ @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
+ */
+void InitializeICP::Reset(uint64_t CurrentSimNanos)
+{
+    if (!this->inputMeasuredPointCloud.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "Measured Point Cloud wasn't connected.");
+    }
+    if (!this->ephemerisInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "Ephemeris message wasn't connected.");
+    }
+    if (!this->cameraConfigInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "Camera message was not linked.");
+    }
+
+    //! If the module is reset, use the ephemeris message for initialization
+    this->initialPhase = true;
+}
+
+/*! Normalize the point cloud with the average norm of all points.
+ @return void
+ */
+void InitializeICP::normalizePointCloud()
+{
+    PointCloudMsgPayload measuredCloudBuffer = this->inputMeasuredPointCloud();
+    this->normalizedCloudBuffer = this->measuredPointCloud.zeroMsgPayload;
+    Eigen::MatrixXd measuredPoints = cArray2EigenMatrixXd(measuredCloudBuffer.points,
+                                                          POINT_DIM,
+                                                          measuredCloudBuffer.numberOfPoints);
+    Eigen::MatrixXd normalizedPoints = Eigen::MatrixXd::Zero(POINT_DIM, measuredCloudBuffer.numberOfPoints);
+    //! If there is a valid point cloud present, average the point norms to normalize each point
+    if (measuredCloudBuffer.valid && measuredCloudBuffer.numberOfPoints > 0) {
+        this->averageNorm = 0;
+        for (int i = 0; i < measuredCloudBuffer.numberOfPoints; i++) {
+            this->averageNorm += measuredPoints.col(i).norm();
+        }
+        this->averageNorm = this->averageNorm / measuredCloudBuffer.numberOfPoints;
+        if (this->normalizeMeasuredCloud) {
+            normalizedPoints = measuredPoints / this->averageNorm;
+            eigenMatrixXd2CArray(normalizedPoints.transpose(), this->normalizedCloudBuffer.points);
+        }
+        else{
+            eigenMatrixXd2CArray(measuredPoints.transpose(), this->normalizedCloudBuffer.points);
+        }
+    }else{
+        this->normalizedCloudBuffer = this->measuredPointCloud.zeroMsgPayload;
+    }
+
+    this->normalizedCloudBuffer.valid = measuredCloudBuffer.valid;
+    this->normalizedCloudBuffer.numberOfPoints = measuredCloudBuffer.numberOfPoints;
+}
+
+/*! Set initial conditions either with the ephemeris information of the spacecraft, or the previous ICP iteration
+ * depending on the initialPhase status
+ @return void
+ */
+void InitializeICP::setInitialConditions(uint64_t CurrentSimNanos){
+    CameraConfigMsgPayload cameraBuffer = this->cameraConfigInMsg();
+    SICPMsgPayload sicpBuffer = this->inputSICPData();
+
+    //!< Allocate appropriate memory to the arrays that will be populated
+    Eigen::MatrixXd R_prev = Eigen::MatrixXd::Identity(POINT_DIM, POINT_DIM);
+    Eigen::MatrixXd t_prev = Eigen::VectorXd::Zero(POINT_DIM);
+    double s_prev = 1;
+
+    //!< When a valid ICP solution has been computed, use that instead of ephemeris information as a priority
+    if (sicpBuffer.valid) {
+        this->R_logged = cArray2EigenMatrixXd(
+                &sicpBuffer.rotationMatrix[(sicpBuffer.numberOfIteration - 1) * POINT_DIM * POINT_DIM],
+                POINT_DIM,
+                POINT_DIM);
+        this->t_logged = cArray2EigenMatrixXd(&sicpBuffer.translation[(sicpBuffer.numberOfIteration - 1) * POINT_DIM],
+                                            1,
+                                            POINT_DIM);
+        this->s_logged = sicpBuffer.scaleFactor[sicpBuffer.numberOfIteration - 1];
+        this->initialPhase = false;
+        this->previousTimeTag = sicpBuffer.timeTag;
+    }
+    double timeSinceICPSolution = (double)(CurrentSimNanos - this->previousTimeTag)*1E-9;
+    //! - If the current point cloud is valid check if there is a recent ICP solution to use. If there isn't use
+    //! ephemeris information
+    if (this->normalizedCloudBuffer.valid) {
+        if (this->initialPhase || timeSinceICPSolution > this->maxTimeBetweenMeasurements) {
+            EphemerisMsgPayload ephemerisInMsgBuffer = this->ephemerisInMsg();
+            Eigen::Vector3d r_BN_N = cArray2EigenVector3d(ephemerisInMsgBuffer.r_BdyZero_N);
+
+            Eigen::MRPd sigma_CB = cArray2EigenMRPd(cameraBuffer.sigma_CB);
+            Eigen::Matrix3d dcm_CB = sigma_CB.toRotationMatrix().transpose();
+
+            Eigen::MRPd sigma_BN = cArray2EigenMRPd(ephemerisInMsgBuffer.sigma_BN);
+            Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
+
+            R_prev = (dcm_CB*dcm_BN);
+            t_prev = r_BN_N;
+            s_prev = 1;
+            this->outputIcpBuffer.valid = true;
+        } else {
+            R_prev = this->R_logged;
+            t_prev = this->t_logged;
+            s_prev = this->s_logged;
+            this->outputIcpBuffer.valid = true;
+        }
+    }
+    else{
+        this->outputIcpBuffer = this->initializeSICPMsg.zeroMsgPayload;
+    }
+
+    this->outputIcpBuffer.scaleFactor[0] = s_prev;
+    eigenMatrixXd2CArray(R_prev, this->outputIcpBuffer.rotationMatrix);
+    eigenMatrixXd2CArray(t_prev, this->outputIcpBuffer.translation);
+    this->outputIcpBuffer.numberOfIteration = 0;
+}
+
+/*! Write out the messages with the transformed data
+ @return void
+ @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
+ */
+void InitializeICP::writeOutputMessages(uint64_t CurrentSimNanos){
+    //! - Write the algorithm output data with zeros are results
+    this->measuredPointCloud.write(&this->normalizedCloudBuffer, this->moduleID, CurrentSimNanos);
+    this->initializeSICPMsg.write(&this->outputIcpBuffer, this->moduleID, CurrentSimNanos);
+}
+
+/*! This module reads a point cloud and performs an normalization on the points, it then reads the last messages
+ * containing attitude and position information to seed the ICP algorithm that follows, or uses the
+ @return void
+ @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
+ */
+void InitializeICP::UpdateState(uint64_t CurrentSimNanos)
+{
+    //! - Normalize the measured point cloud if it is valid
+    this->normalizePointCloud();
+    //! - Use previous ICP solution (if previous solution was valid) or spacecraft ephemeris otherwise
+    this->setInitialConditions(CurrentSimNanos);
+    //! - Write output messages
+    this->writeOutputMessages(CurrentSimNanos);
+
+}

--- a/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.h
+++ b/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.h
@@ -1,0 +1,79 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#ifndef _INITSICP_H_
+#define _INITSICP_H_
+
+#include <stdint.h>
+#include <Eigen/Dense>
+#include "fswAlgorithms/pointCloudProcessing/SICP/sicpDefinitions.h"
+#include "architecture/messaging/messaging.h"
+
+#include "architecture/msgPayloadDefCpp/SICPMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/PointCloudMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/bskLogging.h"
+
+/*! @brief Scaling iterative Closest Point Algorithm */
+class InitializeICP: public SysModel {
+public:
+    InitializeICP();
+    ~InitializeICP();
+    
+    void UpdateState(uint64_t CurrentSimNanos) override;
+    void Reset(uint64_t CurrentSimNanos) override;
+
+    ReadFunctor<SICPMsgPayload> inputSICPData;  //!< The output algorithm data
+    ReadFunctor<EphemerisMsgPayload> ephemerisInMsg; //!< ephemeris input message
+    ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg; //!< camera configuration input message
+    ReadFunctor<PointCloudMsgPayload> inputMeasuredPointCloud;          //!< The input measured data
+    Message<PointCloudMsgPayload> measuredPointCloud;  //!< The output fitted point cloud
+    Message<SICPMsgPayload> initializeSICPMsg;  //!< The output algorithm data
+
+    BSKLogger bskLogger;                //!< -- BSK Logging
+
+    double maxTimeBetweenMeasurements = 600;
+    bool normalizeMeasuredCloud = false;
+
+private:
+    void normalizePointCloud();
+    void setInitialConditions(uint64_t CurrentSimNanos);
+    void writeOutputMessages(uint64_t CurrentSimNanos);
+
+    PointCloudMsgPayload normalizedCloudBuffer;
+    SICPMsgPayload outputIcpBuffer;
+    double averageNorm = 0;
+    Eigen::VectorXd averagePoint;
+    Eigen::VectorXd referencePoint;
+    bool initialPhase = true;
+
+    //!< Logged results that will be used when this module is called again
+    Eigen::MatrixXd R_logged = Eigen::MatrixXd::Identity(POINT_DIM, POINT_DIM);
+    Eigen::MatrixXd t_logged = Eigen::VectorXd::Zero(POINT_DIM);
+    double s_logged = 1;
+    uint64_t previousTimeTag = 0;
+
+};
+
+#endif

--- a/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.i
+++ b/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.i
@@ -1,0 +1,47 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+%module initializeICP
+%{
+   #include "initializeICP.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "stdint.i"
+%include "sys_model.h"
+%include "std_array.i"
+%include "std_string.i"
+%include "swig_conly_data.i"
+
+%include "initializeICP.h"
+
+%include "architecture/msgPayloadDefCpp/SICPMsgPayload.h"
+%include "architecture/msgPayloadDefCpp/PointCloudMsgPayload.h"
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+struct CameraConfigMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.rst
+++ b/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.rst
@@ -1,0 +1,85 @@
+Executive Summary
+-----------------
+
+Module to initialize and prepare data going into an Iterative Closest Point algorithm.
+The module reads previous ICP results and ephemeris/camera data and sets the initial conditions
+depending on if the module had been recently reset.
+This process produces a normalized measured point cloud as well as an ICP message containing
+a set of R, S, and t parameters to initialize the next ICP attempt.
+
+
+Message Connection Descriptions
+-------------------------------
+
+The input messages are both of the same type since they are both point clouds. One is a
+measured point cloud (which could be output by a LIDAR for instance) and the reference
+is input given the space model of the target.
+The output messages are the geometrical transformations identified by the algorithm
+(translation, scale, and rotation), and the resulting measured point cloud after it has
+been transformed to fit the reference.
+
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - inputMeasuredPointCloud
+      - :ref:`PointCloudMsgPayload`
+      - input point cloud that was measured and is unnormalized
+    * - inputSICPData
+      - :ref:`SICPMsgPayload`
+      - ICP data from the algorithms previous iteration
+    * - ephemerisInMsg
+      - :ref:`EphemerisMsgPayload`
+      - Ephemeris of the spacecraft to get initial
+    * - inputSICPData
+      - :ref:`SICPMsgPayload`
+      - ICP data from the algorithms previous iteration
+    * - normalizedMeasuredPointCloud
+      - :ref:`PointCloudMsgPayload`
+      - ouput point cloud after normalization
+    * - initializeSICPMsg
+      - :ref:`SICPMsgPayload`
+      - output transformations to apply as initial conditions to ICP
+
+Detailed Module Description
+---------------------------
+
+The module first takes the average of all the points in the measured point cloud.
+It then divides each point by this average norm.
+
+In case a reset has recently been called, the spacecraft ephemeris is read as well as the camera frame relative
+to the body. These are used to set the base rotation, translation, and scale.
+
+If previous ICP algorithms have produced results, the last results are used directly as initalization.
+
+
+User Guide
+----------
+This section is to outline the steps needed to setup a SICPin Python.
+
+#. Import the SICP class::
+
+    from Basilisk.fswAlgorithms import initializeICP
+
+#. Create an instantiation of the module::
+
+    initICP = initializeICP.InitializeICP()
+
+#. Define all physical parameters. The max number of iterations describes how times SICP will
+try and fit the data if the min errors are not met. The errorTolerance defines that maximum
+error, scalingMin and Max are the max allowable scaling range for the scalar term::
+
+    initICP.maxIterations = 20
+    initICP.errorTolerance = 1E-5
+    initICP.scalingMax = 1.1
+    initICP.scalingMin = 0.9
+
+#. Subscribe to the input cloud messages ::
+
+    inputPointCloud = messaging.PointCloudMsgPayload()
+    referencePointCloud = messaging.PointCloudMsgPayload()
+


### PR DESCRIPTION
* **Tickets addressed:** bsk-335
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
This module is needed to initialize the ICP process. It uses known spacecraft attitude/ephemeris information or previous ICP information to set the R,S,T values for ICP. 

## Verification
Unit test was added to test functionality

## Documentation
Documentation in rst form was added

## Future work
Improvements need to be added to use the filter solution and update which messages are read to initialize. Not an urgent chance for basic functionality 
