### PR TITLE
Update the solar array dispersions

### DIFF
--- a/src/utilities/MonteCarlo/Dispersions.py
+++ b/src/utilities/MonteCarlo/Dispersions.py
@@ -673,24 +673,42 @@ class MRPDispersionPerAxis(VectorVariableDispersion):
         return dispMRP
 
 
-class SymmetricSolarArrayDispersion():
-    def __init__(self, angle1Dyn_str, angle2Dyn_str, angle1Controller_str, angle2Controller_str, angle1Profiler_str,
-                 angle2Profiler_str, bounds=None):
+class SymmetricSolarArrayAnglesDispersion():
+    def __init__(self,
+                 angle1Dyn_str,
+                 angle2Dyn_str,
+                 angle1RefDyn_str,
+                 angle2RefDyn_str,
+                 angle1ControllerInit_str,
+                 angle2ControllerInit_str,
+                 angle1ControllerCurr_str,
+                 angle2ControllerCurr_str,
+                 angle1Profiler_str,
+                 angle2Profiler_str,
+                 bounds=None):
         self.angle1Dyn_str = angle1Dyn_str
         self.angle2Dyn_str = angle2Dyn_str
-        self.angle1Controller_str = angle1Controller_str
-        self.angle2Controller_str = angle2Controller_str
+        self.angle1RefDyn_str = angle1RefDyn_str
+        self.angle2RefDyn_str = angle2RefDyn_str
+        self.angle1ControllerInit_str = angle1ControllerInit_str
+        self.angle2ControllerInit_str = angle2ControllerInit_str
+        self.angle1ControllerCurr_str = angle1ControllerCurr_str
+        self.angle2ControllerCurr_str = angle2ControllerCurr_str
         self.angle1Profiler_str = angle1Profiler_str
         self.angle2Profiler_str = angle2Profiler_str
         self.bounds = bounds
-        self.numberOfSubDisps = 6
+        self.numberOfSubDisps = 10
 
     def generate(self, sim=None):
         dispValue = random.uniform(self.bounds[0], self.bounds[1])
         self.angle1Dyn_val = dispValue
         self.angle2Dyn_val = -dispValue
-        self.angle1Controller_val = dispValue
-        self.angle2Controller_val = -dispValue
+        self.angle1RefDyn_val = dispValue
+        self.angle2RefDyn_val = -dispValue
+        self.angle1ControllerInit_val = dispValue
+        self.angle2ControllerInit_val = -dispValue
+        self.angle1ControllerCurr_val = dispValue
+        self.angle2ControllerCurr_val = -dispValue
         self.angle1Profiler_val = dispValue
         self.angle2Profiler_val = -dispValue
 
@@ -700,12 +718,20 @@ class SymmetricSolarArrayDispersion():
         if index == 2:
             nextValue = self.angle2Dyn_val
         if index == 3:
-            nextValue = self.angle1Controller_val
+            nextValue = self.angle1RefDyn_val
         if index == 4:
-            nextValue = self.angle2Controller_val
+            nextValue = self.angle2RefDyn_val
         if index == 5:
-            nextValue = self.angle1Profiler_val
+            nextValue = self.angle1ControllerInit_val
         if index == 6:
+            nextValue = self.angle2ControllerInit_val
+        if index == 7:
+            nextValue = self.angle1ControllerCurr_val
+        if index == 8:
+            nextValue = self.angle2ControllerCurr_val
+        if index == 9:
+            nextValue = self.angle1Profiler_val
+        if index == 10:
             nextValue = self.angle2Profiler_val
         val = str(nextValue)
         return val
@@ -716,36 +742,64 @@ class SymmetricSolarArrayDispersion():
         if index == 2:
             return self.angle2Dyn_str
         if index == 3:
-            return self.angle1Controller_str
+            return self.angle1RefDyn_str
         if index == 4:
-            return self.angle2Controller_str
+            return self.angle2RefDyn_str
         if index == 5:
-            return self.angle1Profiler_str
+            return self.angle1ControllerInit_str
         if index == 6:
+            return self.angle2ControllerInit_str
+        if index == 7:
+            return self.angle1ControllerCurr_str
+        if index == 8:
+            return self.angle2ControllerCurr_str
+        if index == 9:
+            return self.angle1Profiler_str
+        if index == 10:
             return self.angle2Profiler_str
 
 
-class SymmetricSolarArrayWithReferenceDispersion():
-    def __init__(self, angle1Dyn_str, angle2Dyn_str, angle1Controller_str, angle2Controller_str, angle1Profiler_str,
-                 angle2Profiler_str, refAngle1_str, refAngle2_str, bounds=None):
+class SymmetricSolarArrayAnglesWithReferenceDispersion():
+    def __init__(self,
+                 angle1Dyn_str,
+                 angle2Dyn_str,
+                 angle1RefDyn_str,
+                 angle2RefDyn_str,
+                 angle1ControllerInit_str,
+                 angle2ControllerInit_str,
+                 angle1ControllerCurr_str,
+                 angle2ControllerCurr_str,
+                 angle1Profiler_str,
+                 angle2Profiler_str,
+                 refAngle1_str,
+                 refAngle2_str,
+                 bounds=None):
         self.angle1Dyn_str = angle1Dyn_str
         self.angle2Dyn_str = angle2Dyn_str
