### PR TITLE
Feature/206 single axis profiler

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -64,6 +64,8 @@ Version |release|
   multi-body prescribed motion.
 - The fuel tank module is refactored to remove the limitation of a only being able to have a single instance of a
   specific tank model type.
+- Created a :ref:`singleAxisProfiler` simulation module to profile 1 DOF rotational prescribed motion about a
+  single hub-fixed axis.
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------

--- a/src/simulation/deviceInterface/singleAxisProfiler/_UnitTest/test_singleAxisProfiler.py
+++ b/src/simulation/deviceInterface/singleAxisProfiler/_UnitTest/test_singleAxisProfiler.py
@@ -1,0 +1,150 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+#
+#   Unit Test Script
+#   Module Name:        singleAxisProfiler
+#   Author:             Leah Kiner
+#   Created:            March 20, 2024
+#
+
+import inspect
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import pytest
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging
+from Basilisk.simulation import singleAxisProfiler
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+@pytest.mark.parametrize("theta", [0.0 * macros.D2R, 5.2 * macros.D2R, -10.1 * macros.D2R]) # [rad]
+@pytest.mark.parametrize("thetaDot", [0.0 * macros.D2R, 0.1 * macros.D2R, -0.1 * macros.D2R])  # [rad/s]
+@pytest.mark.parametrize("thetaDDot", [0.0 * macros.D2R, 0.1 * macros.D2R, -0.1 * macros.D2R])  # [rad/s^2]
+@pytest.mark.parametrize("rotAxis_MAngle", [0.0 * macros.D2R,  -5.2 * macros.D2R, 10.1 * macros.D2R])  # [rad]
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_singleAxisProfiler(show_plots, theta, thetaDot, thetaDDot, rotAxis_MAngle, accuracy):
+    r"""
+    **Validation Test Description**
+
+    The unit test for this module ensures that the single-axis hub-relative rotational scalar states ``theta``,
+    ``thetaDot``, and ``thetaDDot`` are properly converted to prescribed hub-relative rotational states ``sigma_FM``,
+    ``omega_FM_F``, and ``omegaPrime_FM_F``. The scalar states are varied in this test, along with a single angle
+    ``rotAxis_MAngle`` that is used to vary the axis of rotation ``rotAxis_M`` associated with the given
+    scalar information. To verify the module, the final prescribed rotational states are logged from the module. The
+    final attitude is checked with the computed true attitude. The dot product between the given rotation axis and
+    the final angular velocity and angular acceleration is checked to match the given scalar angle rate and angle
+    acceleration.
+
+    **Test Parameters**
+
+    Args:
+        show_plots (bool): Variable for choosing whether plots should be displayed
+        theta (float): [rad] Current hub-relative scalar angle about the given rotation axis rotAxis_M
+        thetaDot (float): [rad/s] Current hub-relative scalar angle rate about the given rotation axis rotAxis_M
+        thetaDDot (float): [rad/s^2] Current hub-relative scalar angular acceleration about the given rotation axis rotAxis_M
+        accuracy (float): Absolute accuracy value used in the validation tests
+
+    **Description of Variables Being Tested**
+
+    This unit test checks that the prescribed rotational module output states ``sigma_FM``, ``omega_FM_F``,
+    and ``omegaPrime_FM_F`` are correctly determined. The output state ``sigma_FM`` is checked to match the initial
+    attitude. The dot product between the given rotation axis and the module output states ``omega_FM_F`` and
+    ``omegaPrime_FM_F`` is checked to match the given scalar states ``thetaDot`` and ``thetaDDot``.
+    """
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    testTimeStepSec = 0.1  # [s]
+    testProcessRate = macros.sec2nano(testTimeStepSec)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create an instance of the singleAxisProfiler module to be tested
+    rotAxis_M = np.array([np.cos(rotAxis_MAngle), np.sin(rotAxis_MAngle), 0.0])
+    singleAxisRotProfiler = singleAxisProfiler.SingleAxisProfiler()
+    singleAxisRotProfiler.ModelTag = "singleAxisProfiler"
+    singleAxisRotProfiler.setRotHat_M(rotAxis_M)
+    unitTestSim.AddModelToTask(unitTaskName, singleAxisRotProfiler)
+
+    # Create the stepper motor input message
+    stepperMotorMessageData = messaging.StepperMotorMsgPayload()
+    stepperMotorMessageData.theta = theta  # [rad]
+    stepperMotorMessageData.thetaDot = thetaDot  # [rad/s]
+    stepperMotorMessageData.thetaDDot = thetaDDot  # [rad/s^2]
+    stepperMotorMessage = messaging.StepperMotorMsg().write(stepperMotorMessageData)
+    singleAxisRotProfiler.stepperMotorInMsg.subscribeTo(stepperMotorMessage)
+
+    # Log module data for module unit test validation
+    prescribedStatesDataLog = singleAxisRotProfiler.prescribedRotationOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, prescribedStatesDataLog)
+
+    # Execute the first translation segment
+    simTime = 1.0  # [s]
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
+    unitTestSim.ExecuteSimulation()
+
+    # Extract the logged data for plotting and data comparison
+    sigma_FM = prescribedStatesDataLog.sigma_FM
+    omega_FM_F = prescribedStatesDataLog.omega_FM_F  # [rad/s]
+    omegaPrime_FM_F = prescribedStatesDataLog.omegaPrime_FM_F  # [rad/s^2]
+
+    # Unit test validation: Check that the module prescribed rotational output states are correct
+    sigma_FMTrue = [0.0, 0.0, 0.0]
+    if theta != 0.0:
+        sigma_FMTrue = rbk.PRV2MRP(theta * rotAxis_M)
+    np.testing.assert_allclose(sigma_FMTrue,
+                               sigma_FM[-1],
+                               atol=accuracy,
+                               verbose=True)
+
+    thetaDotCheck = omega_FM_F[-1].dot(rotAxis_M)  # [rad/s]
+    np.testing.assert_allclose(thetaDot,
+                               thetaDotCheck,
+                               atol=accuracy,
+                               verbose=True)
+
+    thetaDDotCheck = omegaPrime_FM_F[-1].dot(rotAxis_M)  # [rad/s^2]
+    np.testing.assert_allclose(thetaDDot,
+                               thetaDDotCheck,
+                               atol=accuracy,
+                               verbose=True)
+
+if __name__ == "__main__":
+    test_singleAxisProfiler(
+        True,  # show_plots
+        5.2 * macros.D2R,  # [rad] theta
+        0.5 * macros.D2R,  # [rad/s] thetaDot
+        0.1 * macros.D2R,  # [rad/s^2] thetaDDot
+        -10.0 * macros.D2R,   # [rad] rotAxis_MAngle
+        1e-12  # accuracy
+    )
+    

