### PR TITLE
Feature/178 target point

### DIFF
--- a/src/fswAlgorithms/attGuidance/targetPoint/_UnitTest/test_targetPoint0.py
+++ b/src/fswAlgorithms/attGuidance/targetPoint/_UnitTest/test_targetPoint0.py
@@ -1,0 +1,218 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import pytest
+import os
+import inspect
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.fswAlgorithms import targetPoint
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+def computeGamma(alpha, delta):
+
+    if alpha >= 0 and alpha <= np.pi/2:
+        if delta < np.pi/2 - alpha:
+            gamma = np.pi/2 - alpha - delta
+        elif delta > alpha + np.pi/2:
+            gamma = - np.pi/2 - alpha + delta
+        else:
+            gamma = 0
+    else:
+        if delta < alpha - np.pi/2:
+            gamma = - np.pi/2 + alpha - delta 
+        elif delta > 3/2*np.pi - alpha:
+            gamma = alpha + delta - 3/2*np.pi
+        else:
+            gamma = 0
+
+    return gamma
+
+
+# The 'ang' array spans the interval from 0 to pi.  pi is excluded because
+# the code is less accurate around this point;
+ang = np.linspace(0, np.pi, 10, endpoint=False)
+ang = list(ang)
+
+
+@pytest.mark.parametrize("alpha", ang)
+@pytest.mark.parametrize("delta", ang)
+@pytest.mark.parametrize("alignmentPriority", [0])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_(show_plots, alpha, delta, alignmentPriority, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`targetPoint`.
+    The correctness of the output is determined based on whether the reference attitude causes the solar array drive
+    axis :math:`\hat{a}_1` to be at an angle :math:`\gamma` from the Sun direction :math:`\hat{r}_{S/B}`.
+
+    **Test Parameters**
+
+    This test generates an array ``ang`` of linearly-spaced points between 0 and :math:`\pi`. Values of
+    :math:`\alpha` and :math:`\delta` are drawn from all possible combinations of such linearly spaced values.
+    In the test, values of :math:`\alpha` and :math:`\delta` are used to set the angular distance between the vectors
+    :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`, and :math:`{}^\mathcal{B}\hat{h}_1`
+    and :math:`{}^\mathcal{B}\hat{a}_1`.
+
+    Args:
+        alpha (rad): angle between :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`
+        delta (rad): angle between :math:`{}^\mathcal{B}\hat{h}_1` and :math:`{}^\mathcal{B}\hat{a}_1`
+        alignmentPriority (int): 0 to prioritize body heading alignment and incidence on solar arrays.
+
+    **Description of Variables Being Tested**
+
+    The angle :math:`\gamma` is a function of the angles :math:`\alpha` and :math:`\delta`, where :math:`\alpha` is the
+    angle between the Sun direction :math:`{}^\mathcal{N}\hat{r}_{S/B}` and the relative celestial body direction,
+    whereas :math:`\delta` is the angle between the body-frame heading
+    :math:`{}^\mathcal{B}\hat{h}_1` and the solar array axis drive :math:`{}^\mathcal{B}\hat{a}_1`.
+    The angle :math:`\gamma` is computed from the output reference attitude and compared with the results of a
+    python function that computes the correct output based on the geometry of the problem. For a description of how
+    such correct result is obtained, see R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft
+    with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
+
+    **General Documentation Comments**
+
+    This unit test verifies the correctness of the generated reference attitude. It does not test the correctness of the
+    reference angular rates and accelerations contained in the ``attRefOutMsg``, because this would require to run the
+    module for multiple update calls. To ensure fast execution of the unit test, this is avoided.
+    """
+
+    gamma_true = computeGamma(alpha, delta)
+
+    rHat_SB_N = np.array([1, -2, 3])                            # Sun direction in inertial coordinates
+    rHat_SB_N = rHat_SB_N / np.linalg.norm(rHat_SB_N)
+    a1Hat_B = np.array([-9, 8, 7])                            # array axis direction in body frame
+    a1Hat_B = a1Hat_B / np.linalg.norm(a1Hat_B)
+
+    a = np.cross(rHat_SB_N, [4, 5, -6])
+    a = a / np.linalg.norm(a)
+    
+    d = np.cross(a1Hat_B, [6, -5, 4])
+    d = d / np.linalg.norm(d)
+    
+    DCM1 = rbk.PRV2C(a * alpha)
+    DCM2 = rbk.PRV2C(d * delta)
+
+    hHat_N = np.matmul(DCM1, rHat_SB_N)             # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+    hHat_B = np.matmul(DCM2, a1Hat_B)               # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    attGuid = targetPoint.TargetPoint()
+    attGuid.hRefHat_B = hHat_B
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.alignmentPriority = alignmentPriority
+    attGuid.ModelTag = "targetPoint"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, attGuid)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+
+    # Create input attitude navigation message
+    sigma_BN = np.array([0, 0, 0])
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rHat_SB_N)
+    NavAttMessageData = messaging.NavAttMsgPayload()     
+    NavAttMessageData.sigma_BN = sigma_BN
+    NavAttMessageData.vehSunPntBdy = rS_B
+    NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
+    attGuid.attNavInMsg.subscribeTo(NavAttMsg)
+
+    # Create input translation navigation msg
+    transNavData = messaging.NavTransMsgPayload()
+    transNavData.r_BN_N = [0, 0, 0]
+    transNavMsg = messaging.NavTransMsg().write(transNavData)
+    attGuid.transNavInMsg.subscribeTo(transNavMsg)
+
+    # Create input ephemeris msg
+    ephemerisData = messaging.EphemerisMsgPayload()
+    ephemerisData.r_BdyZero_N = hHat_N
+    ephemerisMsg = messaging.EphemerisMsg().write(ephemerisData)
+    attGuid.ephemerisInMsg.subscribeTo(ephemerisMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = attGuid.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    dataLogC = attGuid.attRefOutMsgC.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogC)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    moduleOutput = dataLog.sigma_RN
+    sigma_RN = moduleOutput[0]
+    RN = rbk.MRP2C(sigma_RN)
+    NR = RN.transpose()
+    a1Hat_N = np.matmul(NR, a1Hat_B)
+    gamma_sim = np.arcsin( abs( np.clip( np.dot(rHat_SB_N, a1Hat_N), -1, 1 ) ) )
+
+    # set the filtered output truth states
+    np.testing.assert_allclose(gamma_sim, gamma_true, rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(hHat_B, np.matmul(RN, hHat_N), rtol=0, atol=accuracy, verbose=True)
+
+    return
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_(
+                 False,
+                 0.62831,    # alpha
+                 0.79586,    # delta
+                 0,          # priorityFlag
+                 1e-12       # accuracy
+               )

--- a/src/fswAlgorithms/attGuidance/targetPoint/_UnitTest/test_targetPoint1.py
+++ b/src/fswAlgorithms/attGuidance/targetPoint/_UnitTest/test_targetPoint1.py
@@ -1,0 +1,194 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import pytest
+import os
+import inspect
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.fswAlgorithms import targetPoint
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+# The 'ang' array spans the interval from 0 to pi.  pi is excluded because
+# the code is less accurate around this point;
+ang = np.linspace(0, np.pi, 50, endpoint=False)
+ang = list(ang)
+
+
+@pytest.mark.parametrize("alpha", ang)
+@pytest.mark.parametrize("alignmentPriority", [1])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_(show_plots, alpha, alignmentPriority, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`sepPoint`.
+    The correctness of the output is determined based on whether the reference attitude causes the Sun-constrained
+    axis :math:`\hat{a}_2` to be within an angle :math:`\beta` from the Sun direction :math:`\hat{r}_{S/B}`.
+
+    **Test Parameters**
+
+    This test generates an array ``ang`` of linearly-spaced points between 0 and :math:`\pi`. Values of
+    :math:`\alpha` are drawn from all possible combinations of such linearly spaced values.
+    In the test, values of :math:`\alpha` are used to set the angular distance between the vectors
+    :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`.
+
+    Args:
+        alpha (rad): angle between :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`
+        alignmentPriority (int): 1 to prioritize body heading alignment and Sun-constrained body-frame axis.
+
+    **Description of Variables Being Tested**
+
+    In this unit test, the module computes a solution that is compliant with the keep-in condition on the
+    Sun-constrained body-frame axis. The correctness of the solution is assessed verifying whether the angle between
+    such axis and the Sun direction is smaller or equal than the maximum allowed value :math:`\beta`. Within the range
+    of admissible solutions, the module also chooses the one that maximizes the incidence of sunlight on the solar
+    arrays. See R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft
+    with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
+
+    **General Documentation Comments**
+
+    This module only tests the case :math:`\beta = \pi/2`, which is known to always have a compliant solution. When
+    :math:`\beta < \pi/2`, it is not in general possible to guarantee that the solution is compliant with the
+    requirements on the Sun-constrained direction, which makes testing difficult. The user can input smaller values for
+    :math:`\beta` to verify that it will cause some instantiations of the test to fail. This unit test verifies the
+    correctness of the generated reference attitude. It does not test the correctness of the reference angular rates
+    and accelerations contained in the ``attRefOutMsg``, because this would require to run the module for multiple
+    update calls. To ensure fast execution of the unit test, this is avoided.
+    """
+
+    rHat_SB_N = np.array([1, -2, 3])                            # Sun direction in inertial coordinates
+    rHat_SB_N = rHat_SB_N / np.linalg.norm(rHat_SB_N)
+
+    a = np.cross(rHat_SB_N, [4, 5, -6])
+    a = a / np.linalg.norm(a)
+
+    DCM1 = rbk.PRV2C(a * alpha)
+
+    hHat_N = np.matmul(DCM1, rHat_SB_N)             # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+
+    hHat_B  = [0, 0, 1]
+    a1Hat_B = [1, 0, 0]
+    a2Hat_B = [0, 1, 0]
+    beta = np.pi/2
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    attGuid = targetPoint.TargetPoint()
+    attGuid.hRefHat_B = hHat_B
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.a2Hat_B = a2Hat_B
+    attGuid.beta = beta
+    attGuid.alignmentPriority = alignmentPriority
+    attGuid.ModelTag = "targetPoint"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, attGuid)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+
+    # Create input attitude navigation message
+    sigma_BN = np.array([0, 0, 0])
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rHat_SB_N)
+    NavAttMessageData = messaging.NavAttMsgPayload()     
+    NavAttMessageData.sigma_BN = sigma_BN
+    NavAttMessageData.vehSunPntBdy = rS_B
+    NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
+    attGuid.attNavInMsg.subscribeTo(NavAttMsg)
+
+    # Create input translation navigation msg
+    transNavData = messaging.NavTransMsgPayload()
+    transNavData.r_BN_N = [0, 0, 0]
+    transNavMsg = messaging.NavTransMsg().write(transNavData)
+    attGuid.transNavInMsg.subscribeTo(transNavMsg)
+
+    # Create input ephemeris msg
+    ephemerisData = messaging.EphemerisMsgPayload()
+    ephemerisData.r_BdyZero_N = hHat_N
+    ephemerisMsg = messaging.EphemerisMsg().write(ephemerisData)
+    attGuid.ephemerisInMsg.subscribeTo(ephemerisMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = attGuid.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    dataLogC = attGuid.attRefOutMsgC.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogC)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    moduleOutput = dataLog.sigma_RN
+    sigma_RN = moduleOutput[0]
+    RN = rbk.MRP2C(sigma_RN)
+    NR = RN.transpose()
+    a1Hat_N = np.matmul(NR, a1Hat_B)
+    gamma_sim = np.arcsin( abs( np.clip( np.dot(rHat_SB_N, a1Hat_N), -1, 1 ) ) )
+
+    # set the filtered output truth states
+    np.testing.assert_allclose(hHat_B, np.matmul(RN, hHat_N), rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_array_less(np.cos(beta), np.dot(a2Hat_B, np.matmul(RN, rHat_SB_N)) + accuracy, verbose=True)
+
+    return
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_(
+                 False,
+                 0.62831,    # alpha
+                 1,          # priorityFlag
+                 1e-12       # accuracy
+               )

--- a/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.cpp
@@ -63,6 +63,69 @@ void TargetPoint::Reset(uint64_t CurrentSimNanos)
  */
 void TargetPoint::UpdateState(uint64_t CurrentSimNanos)
 {
+    /*! create and zero the output message */
+    AttRefMsgPayload attRefOut = this->attRefOutMsg.zeroMsgPayload;
 
+    /*! read and allocate the input attitude navigation message */
+    NavAttMsgPayload attNavIn = this->attNavInMsg();
+
+    /*! read and allocate the input translational navigation message */
+    NavTransMsgPayload transNavIn = this->transNavInMsg();
+
+    /*! read and allocate the input ephemeris message */
+    EphemerisMsgPayload ephemerisIn = this->ephemerisInMsg();
+
+    /*! compute and allocate inertial requested heading */
+    double hReqHat_N[3];
+    v3Subtract(ephemerisIn.r_BdyZero_N, transNavIn.r_BN_N, hReqHat_N);
+    v3Normalize(hReqHat_N, hReqHat_N);
+
+    /*! define the body frame orientation DCM BN */
+    double BN[3][3];
+    MRP2C(attNavIn.sigma_BN, BN);
+
+    /*! normalize the solar array drive axis and sun constrained axis */
+    v3Normalize(this->a1Hat_B, this->a1Hat_B);
+    v3Normalize(this->a2Hat_B, this->a2Hat_B);
+
+    /*! normalize the antenna direction axes */
+    v3Normalize(this->hRefHat_B, this->hRefHat_B);
+
+    /*! read Sun direction in B frame from the attNav message */
+    double rHat_SB_B[3];
+    v3Copy(attNavIn.vehSunPntBdy, rHat_SB_B);
+
+    /*! compute reference frame RN */
+    double RN[3][3];
+    computeReferenceFrame(this->hRefHat_B, hReqHat_N, rHat_SB_B, this->a1Hat_B, this->a2Hat_B, this->beta, BN,
+                          this->alignmentPriority, epsilon, RN);
+
+    /*! compute reference MRP */
+    double sigma_RN[3];
+    C2MRP(RN, sigma_RN);
+    v3Copy(sigma_RN, attRefOut.sigma_RN);
+
+    /*! compute reference angular rates and accelerations via finite differences */
+    double omega_RN_R[3];
+    double omegaDot_RN_R[3];
+    finiteDifferencesRatesAndAcc(sigma_RN,
+                                 this->sigma_RN_1,
+                                 this->sigma_RN_2,
+                                 &CurrentSimNanos,
+                                 &this->T1NanoSeconds,
+                                 &this->T2NanoSeconds,
+                                 &this->callCount,
+                                 omega_RN_R,
+                                 omegaDot_RN_R);
+
+    /*! compute angular rates and accelerations in N frame and store in buffer msg */
+    m33tMultV3(RN, omega_RN_R, attRefOut.omega_RN_N);
+    m33tMultV3(RN, omegaDot_RN_R, attRefOut.domega_RN_N);
+
+    /*! Write the output messages */
+    this->attRefOutMsg.write(&attRefOut, this->moduleID, CurrentSimNanos);
+
+    /*! Write the C-wrapped output messages */
+    AttRefMsg_C_write(&attRefOut, &this->attRefOutMsgC, this->moduleID, CurrentSimNanos);
 }
 

--- a/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.cpp
@@ -1,0 +1,59 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#include "targetPoint.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+
+const double epsilon = 1e-12;                           // module tolerance for zero
+
+/*! Module constructor */
+TargetPoint::TargetPoint() = default;
+
+
+/*! Module destructor */
+TargetPoint::~TargetPoint() = default;
+
+
+/*! Initialize C-wrapped output messages */
+void TargetPoint::SelfInit(){
+    AttRefMsg_C_init(&this->attRefOutMsgC);
+}
+
+/*! This method is used to reset the module.
+ @return void
+ */
+void TargetPoint::Reset(uint64_t CurrentSimNanos)
+{
+
+}
+
+
+/*! This method is the main carrier for the boresight calculation routine.  If it detects
+ that it needs to re-init (direction change maybe) it will re-init itself.
+ Then it will compute the angles away that the boresight is from the celestial target.
+ @return void
+ @param CurrentSimNanos The current simulation time for system
+ */
+void TargetPoint::UpdateState(uint64_t CurrentSimNanos)
+{
+
+}
+

--- a/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.cpp
@@ -42,7 +42,16 @@ void TargetPoint::SelfInit(){
  */
 void TargetPoint::Reset(uint64_t CurrentSimNanos)
 {
-
+    if (!this->attNavInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".attNavInMsg wasn't connected.");
+    }
+    if (!this->transNavInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".transNavInMsg wasn't connected.");
+    }
+    if (!this->ephemerisInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".ephemerisInMsg wasn't connected.");
+    }
+    this->callCount = 0;
 }
 
 

