### PR TITLE
Update zmq protobuf dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -197,8 +197,8 @@ class BasiliskConan(ConanFile):
 
         if self.options.vizInterface or self.options.opNav:
             self.requires.add("libsodium/1.0.18")
-            self.requires.add("protobuf/3.17.1")
             self.requires.add("cppzmq/4.3.0@bincrafters/stable")
+            self.requires.add("protobuf/3.17.1#ffb2039b66b5a372f7a2a8a0b1ddfd13")
 
     def configure(self):
         if self.options.clean:

--- a/conanfile.py
+++ b/conanfile.py
@@ -196,9 +196,9 @@ class BasiliskConan(ConanFile):
             self.requires.add("xz_utils/5.4.0")
 
         if self.options.vizInterface or self.options.opNav:
-            self.requires.add("libsodium/1.0.18")
-            self.requires.add("cppzmq/4.3.0@bincrafters/stable")
             self.requires.add("protobuf/3.17.1#ffb2039b66b5a372f7a2a8a0b1ddfd13")
+            self.options['zeromq'].encryption = False  # Basilisk does not use data streaming encryption.
+            self.requires.add("cppzmq/4.5.0#7806ca4d6fc21b3f8af77ec4401ecf31")
 
     def configure(self):
         if self.options.clean:

--- a/conanfile.py
+++ b/conanfile.py
@@ -111,18 +111,6 @@ class BasiliskConan(ConanFile):
                 pass
 
     print(statusColor + "Checking conan configuration:" + endColor + " Done")
-
-    try:
-        consoleReturn = str(subprocess.check_output(["conan", "remote", "list", "--raw"]))
-        conanRepos = ["bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan"
-                      ]
-        for item in conanRepos:
-            if item not in consoleReturn:
-                print("Configuring: " + statusColor + item + endColor)
-                cmdString = ["conan", "remote", "add"] + item.split(" ")
-                subprocess.check_call(cmdString)
-    except:
-        print("conan: " + failColor + "Error configuring conan repo information." + endColor)
         
     try:
         # enable this flag for access revised conan modules.


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Bincrafters is deprecated and we can now move to updated versions of these dependencies sourced from conan center.

## Verification
CI successful

## Documentation
NA

## Future work
NA
