### PR TITLE
Refactor/205 refactor stepper motor profiler

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfiler.py
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfiler.py
@@ -97,15 +97,10 @@ def stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommand
     # Create an instance of the stepperMotorProfiler module to be tested
     StepperMotorProfiler = stepperMotorProfiler.stepperMotorProfiler()
     StepperMotorProfiler.ModelTag = "StepperMotorProfiler"
-    rotAxis_M = np.array([1.0, 0.0, 0.0])
-    StepperMotorProfiler.rotAxis_M = rotAxis_M
     StepperMotorProfiler.thetaInit = initialMotorAngle
     StepperMotorProfiler.stepAngle = stepAngle
     StepperMotorProfiler.stepTime = stepTime
     StepperMotorProfiler.thetaDDotMax = stepAngle / (0.25 * stepTime * stepTime)
-    StepperMotorProfiler.r_FM_M = np.array([0.0, 0.0, 0.0])
-    StepperMotorProfiler.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-    StepperMotorProfiler.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
 
     # Add the test module to the runtime call list
     unitTestSim.AddModelToTask(unitTaskName, StepperMotorProfiler)
@@ -118,9 +113,7 @@ def stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommand
 
     # Log the test module output message for data comparison
     stepperMotorDataLog = StepperMotorProfiler.stepperMotorOutMsg.recorder()
-    prescribedDataLog = StepperMotorProfiler.prescribedMotionOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, stepperMotorDataLog)
-    unitTestSim.AddModelToTask(unitTaskName, prescribedDataLog)
 
     # Initialize the simulation, set the sim run time, and execute the simulation
     unitTestSim.InitializeSimulation()
@@ -136,9 +129,6 @@ def stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommand
     thetaDDot = (180 / np.pi) * stepperMotorDataLog.thetaDDot
     motorStepCount = stepperMotorDataLog.stepCount
     motorCommandedSteps = stepperMotorDataLog.stepsCommanded
-    sigma_FM = prescribedDataLog.sigma_FM
-    omega_FM_F = prescribedDataLog.omega_FM_F
-    omegaPrime_FM_F = prescribedDataLog.omegaPrime_FM_F
 
     # Only show plots if the motor actuates
     if (stepsCommanded == 0):
