### PR TITLE
Stepper motor/stepper motor profiler

### DIFF
--- a/src/architecture/msgPayloadDefC/StepperMotorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/StepperMotorMsgPayload.h
@@ -1,0 +1,34 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef stepperMotorSimMsg_h
+#define stepperMotorSimMsg_h
+
+
+ /*! @brief Structure containing stepper motor state information */
+typedef struct {
+    double theta;               //!< [rad] Current motor angle
+    double thetaDot;            //!< [rad/s] Current motor angle rate
+    double thetaDDot;           //!< [rad/s^2] Current motor angular acceleration
+    int stepsCommanded;         //!< Current number of commanded motor steps
+    int stepCount;              //!< Current motor step count (number of steps taken)
+}StepperMotorMsgPayload;
+
+
+#endif /* stepperMotorSimMsg_h */

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfiler.py
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfiler.py
@@ -1,0 +1,247 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+#
+#   Unit Test Script
+#   Module Name:        stepperMotorProfiler
+#   Author:             Leah Kiner
+#   Creation Date:      Sept 29, 2023
+#
+
+import inspect
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import stepperMotorProfiler
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import unitTestSupport
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+@pytest.mark.parametrize("initialMotorAngle", [0.0 * (np.pi / 180), 10.0 * (np.pi / 180), -5.0 * (np.pi / 180)])
+@pytest.mark.parametrize("stepsCommanded", [0, 5, -5])
+@pytest.mark.parametrize("stepAngle", [0.01 * (np.pi / 180), 0.5 * (np.pi / 180), 1.0 * (np.pi / 180)])
+@pytest.mark.parametrize("stepTime", [0.1, 0.5, 1.0])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommanded, stepAngle, stepTime, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test ensures that the stepper motor profiler module correctly actuates the stepper motor from an initial
+    angle to a final reference angle, given an input integer number of commanded steps contained in the
+    ``motorStepCommand`` input message. The initial motor angle and number of commanded steps are varied so that the
+    module is shown to work for both positive and negative steps. The motor states are profiled for each step using
+    a bang-bang constant positive, constant negative acceleration profile. The motor acceleration is determined from
+    the given constant step angle and constant step time.
+
+    **Test Parameters**
+
+    Args:
+        initialMotorAngle (float): [rad] Initial stepper motor angle
+        stepsCommanded (int): [steps] Number of steps commanded to the stepper motor
+        stepAngle (float): [rad] Angle the stepper motor moves through for a single step (constant)
+        stepTime (float): [sec] Time required for a single motor step (constant)
+        accuracy (float): absolute accuracy value used in the validation tests
+
+    **Description of Variables Being Tested**
+
+    This unit test checks that the final motor angle matches the reference motor angele. The reference motor angle is
+    determined from the initial motor angle and number of commanded steps. The test also checks that the module
+    keeps track of the motor step count correctly by comparing the final motor step count with the number of steps
+    commanded from the module ``motorStepCommand`` input message.
+
+    """
+    [testResults, testMessage] = stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommanded, stepAngle, stepTime, accuracy)
+
+    assert testResults < 1, testMessage
+
+
+def stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommanded, stepAngle, stepTime, accuracy):
+    """Call this routine directly to run the unit test."""
+    testFailCount = 0
+    testMessages = []
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create the test thread
+    testProcessRate = macros.sec2nano(0.1)     # Set process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create an instance of the stepperMotorProfiler module to be tested
+    StepperMotorProfiler = stepperMotorProfiler.stepperMotorProfiler()
+    StepperMotorProfiler.ModelTag = "StepperMotorProfiler"
+    rotAxis_M = np.array([1.0, 0.0, 0.0])
+    StepperMotorProfiler.rotAxis_M = rotAxis_M
+    StepperMotorProfiler.thetaInit = initialMotorAngle
+    StepperMotorProfiler.stepAngle = stepAngle
+    StepperMotorProfiler.stepTime = stepTime
+    StepperMotorProfiler.thetaDDotMax = stepAngle / (0.25 * stepTime * stepTime)
+    StepperMotorProfiler.r_FM_M = np.array([0.0, 0.0, 0.0])
+    StepperMotorProfiler.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    StepperMotorProfiler.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+
+    # Add the test module to the runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, StepperMotorProfiler)
+
+    # Create the StepperMotorProfiler input message
+    MotorStepCommandMessageData = messaging.MotorStepCommandMsgPayload()
+    MotorStepCommandMessageData.stepsCommanded = stepsCommanded
+    MotorStepCommandMessage = messaging.MotorStepCommandMsg().write(MotorStepCommandMessageData)
+    StepperMotorProfiler.motorStepCommandInMsg.subscribeTo(MotorStepCommandMessage)
+
+    # Log the test module output message for data comparison
+    stepperMotorDataLog = StepperMotorProfiler.stepperMotorOutMsg.recorder()
+    prescribedDataLog = StepperMotorProfiler.prescribedMotionOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, stepperMotorDataLog)
+    unitTestSim.AddModelToTask(unitTaskName, prescribedDataLog)
+
+    # Initialize the simulation, set the sim run time, and execute the simulation
+    unitTestSim.InitializeSimulation()
+    actuateTime = stepTime * np.abs(stepsCommanded)  # [sec] Time for the motor to actuate to the desired angle
+    holdTime = 5  # [sec] Time the simulation will continue while holding the final angle
+    unitTestSim.ConfigureStopTime(macros.sec2nano(actuateTime + holdTime))
+    unitTestSim.ExecuteSimulation()
+
+    # Extract the logged data for plotting and data comparison
+    timespan = stepperMotorDataLog.times()
+    theta = (180 / np.pi) * stepperMotorDataLog.theta
+    thetaDot = (180 / np.pi) * stepperMotorDataLog.thetaDot
+    thetaDDot = (180 / np.pi) * stepperMotorDataLog.thetaDDot
+    motorStepCount = stepperMotorDataLog.stepCount
+    motorCommandedSteps = stepperMotorDataLog.stepsCommanded
+    sigma_FM = prescribedDataLog.sigma_FM
+    omega_FM_F = prescribedDataLog.omega_FM_F
+    omegaPrime_FM_F = prescribedDataLog.omegaPrime_FM_F
+
+    # Only show plots if the motor actuates
+    if (stepsCommanded == 0):
+        show_plots = False
+
+    # Plot motor angle
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, theta, label=r"$\theta$")
+    plt.title(r'Stepper Motor Angle $\theta_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+    plt.ylabel('(deg)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot motor thetaDot
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, thetaDot, label=r"$\dot{\theta}$")
+    plt.title(r'Stepper Motor Angle Rate $\dot{\theta}_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+    plt.ylabel('(deg/s)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot motor thetaDDot
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, thetaDDot, label=r"$\ddot{\theta}$")
+    plt.title(r'Stepper Motor Angular Acceleration $\ddot{\theta}_{\mathcal{F}/\mathcal{M}}$ ', fontsize=14)
+    plt.ylabel('(deg/s$^2$)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot steps commanded and motor steps taken
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, motorStepCount)
+    plt.plot(timespan * macros.NANO2SEC, motorCommandedSteps, '--', label='Commanded')
+    plt.title(r'Motor Step History', fontsize=14)
+    plt.ylabel('Steps', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot omega_FM_F
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 0], label=r'$\omega_{1}$')
+    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 1], label=r'$\omega_{2}$')
+    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 2], label=r'$\omega_{3}$')
+    plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(deg/s)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot omegaPrime_FM_F
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 0], label=r'1')
+    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 1], label=r'2')
+    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 2], label=r'3')
+    plt.title(r'${}^\mathcal{F} \omega Prime_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(deg/s$^2$)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # Check to ensure the initial angle converged to the reference angle
+    desiredMotorAngleTrue = initialMotorAngle + (stepsCommanded * stepAngle)
+    if not unitTestSupport.isDoubleEqual(theta[-1], (180 / np.pi) * desiredMotorAngleTrue, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + StepperMotorProfiler.ModelTag + " Final motor angle does not match the reference angle.")
+
+    # Check to ensure the initial angle rate converged to the reference angle rate
+    if not unitTestSupport.isDoubleEqual(thetaDot[-1], 0.0, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + StepperMotorProfiler.ModelTag + " Final motor angle rate does not match the reference rate.")
+
+    # Check the motor achieved the commanded steps
+    if not (stepsCommanded == motorStepCount[-1]):
+        testFailCount += 1
+        testMessages.append("FAILED: " + StepperMotorProfiler.ModelTag + " Motor did not complete the number of commanded steps.")
+        print(stepsCommanded)
+        print(motorStepCount[-1])
+
+    return [testFailCount, ''.join(testMessages)]
+
+#
+# This statement below ensures that the unitTestScript can be run as a stand-along python script
+#
+if __name__ == "__main__":
+    stepperMotorProfilerTestFunction(
+                 True,
+                 0.0,                       # initialMotorAngle
+                 10,                        # stepsCommanded
+                 1.0 * (np.pi / 180),       # stepAngle
+                 1.0,                       # stepTime
+                 1e-12                      # accuracy
+               )

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfilerInterrupt.py
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfilerInterrupt.py
@@ -1,0 +1,319 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        stepperMotorProfiler
+#   Author:             Leah Kiner
+#   Creation Date:      Sept 29, 2023
+#
+
+import inspect
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import pytest
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import stepperMotorController
+from Basilisk.fswAlgorithms import stepperMotorProfiler
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import unitTestSupport
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+@pytest.mark.parametrize("stepAngle", [1.0 * (np.pi / 180)])
+@pytest.mark.parametrize("stepTime", [1.0])
+@pytest.mark.parametrize("initialMotorAngle", [0.0])
+@pytest.mark.parametrize("desiredMotorAngle1", [10.0 * (np.pi / 180), -10.0 * (np.pi / 180)])
+@pytest.mark.parametrize("desiredMotorAngle2", [0.0, 10.0 * (np.pi / 180), 5.0 * (np.pi / 180)])
+@pytest.mark.parametrize("interruptFraction", [0.0, 0.25, 0.5, 0.75])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMotorAngle, desiredMotorAngle1, desiredMotorAngle2, interruptFraction, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test ensures that the stepper motor profiler module correctly actuates the stepper motor from an initial
+    angle to a final reference angle, given an input number of steps commanded. An interrupted message is introduced
+    during the motor actuation that specifies a new final reference angle. The initial and desired motor angles are
+    varied so that combinations of both positive and negative steps are taken. The time of step interruption is varied
+    to ensure that once a step begins, it is completed regardless of when the interrupted message is written. Because
+    the other unit test script for this module checked the basic module functionality for a single positive or negative
+    step command, the step angle, step time, initial and desired angles chosen in this script are set to simple values.
+
+    **Test Parameters**
+
+    Args:
+        stepAngle (float): [rad] Angle the stepper motor moves through for a single step (constant)
+        stepTime (float): [sec] Time required for a single motor step (constant)
+        initialMotorAngle (float): [rad] Initial stepper motor angle
+        desiredMotorAngle1 (float): [rad] Desired stepper motor angle 1
+        desiredMotorAngle2 (float): [rad] Desired stepper motor angle 2
+        interruptFraction (float): Specifies what fraction of a step is completed when the interrupted message is written
+        accuracy (float): absolute accuracy value used in the validation tests
+
+    **Description of Variables Being Tested**
+
+    This test checks that the final motor angle matches the second desired motor angle.
+
+    """
+
+    [testResults, testMessage] = stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMotorAngle, desiredMotorAngle1, desiredMotorAngle2, interruptFraction, accuracy)
+
+    assert testResults < 1, testMessage
+
+def stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMotorAngle, desiredMotorAngle1, desiredMotorAngle2, interruptFraction, accuracy):
+    testFailCount = 0
+    testMessages = []
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create the test thread
+    testProcessRate = macros.sec2nano(0.1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create an instance of the stepperMotorController module to be tested
+    StepperMotorController = stepperMotorController.stepperMotorController()
+    StepperMotorController.ModelTag = "stepperMotorController"
+    StepperMotorController.stepAngle = stepAngle
+    StepperMotorController.stepTime = stepTime
+    StepperMotorController.initAngle = initialMotorAngle
+    StepperMotorController.currentAngle = initialMotorAngle
+
+    # Add the stepperMotorController test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, StepperMotorController)
+
+    # Create the stepperMotorController input message
+    HingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
+    HingedRigidBodyMessageData.theta = desiredMotorAngle1
+    HingedRigidBodyMessage = messaging.HingedRigidBodyMsg().write(HingedRigidBodyMessageData)
+    StepperMotorController.spinningBodyInMsg.subscribeTo(HingedRigidBodyMessage)
+
+    # Create an instance of the stepperMotorProfiler module to be tested
+    StepperMotorProfiler = stepperMotorProfiler.stepperMotorProfiler()
+    StepperMotorProfiler.ModelTag = "stepperMotorProfiler"
+    rotAxis_M = np.array([1.0, 0.0, 0.0])
+    StepperMotorProfiler.rotAxis_M = rotAxis_M
+    StepperMotorProfiler.thetaInit = initialMotorAngle
+    StepperMotorProfiler.stepAngle = stepAngle
+    StepperMotorProfiler.stepTime = stepTime
+    StepperMotorProfiler.thetaDDotMax = stepAngle / (0.25 * stepTime * stepTime)
+    StepperMotorProfiler.r_FM_M = np.array([0.0, 0.0, 0.0])
+    StepperMotorProfiler.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    StepperMotorProfiler.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+
+    # Add the stepperMotorProfiler test module to the runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, StepperMotorProfiler)
+
+    # Subscribe the step command message to the stepper motor profiler module
+    StepperMotorProfiler.motorStepCommandInMsg.subscribeTo(StepperMotorController.motorStepCommandOutMsg)
+
+    # Log the test module output message for data comparison
+    stepCommandDataLog = StepperMotorController.motorStepCommandOutMsg.recorder(testProcessRate)
+    stepperMotorDataLog = StepperMotorProfiler.stepperMotorOutMsg.recorder(testProcessRate)
+    prescribedDataLog = StepperMotorProfiler.prescribedMotionOutMsg.recorder(testProcessRate)
+    unitTestSim.AddModelToTask(unitTaskName, stepCommandDataLog)
+    unitTestSim.AddModelToTask(unitTaskName, stepperMotorDataLog)
+    unitTestSim.AddModelToTask(unitTaskName, prescribedDataLog)
+
+    # Initialize the simulation
+    unitTestSim.InitializeSimulation()
+
+    # Calculate required number of steps for validation
+    if (initialMotorAngle > 0):
+        trueNumSteps1 = (desiredMotorAngle1 - (np.ceil(initialMotorAngle/stepAngle)*stepAngle)) / stepAngle
+    else:
+        trueNumSteps1 = (desiredMotorAngle1 - (np.floor(initialMotorAngle/stepAngle)*stepAngle)) / stepAngle
+
+    # If the desired motor angle is not a multiple of the step angle, the number of steps calculated is not an integer
+    # and it must be rounded to the nearest whole step
+    lowerStepFraction = trueNumSteps1 - np.floor(trueNumSteps1)
+    upperStepFraction = np.ceil(trueNumSteps1) - trueNumSteps1
+    if (upperStepFraction > lowerStepFraction):
+        trueNumSteps1 = np.floor(trueNumSteps1)
+    else:
+        trueNumSteps1 = np.ceil(trueNumSteps1)
+
+    # If the desired motor angle is not a multiple of the step angle, a new desired angle is calculated
+    newMotorDesiredAngle = initialMotorAngle + (trueNumSteps1 * stepAngle)
+
+    # Set the simulation time
+    actuateTime1 = stepTime * np.abs(trueNumSteps1)  # [sec] Time for the motor to actuate to the desired angle
+    simTime1 = (actuateTime1 / 2) + (interruptFraction * stepTime)  # [sec] Time before the first message is interrupted
+    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime1))
+
+    # Begin the simulation
+    unitTestSim.ExecuteSimulation()
+
+    # Create the second interruption message
+    HingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
+    HingedRigidBodyMessageData.theta = desiredMotorAngle2
+    HingedRigidBodyMessage = messaging.HingedRigidBodyMsg().write(HingedRigidBodyMessageData, unitTestSim.TotalSim.CurrentNanos)
+    StepperMotorController.spinningBodyInMsg.subscribeTo(HingedRigidBodyMessage)
+
+    # Calculate number of steps to actuate from interrupted motor position to the second desired motor angle
+    if (trueNumSteps1 > 0):
+        interruptedMotorAngle = initialMotorAngle + ((simTime1 / stepTime) * stepAngle)
+        # Ensure the interrupted motor angle is set to the next multiple of the motor step angle
+        # (If the motor is interrupted during a step)
+        interruptedMotorAngle = np.ceil(interruptedMotorAngle / stepAngle) * stepAngle
+    else:
+        interruptedMotorAngle = initialMotorAngle - ((simTime1 / stepTime) * stepAngle)
+        # Ensure the interrupted motor angle is set to the next multiple of the motor step angle
+        # (If the motor is interrupted during a step)
+        interruptedMotorAngle = np.floor(interruptedMotorAngle / stepAngle) * stepAngle
+
+    trueNumSteps2 = (desiredMotorAngle2 - interruptedMotorAngle) / stepAngle
+
+    # If the desired motor angle is not a multiple of the step angle, the number of steps calculated is not an integer
+    # and it must be rounded to the nearest whole step
+    lowerStepFraction = trueNumSteps2 - np.floor(trueNumSteps2)
+    upperStepFraction = np.ceil(trueNumSteps2) - trueNumSteps2
+    if (upperStepFraction > lowerStepFraction):
+        trueNumSteps2 = np.floor(trueNumSteps2)
+    else:
+        trueNumSteps2 = np.ceil(trueNumSteps2)
+
+    # If the desired motor angle is not a multiple of the step angle, a new desired angle is calculated
+    newMotorDesiredAngle2 = interruptedMotorAngle + (trueNumSteps2 * stepAngle)
+
+    # Set the simulation time for chunk 2
+    actuateTime2 = stepTime * np.abs(trueNumSteps2)  # [sec] Time for the motor to actuate to the desired angle
+    holdTime = 5  # [sec] Time the simulation will continue while holding the final angle
+    simTime2 = actuateTime2 + holdTime
+    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime1 + simTime2))
+
+    # Execute simulation chunk 2
+    unitTestSim.ExecuteSimulation()
+
+    # Pull the logged motor step data
+    timespan = stepperMotorDataLog.times()
+    theta = (180 / np.pi) * stepperMotorDataLog.theta
+    thetaDot = (180 / np.pi) * stepperMotorDataLog.thetaDot
+    thetaDDot = (180 / np.pi) * stepperMotorDataLog.thetaDDot
+    motorStepCount = stepperMotorDataLog.stepCount
+    motorCommandedSteps = stepperMotorDataLog.stepsCommanded
+    sigma_FM = prescribedDataLog.sigma_FM
+    omega_FM_F = prescribedDataLog.omega_FM_F
+    omegaPrime_FM_F = prescribedDataLog.omegaPrime_FM_F
+
+    # Plot motor angle
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, theta, label=r"$\theta$")
+    plt.title(r'Stepper Motor Angle $\theta_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+    plt.ylabel('(deg)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot motor thetaDot
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, thetaDot, label=r"$\dot{\theta}$")
+    plt.title(r'Stepper Motor Angle Rate $\dot{\theta}_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+    plt.ylabel('(deg/s)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot motor thetaDDot
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, thetaDDot, label=r"$\ddot{\theta}$")
+    plt.title(r'Stepper Motor Angular Acceleration $\ddot{\theta}_{\mathcal{F}/\mathcal{M}}$ ', fontsize=14)
+    plt.ylabel('(deg/s$^2$)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot steps commanded and motor steps taken
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, motorStepCount)
+    plt.plot(timespan * macros.NANO2SEC, motorCommandedSteps, '--', label='Commanded')
+    plt.title(r'Motor Step History', fontsize=14)
+    plt.ylabel('Steps', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot omega_FM_F
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 0], label=r'$\omega_{1}$')
+    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 1], label=r'$\omega_{2}$')
+    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 2], label=r'$\omega_{3}$')
+    plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(deg/s)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # Plot omegaPrime_FM_F
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 0], label=r'1')
+    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 1], label=r'2')
+    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 2], label=r'3')
+    plt.title(r'${}^\mathcal{F} \omega Prime_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(deg/s$^2$)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # Check that the final motor angle matches the motor reference angle desiredMotorAngle2
+    desiredMotorAngle2 = (180 / np.pi) * desiredMotorAngle2
+    if not unitTestSupport.isDoubleEqual(theta[-1], desiredMotorAngle2, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + StepperMotorProfiler.ModelTag + " Final motor angle does not match the reference angle.")
+        print("TRUE FINAL ANGLE: \n")
+        print(desiredMotorAngle2)
+        print("MODULE FINAL ANGLE: \n")
+        print(theta[-1])
+
+    return [testFailCount, ''.join(testMessages)]
+
+
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+if __name__ == "__main__":
+    stepperMotorProfilerTestFunction(
+                 True,
+                 1.0 * (np.pi / 180),     # stepAngle
+                 1.0,                     # stepTime
+                 0.0,                     # initialMotorAngle
+                 10.0 * (np.pi / 180),    # desiredMotorAngle1,
+                 5.0 * (np.pi / 180),     # desiredMotorAngle2
+                 0.0,                     # interruptFraction
+                 1e-12                    # accuracy
+               )

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.c
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.c
@@ -1,0 +1,247 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "stepperMotorProfiler.h"
+#include <stdbool.h>
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/macroDefinitions.h"
+
+/*! This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_stepperMotorProfiler(StepperMotorProfilerConfig *configData, int64_t moduleID) {
+    StepperMotorMsg_C_init(&configData->stepperMotorOutMsg);
+    HingedRigidBodyMsg_C_init(&configData->hingedRigidBodyOutMsg);
+    PrescribedMotionMsg_C_init(&configData->prescribedMotionOutMsg);
+}
+
+/*! This method performs a complete reset of the module. The input messages are checked to ensure they are linked.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] Time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_t callTime, int64_t moduleID) {
+    // Check if the input message is linked
+    if (!MotorStepCommandMsg_C_isLinked(&configData->motorStepCommandInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: prescribedRot1DOF.motorStepCommandInMsg wasn't connected.");
+    }
+
+    // Initialize the module parameters to zero
+    configData->theta = configData->thetaInit;
+    configData->maneuverThetaInit = configData->thetaInit;
+    configData->thetaDotInit = 0.0;
+    configData->thetaDot = 0.0;
+    configData->thetaDotRef = 0.0;
+    configData->thetaDDot = 0.0;
+    configData->tInit = 0.0;
+    configData->stepCount = 0;
+
+    // Initialize the prescribed states not set by the user
+    v3Scale(configData->thetaDotInit, configData->rotAxis_M, configData->omega_FM_F);
+    v3Scale(configData->thetaDDot, configData->rotAxis_M, configData->omegaPrime_FM_F);
+    double prv_F0M_array[3];
+    v3Scale(configData->thetaInit, configData->rotAxis_M, prv_F0M_array);
+    PRV2MRP(prv_F0M_array, configData->sigma_FM);
+
+    // Set the previous written time to a negative value to capture a message written at time zero
+    configData->previousWrittenTime = -1;
+
+    // Initialize the module boolean parameters
+    configData->completion = true;
+    configData->stepComplete = true;
+    configData->newMsg = false;
+}
+
+/*! This method profiles the stepper motor trajectory and updates the prescribed motor states as a function of time.
+The motor states are then written to the output messages.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] Time the method is called
+ @param moduleID The module identifier
+*/
+void Update_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_t callTime, int64_t moduleID) {
+    // Create the buffer messages
+    MotorStepCommandMsgPayload motorStepCommandIn;
+    StepperMotorMsgPayload stepperMotorOut;
+    HingedRigidBodyMsgPayload hingedRigidBodyOut;
+    PrescribedMotionMsgPayload prescribedMotionOut;
+
+    // Zero the buffer messages
+    motorStepCommandIn = MotorStepCommandMsg_C_zeroMsgPayload();
+    stepperMotorOut = StepperMotorMsg_C_zeroMsgPayload();
+    hingedRigidBodyOut = HingedRigidBodyMsg_C_zeroMsgPayload();
+    prescribedMotionOut = PrescribedMotionMsg_C_zeroMsgPayload();
+
+    // Read the input message
+    if (MotorStepCommandMsg_C_isWritten(&configData->motorStepCommandInMsg)) {
+        motorStepCommandIn = MotorStepCommandMsg_C_read(&configData->motorStepCommandInMsg);
+        // Store the number of commanded motor steps when a new message is written
+        if (configData->previousWrittenTime <  MotorStepCommandMsg_C_timeWritten(&configData->motorStepCommandInMsg)) {
+            configData->previousWrittenTime = MotorStepCommandMsg_C_timeWritten(&configData->motorStepCommandInMsg);
+            configData->stepsCommanded = motorStepCommandIn.stepsCommanded;
+            if (configData->stepsCommanded != 0) {
+                configData->completion = false;
+            } else {
+                configData->completion = true;
+            }
+            configData->newMsg = true;
+        }
+    }
+
+    // Reset the motor states for the next maneuver ONLY when the current step is completed
+    if (!(configData->completion)) {
+        if (configData->newMsg && configData->stepComplete) {
+
+            // Update the step count to zero
+            configData->stepCount = 0;
+
+            // Calculate the current ange and angle rate
+            configData->maneuverThetaInit = configData->theta;
+            configData->thetaDotInit = configData->thetaDot;
+
+            // Store the initial time as the current simulation time
+            configData->tInit = callTime * NANO2SEC;
+
+            configData->newMsg = false;
+        }
+
+        // Define temporal information for the maneuver
+        configData->tf = configData->tInit + configData->stepTime;
+        configData->ts = configData->tInit + configData->stepTime / 2;
+
+        // Update the intermediate initial and reference motor angles and the parabolic constants when a step is completed
+        if (configData->stepComplete) {
+            if (configData->stepsCommanded > 0) {
+                configData->intermediateThetaInit = configData->maneuverThetaInit + (configData->stepCount * configData->stepAngle);
+                configData->intermediateThetaRef = configData->maneuverThetaInit + ((configData->stepCount + 1) * configData->stepAngle);
+                configData->a = 0.5 * (configData->stepAngle) / ((configData->ts - configData->tInit) * (configData->ts - configData->tInit));
+                configData->b = -0.5 * (configData->stepAngle) / ((configData->ts - configData->tf) * (configData->ts - configData->tf));
+            } else {
+                configData->intermediateThetaInit = configData->maneuverThetaInit + (configData->stepCount * configData->stepAngle);
+                configData->intermediateThetaRef = configData->maneuverThetaInit + ((configData->stepCount - 1) * configData->stepAngle);
+                configData->a = 0.5 * (-configData->stepAngle) / ((configData->ts - configData->tInit) * (configData->ts - configData->tInit));
+                configData->b = -0.5 * (-configData->stepAngle) / ((configData->ts - configData->tf) * (configData->ts - configData->tf));
+            }
+        }
+
+        // Store the current simulation time
+        double t = callTime * NANO2SEC;
+
+        // Update the scalar motor states during each step
+        if ((t < configData->ts || t == configData->ts) && configData->tf - configData->tInit != 0) { // Entered during the first half of the maneuver
+            if (configData->stepsCommanded > 0 && !configData->newMsg) {
+                configData->thetaDDot = configData->thetaDDotMax;
+            } else if (!configData->newMsg) {
+                configData->thetaDDot = -configData->thetaDDotMax;
+            }
+            configData->thetaDot = configData->thetaDDot * (t - configData->tInit) + configData->thetaDotInit;
+            configData->theta = configData->a * (t - configData->tInit) * (t - configData->tInit) + configData->intermediateThetaInit;
+            configData->stepComplete = false;
+        } else if (t > configData->ts && t < configData->tf && configData->tf - configData->tInit != 0) { // Entered during the second half of the maneuver
+            if (configData->stepsCommanded > 0 && !configData->newMsg){
+                configData->thetaDDot = -configData->thetaDDotMax;
+            } else if (!configData->newMsg) {
+                configData->thetaDDot = configData->thetaDDotMax;
+            }
+            configData->thetaDot = configData->thetaDDot * (t - configData->tInit) + configData->thetaDotInit - configData->thetaDDot * (configData->tf - configData->tInit);
+            configData->theta = configData->b * (t - configData->tf) * (t - configData->tf) + configData->intermediateThetaRef;
+            configData->stepComplete = false;
+        } else { // Entered when a step is complete
+            configData->stepComplete = true;
+            configData->thetaDDot = 0.0;
+            configData->thetaDot = configData->thetaDotRef;
+            configData->theta = configData->intermediateThetaRef;
+
+            // Update the motor step count
+            if (!configData->newMsg) {
+                if (configData->stepsCommanded > 0) {
+                    configData->stepCount++;
+                } else {
+                    configData->stepCount--;
+                }
+            } else {
+                if (configData->intermediateThetaRef > configData->intermediateThetaInit) {
+                    configData->stepCount++;
+                } else {
+                    configData->stepCount--;
+                }
+            }
+
+            // Update the initial time
+            configData->tInit = callTime * NANO2SEC;
+
+            // Update the completion boolean variable only when motor actuation is complete
+            if ((configData->stepCount == configData->stepsCommanded) && !configData->newMsg) {
+                configData->completion = true;
+            }
+        }
+    }
+
+    // Determine the prescribed parameters: omega_FM_F and omegaPrime_FM_F
+    v3Normalize(configData->rotAxis_M, configData->rotAxis_M);
+    v3Scale(configData->thetaDot, configData->rotAxis_M, configData->omega_FM_F);
+    v3Scale(configData->thetaDDot, configData->rotAxis_M, configData->omegaPrime_FM_F);
+
+    // Determine dcm_FF0
+    double dcm_FF0[3][3];
+    double prv_FF0_array[3];
+    double theta_FF0 = configData->theta - configData->thetaInit;
+    v3Scale(theta_FF0, configData->rotAxis_M, prv_FF0_array);
+    PRV2C(prv_FF0_array, dcm_FF0);
+
+    // Determine dcm_F0M
+    double dcm_F0M[3][3];
+    double prv_F0M_array[3];
+    v3Scale(configData->thetaInit, configData->rotAxis_M, prv_F0M_array);
+    PRV2C(prv_F0M_array, dcm_F0M);
+
+    // Determine dcm_FM
+    double dcm_FM[3][3];
+    m33MultM33(dcm_FF0, dcm_F0M, dcm_FM);
+
+    // Determine the MRP attitude: sigma_FM
+    C2MRP(dcm_FM, configData->sigma_FM);
+
+    // Copy motor information to the stepper motor message
+    stepperMotorOut.theta = configData->theta;
+    stepperMotorOut.thetaDot = configData->thetaDot;
+    stepperMotorOut.thetaDDot = configData->thetaDDot;
+    stepperMotorOut.stepsCommanded = configData->stepsCommanded;
+    stepperMotorOut.stepCount = configData->stepCount;
+
+    // Copy motor states to the hinged rigid body message
+    hingedRigidBodyOut.theta = configData->theta;
+    hingedRigidBodyOut.thetaDot = configData->thetaDot;
+
+    // Copy the prescribed states to the prescribed motion output message
+    v3Copy(configData->r_FM_M, prescribedMotionOut.r_FM_M);
+    v3Copy(configData->rPrime_FM_M, prescribedMotionOut.rPrime_FM_M);
+    v3Copy(configData->rPrimePrime_FM_M, prescribedMotionOut.rPrimePrime_FM_M);
+    v3Copy(configData->sigma_FM, prescribedMotionOut.sigma_FM);
+    v3Copy(configData->omega_FM_F, prescribedMotionOut.omega_FM_F);
+    v3Copy(configData->omegaPrime_FM_F, prescribedMotionOut.omegaPrime_FM_F);
+
+    // Write the output messages
+    StepperMotorMsg_C_write(&stepperMotorOut, &configData->stepperMotorOutMsg, moduleID, callTime);
+    HingedRigidBodyMsg_C_write(&hingedRigidBodyOut, &configData->hingedRigidBodyOutMsg, moduleID, callTime);
+    PrescribedMotionMsg_C_write(&prescribedMotionOut, &configData->prescribedMotionOutMsg, moduleID, callTime);
+}

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.h
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.h
@@ -1,0 +1,96 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _STEPPERMOTORPROFILER_
+#define _STEPPERMOTORPROFILER_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/MotorStepCommandMsg_C.h"
+#include "cMsgCInterface/StepperMotorMsg_C.h"
+#include "cMsgCInterface/PrescribedMotionMsg_C.h"
+#include "cMsgCInterface/HingedRigidBodyMsg_C.h"
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+    /* User-configured parameters (required) */
+    double rotAxis_M[3];                                   //!< Stepper motor rotation axis
+    double thetaInit;                                      //!< [rad] Initial motor angle
+    double stepAngle;                                      //!< [rad] Angle the stepper motor moves through for a single step
+    double stepTime;                                       //!< [s] Time required for a single motor step (constant)
+    double thetaDDotMax;                                   //!< [rad/s^2] Maximum angular acceleration of the stepper motor
+    double r_FM_M[3];                                      //!< [m] Position of the F frame origin with respect to the M frame origin in M frame components (fixed)
+    double rPrime_FM_M[3];                                 //!< [m/s] B frame time derivative of r_FM_M in M frame components (fixed)
+    double rPrimePrime_FM_M[3];                            //!< [m/s^2] B frame time derivative of rPrime_FM_M in M frame components (fixed)
+
+    /* Other prescribed parameters */
+    double sigma_FM[3];                                    //!< MRP attitude of frame F with respect to frame M
+    double omega_FM_F[3];                                  //!< [rad/s] Angular velocity of frame F wrt frame M in F frame components
+    double omegaPrime_FM_F[3];                             //!< [rad/s^2] B frame time derivative of omega_FM_F in F frame components
+
+    /* Step parameters */
+    int stepsCommanded;                                    //!< [steps] Number of commanded steps
+    int stepCount;                                         //!< [steps] Current motor step count (number of steps taken)
+
+    /* Motor angle parameters */
+    double maneuverThetaInit;                              //!< [rad] Initial motor angle
+    double intermediateThetaInit;                          //!< [rad] Motor angle at the start of a new maneuver
+    double theta;                                          //!< [rad] Current motor angle
+    double thetaDotInit;                                   //!< [rad/s] Initial motor angle rate
+    double thetaDot;                                       //!< [rad/s] Current motor angle rate
+    double thetaDDot;                                      //!< [rad/s^2] Current motor angular acceleration
+    double intermediateThetaRef;                           //!< [rad] Motor angle at the end of each step
+    double thetaDotRef;                                    //!< [rad/s] Reference angle rate
+
+    /* Temporal parameters */
+    double tInit;                                          //!< [s] Simulation time at the beginning of the maneuver
+    double previousWrittenTime;                            //!< [ns] Time the last input message was written
+    double ts;                                             //!< [s] The simulation time halfway through the maneuver (switch time for ang accel)
+    double tf;                                             //!< [s] Simulation time when the maneuver is finished
+
+    /* Boolean parameters */
+    bool completion;                                       //!< Boolean designating a fully completed maneuver
+    bool stepComplete;                                     //!< Boolean designating a completed step
+    bool newMsg;                                           //!< Boolean designating a new message was written
+
+    /* Constant parameters */
+    double a;                                              //!< Parabolic constant for the first half of a step
+    double b;                                              //!< Parabolic constant for the second half of a step
+
+    BSKLogger *bskLogger;                                  //!< BSK Logging
+
+    /* Messages */
+    MotorStepCommandMsg_C motorStepCommandInMsg;           //!< Input msg for the number of commanded motor step counts
+    StepperMotorMsg_C stepperMotorOutMsg;                  //!< Output msg for the stepper motor information
+    HingedRigidBodyMsg_C hingedRigidBodyOutMsg;            //!< Output msg for the spinning body module
+    PrescribedMotionMsg_C prescribedMotionOutMsg;          //!< Output msg for the spinning body prescribed states
+
+}StepperMotorProfilerConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void SelfInit_stepperMotorProfiler(StepperMotorProfilerConfig *configData, int64_t moduleID);                     //!< Method for module initialization
+    void Reset_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_t callTime, int64_t moduleID);     //!< Method for module reset
+    void Update_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_t callTime, int64_t moduleID);    //!< Method for module time update
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.i
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.i
@@ -1,0 +1,39 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module stepperMotorProfiler
+%{
+   #include "stepperMotorProfiler.h"
+%}
+
+%include "swig_c_wrap.i"
+%c_wrap_2(stepperMotorProfiler, StepperMotorProfilerConfig);
+
+%include "architecture/msgPayloadDefC/MotorStepCommandMsgPayload.h"
+struct MotorStepCommandMsg_C;
+%include "architecture/msgPayloadDefC/StepperMotorMsgPayload.h"
+struct StepperMotorMsg_C;
+%include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
+struct HingedRigidBodyMsg_C;
+%include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
+struct PrescribedMotionMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** by commit
* **Merge strategy:** merge (no squash)

## Description
This stepper motor profiler module actuates a stepper motor from an initial angle to a final reference angle, given an input integer number of commanded steps contained in a `motorStepCommand` input message. The motor states are profiled for each step using a bang-bang constant positive, constant negative acceleration profile. The motor acceleration is determined from the given constant step angle and constant step time.

## Verification
There are two unit tests included in this PR. The first tests the module for both positive and negative steps. The second test script is an integrated test with the `stepperMotorController` module, where module is checked to work correctly for new messages that interrupt the motor actuation.

## Documentation
No documentation is added currently.

## Future work
Documentation for this module will be added in the future.
