### PR TITLE
Add capability to thrForceMapping for 3-axis attitude control with DV thrusters

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.c
@@ -180,8 +180,8 @@ void Update_thrForceMapping(thrForceMappingConfig *configData, uint64_t callTime
     {
         substractMin(F, configData->numThrusters);
     }
-    
-    if (configData->thrForceSign<0 || configData->use2ndLoop)
+
+    if ((configData->thrForceSign<0 && configData->numControlAxes<3) || configData->use2ndLoop)
     {
         counterPosForces = 0;
         memset(thrusterUsed,0x0,MAX_EFF_CNT*sizeof(int));


### PR DESCRIPTION
* **Tickets addressed:** No ticket
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The thrForceMapping module implicitly assumes that DV thrusters can only control attitude around 2 axes by always performing a second loop to determine the thrust forces. However, this second loop is designed for partial controllability. This issue was fixed by calling the second loop if the DV thrusters only have partial controllability.

## Verification
The corresponding UnitTests still pass. However, the UnitTest should be updated (see Future Work).

## Documentation
Part of the documentation is invalidated and will be updated in the future

## Future work
The UnitTests and Documentation will be updated in the future to reflect the change to this module.
