### PR TITLE
Fix docker container build fail dockerfile path

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -40,8 +40,8 @@ RUN python -m pip install conan==1.61.0 pandas parse matplotlib numpy Pillow pyt
 ENV CONAN_REVISIONS_ENABLED=1
 ENV PYTHONUNBUFFERED=1
 RUN conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan
-RUN conan install . --build=missing -s build_type=Release -if dist3/conan \
-    -o opNav=True \
+RUN conan install . --build=missing -s build_type=Debug -if dist3/conan \
+    -o opNav=False \
     -o vizInterface=False \
     -o generator="Ninja"
 

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -43,7 +43,7 @@ RUN conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/co
 RUN conan install . --build=missing -s build_type=Release -if dist3/conan \
     -o opNav=True \
     -o vizInterface=False \
-    -o generator="Ninja" \
+    -o generator="Ninja"
 
 # RUN python conanfile.py --buildType Release --opNav True --vizInterface False --autoKey u
 RUN conan build . -if dist3/conan

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -57,7 +57,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.components.image }}
 
       - name: Build and push ${{ matrix.components.image }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.components.context }}
           file: ${{ matrix.components.file }}

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to ${{ env.REGISTRY }}
         uses: docker/login-action@v2

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -30,7 +30,6 @@ jobs:
       matrix:
         components:
           - image: lasp-basilisk
-            context: lasp-basilisk
             file: .github/workflows/Dockerfile
 
     name: ${{ matrix.components.image }}
@@ -59,7 +58,6 @@ jobs:
       - name: Build and push ${{ matrix.components.image }}
         uses: docker/build-push-action@v5
         with:
-          context: ${{ matrix.components.context }}
           file: ${{ matrix.components.file }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -3,7 +3,7 @@ name: "Publish Develop Basilisk"
 on:
   push:
     branches:
-      - develop
+      - ci/docker-container-build-fail-dockerfile-path
     tags:
       - v*
 

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -57,7 +57,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          file: Dockerfile
+          file: .github/workflows/Dockerfile
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -11,55 +11,106 @@ env:
   REGISTRY: ghcr.io
   OWNER: lasp
   IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  REGISTRY_IMAGE: "lasp-basilisk"
 
 jobs:
-  init:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-
-  containers:
-    runs-on: ubuntu-latest
-    needs: init
-    permissions:
-      contents: read
-      packages: write
     strategy:
+      fail-fast: false
       matrix:
-        components:
-          - image: lasp-basilisk
-            file: .github/workflows/Dockerfile
-
-    name: ${{ matrix.components.image }}
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
-
-      - name: Set up Docker Buildx
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to ${{ env.REGISTRY }}
+      -
+        name: Login to ${{ env.REGISTRY }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
-
-      - name: Extract metadata (tags, labels) for ${{ matrix.components.image }}
-        id: metadata-step
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.components.image }}
-
-      - name: Build and push ${{ matrix.components.image }}
+      -
+        name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
-          file: ${{ matrix.components.file }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.metadata-step.outputs.tags }}
-          labels: ${{ steps.metadata-step.outputs.labels }}
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Login to ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -11,7 +11,7 @@ env:
   REGISTRY: ghcr.io
   OWNER: lasp
   IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  REGISTRY_IMAGE: "lasp-basilisk"
+  REGISTRY_IMAGE: "basilisk"
 
 jobs:
   build:
@@ -21,8 +21,6 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm/v6
-          - linux/arm/v7
           - linux/arm64
     steps:
       -
@@ -38,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REGISTRY_IMAGE }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -97,7 +95,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.REGISTRY_IMAGE }}
       -
         name: Login to ${{ env.REGISTRY }}
         uses: docker/login-action@v3

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -35,8 +35,6 @@ jobs:
 
     name: ${{ matrix.components.image }}
     steps:
-      - uses: actions/checkout@v3
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:

--- a/.github/workflows/build-publish-develop-image.yml
+++ b/.github/workflows/build-publish-develop-image.yml
@@ -57,6 +57,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
+          file: Dockerfile
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
The github workflow responsible for building a Basilisk development environment docker image is failing due to incorrect path to the dockerfile. Further the docker context was incorrect. This has been fixed with the context being left as the default context and the Dockerfile path being fixed as relative to the action file. Additionally, the qemu, buildx, docker login, and build and push actions are all updated to the latest versions.

## Verification
Workflow to run successfully.

## Documentation
NA

## Future work
Nona