--- a/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.cpp
+++ b/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.cpp
@@ -1,0 +1,102 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#include "singleAxisProfiler.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include <cmath>
+
+/*! This method checks the input message to ensure it is linked.
+ @return void
+ @param callTime [ns] Time the method is called
+*/
+void SingleAxisProfiler::Reset(uint64_t callTime) {
+    if (!this->stepperMotorInMsg.isLinked()) {
+        _bskLog(this->bskLogger, BSK_ERROR, "singleAxisProfiler.stepperMotorInMsg wasn't connected.");
+    }
+}
+
+/*! This method converts the stepper motor scalar rotational states to the prescribed motion hub-relative rotational
+states. The prescribed rotational states are then written to the output message.
+ @return void
+ @param callTime [ns] Time the method is called
+*/
+void SingleAxisProfiler::UpdateState(uint64_t callTime) {
+    // Read the input message
+    StepperMotorMsgPayload stepperMotorIn;
+    if (this->stepperMotorInMsg.isWritten()) {
+        stepperMotorIn = StepperMotorMsgPayload();
+        stepperMotorIn = this->stepperMotorInMsg();
+    }
+
+    // Create the output buffer message
+    PrescribedRotationMsgPayload prescribedRotationOut;
+    prescribedRotationOut = PrescribedRotationMsgPayload();
+
+    // Compute the angular velocity of frame F wrt frame M in F frame components
+    Eigen::Vector3d omega_FM_F = stepperMotorIn.thetaDot * this->rotHat_M;  // [rad/s]
+
+    // Compute the B frame time derivative of omega_FM_F in F frame components
+    Eigen::Vector3d omegaPrime_FM_F = stepperMotorIn.thetaDDot * this->rotHat_M;  // [rad/s^2]
+
+    // Compute the MRP attitude of spinning body frame F with respect to frame M
+    Eigen::Vector3d sigma_FM = this->computeSigma_FM(stepperMotorIn.theta);
+
+    // Copy the prescribed rotational states to the output buffer message
+    eigenVector3d2CArray(omega_FM_F, prescribedRotationOut.omega_FM_F);
+    eigenVector3d2CArray(omegaPrime_FM_F, prescribedRotationOut.omegaPrime_FM_F);
+    eigenVector3d2CArray(sigma_FM, prescribedRotationOut.sigma_FM);
+
+    // Write the output message
+    this->prescribedRotationOutMsg.write(&prescribedRotationOut, moduleID, callTime);
+}
+
+/*! This method computes the current spinning body MRP attitude relative to the mount frame: sigma_FM
+ @return void
+*/
+Eigen::Vector3d SingleAxisProfiler::computeSigma_FM(double theta) {
+    // Determine dcm_FM for the current spinning body attitude relative to the mount frame
+    double dcm_FM[3][3];
+    double prv_FM_array[3];
+    Eigen::Vector3d prv_FM = theta * this->rotHat_M;
+    eigenVector3d2CArray(prv_FM, prv_FM_array);
+    PRV2C(prv_FM_array, dcm_FM);
+
+    // Compute the MRP sigma_FM representing the current spinning body attitude relative to the mount frame
+    double sigma_FM_array[3];
+    C2MRP(dcm_FM, sigma_FM_array);
+    return cArray2EigenVector3d(sigma_FM_array);
+}
+
+/*! Setter method for the spinning body rotation axis.
+ @return void
+ @param rotHat_M Spinning body rotation axis (unit vector)
+*/
+void SingleAxisProfiler::setRotHat_M(const Eigen::Vector3d &rotHat_M) {
+    this->rotHat_M = rotHat_M / rotHat_M.norm();
+}
+
+/*! Getter method for the spinning body rotation axis.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d &SingleAxisProfiler::getRotHat_M() const {
+    return this->rotHat_M;
+}

--- a/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.h
+++ b/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.h
@@ -1,0 +1,52 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _SINGLEAXISPROFILER_
+#define _SINGLEAXISPROFILER_
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/StepperMotorMsg_C.h"
+#include "cMsgCInterface/PrescribedRotationMsg_C.h"
+#include <Eigen/Dense>
+#include <cstdint>
+
+/*! @brief Single Axis Profiler Class */
+class SingleAxisProfiler: public SysModel {
+public:
+    SingleAxisProfiler() = default;                                    //!< Constructor
+    ~SingleAxisProfiler() = default;                                   //!< Destructor
+
+    void Reset(uint64_t CurrentSimNanos) override;                     //!< Reset member function
+    void UpdateState(uint64_t CurrentSimNanos) override;               //!< Update member function
+    void setRotHat_M(const Eigen::Vector3d &rotHat_M);                 //!< Setter for the spinning body rotation axis
+    const Eigen::Vector3d &getRotHat_M() const;                        //!< Getter for the spinning body rotation axis
+
+    ReadFunctor<StepperMotorMsgPayload> stepperMotorInMsg;             //!< Input msg for the stepper motor state information
+    Message<PrescribedRotationMsgPayload> prescribedRotationOutMsg;    //!< Output msg for the hub-relative prescribed rotational states
+
+    BSKLogger *bskLogger;                                              //!< BSK Logging
+
+private:
+    Eigen::Vector3d computeSigma_FM(double theta);                     //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_FM
+    Eigen::Vector3d rotHat_M;                                          //!< Spinning body rotation axis expressed in M frame components
+
+};
+
+#endif

