### PR TITLE
Refactor/161 one axis solar array point singularity patch

### DIFF
--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
@@ -418,7 +418,7 @@ void oasapComputeThirdRotation(int alignmentPriority, double hRefHat_B[3], doubl
 }
 
 /*! This helper function computes the final rotation as a product of the first three DCMs */
-void oasapComputeFinalRotation(CelestialBody celestialBody, int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3])
+void oasapComputeFinalRotation(CelestialBody celestialBody, AlignmentPriority alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3])
 {
     /*! compute the first rotation DCM */
     double R1B[3][3];

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -99,7 +99,7 @@ extern "C" {
     void oasapComputeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3]);
     void oasapComputeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3], RefFrameSolution *refFrameSolution);
     void oasapComputeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3]);
-    void oasapComputeFinalRotation(CelestialBody celestialBody, int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
+    void oasapComputeFinalRotation(CelestialBody celestialBody, AlignmentPriority alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
 
 #ifdef __cplusplus
 }

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -29,6 +29,10 @@
 #include "cMsgCInterface/EphemerisMsg_C.h"
 #include "cMsgCInterface/NavAttMsg_C.h"
 
+typedef enum celestialBody{
+    notSun = 0,
+    Sun = 1
+} CelestialBody;
 
 typedef enum alignmentPriority{
     prioritizeAxisAlignment = 0,
@@ -63,6 +67,7 @@ typedef struct {
     double h2Hat_B[3];                           //!< secondary heading in B frame coordinates
     double hHat_N[3];                            //!< main heading in N frame coordinates
     double a2Hat_B[3];                           //!< body frame heading that should remain as close as possible to Sun heading
+    CelestialBody celestialBodyInput;
 
     /*! declare these internal variables that are used by the module and should not be declared by the user */
     BodyAxisInput      bodyAxisInput;            //!< flag variable to determine how the body axis input is specified
@@ -94,7 +99,7 @@ extern "C" {
     void oasapComputeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3]);
     void oasapComputeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3], RefFrameSolution *refFrameSolution);
     void oasapComputeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3]);
-    void oasapComputeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
+    void oasapComputeFinalRotation(CelestialBody celestialBody, int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
 
 #ifdef __cplusplus
 }

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.rst
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.rst
@@ -90,3 +90,6 @@ The module is configurable with the following parameters:
    * - ``h2Hat_B`` (optional)
      - [0, 0, 0]
      - second body-frame heading
+   * - ``celestialBodyInput`` (optional)
+     - 0
+     - should be set to 1 when the celestial body pointed at is the Sun.


### PR DESCRIPTION
* **Tickets addressed:** bsk-161
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
A module variable is added to bypass the routine where the singularity arises when the celestial body is the Sun. This is done in Commit 1. Commit 2 changes some variable definitions in the module functions for consistency. Documentation is updated in Commit 3.

## Verification
Change in functionality does not affect the UnitTest

## Documentation
Documentation is updated to reflect the changes

## Future work
This problem might still arise during conjunctions scenarios where the inertial requested direction coincides with the Sun direction. Further analysis is required to better characterize the tolerance of zero within the module and / or provide a more robust solution for these scenarios.
