### PR TITLE
dvExecuteGuidance module burn time fix

### DIFF
--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/_UnitTest/test_dvExecuteGuidance.py
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/_UnitTest/test_dvExecuteGuidance.py
@@ -86,6 +86,7 @@ def dvExecuteGuidanceTestFunction(show_plots, p1_dv, p2_tmin, p3_tmax):
     unitTestSim.AddModelToTask(unitTaskName, module)
 
     # Initialize the test module configuration data
+    module.defaultControlPeriod = updateRate
     module.minTime = p2_tmin
     module.maxTime = p3_tmax
 
@@ -137,8 +138,8 @@ def dvExecuteGuidanceTestFunction(show_plots, p1_dv, p2_tmin, p3_tmax):
         unitTestSim.ExecuteSimulation()
 
         if (np.linalg.norm(navTransMsgData.vehAccumDV) >= np.linalg.norm(dvBurnCmdMsgData.dvInrtlCmd)) and \
-                (updateRate * i > module.minTime) or \
-                (module.maxTime != 0.0 and updateRate * i > module.maxTime):
+                (updateRate * (i+1) > module.minTime) or \
+                (module.maxTime != 0.0 and updateRate * (i+1) > module.maxTime):
             onTimeTrue[i] = np.zeros(numThrusters)
             burnExecutingTrue[i] = 0
             burnCompleteTrue[i] = 1

--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.h
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.h
@@ -43,6 +43,7 @@ typedef struct {
     uint64_t prevCallTime;   /*!< [-] Call time register for computing total burn time*/
     double minTime;           /*!< [s] Minimum count of burn time allowed to elapse*/
     double maxTime;           /*!< [s] Maximum count of burn time allowed to elapse*/
+    double defaultControlPeriod; /*!< [s] Default control period used for first call*/
 
     BSKLogger *bskLogger;   //!< BSK Logging
 }dvExecuteGuidanceConfig;

--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.rst
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.rst
@@ -9,6 +9,8 @@ thrusters are only turned off once the desired Delta-V has been accumulated and 
 specified minimum time (defaults to 0.0 seconds), unless the burn time exceeds the maximum time. If the burn time is
 greater than the maximum time, the thrusters are turned off regardless of the accumulated Delta-V. If no maximum time
 is specified, the burn is only stopped using the accumulated Delta-V criteria.
+The user should specify the flight software time step (control period) using the defaultControlPeriod parameter.
+Otherwise the burn time is not accurately computed.
 
 If the same set of DV thrusters is also used for attitude control (with the :ref:`thrForceMapping`,
 :ref:`thrFiringRemainder` or :ref:`thrFiringSchmitt` modules and the baseThrustState in the corresponding modules
@@ -53,6 +55,7 @@ The module is first initialized as follows:
     moduleConfig = dvExecuteGuidance.dvExecuteGuidanceConfig()
     moduleWrap = unitTestSim.setModelDataWrap(moduleConfig)
     moduleWrap.ModelTag = "dvExecuteGuidance"
+    moduleConfig.defaultControlPeriod = 0.5
     moduleConfig.minTime = 2.0
     moduleConfig.maxTime = 10.0
     unitTestSim.AddModelToTask(unitTaskName, moduleWrap, moduleConfig)


### PR DESCRIPTION
* **Tickets addressed:** none
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The burn time was inaccurately computed if the burn does not start at t=0. The cause of this issue is that the fsw time step (the control period) is not known the first time the module is called. The issue is solved by using a user-specified defaultControlPeriod that is used for the first time step.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
The UnitTest passes after updating it.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
The documentation was updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The way the burn time is computed will likely be restructured in the near future. A change to the dvGuidance module for attitude control is also expected, to make the two modules work better together.