### PR TITLE
Pass sim instance to dispersion generate

### DIFF
--- a/src/utilities/MonteCarlo/Controller.py
+++ b/src/utilities/MonteCarlo/Controller.py
@@ -797,7 +797,7 @@ class SimulationExecutor:
                             magnitudes[name] = disp.generateMagString()
                 except TypeError:
                     # This accomodates dispersion variables that are co-dependent
-                    disp.generate()
+                    disp.generate(simInstance)
                     for i in range(1, disp.numberOfSubDisps+1):
                         name = disp.getName(i)
                         if name not in modifications:  # could be using a saved parameter.


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
To dispersion two variables with a correlated dispersion, the `simInstance` needs to be passed to the dispersion generate function.

## Verification
Test must pass

## Documentation
NA

## Future work
Correlated dispersion infrastructure needs a refactor.
