### PR TITLE
Feature/450 flyby reference configure

### DIFF
--- a/examples/scenarioFlybyPoint.py
+++ b/examples/scenarioFlybyPoint.py
@@ -190,10 +190,11 @@ def run(show_plots, zeroEarthGravity, dtFilterData):
     flybyGuid = flybyPoint.FlybyPoint()
     flybyGuid.ModelTag = "flybyPoint"
     flybyGuid.dtFilterData = dtFilterData
+    flybyGuid.signOfOrbitNormalFrameVector = -1
     scSim.AddModelToTask(simTaskName, flybyGuid)
 
     cameraAxis_B = np.array([0, 1, 0])
-    outOfPlaneAxis_B = np.array([1, 0, 0])
+    outOfPlaneAxis_B = np.array([flybyGuid.signOfOrbitNormalFrameVector, 0, 0])
     crossProductAxis_B = np.cross(cameraAxis_B, outOfPlaneAxis_B)
     R0R = np.array([-cameraAxis_B,
                     crossProductAxis_B,
@@ -300,6 +301,9 @@ def run(show_plots, zeroEarthGravity, dtFilterData):
     for i in range(len(dataPos)):
         ur = dataPos[i] / np.linalg.norm(dataPos[i])
         uh = np.cross(dataPos[i], dataVel[i]) / np.linalg.norm(np.cross(dataPos[i], dataVel[i]))
+        ut = np.cross(uh, ur)
+        if flybyGuid.signOfOrbitNormalFrameVector == -1:
+            uh = np.cross(ut, ur)
         BN = rbk.MRP2C(att[i])
         NB = BN.transpose()
         cameraAxis_N.append(np.matmul(NB, cameraAxis_B))

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.cpp
@@ -130,7 +130,7 @@ void FlybyPoint::UpdateState(uint64_t CurrentSimNanos)
     /*! compute rotation angle of reference frame from last read time */
     double theta;
     if (this->singularityFlag == nonSingular) {
-        theta = atan(tan(this->gamma0) + this->f0 / cos(this->gamma0) * dt) - this->gamma0;
+        theta = atan(tan(this->gamma0) +this->f0 / cos(this->gamma0) * dt) - this->gamma0;
     }
     else {
         theta = 0;
@@ -154,6 +154,10 @@ void FlybyPoint::UpdateState(uint64_t CurrentSimNanos)
 
     /*! populate attRefOut with reference frame information */
     C2MRP(RtN, attMsgBuffer.sigma_RN);
+    if (this->signOfOrbitNormalFrameVector == -1) {
+        double halfRotationX[3] = {1, 0, 0};
+        addMRP(attMsgBuffer.sigma_RN, halfRotationX, attMsgBuffer.sigma_RN);
+    }
     m33tMultV3(RtN, omega_RN_R, attMsgBuffer.omega_RN_N);
     m33tMultV3(RtN, omegaDot_RN_R, attMsgBuffer.domega_RN_N);
 

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.h
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.h
@@ -52,6 +52,7 @@ public:
     
     double     dtFilterData = 0;       //!< time between two subsequent reads of the filter information
     double     epsilon = 0;            //!< tolerance for singular conditions when position and velocity are collinear
+    int64_t    signOfOrbitNormalFrameVector = 1;  //!< Sign of orbit normal vector to complete reference frame
     FlybyModel flybyModel;             //!< flag to indicate which flyby model is being used
 
     ReadFunctor<NavTransMsgPayload>  filterInMsg;               //!< input msg relative position w.r.t. asteroid

--- a/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.rst
+++ b/src/fswAlgorithms/attGuidance/flybyPoint/flybyPoint.rst
@@ -62,6 +62,7 @@ The required module configuration is::
     flybyGuid = flybyPoint.FlybyPoint()
     flybyWrap.ModelTag = "flybyPoint"
     flybyGuid.dtFilterData = 60
+    flybyGuid.signOfOrbitNormalFrameVector = 1
     unitTestSim.AddModelToTask(unitTaskName, flybyGuid)
 	
 The module is configurable with the following parameters:
@@ -76,6 +77,9 @@ The module is configurable with the following parameters:
    * - ``dtFilterData``
      - 0
      - time between two consecutive filter reads. If defaulted to zero, the filter information is read at every update call
+   * - ``signOfOrbitNormalFrameVector``
+     - 1
+     - Sign of the orbit normal rxv vector used to build the frame. If equal to 1, the frame is a traditional Hill frame if -1, it flips the orbit normal axis to point "down" relative to the orbtial momentum
    * - ``flybyModel``
      - 0
      - 0 for rectilinear flyby model, 1 for Clohessy-Wiltshire model


### PR DESCRIPTION
* **Tickets addressed:** bsk-450
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
Add a variable to switch the sign of the reference frame orbit normal component for the flyby guidance modules.

## Verification
Unit test still passes with the previous setup, and passes with the new expected component. 

## Documentation
Documentation was updated

## Future work
None
