### PR TITLE
Feature/183 sun point

### DIFF
--- a/src/fswAlgorithms/attGuidance/sunPoint/_UnitTest/test_sunPoint.py
+++ b/src/fswAlgorithms/attGuidance/sunPoint/_UnitTest/test_sunPoint.py
@@ -1,0 +1,150 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+import pytest
+import os
+import inspect
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.fswAlgorithms import sunPoint
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+@pytest.mark.parametrize("sigma_BN", [[0.0, 0.0, 0.0],
+                                      [0.1, 0.2, 0.3],
+                                      [1.1, 2.2, 3.3]])
+@pytest.mark.parametrize("hRefHat_B", [[0.0, 1.0, 0.0],
+                                       [0.5, 0.5, 0.5],
+                                       [0.1, 0.1, -0.9]])
+@pytest.mark.parametrize("omegaRoll", [0.0, 0.01, -0.03])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_(show_plots, sigma_BN, hRefHat_B, omegaRoll, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`sunPointRoll`.
+    The correctness of the output is determined based on whether the reference attitude drives the desired body-frame
+    heading :math:`\hat{h}_\text{ref}` onto the relative Sun direction :math:`\hat{r}_{S/B}`.
+
+    **Test Parameters**
+
+    Args:
+        sigma_BN (MRP): initial spacecraft attitude
+        hRefHat_B (rad): desired body-frame axis to align with Sun
+        omegaRoll (rad/s): roll rate about the sunline axis
+        accuracy: accuracy of the result.
+    """
+
+    rHat_SB_N = np.array([1, -2, 3])                            # Sun direction in inertial coordinates
+    rHat_SB_N = rHat_SB_N / np.linalg.norm(rHat_SB_N)
+    a1Hat_B = np.array([-9, 8, 7])                            # array axis direction in body frame
+    a1Hat_B = a1Hat_B / np.linalg.norm(a1Hat_B)
+
+    hRefHat_B = np.array(hRefHat_B) / np.linalg.norm(hRefHat_B)
+
+    unitTaskName = "unitTask"                                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"                          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    attGuid = sunPoint.SunPoint()
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.hRefHat_B = hRefHat_B
+    attGuid.omegaRoll = omegaRoll
+    attGuid.ModelTag = "sunPointRoll"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, attGuid)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+
+    # Create input navigation message
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rHat_SB_N)
+    NavAttMessageData = messaging.NavAttMsgPayload()
+    NavAttMessageData.sigma_BN = sigma_BN
+    NavAttMessageData.vehSunPntBdy = rS_B
+    NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
+    attGuid.attNavInMsg.subscribeTo(NavAttMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = attGuid.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    dataLogC = attGuid.attRefOutMsgC.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogC)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    # test the correctness of the C++ output message
+    RN = rbk.MRP2C(dataLog.sigma_RN[0])
+    omegaRN_N = dataLog.omega_RN_N[0]
+    np.testing.assert_allclose(hRefHat_B, np.matmul(RN, rHat_SB_N), rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(omegaRN_N, omegaRoll*rHat_SB_N, rtol=0, atol=accuracy, verbose=True)
+
+    # test the correctness of the C output message
+    RN = rbk.MRP2C(dataLogC.sigma_RN[0])
+    omegaRN_N = dataLogC.omega_RN_N[0]
+    np.testing.assert_allclose(hRefHat_B, np.matmul(RN, rHat_SB_N), rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(omegaRN_N, omegaRoll*rHat_SB_N, rtol=0, atol=accuracy, verbose=True)
+
+    return
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_(
+        False,
+        [0, 0, 0],
+        [0, 1, 0],
+        0.01,
+        1e-12
+    )

--- a/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.cpp
@@ -54,6 +54,81 @@ void SunPoint::Reset(uint64_t CurrentSimNanos)
  */
 void SunPoint::UpdateState(uint64_t CurrentSimNanos)
 {
+    /*! create and zero the output message */
+    AttRefMsgPayload attRefOut = this->attRefOutMsg.zeroMsgPayload;
+
+    /*! read and allocate the input attitude navigation message */
+    NavAttMsgPayload attNavIn = this->attNavInMsg();
+
+    /*! define the body frame orientation DCM BN */
+    double BN[3][3];
+    MRP2C(attNavIn.sigma_BN, BN);
+
+    /*! get the solar array drive direction in body frame coordinates */
+    double a1Hat_B[3];
+    v3Normalize(this->a1Hat_B, a1Hat_B);
+
+    /*! read Sun direction in N frame from the attNav message */
+    double rHat_SB_N[3];
+    m33tMultV3(BN, attNavIn.vehSunPntBdy, rHat_SB_N);
+
+    /*! compute intermediate reference frame DN to align vector with Sun */
+    double d1[3];
+    double d2[3];
+    double d3[3];
+    v3Normalize(this->hRefHat_B, d1);
+    v3Cross(d1, a1Hat_B, d2);
+    v3Normalize(d2, d2);
+    v3Cross(d1, d2, d3);
+
+    double n1[3];
+    double n2[3] = {0, 0, 1};
+    double n3[3];
+    v3Copy(rHat_SB_N, n1);
+    v3Cross(n1, n2, n3);
+    v3Normalize(n3, n3);
+    v3Cross(n3, n1, n2);
+
+    double DT[3][3];
+    double NT[3][3];
+    for (int i=0; i<3; ++i) {
+        DT[i][0] = d1[i];
+        DT[i][1] = d2[i];
+        DT[i][2] = d3[i];
+        NT[i][0] = n1[i];
+        NT[i][1] = n2[i];
+        NT[i][2] = n3[i];
+    }
+
+    double DN[3][3];
+    m33MultM33t(DT, NT, DN);
+
+    /*! compute intermediate reference RD that accounts for the roll about the sunline */
+    double pra = this->omegaRoll * (double (CurrentSimNanos - this->resetTime));
+    double prv_RD[3];
+    v3Scale(pra, a1Hat_B, prv_RD);
+
+    double RD[3][3];
+    PRV2C(prv_RD, RD);
+
+    /*! compute final reference frame RN */
+    double RN[3][3];
+    m33MultM33(RD, DN, RN);
+
+    /*! compute reference MRP */
+    double sigma_RN[3];
+    C2MRP(RN, sigma_RN);
+    v3Copy(sigma_RN, attRefOut.sigma_RN);
+
+    /*! write omega roll into the reference message */
+    double omega_RN_R[3];
+    v3Scale(this->omegaRoll, this->hRefHat_B, omega_RN_R);
+    m33tMultV3(RN, omega_RN_R, attRefOut.omega_RN_N);
+
+    /*! Write the output messages */
+    this->attRefOutMsg.write(&attRefOut, this->moduleID, CurrentSimNanos);
+
+    /*! Write the C-wrapped output messages */
+    AttRefMsg_C_write(&attRefOut, &this->attRefOutMsgC, this->moduleID, CurrentSimNanos);
 
 }
-

--- a/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.cpp
@@ -42,7 +42,10 @@ void SunPoint::SelfInit(){
  */
 void SunPoint::Reset(uint64_t CurrentSimNanos)
 {
-
+    if (!this->attNavInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, ".attNavInMsg wasn't connected.");
+    }
+    this->resetTime = CurrentSimNanos;
 }
 
 

--- a/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.cpp
@@ -1,0 +1,56 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#include "sunPoint.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+
+const double epsilon = 1e-12;                           // module tolerance for zero
+
+/*! Module constructor */
+SunPoint::SunPoint() = default;
+
+
+/*! Module destructor */
+SunPoint::~SunPoint() = default;
+
+
+/*! Initialize C-wrapped output messages */
+void SunPoint::SelfInit(){
+    AttRefMsg_C_init(&this->attRefOutMsgC);
+}
+
+/*! This method is used to reset the module.
+ @return void
+ */
+void SunPoint::Reset(uint64_t CurrentSimNanos)
+{
+
+}
+
+
+/*! This method is the main carrier for the reference frame calculation routine.
+ @param CurrentSimNanos The current simulation time for system
+ */
+void SunPoint::UpdateState(uint64_t CurrentSimNanos)
+{
+
+}
+

--- a/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.h
+++ b/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.h
@@ -1,0 +1,54 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _SUN_POINT_
+#define _SUN_POINT_
+
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+#include "cMsgCInterface/AttRefMsg_C.h"
+
+
+/*! @brief A class to perform EMA Sun pointing */
+class SunPoint: public SysModel {
+public:
+    SunPoint();
+    ~SunPoint();
+    void SelfInit();                                               //!< Self initialization for C-wrapped messages
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+
+    double            hRefHat_B[3];                                //!< Sun-pointing direction in B-frame coordinates
+    double            a1Hat_B[3];                                  //!< solar array drive axis in B-frame coordinates
+    double            omegaRoll = 0;                               //!< roll rate about Sun direction [rad/s]
+
+    ReadFunctor<NavAttMsgPayload>          attNavInMsg;            //!< input msg measured attitude
+    Message<AttRefMsgPayload>              attRefOutMsg;           //!< Attitude reference output message
+    AttRefMsg_C                            attRefOutMsgC = {};     //!< C-wrapped attitude reference output message
+
+private:
+    uint64_t          resetTime;                                   //!< callTime one update step prior
+    double            sigma_RN_1[3];                               //!< reference attitude one update step prior
+    double            sigma_RN_2[3];                               //!< reference attitude two update steps prior
+    BSKLogger                              bskLogger;              //!< BSK Logging
+};
+
+#endif

--- a/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.i
+++ b/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.i
@@ -1,0 +1,42 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module sunPoint
+%{
+#include "sunPoint.h"
+%}
+
+%include "std_string.i"
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "swig_conly_data.i"
+
+%include "sys_model.h"
+%include "sunPoint.h"
+
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+struct AttRefMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.rst
+++ b/src/fswAlgorithms/attGuidance/sunPoint/sunPoint.rst
@@ -1,0 +1,60 @@
+Executive Summary
+-----------------
+This module computes a reference attitude for a Sun-pointing spacecraft. The reference is defined such that the body-frame-defined axis :math:`{}^\mathcal{B}\hat{h}_\text{ref}` is aligned with the direction of the Sun relative to the spacecraft. The third degree of freedom to uniquely define the reference frame is chosen arbitrarily. A roll rate can be defined by the user such that the reference frame rolls about the sunline at a constant rate. This ensures constant pointing towards the Sun while mitigating solar radiation pressure effects.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages. The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - attNavInMsg
+      - :ref:`NavAttMsgPayload`
+      - Input message containing current attitude and Sun direction in body-frame coordinates. Note that, for the Sun direction to appear in the message, the :ref:`SpicePlanetStateMsgPayload` must be provided as input msg to :ref:`simpleNav`, otherwise the Sun direction is zeroed by default.
+    * - attRefOutMsg
+      - :ref:`AttRefMsgPayload`
+      - Output attitude reference message containing reference attitude, reference angular rates and accelerations.
+
+
+Detailed Module Description
+---------------------------
+Two of the three degrees of freedom associated with the definition of a reference frame are determined by the condition to align the desired axis with the Sun direction. The third degree of freedom is determined using the J2000.0 :math:`z` axis, which in Basilisk coincides with the third axis of the inertial frame :math:`\mathcal{N}`.
+
+The user is required to define the solar array drive axis :math:`{}^\mathcal{B}\hat{a}_1` to help with the definition of a right-handed frame. When this information is not available or does not apply to the spacecraft, this can be any axis that is not collinear with :math:`{}^\mathcal{B}\hat{h}_\text{ref}`.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    attGuid = sunPoint.SunPoint()
+    attGuid.hRefHat_B = hRefHat_B
+    attGuid.a1Hat_B = a1Hat_B
+    attGuid.omegaRoll = omegaRoll
+    attGuid.ModelTag = "sepPoint"
+
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``hRefHat_B``
+     - [0, 0, 0]
+     - body-frame axis that needs to point at the Sun
+   * - ``a1Hat_B``
+     - [0, 0, 0]
+     - solar array drive direction in body-frame coordinates
+   * - ``omegaRoll``
+     - 0
+     - roll rate about the sunline axis.


### PR DESCRIPTION
* **Tickets addressed:** bsk-183
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module computes a reference attitude for a Sun-pointing spacecraft. The reference is defined such that the body-frame-defined axis is aligned with the direction of the Sun relative to the spacecraft. A roll rate can be defined by the user such that the reference frame rolls about the sunline at a constant rate. This ensures constant pointing towards the Sun while mitigating solar radiation pressure effects.

## Verification
A unit test is provided to test the accuracy of the pointing and the angular velocity of the reference given the requested roll rate.

## Documentation
Documentation is provided.

## Future work
N/A