@@ -181,30 +171,6 @@ def stepperMotorProfilerTestFunction(show_plots, initialMotorAngle, stepsCommand
     plt.plot(timespan * macros.NANO2SEC, motorCommandedSteps, '--', label='Commanded')
     plt.title(r'Motor Step History', fontsize=14)
     plt.ylabel('Steps', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
-
-    # Plot omega_FM_F
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 0], label=r'$\omega_{1}$')
-    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 1], label=r'$\omega_{2}$')
-    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 2], label=r'$\omega_{3}$')
-    plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
-    plt.ylabel('(deg/s)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
-
-    # Plot omegaPrime_FM_F
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 0], label=r'1')
-    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 1], label=r'2')
-    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 2], label=r'3')
-    plt.title(r'${}^\mathcal{F} \omega Prime_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
-    plt.ylabel('(deg/s$^2$)', fontsize=14)
     plt.xlabel('Time (s)', fontsize=14)
     plt.legend(loc='upper right', prop={'size': 12})
     plt.grid(True)

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfilerInterrupt.py
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/_UnitTest/test_stepperMotorProfilerInterrupt.py
@@ -117,15 +117,10 @@ def stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMot
     # Create an instance of the stepperMotorProfiler module to be tested
     StepperMotorProfiler = stepperMotorProfiler.stepperMotorProfiler()
     StepperMotorProfiler.ModelTag = "stepperMotorProfiler"
-    rotAxis_M = np.array([1.0, 0.0, 0.0])
-    StepperMotorProfiler.rotAxis_M = rotAxis_M
     StepperMotorProfiler.thetaInit = initialMotorAngle
     StepperMotorProfiler.stepAngle = stepAngle
     StepperMotorProfiler.stepTime = stepTime
     StepperMotorProfiler.thetaDDotMax = stepAngle / (0.25 * stepTime * stepTime)
-    StepperMotorProfiler.r_FM_M = np.array([0.0, 0.0, 0.0])
-    StepperMotorProfiler.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-    StepperMotorProfiler.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
 
     # Add the stepperMotorProfiler test module to the runtime call list
     unitTestSim.AddModelToTask(unitTaskName, StepperMotorProfiler)
@@ -136,10 +131,8 @@ def stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMot
     # Log the test module output message for data comparison
     stepCommandDataLog = StepperMotorController.motorStepCommandOutMsg.recorder(testProcessRate)
     stepperMotorDataLog = StepperMotorProfiler.stepperMotorOutMsg.recorder(testProcessRate)
-    prescribedDataLog = StepperMotorProfiler.prescribedMotionOutMsg.recorder(testProcessRate)
     unitTestSim.AddModelToTask(unitTaskName, stepCommandDataLog)
     unitTestSim.AddModelToTask(unitTaskName, stepperMotorDataLog)
-    unitTestSim.AddModelToTask(unitTaskName, prescribedDataLog)
 
     # Initialize the simulation
     unitTestSim.InitializeSimulation()
@@ -218,9 +211,6 @@ def stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMot
     thetaDDot = (180 / np.pi) * stepperMotorDataLog.thetaDDot
     motorStepCount = stepperMotorDataLog.stepCount
     motorCommandedSteps = stepperMotorDataLog.stepsCommanded
-    sigma_FM = prescribedDataLog.sigma_FM
-    omega_FM_F = prescribedDataLog.omega_FM_F
-    omegaPrime_FM_F = prescribedDataLog.omegaPrime_FM_F
 
     # Plot motor angle
     plt.figure()
@@ -259,30 +249,6 @@ def stepperMotorProfilerTestFunction(show_plots, stepAngle, stepTime, initialMot
     plt.plot(timespan * macros.NANO2SEC, motorCommandedSteps, '--', label='Commanded')
     plt.title(r'Motor Step History', fontsize=14)
     plt.ylabel('Steps', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
-
-    # Plot omega_FM_F
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 0], label=r'$\omega_{1}$')
-    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 1], label=r'$\omega_{2}$')
-    plt.plot(timespan * macros.NANO2SEC, omega_FM_F[:, 2], label=r'$\omega_{3}$')
-    plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
-    plt.ylabel('(deg/s)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
-
-    # Plot omegaPrime_FM_F
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 0], label=r'1')
-    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 1], label=r'2')
-    plt.plot(timespan * macros.NANO2SEC, omegaPrime_FM_F[:, 2], label=r'3')
-    plt.title(r'${}^\mathcal{F} \omega Prime_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
-    plt.ylabel('(deg/s$^2$)', fontsize=14)
     plt.xlabel('Time (s)', fontsize=14)
     plt.legend(loc='upper right', prop={'size': 12})
     plt.grid(True)

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.c
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.c
@@ -29,7 +29,6 @@
  */
 void SelfInit_stepperMotorProfiler(StepperMotorProfilerConfig *configData, int64_t moduleID) {
     StepperMotorMsg_C_init(&configData->stepperMotorOutMsg);
-    HingedRigidBodyMsg_C_init(&configData->hingedRigidBodyOutMsg);
     PrescribedMotionMsg_C_init(&configData->prescribedMotionOutMsg);
 }
 
@@ -82,13 +81,11 @@ void Update_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_
     // Create the buffer messages
     MotorStepCommandMsgPayload motorStepCommandIn;
     StepperMotorMsgPayload stepperMotorOut;
-    HingedRigidBodyMsgPayload hingedRigidBodyOut;
     PrescribedMotionMsgPayload prescribedMotionOut;
 
     // Zero the buffer messages
     motorStepCommandIn = MotorStepCommandMsg_C_zeroMsgPayload();
     stepperMotorOut = StepperMotorMsg_C_zeroMsgPayload();
-    hingedRigidBodyOut = HingedRigidBodyMsg_C_zeroMsgPayload();
     prescribedMotionOut = PrescribedMotionMsg_C_zeroMsgPayload();
 
     // Read the input message
@@ -228,10 +225,6 @@ void Update_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_
     stepperMotorOut.stepsCommanded = configData->stepsCommanded;
     stepperMotorOut.stepCount = configData->stepCount;
 
-    // Copy motor states to the hinged rigid body message
-    hingedRigidBodyOut.theta = configData->theta;
-    hingedRigidBodyOut.thetaDot = configData->thetaDot;
-
     // Copy the prescribed states to the prescribed motion output message
     v3Copy(configData->r_FM_M, prescribedMotionOut.r_FM_M);
     v3Copy(configData->rPrime_FM_M, prescribedMotionOut.rPrime_FM_M);
@@ -242,6 +235,5 @@ void Update_stepperMotorProfiler(StepperMotorProfilerConfig *configData, uint64_
 
     // Write the output messages
     StepperMotorMsg_C_write(&stepperMotorOut, &configData->stepperMotorOutMsg, moduleID, callTime);
-    HingedRigidBodyMsg_C_write(&hingedRigidBodyOut, &configData->hingedRigidBodyOutMsg, moduleID, callTime);
     PrescribedMotionMsg_C_write(&prescribedMotionOut, &configData->prescribedMotionOutMsg, moduleID, callTime);
 }

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.h
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.h
@@ -25,7 +25,6 @@
 #include "cMsgCInterface/MotorStepCommandMsg_C.h"
 #include "cMsgCInterface/StepperMotorMsg_C.h"
 #include "cMsgCInterface/PrescribedMotionMsg_C.h"
-#include "cMsgCInterface/HingedRigidBodyMsg_C.h"
 
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
@@ -78,7 +77,6 @@ typedef struct {
     /* Messages */
     MotorStepCommandMsg_C motorStepCommandInMsg;           //!< Input msg for the number of commanded motor step counts
     StepperMotorMsg_C stepperMotorOutMsg;                  //!< Output msg for the stepper motor information
-    HingedRigidBodyMsg_C hingedRigidBodyOutMsg;            //!< Output msg for the spinning body module
     PrescribedMotionMsg_C prescribedMotionOutMsg;          //!< Output msg for the spinning body prescribed states
 
 }StepperMotorProfilerConfig;

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.h
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.h
@@ -24,24 +24,14 @@
 #include "architecture/utilities/bskLogging.h"
 #include "cMsgCInterface/MotorStepCommandMsg_C.h"
 #include "cMsgCInterface/StepperMotorMsg_C.h"
-#include "cMsgCInterface/PrescribedMotionMsg_C.h"
 
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
     /* User-configured parameters (required) */
-    double rotAxis_M[3];                                   //!< Stepper motor rotation axis
     double thetaInit;                                      //!< [rad] Initial motor angle
     double stepAngle;                                      //!< [rad] Angle the stepper motor moves through for a single step
     double stepTime;                                       //!< [s] Time required for a single motor step (constant)
     double thetaDDotMax;                                   //!< [rad/s^2] Maximum angular acceleration of the stepper motor
-    double r_FM_M[3];                                      //!< [m] Position of the F frame origin with respect to the M frame origin in M frame components (fixed)
-    double rPrime_FM_M[3];                                 //!< [m/s] B frame time derivative of r_FM_M in M frame components (fixed)
-    double rPrimePrime_FM_M[3];                            //!< [m/s^2] B frame time derivative of rPrime_FM_M in M frame components (fixed)
-
-    /* Other prescribed parameters */
-    double sigma_FM[3];                                    //!< MRP attitude of frame F with respect to frame M
-    double omega_FM_F[3];                                  //!< [rad/s] Angular velocity of frame F wrt frame M in F frame components
-    double omegaPrime_FM_F[3];                             //!< [rad/s^2] B frame time derivative of omega_FM_F in F frame components
 
     /* Step parameters */
     int stepsCommanded;                                    //!< [steps] Number of commanded steps
@@ -77,7 +67,6 @@ typedef struct {
     /* Messages */
     MotorStepCommandMsg_C motorStepCommandInMsg;           //!< Input msg for the number of commanded motor step counts
     StepperMotorMsg_C stepperMotorOutMsg;                  //!< Output msg for the stepper motor information
-    PrescribedMotionMsg_C prescribedMotionOutMsg;          //!< Output msg for the spinning body prescribed states
 
 }StepperMotorProfilerConfig;
 

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.i
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.i
@@ -28,8 +28,6 @@
 struct MotorStepCommandMsg_C;
 %include "architecture/msgPayloadDefC/StepperMotorMsgPayload.h"
 struct StepperMotorMsg_C;
-%include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
-struct PrescribedMotionMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.i
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.i
@@ -28,8 +28,6 @@
 struct MotorStepCommandMsg_C;
 %include "architecture/msgPayloadDefC/StepperMotorMsgPayload.h"
 struct StepperMotorMsg_C;
-%include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
-struct HingedRigidBodyMsg_C;
 %include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
 struct PrescribedMotionMsg_C;
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-205
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR refactors the existing `stepperMotorProfiler` C  module. The following changes are made to the module:
1. The module output message `hingedRigidBodyMsgPayload` is be removed.
2. The module will no longer compute or output the prescribed motion hub-relative states (A separate module will be created for this purpose [https://github.com/lasp/basilisk/issues/206]) Therefore, the module output message `prescribedMotionMsgPayload` will be removed.

## Verification
The module unit test is not affected by removing these messages.

## Documentation
N/A

## Future work
N/A
