### PR TITLE
Increase number css measurements csswls

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -87,6 +87,7 @@ Version |release|
   prior versions of Xcode.
 - Fixed a bug in the conanfile where the ``stderr`` output from a ``subprocess.Popen`` call was being interpreted as an
   error. Rather, the process return code (0 for success, and anything else for failure) indicates the success.
+- The MAX_N_CSS_MEAS define is increased to 32 so that it matches the allowed maximum number of coarse sun sensors.
 
 Version 2.2.0 (June 28, 2023)
 -----------------------------

--- a/src/architecture/msgPayloadDefC/SunlineFilterMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/SunlineFilterMsgPayload.h
@@ -25,7 +25,7 @@
 #define SKF_N_STATES_SWITCH 6
 #define EKF_N_STATES_SWITCH 5
 #define SKF_N_STATES_HALF 3
-#define MAX_N_CSS_MEAS 8
+#define MAX_N_CSS_MEAS 32
 
 /*! @brief structure for filter-states output for the unscented kalman filter
  implementation of the sunline state estimator*/


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
The `#MAX_N_CSS_MEAS` define is set to 8. The `cssWls` module calls a `memset` ☹️ on line 90 in `computeWlsResiduals`, which computes the size of memory to set to 0x0 from the number of coarse sun sensors. The residuals variable which is being set has a size of 8 x `double`. If one has more than 8 coarse sun sensors then the `memset` will stomp more than 8 x 'double' amount of memory. We along with many other spacecraft have more than 8 CSS sensors and therefore the filter will expect to compute more than 8 measurement residuals. This commit changes the max number of measurements to be the same value as the max number of CSS. (Maybe they should both use the same `define`. I'm not sure.)

## Verification
CI runs successfully.

## Documentation
NA

## Future work
NA
