### PR TITLE
Refactor/142 thruster platform reference integral feedback

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -136,7 +136,7 @@ Version 2.2.0 (June 28, 2023)
 - Reworked how integrators are implemented. New Runge-Kutta integrators may
   now be added simply by specifying the relevant coefficients.
 - Added a scenario that showcases differences between integrators. See :ref:`scenarioIntegratorsComparison`
-
+- Updated :ref:`thrusterPlatformReference` to add an integral feedback term which dumps steady-state momentum in case of uncertainties on the CM location.
 
 Version 2.1.7 (March 24, 2023)
 ------------------------------

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -131,10 +131,32 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
         tprComputeFinalRotation(r_CMd_M, r_TM_F, T_F, FM);
     }
 
+    double theta1 = atan2(FM[1][2], FM[1][1]);
+    double theta2 = atan2(FM[2][0], FM[0][0]);
+
+    /*! bound reference angles between limits */
+    if ((configData->theta1Max > epsilon) && (theta1 > configData->theta1Max)) {
+        theta1 = configData->theta1Max;
+    }
+    else if ((configData->theta1Max > epsilon) && (theta1 < -configData->theta1Max)) {
+        theta1 = -configData->theta1Max;
+    }
+    if ((configData->theta2Max > epsilon) && (theta2 > configData->theta2Max)) {
+        theta2 = configData->theta2Max;
+    }
+    else if ((configData->theta2Max > epsilon) && (theta2 < -configData->theta2Max)) {
+        theta2 = -configData->theta2Max;
+    }
+
+    /*! rewrite DCM with updated angles */
+    FM[0][0] = cos(theta2);     FM[0][1] = sin(theta1)*sin(theta2);     FM[0][2] = -cos(theta1)*sin(theta2);
+    FM[1][0] = 0;               FM[1][1] = cos(theta1);                 FM[1][2] = sin(theta1);
+    FM[2][0] = sin(theta2);     FM[2][1] = -sin(theta1)*cos(theta2);    FM[2][2] = cos(theta1)*cos(theta2);
+
     /*! extract theta1 and theta2 angles */
-    hingedRigidBodyRef1Out.theta = atan2(FM[1][2], FM[1][1]);
+    hingedRigidBodyRef1Out.theta = theta1;
     hingedRigidBodyRef1Out.thetaDot = 0;