-        self.angle1Controller_str = angle1Controller_str
-        self.angle2Controller_str = angle2Controller_str
+        self.angle1RefDyn_str = angle1RefDyn_str
+        self.angle2RefDyn_str = angle2RefDyn_str
+        self.angle1ControllerInit_str = angle1ControllerInit_str
+        self.angle2ControllerInit_str = angle2ControllerInit_str
+        self.angle1ControllerCurr_str = angle1ControllerCurr_str
+        self.angle2ControllerCurr_str = angle2ControllerCurr_str
         self.angle1Profiler_str = angle1Profiler_str
         self.angle2Profiler_str = angle2Profiler_str
         self.refAngle1_str = refAngle1_str
         self.refAngle2_str = refAngle2_str
         self.bounds = bounds
-        self.numberOfSubDisps = 8
+        self.numberOfSubDisps = 12
 
     def generate(self, sim=None):
         dispValue = random.uniform(self.bounds[0], self.bounds[1])
 
         self.angle1Dyn_val = dispValue
         self.angle2Dyn_val = -dispValue
-        self.angle1Controller_val = dispValue
-        self.angle2Controller_val = -dispValue
+        self.angle1RefDyn_val = dispValue
+        self.angle2RefDyn_val = -dispValue
+        self.angle1ControllerInit_val = dispValue
+        self.angle2ControllerInit_val = -dispValue
+        self.angle1ControllerCurr_val = dispValue
+        self.angle2ControllerCurr_val = -dispValue
         self.angle1Profiler_val = dispValue
         self.angle2Profiler_val = -dispValue
         self.refAngle1_val = dispValue
@@ -757,16 +811,24 @@ class SymmetricSolarArrayWithReferenceDispersion():
         if index == 2:
             nextValue = self.angle2Dyn_val
         if index == 3:
-            nextValue = self.angle1Controller_val
+            nextValue = self.angle1RefDyn_val
         if index == 4:
-            nextValue = self.angle2Controller_val
+            nextValue = self.angle2RefDyn_val
         if index == 5:
-            nextValue = self.angle1Profiler_val
+            nextValue = self.angle1ControllerInit_val
         if index == 6:
-            nextValue = self.angle2Profiler_val
+            nextValue = self.angle2ControllerInit_val
         if index == 7:
-            nextValue = self.refAngle1_val
+            nextValue = self.angle1ControllerCurr_val
         if index == 8:
+            nextValue = self.angle2ControllerCurr_val
+        if index == 9:
+            nextValue = self.angle1Profiler_val
+        if index == 10:
+            nextValue = self.angle2Profiler_val
+        if index == 11:
+            nextValue = self.refAngle1_val
+        if index == 12:
             nextValue = self.refAngle2_val
         val = str(nextValue)
         return val
@@ -777,14 +839,51 @@ class SymmetricSolarArrayWithReferenceDispersion():
         if index == 2:
             return self.angle2Dyn_str
         if index == 3:
-            return self.angle1Controller_str
+            return self.angle1RefDyn_str
         if index == 4:
-            return self.angle2Controller_str
+            return self.angle2RefDyn_str
         if index == 5:
-            return self.angle1Profiler_str
+            return self.angle1ControllerInit_str
         if index == 6:
-            return self.angle2Profiler_str
+            return self.angle2ControllerInit_str
         if index == 7:
-            return self.refAngle1_str
+            return self.angle1ControllerCurr_str
         if index == 8:
+            return self.angle2ControllerCurr_str
+        if index == 9:
+            return self.angle1Profiler_str
+        if index == 10:
+            return self.angle2Profiler_str
+        if index == 11:
+            return self.refAngle1_str
+        if index == 12:
             return self.refAngle2_str
+
+class SymmetricSolarArrayReferenceDispersion():
+    def __init__(self,
+                 angle1Ref_str,
+                 angle2Ref_str,
+                 bounds=None):
+        self.angle1Ref_str = angle1Ref_str
+        self.angle2Ref_str = angle2Ref_str
+        self.bounds = bounds
+        self.numberOfSubDisps = 2
+
+    def generate(self, sim=None):
+        dispValue = random.uniform(self.bounds[0], self.bounds[1])
+        self.angle1Ref_val = dispValue
+        self.angle2Ref_val = -dispValue
+
+    def generateString(self, index, sim=None):
+        if index == 1:
+            nextValue = self.angle1Ref_val
+        if index == 2:
+            nextValue = self.angle2Ref_val
+        val = str(nextValue)
+        return val
+
+    def getName(self, index):
+        if index == 1:
+            return self.angle1Ref_str
+        if index == 2:
+            return self.angle2Ref_str


### PR DESCRIPTION
* **Tickets addressed:**
* **Review:** By commit  
* **Merge strategy:** squash and merge

## Description
The old dispersion functions are updated to include four required angles that were left out in the first PR. A new dispersion is also added for the solar array reference angles. NOTE: The private variable `theta1Ref` in the `spinningBodiesTwoDOF` module must be public to use the solar array dispersions!!

## Verification
N/A

## Documentation
N/A

## Future work
N/A