### PR TITLE
Explicitly include used std lib includes in rigid body kinematics

### DIFF
--- a/src/architecture/utilities/rigidBodyKinematics.cpp
+++ b/src/architecture/utilities/rigidBodyKinematics.cpp
@@ -18,6 +18,10 @@
  */
 
 #include "rigidBodyKinematics.hpp"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
 
 constexpr double eps = std::numeric_limits<double>::epsilon();
 


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We did not explicitly include the used standard library headers in rigidBodyKinematics.cpp. This caused compilation failure on some compilers.

## Verification
Tested against the compiler that was failing and CI tests.

## Documentation
None invalidated, none new.

## Future work
Add an analysis tool like Include what you use (IWYU) to require explicit includes and to prevent unused includes and absent includes.