--- a/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.i
+++ b/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.i
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module singleAxisProfiler
+%{
+   #include "singleAxisProfiler.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "swig_eigen.i"
+
+%include "sys_model.i"
+%include "singleAxisProfiler.h"
+
+%include "architecture/msgPayloadDefC/StepperMotorMsgPayload.h"
+struct StepperMotorMsg_C;
+
+%include "architecture/msgPayloadDefC/PrescribedRotationMsgPayload.h"
+struct PrescribedRotationMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.rst
+++ b/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.rst
@@ -1,0 +1,105 @@
+Executive Summary
+-----------------
+This prescribed motion-specific module computes the hub-relative rotational states of a spinning body following
+prescribed rotational one degree-of-freedom (DOF) motion about a single hub-fixed axis. The body frame of the spinning
+body is designated by the frame :math:`\mathcal{F}`. The spinning body's states are profiled relative to a hub-fixed
+frame :math:`\mathcal{M}`. The input message to this module is the :ref:`StepperMotorMsgPayload` message which provides
+the scalar spinning body states relative to the hub ``theta``, ``thetaDot``, and ``thetaDDot``. Given these scalar
+states together with the spinning body rotation axis specified by the user, the prescribed rotational states
+``sigma_FM``, ``omega_FM_F``, and ``omegaPrime_FM_F`` are computed and output from the module using the
+:ref:`PrescribedRotationMsgPayload` message. The only required input to this module that must be set by the user is
+the spinning body rotation axis expressed as a unit vector in Mount frame components ``rotHat_M``.
+
+.. important::
+    To use this module for prescribed motion, it must be connected to the :ref:`PrescribedMotionStateEffector`
+    dynamics module. This ensures the spinning body's states are correctly incorporated into the spacecraft dynamics.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  
+The module msg connection is set by the user from python.  
+The msg type contains a link to the message structure definition, while the description 
+provides information on what the message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - stepperMotorInMsg
+      - :ref:`StepperMotorMsgPayload`
+      - input msg with the stepper motor scalar states
+    * - prescribedRotationOutMsg
+      - :ref:`PrescribedRotationMsgPayload`
+      - output message with the prescribed spinning body rotational states
+
+Detailed Module Description
+---------------------------
+To compute the spinning body attitude relative to the hub-fixed mount frame, the given axis of rotation and the current
+stepper motor scalar angle are used in the following expression:
+
+.. math::
+    \boldsymbol{\sigma}_{\mathcal{F}/\mathcal{M}} = \tan \left ( \frac{\theta}{4} \right ) \hat{\boldsymbol{s}}
+
+where :math:`\hat{\boldsymbol{s}}` is the given axis of rotation.
+
+The spinning body angular velocity relative to the mount frame is computed using the following expression:
+
+.. math::
+    {}^{\mathcal{F}} \boldsymbol{\omega}_{\mathcal{F}/\mathcal{M}} = \dot{\theta} \ {}^{\mathcal{M}} \hat{\boldsymbol{s}}
+
+The spinning body angular acceleration relative to the mount frame is similarly computed:
+
+.. math::
+    {}^{\mathcal{F}} \boldsymbol{\omega}^{'}_{\mathcal{F}/\mathcal{M}} = \ddot{\theta} \ {}^{\mathcal{M}} \hat{\boldsymbol{s}}
+
+The computed prescribed rotational states ``sigma_FM``, ``omega_FM_F``, and ``omegaPrime_FM_F`` are then written to the
+:ref:`PrescribedRotationMsgPayload` module output message.
+
+Module Testing
+^^^^^^^^^^^^^^
+The unit test for this module ensures that the single-axis hub-relative rotational scalar states ``theta``,
+``thetaDot``, and ``thetaDDot`` are properly converted to prescribed hub-relative rotational states ``sigma_FM``,
+``omega_FM_F``, and ``omegaPrime_FM_F``. The scalar states are varied in the test, along with a single angle
+``rotAxis_MAngle`` that is used to vary the axis of rotation ``rotAxis_M`` associated with the given
+scalar information. To verify the module, the final prescribed rotational states are logged from the module. The
+final attitude is checked with the computed true attitude. The dot product between the given rotation axis and
+the final angular velocity and angular acceleration is checked to match the given scalar angle rate and angle
+acceleration.
+
+User Guide
+----------
+The only required input to this module that must be set by the user is the spinning body rotation axis expressed
+as a unit vector in Mount frame components ``rotHat_M``. This section outlines the steps needed to set up this
+single axis profiler module in python using Basilisk.
+
+#. Import the singleAxisProfiler class::
+
+    from Basilisk.simulation import singleAxisProfiler
+
+#. Create an instantiation of the module::
+
+    singleAxisRotProfiler = singleAxisProfiler.SingleAxisProfiler()
+
+#. Define all of the configuration data associated with the module::
+
+    singleAxisRotProfiler.ModelTag = "singleAxisProfiler"
+    singleAxisRotProfiler.setRotHat_M([1.0, 0.0, 0.0])
+
+#. Connect the :ref:`StepperMotorMsgPayload` input message to the module that tracks the stepper motor states in time. For example, the user can create a stand-alone message to specify a non-rotating spinning body::
+
+    stepperMotorMessageData = messaging.StepperMotorMsgPayload()
+    stepperMotorMessageData.theta = 10.0 * np.pi / 180.0  # [rad]
+    stepperMotorMessageData.thetaDot = 0.0 * np.pi / 180.0  # [rad/s]
+    stepperMotorMessageData.thetaDDot = 0.0 * np.pi / 180.0  # [rad/s^2]
+    stepperMotorMessage = messaging.StepperMotorMsg().write(stepperMotorMessageData)
+
+#. Subscribe the singleAxisProfiler module input message to the stepper motor message::
+
+    singleAxisRotProfiler.stepperMotorInMsg.subscribeTo(stepperMotorMessage)
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, singleAxisRotProfiler)


### PR DESCRIPTION
* **Tickets addressed:** bsk-206
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
This PR creates a new prescribed motion `signleAxisProfiler` simulation module for modeling a Solar Array Drive Assembly (SADA) or any single-axis rotating body relative to the spacecraft hub. This module is needed because the current `stepperMotorProfiler` module is being refactored and split into two separate modules. The first module is addressed in the issue [https://github.com/lasp/basilisk/issues/205]. This second module addresses only the prescribed motion component of the single-axis spinning body, where the conversion from the scalar stepper motor states to the hub-relative prescribed states (`sigma_FM`, `omega_FM_F`, and `omegaPrime_FM_F`) is done in this module. This conversion is being removed from the current `stepperMotorProfiler`  module and is being moved into this new module.

The module input message is the `stepperMotorMsgPayload`, which is provided by the refactored module [https://github.com/lasp/basilisk/issues/205]. The module converts the scalar stepper motor states to the prescribed motion hub-relative states. Note that the old stepperMotorProfiler module already computes this. The module outputs the hub-relative states using the `prescribedRotationMsgPayload` message.

## Verification
The unit test for this module ensures that the single-axis hub-relative rotational scalar states ``theta``, ``thetaDot``, and ``thetaDDot`` are properly converted to prescribed hub-relative rotational states ``sigma_FM``, ``omega_FM_F``, and ``omegaPrime_FM_F``. The scalar states are varied in this test, along with a single angle ``rotAxis_MAngle`` that is used to vary the axis of rotation ``rotAxis_M`` associated with the given scalar information. To verify the module, the final prescribed rotational states are logged from the module. The final attitude is checked with the computed true attitude. The dot product between the given rotation axis and the final angular velocity and angular acceleration is checked to match the given scalar angle rate and angle acceleration.

## Documentation
RST documentation is added to this PR for this new module.

## Future work
N/A