--- a/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.h
+++ b/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.h
@@ -1,0 +1,64 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _TARGET_POINT_
+#define _TARGET_POINT_
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+#include "cMsgCInterface/AttRefMsg_C.h"
+#include "fswAlgorithms/attGuidance/_GeneralModuleFiles/constrainedAxisPointingLibrary.h"
+
+
+/*! @brief A class to perform EMA SEP pointing */
+class TargetPoint: public SysModel {
+public:
+    TargetPoint();
+    ~TargetPoint();
+    void SelfInit();                                               //!< Self initialization for C-wrapped messages
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+
+    AlignmentPriority alignmentPriority;                           //!< flag to indicate which flyby model is being used
+    double            hRefHat_B[3];                                //!< first antenna direction in B-frame coordinates
+    double            a1Hat_B[3];                                  //!< solar array drive axis in B-frame coordinates
+    double            a2Hat_B[3];                                  //!< Sun-constrained axis in B-frame coordinates
+    double            beta;                                        //!< Sun-constraint half-cone angle
+
+    ReadFunctor<NavAttMsgPayload>          attNavInMsg;            //!< input msg measured attitude
+    ReadFunctor<NavTransMsgPayload>        transNavInMsg;          //!< input msg measured position
+    ReadFunctor<EphemerisMsgPayload>       ephemerisInMsg;         //!< input ephemeris msg
+    Message<AttRefMsgPayload>              attRefOutMsg;           //!< Attitude reference output message
+    AttRefMsg_C                            attRefOutMsgC = {};     //!< C-wrapped attitude reference output message
+
+private:
+    int               callCount;                                   //!< count variable used in the finite difference logic
+    uint64_t          T1NanoSeconds;                               //!< callTime one update step prior
+    uint64_t          T2NanoSeconds;                               //!< callTime two update steps prior
+    double            sigma_RN_1[3];                               //!< reference attitude one update step prior
+    double            sigma_RN_2[3];                               //!< reference attitude two update steps prior
+    BSKLogger                              bskLogger;              //!< BSK Logging
+};
+
+#endif

