### PR TITLE
Pin opencv recipe revision

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -186,7 +186,7 @@ class BasiliskConan(ConanFile):
     def requirements(self):
         if self.options.opNav:
             self.requires.add("pcre/8.45")
-            self.requires.add("opencv/4.1.2")
+            self.requires.add("opencv/4.1.2#b610ad323f67adc1b51e402cb5d68d70")
             self.options['opencv'].with_ffmpeg = False  # video frame encoding lib
             self.options['opencv'].with_ade = False  # graph manipulations framework
             self.options['opencv'].with_tiff = False  # generate image in TIFF format


### PR DESCRIPTION
* **Tickets addressed:** hot fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The opencv dependency recipe was [recently updated](https://github.com/conan-io/conan-center-index/commit/f9102fd6be2e512122b5b66d14c5589d83fc9733?diff=split) and now results in a Basilisk compile error. This PR pins the package to the previous (working) package recipe version number. 

## Verification
The CI process builds and tests successfully.

## Documentation
None invalidated, none new needed.

## Future work
Investigate why the latest recipe fails to compile. A ticket has been created to capture this.