-    hingedRigidBodyRef2Out.theta = atan2(FM[2][0], FM[0][0]);
+    hingedRigidBodyRef2Out.theta = theta2;
     hingedRigidBodyRef2Out.thetaDot = 0;
 
     /*! write output spinning body messages */

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -39,12 +39,13 @@ enum momentumDumping{
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
 
-    /* declare these user-defined quantities */
+    /*! declare these user-defined quantities */
     double sigma_MB[3];                                   //!< orientation of the M frame w.r.t. the B frame
     double r_BM_M[3];                                     //!< position of B frame origin w.r.t. M frame origin, in M frame coordinates
     double r_FM_F[3];                                     //!< position of F frame origin w.r.t. M frame origin, in F frame coordinates
 
-    double K;                                             //!< momentum dumping time constant [1/s]
+    double K;                                             //!< momentum dumping proportional gain [1/s]
+    double Ki;                                            //!< momentum dumping integral gain [1]
 
     double theta1Max;                                     //!< absolute bound on tip angle [rad]
     double theta2Max;                                     //!< absolute bound on tilt angle [rad]
@@ -52,10 +53,13 @@ typedef struct {
     /*! declare variables for internal module calculations */
     RWArrayConfigMsgPayload   rwConfigParams;             //!< struct to store message containing RW config parameters in body B frame
     int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
+    double                    hsInt_M[3];                 //!< integral of RW momentum
+    double                    priorHs_M[3];               //!< prior RW momentum
+    uint64_t                  priorTime;                  //!< prior call time
 
-    /* declare module IO interfaces */
-    VehicleConfigMsg_C        vehConfigInMsg;            //!< input msg vehicle configuration msg (needed for CM location)
-    THRConfigMsg_C            thrusterConfigFInMsg;        //!< input thruster configuration msg
+    /*! declare module IO interfaces */
+    VehicleConfigMsg_C        vehConfigInMsg;             //!< input msg vehicle configuration msg (needed for CM location)
+    THRConfigMsg_C            thrusterConfigFInMsg;       //!< input thruster configuration msg
     RWSpeedMsg_C              rwSpeedsInMsg;              //!< input reaction wheel speeds message
     RWArrayConfigMsg_C        rwConfigDataInMsg;          //!< input RWA configuration message
     HingedRigidBodyMsg_C      hingedRigidBodyRef1OutMsg;  //!< output msg containing theta1 reference and thetaDot1 reference

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -46,7 +46,10 @@ typedef struct {
 
     double K;                                             //!< momentum dumping time constant [1/s]
 
-    /* declare variables for internal module calculations */
+    double theta1Max;                                     //!< absolute bound on tip angle [rad]
+    double theta2Max;                                     //!< absolute bound on tilt angle [rad]
+
+    /*! declare variables for internal module calculations */
     RWArrayConfigMsgPayload   rwConfigParams;             //!< struct to store message containing RW config parameters in body B frame
     int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -53,10 +53,14 @@ This module computes a direction cosine matrix :math:`[\mathcal{FM}]` that descr
 When the optional input messages ``rwConfigDataInMsg`` and ``rwSpeedsInMsg`` the user can specify an input parameter ``K``, which is the proportional gain of a control gain that computes an offset with respect to the center of mass: this allows for the thruster to apply a torque on the system that dumps the momentum accumulated on the wheels. Such control law has the expression:
 
 .. math:: 
-    \boldsymbol{d} = \frac{\kappa}{t^2} (\boldsymbol{t} \times \boldsymbol{H}_w)
+    \boldsymbol{d} = -\frac{1}{t^2} \boldsymbol{t} \times(\kappa \boldsymbol{h}_w + \kappa_I \boldsymbol{H}_w)
 
-where :math:`\boldsymbol{H}_w` is the momentum on the wheels.
+where :math:`\boldsymbol{h}_w` is the momentum on the wheels and :math:`\boldsymbol{H}_w` the integral over time of the momentum:
 
+.. math::
+    \boldsymbol{H}_w = \int_{t_0}^t \boldsymbol{h}_w \text{d}t.
+
+The inputs ``theta1Max`` and ``theta2Max`` are used to set bounds on the output reference angles for the platform. If there are no mechanical bounds, setting these inputs to a negative value bypasses the routine that bounds these angles.
 
 Module Assumptions and Limitations
 ----------------------------------
@@ -76,11 +80,14 @@ User Guide
 The required module configuration is::
 
     platform = thrusterPlatformReference.thrusterPlatformReference()
-    platform.ModelTag = "platformReference"
-    platform.sigma_MB = sigma_MB
-    platform.r_BM_M = r_BM_M
-    platform.r_FM_F = r_FM_F
-    platform.K      = K
+    platform.ModelTag  = "platformReference"
+    platform.sigma_MB  = sigma_MB
+    platform.r_BM_M    = r_BM_M
+    platform.r_FM_F    = r_FM_F
+    platform.K         = K
+    platform.Ki        = Ki
+    platform.theta1Max = theta1Max
+    platform.theta2Max = theta2Max
     scSim.AddModelToTaskAddModelToTask(simTaskName, platform)
  	
 The module is configurable with the following parameters:
@@ -104,3 +111,12 @@ The module is configurable with the following parameters:
     * - ``K``
       - 0
       - proportional gain of the momentum dumping control loop
+    * - ``Ki``
+      - 0
+      - integral gain of the momentum dumping control loop
+    * - ``theta1Max``
+      - 0
+      - absolute bound on tip angle
+    * - ``theta2Max``
+      - 0
+      - absolute bound on tilt angle


### PR DESCRIPTION
* **Tickets addressed:** bsk-142
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
An integral feedback term is provided as an input parameter. When the input is negative, or not provided, the integral feedback term is not added, and the control law defaults to a proportional type. 

Two input parameters are define to bound the absolute value of the reference angles. When the computed references exceed these bounds, they are set equal to the bounds. When the inputs are negative, the bounding of the reference angles is bypassed.

Commit 1 addresses an issue in the former version of the module, making sure that the momentum dumping routine is run only when the RW speed message is connected. Commit 2 implements the bounding of the reference angles. Commit 3 computes the integral feedback term and adds it to the control law. Commits 4 and 5 update the unit test and documentation, respectively.

## Verification
A unit test is provided to test the correctness of the output, reflecting the most recent changes.

## Documentation
Documentation is updated to reflect the changes.

## Future work
No future work is foreseen at the moment.