--- a/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.i
+++ b/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.i
@@ -1,0 +1,46 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module targetPoint
+%{
+#include "targetPoint.h"
+%}
+
+%include "std_string.i"
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "swig_conly_data.i"
+
+%include "sys_model.h"
+%include "targetPoint.h"
+%include "fswAlgorithms/attGuidance/_GeneralModuleFiles/constrainedAxisPointingLibrary.h"
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+struct NavTransMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+struct AttRefMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.rst
+++ b/src/fswAlgorithms/attGuidance/targetPoint/targetPoint.rst
@@ -1,0 +1,87 @@
+Executive Summary
+-----------------
+This module computes a reference attitude frame that simultaneously satisfies multiple pointing constraints. The first constraint consists of aligning a body-frame direction :math:`{}^\mathcal{B}\hat{h}_1` with a certain the direction of a certain celestial body. This locks two out of three degrees of freedom that characterize a rigid body rotation. The second constraint consists in achieving maximum power generation on the solar arrays, assuming that the solar arrays can rotate about their drive axis. This condition is obtained ensuring that the body-fixed solar array drive direction :math:`{}^\mathcal{B}\hat{a}_1` is as close to perpendicular as possible to the Sun direction. The third constraint consists in keeping a certain body-fixed, Sun-constrained direction, :math:`{}^\mathcal{B}\hat{a}_2`, within an angle :math:`beta` from the Sun direction.
+
+The second and third constraint can be switched in priority. When solar array incidence is prioritized, there is no guarantee that the Sun-constrained axis can be kept within a certain angular distance from the Sun. Conversely, when the Sun-constrained direction is prioritized, the algorithm searches the space of compliant solutions for the solution that also maximizes Sun incidence on the solar arrays.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages. The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - attNavInMsg
+      - :ref:`NavAttMsgPayload`
+      - Input message containing current attitude and Sun direction in body-frame coordinates. Note that, for the Sun direction to appear in the message, the :ref:`SpicePlanetStateMsgPayload` must be provided as input msg to :ref:`simpleNav`, otherwise the Sun direction is zeroed by default.
+    * - transNavInMsg
+      - :ref:`NavTransMsgPayload`
+      - Input message containing spacecraft inertial position and velocity.
+    * - ephemerisInMsg
+      - :ref:`EphemerisMsgPayload`
+      - Input ephemeris message of the celestial body to be pointed at.
+    * - attRefOutMsg
+      - :ref:`AttRefMsgPayload`
+      - Output attitude reference message containing reference attitude, reference angular rates and accelerations.
+
+
+Detailed Module Description
+---------------------------
+A detailed mathematical derivation of the equations applied by this module can be found in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
+
+The input parameter ``alignmentPriority`` allows to choose which between the second and the third constraint are being prioritized. Regardless of the chosen ``alignmentPriority``, the reference attitude aligns the body-frame and the inertial-frame headings contained in the message before any other constraint.
+
+When ``alignmentPriority = 0``, the reference attitude makes it such that the solar array drive axis :math:`{}^\mathcal{B}\hat{a}_1` is as perpendicular as possible to the Sun direction. When perfectly perpendicular, two compliant solution exist, therefore the module picks the one that keeps the Sun-constrained direction :math:`{}^\mathcal{B}\hat{a}_2` closer to the Sun.
+
+When ``alignmentPriority = 0``, the reference attitude makes it such that the Sun-constrained vector :math:`{}^\mathcal{B}\hat{a}_2` is never more than :math:`\beta` degrees apart from the Sun direction. Within this range of admissible solutions, the module picks the one that also result in maximum incidence on the solar arrays, i.e., the one that drives the solar array drive axis :math:`{}^\mathcal{B}\hat{a}_1` as perpendicular as possible to sunlight.
+
+
+Module Assumptions and Limitations
+----------------------------------
+The limitations of this module are inherent to the geometry of the problem, which determines which of the constraints can be satisfied. For example, as shown in  in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints," In preparation for Journal of Spacecraft and Rockets, depending on the relative orientation of :math:`{}^\mathcal{B}h` and :math:`{}^\mathcal{B}a_1`, it may not be possible to  achieve perfect incidence angle on the solar arrays. Only when perfect incidence is obtained, it is possible to solve for the solution that also drives the body-fixed direction :math:`{}^\mathcal{B}a_2` close to the Sun. When perfect incidence is achievable, two solutions exist. If :math:`{}^\mathcal{B}a_2` is provided as input, this is used to determine which solution to pick. If this input is not provided, one of the two solution is chosen arbitrarily.
+
+Due to the difficulty in developing an analytical formulation for the reference angular rate and angular acceleration vectors, these are computed via second-order finite differences. At every time step, the current reference attitude and time stamp are stored in a module variable and used in the following time updates to compute angular rates and accelerations via finite differences.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    attGuid = sepPoint.SepPoint()
+    attGuid.hRefHat_B = hRefHat_B
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.a2Hat_B = a2Hat_B
+    attGuid.beta = beta
+    attGuid.alignmentPriority = alignmentPriority
+    attGuid.ModelTag = "sepPoint"
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``hRefHat_B``
+     - [0, 0, 0]
+     - body-frame axis that needs to point at the celestial body
+   * - ``a1Hat_B``
+     - [0, 0, 0]
+     - solar array drive direction in body-frame coordinates
+   * - ``a2Hat_B`` (optional)
+     - [0, 0, 0]
+     - Sun-constrained direction in body frame coordinates
+   * - ``beta`` (optional)
+     - [0, 0, 0]
+     - half-cone angle of the keep-in Sun constraint
+   * - ``alignmentPriority``
+     - 0
+     - 0 to prioritize incidence on the arrays, 1 to prioritize Sun-constrained direction.


### PR DESCRIPTION
* **Tickets addressed:** bsk-178
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module computes a reference attitude for a target-pointing spacecraft. The target can be any celestial body connected as the input ephemeris message. The computed reference aligns a desired body-frame axis with the celestial body, and exploits the roll about such direction to drive the solar array rotation axis as close as possible to being perpendicular to the Sun. 

## Verification
A unit test is provided to test the accuracy of the pointing and the angular velocity of the reference given the requested roll rate.

## Documentation
Documentation is provided

## Future work
N/A
