### PR TITLE
Feature/486 update dv guidance

### DIFF
--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.c
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.c
@@ -123,7 +123,7 @@ void Update_dvExecuteGuidance(dvExecuteGuidanceConfig *configData, uint64_t call
     configData->burnComplete |= (configData->maxTime != 0.0 && configData->burnTime > configData->maxTime);
     configData->burnExecuting = configData->burnComplete != 1 && configData->burnExecuting == 1;
 
-    if(configData->burnComplete)
+    if(configData->burnComplete || configData->burnExecuting != 1)
     {
         effCmd = THRArrayOnTimeCmdMsg_C_zeroMsgPayload();
         THRArrayOnTimeCmdMsg_C_write(&effCmd, &configData->thrCmdOutMsg, moduleID, callTime);

--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.rst
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.rst
@@ -2,13 +2,15 @@ Executive Summary
 -----------------
 
 This module compares the magnitude of the accumulated Delta-V from the :ref:`NavTransMsgPayload` message with the
-desired Delta-V magnitude of the burn maneuver from the :ref:`DvBurnCmdMsgPayload` message. The module assumes that the
-thrusters have been turned on by another module (such as :ref:`thrFiringRemainder`, for example), and turns the
-thrusters off once the desired Delta-V has been accumulated. A minimum and maximum time can also be specified. The
-thrusters are only turned off once the desired Delta-V has been accumulated and the burn time is greater than the
-specified minimum time (defaults to 0.0 seconds), unless the burn time exceeds the maximum time. If the burn time is
-greater than the maximum time, the thrusters are turned off regardless of the accumulated Delta-V. If no maximum time
-is specified, the burn is only stopped using the accumulated Delta-V criteria.
+desired Delta-V magnitude of the burn maneuver from the :ref:`DvBurnCmdMsgPayload` message. If the burn start time as
+specified in the :ref:`DvBurnCmdMsgPayload` message has not been reached yet, the module prevents the thrusters from
+firing.
+The module assumes that the thrusters have been turned on by another module (such as :ref:`thrFiringRemainder`,
+for example), and turns the thrusters off once the desired Delta-V has been accumulated. A minimum and maximum time can
+also be specified. The thrusters are only turned off once the desired Delta-V has been accumulated and the burn time is
+greater than the specified minimum time (defaults to 0.0 seconds), unless the burn time exceeds the maximum time. If the
+burn time is greater than the maximum time, the thrusters are turned off regardless of the accumulated Delta-V. If
+nomaximum time is specified, the burn is only stopped using the accumulated Delta-V criteria.
 The user should specify the flight software time step (control period) using the defaultControlPeriod parameter.
 Otherwise the burn time is not accurately computed.
 


### PR DESCRIPTION
* **Tickets addressed:** MAXGNC-486
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The burnStartTime field of the DvBurnCmd message specifies at which time the DV-burn should start. However, this was ignored by the dvExecuteGuidance module, and the burn was started as soon as the module task is activated. This fix prevents the thrusters from firing until the burnStartTime has been reached.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
The UnitTest was updated.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
The documentation was updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
