### PR TITLE
Refactor/refactor prescribed motion state effector

### DIFF
--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -433,7 +433,7 @@ def set_prescribed_motion_effector(prescribed_motion_body):
     prescribed_motion_body.setOmega_FM_F([0.0, 0.0, 0.0])
     prescribed_motion_body.setOmegaPrime_FM_F([0.0, 0.0, 0.0])
     prescribed_motion_body.setSigma_FM([0.0, 0.0, 0.0])
-    prescribed_motion_body.setOmega_MB_B([0.0, 0.0, 0.0])
+    prescribed_motion_body.setOmega_MB_M([0.0, 0.0, 0.0])
     prescribed_motion_body.setOmegaPrime_MB_B([0.0, 0.0, 0.0])
     prescribed_motion_body.setSigma_MB([0.0, 0.0, 0.0])
     prescribed_motion_body.ModelTag = "prescribedMotionBody"

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -519,4 +519,3 @@ if __name__ == "__main__":
         5.0 * macros.D2R,  # theta_ref [rad]
         1e-7  # accuracy
     )
-    

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -43,598 +43,480 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
-@pytest.mark.parametrize("rotTest", [True, False])
-@pytest.mark.parametrize("thetaInit", [0, np.pi/18])
-@pytest.mark.parametrize("theta_Ref", [np.pi/36])
-@pytest.mark.parametrize("posInit", [0, 0.2])
-@pytest.mark.parametrize("posRef", [0.1])
-@pytest.mark.parametrize("accuracy", [1e-8])
-def test_PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posInit, posRef, accuracy):
+@pytest.mark.parametrize("theta_init", [0.0, macros.D2R * 2.0])
+@pytest.mark.parametrize("theta_ref", [0.0, macros.D2R * 5.0])
+@pytest.mark.parametrize("accuracy", [1e-7])
+def test_PrescribedMotionStateEffector_Rotation(show_plots, theta_init, theta_ref, accuracy):
     r"""
-    **Validation Test Description**
+    **Rotational 1-DOF Prescribed Motion Verification Test Description**
 
-    The unit test for this module is an integrated test with two flight software profiler modules. This is required
-    because the dynamics module must be connected to a flight software profiler module to define the states of the
-    prescribed secondary body that is connected to the rigid spacecraft hub. The integrated test for this module has
-    two simple scenarios it is testing. The first scenario prescribes a 1 DOF rotation for the prescribed body
-    using the :ref:`prescribedRotation1DOF` flight software module. The second scenario prescribes
-    linear translation for the prescribed body using the :ref:`prescribedLinearTranslation` flight software module.
+    This prescribed motion unit test function is an integrated test with the :ref:`prescribedRotation1DOF` kinematic
+    profiler module. The profiler module prescribes a 1-degree-of-freedom (1-DOF) rotation for the prescribed state
+    effector relative to the spacecraft hub.
 
-    This unit test ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
-    initial and reference PRV angles and maximum angular accelerations. The final prescribed attitude and angular
-    velocity magnitude are compared with the reference values. This unit test also ensures that the profiled
-    translational maneuver is properly computed for a series of initial and reference positions and maximum
-    accelerations. The final prescribed position and velocity magnitudes are compared with the reference values.
-    Additionally for each scenario, the conservation quantities of orbital angular momentum, rotational angular
-    momentum, and orbital energy are checked to validate the module dynamics.
+    This unit test function verifies the prescribed motion state effector dynamics by checking to ensure that the
+    orbital angular momentum, orbital energy, and spacecraft rotational angular momentum are reasonably conserved.
 
     **Test Parameters**
 
     Args:
-        rotTest (bool): (True) Runs the rotational motion test. (False) Runs the translational motion test.
-        thetaInit (float): [rad] Initial PRV angle of the F frame with respect to the M frame
-        theta_Ref (float): [rad] Reference PRV angle of the F frame with respect to the M frame
-        thetaDDotMax (float): [rad/s^2] Maximum angular acceleration for the attitude maneuver
-        scalarPosInit (float): [m] Initial scalar position of the F frame with respect to the M frame
-        scalarPosRef (float): [m] Reference scalar position of the F frame with respect to the M frame
-        scalarAccelMax (float): [m/s^2] Maximum acceleration for the translational maneuver
-        accuracy (float): absolute accuracy value used in the validation tests
+        theta_init (float): [rad] Initial hub-relative angle of the prescribed motion effector
+        theta_ref (float): [rad] Reference hub-relative angle of the prescribed motion effector
+        accuracy (float): Absolute accuracy value used in the verification tests
 
     **Description of Variables Being Tested**
 
-    This unit test ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
-    initial and reference PRV angles and maximum angular accelerations. The final prescribed angle ``theta_FM_Final``
-    and angular velocity magnitude ``thetaDot_Final`` are compared with the reference values ``theta_Ref`` and
-    ``thetaDot_Ref``, respectively. This unit test also ensures that the profiled translational maneuver is properly
-    computed for a series of initial and reference positions and maximum accelerations. The final prescribed position
-    magnitude ``r_FM_M_Final`` and velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values
-    ``r_FM_M_Ref`` and ``rPrime_FM_M_Ref``, respectively. Additionally for each scenario, the conservation quantities
-    of orbital angular momentum, rotational angular momentum, and orbital energy are checked to validate the module
-    dynamics.
+    This unit test checks to ensure that the initial simulation values of orbital energy, orbital angular momentum,
+    and the spacecraft rotational angular momentum match the final simulation values to a reasonable extent.
     """
 
-    [testResults, testMessage] = PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posInit, posRef, accuracy)
-
-    assert testResults < 1, testMessage
-
-
-def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posInit, posRef, accuracy):
-    """Call this routine directly to run the unit test."""
     __tracebackhide__ = True
 
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty list to store test log messages
-    unitTaskName = "unitTask"
-    unitProcessName = "TestProcess"
+    unit_task_name = "unitTask"
+    unit_process_name = "testProcess"
 
     # Create a sim module as an empty container
-    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testIncrement = 0.1  # [s]
-    testProcessRate = macros.sec2nano(testIncrement)  # update process rate update time
-    testProc = unitTestSim.CreateNewProcess(unitProcessName)
-    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+    test_increment = 0.001  # [s]
+    test_process_rate = macros.sec2nano(test_increment)  # update process rate update time
+    test_process = unit_test_sim.CreateNewProcess(unit_process_name)
+    test_process.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
 
     # Add the spacecraft module to test file
-    scObject = spacecraft.Spacecraft()
-    scObject.ModelTag = "spacecraftBody"
+    sc_object = spacecraft.Spacecraft()
+    sc_object.ModelTag = "spacecraftBody"
+    unit_test_sim.AddModelToTask(unit_task_name, sc_object)
 
     # Define the mass properties of the rigid spacecraft hub
-    scObject.hub.mHub = 750.0
-    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]
+    set_spacecraft_hub(sc_object)
 
-    # Set the initial inertial hub states
-    scObject.hub.r_CN_NInit = [[-4020338.690396649], [7490566.741852513], [5248299.211589362]]
-    scObject.hub.v_CN_NInit = [[-5199.77710904224], [-3436.681645356935], [1041.576797498721]]
-    scObject.hub.omega_BN_BInit = np.array([0.0, 0.0, 0.0])
-    scObject.hub.sigma_BNInit = [[0.0], [0.0], [0.0]]
+    # Create the prescribed motion state effector
+    rot_axis_m = np.array([1.0, 0.0, 0.0])
+    prv_fm_init = theta_init * rot_axis_m
+    sigma_fm = rbk.PRV2MRP(prv_fm_init)
+    prescribed_motion_body = prescribedMotionStateEffector.PrescribedMotionStateEffector()
+    set_prescribed_motion_effector(prescribed_motion_body)
+    prescribed_motion_body.setSigma_FM(sigma_fm)
+    sc_object.addStateEffector(prescribed_motion_body)
+    unit_test_sim.AddModelToTask(unit_task_name, prescribed_motion_body)
 
-    # Add the scObject to the runtime call list
-    unitTestSim.AddModelToTask(unitTaskName, scObject)
+    # Create an instance of the prescribedRotation1DOF module to be tested
+    ang_accel_max = 0.2 * macros.D2R  # [rad/s^2]
+    prescribed_rot_1_dof = prescribedRotation1DOF.PrescribedRotation1DOF()
+    prescribed_rot_1_dof.setRotHat_M(rot_axis_m)
+    prescribed_rot_1_dof.setThetaDDotMax(ang_accel_max)
+    prescribed_rot_1_dof.setThetaInit(theta_init)
+    prescribed_rot_1_dof.setCoastOptionBangDuration(1.0)
+    prescribed_rot_1_dof.setSmoothingDuration(1.0)
+    prescribed_rot_1_dof.ModelTag = "prescribedRotation1DOF"
+    unit_test_sim.AddModelToTask(unit_task_name, prescribed_rot_1_dof)
 
-    # Add the prescribedMotion dynamics module to test file
-    platform = prescribedMotionStateEffector.PrescribedMotionStateEffector()
+    # Create the prescribedRotation1DOF input message
+    spinning_body_message_data = messaging.HingedRigidBodyMsgPayload()
+    spinning_body_message_data.theta = theta_ref
+    spinning_body_message_data.thetaDot = 0.0  # [rad/s]
+    spinning_body_message = messaging.HingedRigidBodyMsg().write(spinning_body_message_data)
+    prescribed_rot_1_dof.spinningBodyInMsg.subscribeTo(spinning_body_message)
+    prescribed_motion_body.prescribedRotationInMsg.subscribeTo(prescribed_rot_1_dof.prescribedRotationOutMsg)
 
-    # Define the state effector properties
-    transAxis_M = np.array([1.0, 0.0, 0.0])
-    rotAxis_M = np.array([1.0, 0.0, 0.0])
-    r_FM_M = posInit * transAxis_M
-    prvInit_FM = thetaInit * rotAxis_M
-    sigma_FM = rbk.PRV2MRP(prvInit_FM)
+    # Add Earth gravity to the simulation
+    earth_grav_body = gravityEffector.GravBodyData()
+    earth_grav_body.planetName = "earth_planet_data"
+    earth_grav_body.mu = 0.3986004415E+15
+    earth_grav_body.isCentralBody = True
+    sc_object.gravField.gravBodies = spacecraft.GravBodyVector([earth_grav_body])
 
-    platform.mass = 100.0
-    platform.IPntFc_F = [[50.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]
-    platform.r_MB_B = [0.0, 0.0, 0.0]
-    platform.r_FcF_F = [0.0, 0.0, 0.0]
-    platform.r_FM_M = r_FM_M
-    platform.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-    platform.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
-    platform.omega_FM_F = np.array([0.0, 0.0, 0.0])
-    platform.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
-    platform.sigma_FM = sigma_FM
-    platform.omega_MB_B = [0.0, 0.0, 0.0]
-    platform.omegaPrime_MB_B = [0.0, 0.0, 0.0]
-    platform.sigma_MB = [0.0, 0.0, 0.0]
-    platform.ModelTag = "Platform"
+    # Log data
+    sc_state_data_log = sc_object.scStateOutMsg.recorder()
+    prescribed_rot_state_data_log = prescribed_motion_body.prescribedRotationOutMsg.recorder()
+    theta_data_log = prescribed_rot_1_dof.spinningBodyOutMsg.recorder()
+    sc_energy_momentum_log = sc_object.logger(["totOrbEnergy",
+                                               "totOrbAngMomPntN_N",
+                                               "totRotAngMomPntC_N",
+                                               "totRotEnergy"])
+    unit_test_sim.AddModelToTask(unit_task_name, sc_state_data_log)
+    unit_test_sim.AddModelToTask(unit_task_name, prescribed_rot_state_data_log)
+    unit_test_sim.AddModelToTask(unit_task_name, theta_data_log)
+    unit_test_sim.AddModelToTask(unit_task_name, sc_energy_momentum_log)
 
-    # Add platform to spacecraft
-    scObject.addStateEffector(platform)
+    # Initialize the simulation
+    unit_test_sim.InitializeSimulation()
 
-    # Add the test module to runtime call list
-    unitTestSim.AddModelToTask(unitTaskName, platform)
+    # Set the simulation time
+    sim_time = 30  # [s]
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
 
-    if rotTest:
-    
-        # ** ** ** ** ** ROTATIONAL 1 DOF INTEGRATED TEST: ** ** ** ** **
+    # Begin the simulation
+    unit_test_sim.ExecuteSimulation()
 
-        # Create an instance of the prescribedRotation1DOF module to be tested
-        PrescribedRot1DOF = prescribedRotation1DOF.PrescribedRotation1DOF()
-        PrescribedRot1DOF.ModelTag = "prescribedRotation1DOF"
+    # Extract the logged data
+    timespan = sc_state_data_log.times() * macros.NANO2SEC  # [s]
+    theta = macros.R2D * theta_data_log.theta  # [deg]
+    omega_fm_f = prescribed_rot_state_data_log.omega_FM_F * macros.R2D  # [deg]
+    omega_prime_fm_f = prescribed_rot_state_data_log.omegaPrime_FM_F * macros.R2D  # [deg]
+    orb_energy = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                               sc_energy_momentum_log.totOrbEnergy)
+    orb_ang_mom_n = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                                  sc_energy_momentum_log.totOrbAngMomPntN_N)
+    rot_ang_mom_n = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                                  sc_energy_momentum_log.totRotAngMomPntC_N)
+    rot_energy = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                               sc_energy_momentum_log.totRotEnergy)
 
-        # Add the prescribedRotation1DOF test module to runtime call list
-        unitTestSim.AddModelToTask(unitTaskName, PrescribedRot1DOF)
-
-        # Initialize the prescribedRotation1DOF test module configuration data
-        accelMax = 0.01  # [rad/s^2]
-        PrescribedRot1DOF.setRotHat_M(rotAxis_M)
-        PrescribedRot1DOF.setThetaDDotMax(accelMax)
-        PrescribedRot1DOF.setThetaInit(thetaInit)
-
-        # Create the prescribedRotation1DOF input message
-        thetaDot_Ref = 0.0  # [rad/s]
-        SpinningBodyMessageData = messaging.HingedRigidBodyMsgPayload()
-        SpinningBodyMessageData.theta = theta_Ref
-        SpinningBodyMessageData.thetaDot = thetaDot_Ref
-        SpinningBodyMessage = messaging.HingedRigidBodyMsg().write(SpinningBodyMessageData)
-        PrescribedRot1DOF.spinningBodyInMsg.subscribeTo(SpinningBodyMessage)
-
-        platform.prescribedRotationInMsg.subscribeTo(PrescribedRot1DOF.prescribedRotationOutMsg)
-
-        # Add Earth gravity to the simulation
-        earthGravBody = gravityEffector.GravBodyData()
-        earthGravBody.planetName = "earth_planet_data"
-        earthGravBody.mu = 0.3986004415E+15
-        earthGravBody.isCentralBody = True
-        scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
-
-        # Add energy and momentum variables to log
-        scObjectLog = scObject.logger(["totOrbEnergy", "totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
-        unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
-
-        # Add other states to log
-        scStateData = scObject.scStateOutMsg.recorder()
-        prescribedRotStateData = platform.prescribedRotationOutMsg.recorder()
-        unitTestSim.AddModelToTask(unitTaskName, scStateData)
-        unitTestSim.AddModelToTask(unitTaskName, prescribedRotStateData)
-
-        # Initialize the simulation
-        unitTestSim.InitializeSimulation()
-
-        # Set the simulation time
-        simTime = np.sqrt(((0.5 * np.abs(theta_Ref - thetaInit)) * 8) / accelMax) + 3 * testIncrement
-        unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
-
-        # Begin the simulation
-        unitTestSim.ExecuteSimulation()
-
-        # Extract the logged data
-        orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
-        orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-        rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-        rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-        omega_BN_B = scStateData.omega_BN_B
-        r_BN_N = scStateData.r_BN_N
-        sigma_BN = scStateData.sigma_BN
-        omega_FM_F = prescribedRotStateData.omega_FM_F
-        omegaPrime_FM_F = prescribedRotStateData.omegaPrime_FM_F
-        sigma_FM = prescribedRotStateData.sigma_FM
-        timespan = prescribedRotStateData.times()
-        thetaDot_Final = np.linalg.norm(omega_FM_F[-1, :])
-        sigma_FM_Final = sigma_FM[-1, :]
-        theta_FM_Final = 4 * np.arctan(np.linalg.norm(sigma_FM_Final))
-
-        # Setup the conservation quantities
-        initialOrbAngMom_N = [[orbAngMom_N[0, 1], orbAngMom_N[0, 2], orbAngMom_N[0, 3]]]
-        finalOrbAngMom = [orbAngMom_N[-1]]
-        initialRotAngMom_N = [[rotAngMom_N[0, 1], rotAngMom_N[0, 2], rotAngMom_N[0, 3]]]
-        finalRotAngMom = [rotAngMom_N[-1]]
-        initialOrbEnergy = [[orbEnergy[0, 1]]]
-        finalOrbEnergy = [orbEnergy[-1]]
-
-        # Convert the logged sigma_FM MRPs to a scalar theta_FM array
-        n = len(timespan)
-        theta_FM = []
-        for i in range(n):
-            theta_FM.append((180 / np.pi) * (4 * np.arctan(np.linalg.norm(sigma_FM[i, :]))))
-
-        plt.close("all")
-
+    # Plot results
+    if show_plots:
         # Plot theta_FM
-        theta_Ref_plotting = np.ones(len(timespan)) * theta_Ref
-        thetaInit_plotting = np.ones(len(timespan)) * thetaInit
+        theta_ref_plotting = np.ones(len(timespan)) * theta_ref * macros.R2D  # [deg]
+        theta_init_plotting = np.ones(len(timespan)) * theta_init * macros.R2D  # [deg]
         plt.figure()
         plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, theta_FM, label=r'$\Phi$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * theta_Ref_plotting, '--', label=r'$\Phi_{Ref}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * thetaInit_plotting, '--', label=r'$\Phi_{0}$')
-        plt.title(r'$\Phi_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.plot(timespan, theta, label=r'$\theta$')
+        plt.plot(timespan, theta_init_plotting, '--', label=r'$\theta_{0}$')
+        plt.plot(timespan, theta_ref_plotting, '--', label=r'$\theta_{Ref}$')
+        plt.title(r'$\theta$ Profiled Trajectory', fontsize=16)
         plt.ylabel('(deg)', fontsize=16)
         plt.xlabel('Time (s)', fontsize=16)
         plt.legend(loc='center right', prop={'size': 16})
+        plt.grid(True)
 
-        # Plot omega_FM_F
+        # Plot omega_fm_f
         plt.figure()
         plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_FM_F[:, 0], label=r'$\omega_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_FM_F[:, 1], label=r'$\omega_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_FM_F[:, 2], label=r'$\omega_{3}$')
-        plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.plot(timespan, omega_fm_f[:, 0], label='1')
+        plt.plot(timespan, omega_fm_f[:, 1], label='2')
+        plt.plot(timespan, omega_fm_f[:, 2], label='3')
+        plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=16)
         plt.ylabel('(deg/s)', fontsize=16)
         plt.xlabel('Time (s)', fontsize=16)
         plt.legend(loc='upper right', prop={'size': 16})
+        plt.grid(True)
 
-        # Plotting omegaPrime_FM_F
+        # Plot omega_prime_fm_f
         plt.figure()
         plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omegaPrime_FM_F[:, 0], label='1')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omegaPrime_FM_F[:, 1], label='2')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omegaPrime_FM_F[:, 2], label='3')
-        plt.title(r'${}^\mathcal{F} \omega Prime_{\mathcal{F}/\mathcal{M}}$ Profiled Angular Acceleration', fontsize=14)
+        plt.plot(timespan, omega_prime_fm_f[:, 0], label='1')
+        plt.plot(timespan, omega_prime_fm_f[:, 1], label='2')
+        plt.plot(timespan, omega_prime_fm_f[:, 2], label='3')
+        plt.title(r'${}^\mathcal{F} \omega Prime_{\mathcal{F}/\mathcal{M}}$ Profiled Angular Acceleration', fontsize=16)
         plt.ylabel(r'(deg/$s^2$)', fontsize=16)
         plt.xlabel('Time (s)', fontsize=16)
         plt.legend(loc='upper right', prop={'size': 16})
+        plt.grid(True)
 
-        # Plot r_BN_N
-        plt.figure()
-        plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, r_BN_N[:, 0], label=r'$r_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, r_BN_N[:, 1], label=r'$r_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, r_BN_N[:, 2], label=r'$r_{3}$')
-        plt.title(r'${}^\mathcal{N} r_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial Trajectory', fontsize=14)
-        plt.ylabel('(m)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
-        plt.legend(loc='center left', prop={'size': 16})
+        # Plot conservation quantities
+        plot_conservation(timespan, orb_ang_mom_n, orb_energy, rot_ang_mom_n, rot_energy)
 
-        # Plot sigma_BN
-        plt.figure()
-        plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, sigma_BN[:, 0], label=r'$\sigma_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, sigma_BN[:, 1], label=r'$\sigma_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, sigma_BN[:, 2], label=r'$\sigma_{3}$')
-        plt.title(r'$\sigma_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial MRP Attitude', fontsize=14)
-        plt.ylabel('', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
-        plt.legend(loc='center left', prop={'size': 16})
+        plt.show()
 
-        # Plot omega_BN_B
-        plt.figure()
-        plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_BN_B[:, 0], label=r'$\omega_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_BN_B[:, 1], label=r'$\omega_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_BN_B[:, 2], label=r'$\omega_{3}$')
-        plt.title(r'Spacecraft Hub Angular Velocity ${}^\mathcal{B} \omega_{\mathcal{B}/\mathcal{N}}$', fontsize=14)
-        plt.xlabel('Time (s)', fontsize=16)
-        plt.ylabel('(deg/s)', fontsize=16)
-        plt.legend(loc='lower right', prop={'size': 16})
+    plt.close("all")
 
-        # Plotting: Conservation quantities
-        plt.figure()
-        plt.clf()
-        plt.plot(orbAngMom_N[:, 0] * macros.NANO2SEC, (orbAngMom_N[:, 1] - orbAngMom_N[0, 1]) / orbAngMom_N[0, 1],
-                 orbAngMom_N[:, 0] * macros.NANO2SEC, (orbAngMom_N[:, 2] - orbAngMom_N[0, 2]) / orbAngMom_N[0, 2],
-                 orbAngMom_N[:, 0] * macros.NANO2SEC, (orbAngMom_N[:, 3] - orbAngMom_N[0, 3]) / orbAngMom_N[0, 3])
-        plt.title('Orbital Angular Momentum Relative Difference', fontsize=14)
-        plt.ylabel('(Nms)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+    # Check conservation quantities
+    check_conservation(orb_ang_mom_n, orb_energy, rot_ang_mom_n, accuracy)
 
-        plt.figure()
-        plt.clf()
-        plt.plot(orbEnergy[:, 0] * macros.NANO2SEC, (orbEnergy[:, 1] - orbEnergy[0, 1]) / orbEnergy[0, 1])
-        plt.title('Orbital Energy Relative Difference', fontsize=14)
-        plt.ylabel('Energy (J)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+@pytest.mark.parametrize("trans_pos_init", [0.0, 0.1])
+@pytest.mark.parametrize("trans_pos_ref", [0.0, 0.1])
+@pytest.mark.parametrize("accuracy", [1e-8])
+def test_PrescribedMotionStateEffector_Translation(show_plots, trans_pos_init, trans_pos_ref, accuracy):
+    r"""
+    **Linear Translational Prescribed Motion Verification Test Description**
 
-        plt.figure()
-        plt.clf()
-        plt.plot(rotAngMom_N[:, 0] * macros.NANO2SEC, (rotAngMom_N[:, 1] - rotAngMom_N[0, 1]),
-                 rotAngMom_N[:, 0] * macros.NANO2SEC, (rotAngMom_N[:, 2] - rotAngMom_N[0, 2]),
-                 rotAngMom_N[:, 0] * macros.NANO2SEC, (rotAngMom_N[:, 3] - rotAngMom_N[0, 3]))
-        plt.title('Rotational Angular Momentum Difference', fontsize=14)
-        plt.ylabel('(Nms)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+    This prescribed motion unit test function is an integrated test with the :ref:`prescribedLinearTranslation`
+    kinematic profiler module. The profiler module prescribes linear translational motion for the prescribed state
+    effector relative to the spacecraft hub.
 
-        plt.figure()
-        plt.clf()
-        plt.plot(rotEnergy[:, 0] * macros.NANO2SEC, (rotEnergy[:, 1] - rotEnergy[0, 1]))
-        plt.title('Total Energy Difference', fontsize=14)
-        plt.ylabel('Energy (J)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+    This unit test function verifies the prescribed motion state effector dynamics by checking to ensure that the
+    orbital angular momentum, orbital energy, and spacecraft rotational angular momentum are reasonably conserved.
 
-        if show_plots:
-            plt.show()
-        plt.close("all")
+    **Test Parameters**
 
-        # Begin the test analysis
-        finalOrbAngMom = np.delete(finalOrbAngMom, 0, axis=1)  # remove the time column
-        finalRotAngMom = np.delete(finalRotAngMom, 0, axis=1)  # remove the time column
-        finalOrbEnergy = np.delete(finalOrbEnergy, 0, axis=1)  # remove the time column
+    Args:
+        trans_pos_init (float): [m] Initial displacement of the prescribed motion effector relative to the spacecraft hub
+        trans_pos_ref (float): [m] Reference displacement of the prescribed motion effector relative to the spacecraft hub
+        accuracy (float): Absolute accuracy value used in the verification tests
 
-        for i in range(0, len(initialOrbAngMom_N)):
-            if not unitTestSupport.isArrayEqualRelative(finalOrbAngMom[i], initialOrbAngMom_N[i], 3, accuracy):
-                testFailCount += 1
-                testMessages.append(
-                    "FAILED: Prescribed Motion integrated test failed orbital angular momentum unit test")
+    **Description of Variables Being Tested**
 
-        for i in range(0, len(initialRotAngMom_N)):
-            if not unitTestSupport.isArrayEqual(finalRotAngMom[i], initialRotAngMom_N[i], 3, accuracy):
-                testFailCount += 1
-                testMessages.append(
-                    "FAILED: Prescribed Motion integrated test failed rotational angular momentum unit test")
+    This unit test checks to ensure that the initial simulation values of orbital energy, orbital angular momentum,
+    and the spacecraft rotational angular momentum match the final simulation values to a reasonable extent.
+    """
 
-        for i in range(0, len(initialOrbEnergy)):
-            if not unitTestSupport.isArrayEqualRelative(finalOrbEnergy[i], initialOrbEnergy[i], 1, accuracy):
-                testFailCount += 1
-                testMessages.append("FAILED: Prescribed Motion integrated test failed orbital energy unit test")
+    __tracebackhide__ = True
 
-        # Check to ensure the initial angle rate converged to the reference angle rate
-        if not unitTestSupport.isDoubleEqual(thetaDot_Final, thetaDot_Ref, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + PrescribedRot1DOF.ModelTag + "thetaDot_Final and thetaDot_Ref do not match")
+    unit_task_name = "unitTask"
+    unit_process_name = "test_processess"
 
-        # Check to ensure the initial angle converged to the reference angle
-        if not unitTestSupport.isDoubleEqual(theta_FM_Final, theta_Ref, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + PrescribedRot1DOF.ModelTag + "theta_FM_Final and theta_Ref do not match")
-            # testMessages.append("theta_FM_Final: " + str(theta_FM_Final) + " theta_Ref: " + str(theta_Ref))
+    # Create a sim module as an empty container
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
 
-        if testFailCount == 0:
-            print("PASSED: " + "prescribedMotion and prescribedRot1DOF integrated test")
+    # Create test thread
+    test_increment = 0.001  # [s]
+    test_process_rate = macros.sec2nano(test_increment)  # update process rate update time
+    test_process = unit_test_sim.CreateNewProcess(unit_process_name)
+    test_process.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
 
-    else:
+    # Add the spacecraft module to test file
+    sc_object = spacecraft.Spacecraft()
+    sc_object.ModelTag = "spacecraftBody"
+    unit_test_sim.AddModelToTask(unit_task_name, sc_object)
 
-        # ** ** ** ** ** TRANSLATIONAL INTEGRATED TEST ** ** ** ** **
+    # Define the mass properties of the rigid spacecraft hub
+    set_spacecraft_hub(sc_object)
 
-        # Create an instance of the prescribedLinearTranslation module to be tested
-        PrescribedTrans = prescribedLinearTranslation.PrescribedLinearTranslation()
-        PrescribedTrans.ModelTag = "prescribedLinearTranslation"
+    # Create the prescribed motion state effector
+    trans_axis_m = np.array([1.0, 0.0, 0.0])
+    prescribed_motion_body = prescribedMotionStateEffector.PrescribedMotionStateEffector()
+    set_prescribed_motion_effector(prescribed_motion_body)
+    prescribed_motion_body.setR_FM_M(trans_pos_init * trans_axis_m)
+    sc_object.addStateEffector(prescribed_motion_body)
+    unit_test_sim.AddModelToTask(unit_task_name, prescribed_motion_body)
 
-        # Add the prescribedLinearTranslation test module to runtime call list
-        unitTestSim.AddModelToTask(unitTaskName, PrescribedTrans)
+    # Create an instance of the prescribedLinearTranslation module to be tested
+    trans_accel_max = 0.005  # [m/s^2]
+    prescribed_translation = prescribedLinearTranslation.PrescribedLinearTranslation()
+    prescribed_translation.setTransHat_M(trans_axis_m)
+    prescribed_translation.setTransAccelMax(trans_accel_max)
+    prescribed_translation.setTransPosInit(trans_pos_init)
+    prescribed_translation.setCoastOptionBangDuration(1.0)
+    prescribed_translation.setSmoothingDuration(1.0)
+    prescribed_translation.ModelTag = "prescribedLinearTranslation"
+    unit_test_sim.AddModelToTask(unit_task_name, prescribed_translation)
 
-        # Initialize the prescribedLinearTranslation test module configuration data
-        accelMax = 0.005  # [m/s^2]
-        PrescribedTrans.setTransHat_M(transAxis_M)
-        PrescribedTrans.setTransAccelMax(accelMax)
-        PrescribedTrans.setTransPosInit(posInit)
+    # Create the prescribed_translation input message
+    linear_translating_body_message_data = messaging.LinearTranslationRigidBodyMsgPayload()
+    linear_translating_body_message_data.rho = trans_pos_ref
+    linear_translating_body_message_data.rhoDot = 0.0
+    linear_translating_body_message = messaging.LinearTranslationRigidBodyMsg().write(linear_translating_body_message_data)
+    prescribed_translation.linearTranslationRigidBodyInMsg.subscribeTo(linear_translating_body_message)
+    prescribed_motion_body.prescribedTranslationInMsg.subscribeTo(prescribed_translation.prescribedTranslationOutMsg)
 
-        # Create the prescribedTrans input message
-        velRef = 0.0  # [m/s]
-        linearTranslationRigidBodyMessageData = messaging.LinearTranslationRigidBodyMsgPayload()
-        linearTranslationRigidBodyMessageData.rho = posRef
-        linearTranslationRigidBodyMessageData.rhoDot = velRef
-        linearTranslationRigidBodyMessage = messaging.LinearTranslationRigidBodyMsg().write(linearTranslationRigidBodyMessageData)
-        PrescribedTrans.linearTranslationRigidBodyInMsg.subscribeTo(linearTranslationRigidBodyMessage)
+    # Add Earth gravity to the simulation
+    earth_grav_body = gravityEffector.GravBodyData()
+    earth_grav_body.planetName = "earth_planet_data"
+    earth_grav_body.mu = 0.3986004415E+15
+    earth_grav_body.isCentralBody = True
+    sc_object.gravField.gravBodies = spacecraft.GravBodyVector([earth_grav_body])
 
-        platform.prescribedTranslationInMsg.subscribeTo(PrescribedTrans.prescribedTranslationOutMsg)
+    # Log data
+    sc_state_data_log = sc_object.scStateOutMsg.recorder()
+    prescribed_trans_state_data_log = prescribed_motion_body.prescribedTranslationOutMsg.recorder()
+    sc_energy_momentum_log = sc_object.logger(["totOrbEnergy",
+                                               "totOrbAngMomPntN_N",
+                                               "totRotAngMomPntC_N",
+                                               "totRotEnergy"])
+    unit_test_sim.AddModelToTask(unit_task_name, sc_state_data_log)
+    unit_test_sim.AddModelToTask(unit_task_name, prescribed_trans_state_data_log)
+    unit_test_sim.AddModelToTask(unit_task_name, sc_energy_momentum_log)
 
-        # Add Earth gravity to the simulation
-        earthGravBody = gravityEffector.GravBodyData()
-        earthGravBody.planetName = "earth_planet_data"
-        earthGravBody.mu = 0.3986004415E+15
-        earthGravBody.isCentralBody = True
-        scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+    # Initialize the simulation
+    unit_test_sim.InitializeSimulation()
+    sim_time = 30
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
+    unit_test_sim.ExecuteSimulation()
 
-        # Add energy and momentum variables to log
-        scObjectLog = scObject.logger(["totOrbEnergy", "totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
-        unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
+    # Extract the logged data
+    timespan = sc_state_data_log.times() * macros.NANO2SEC  # [s]
+    r_fm_m = prescribed_trans_state_data_log.r_FM_M
+    r_prime_fm_m = prescribed_trans_state_data_log.rPrime_FM_M
+    r_prime_prime_fm_m = prescribed_trans_state_data_log.rPrimePrime_FM_M
+    orb_energy = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                               sc_energy_momentum_log.totOrbEnergy)
+    orb_ang_mom_n = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                                  sc_energy_momentum_log.totOrbAngMomPntN_N)
+    rot_ang_mom_n = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                                  sc_energy_momentum_log.totRotAngMomPntC_N)
+    rot_energy = unitTestSupport.addTimeColumn(sc_energy_momentum_log.times(),
+                                               sc_energy_momentum_log.totRotEnergy)
 
-        # Add other states to log
-        scStateData = scObject.scStateOutMsg.recorder()
-        prescribedTransStateData = platform.prescribedTranslationOutMsg.recorder()
-        unitTestSim.AddModelToTask(unitTaskName, scStateData)
-        unitTestSim.AddModelToTask(unitTaskName, prescribedTransStateData)
-
-        # Initialize the simulation
-        unitTestSim.InitializeSimulation()
-
-        # Set the simulation time
-        simTime = np.sqrt(((0.5 * np.abs(posRef - posInit)) * 8) / accelMax) + 3 * testIncrement
-        unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
-
-        # Begin the simulation
-        unitTestSim.ExecuteSimulation()
-
-        # Extract the logged data
-        orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
-        orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-        rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-        rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-        r_BN_N = scStateData.r_BN_N
-        sigma_BN = scStateData.sigma_BN
-        omega_BN_B = scStateData.omega_BN_B
-        r_FM_M = prescribedTransStateData.r_FM_M
-        rPrime_FM_M = prescribedTransStateData.rPrime_FM_M
-        rPrimePrime_FM_M = prescribedTransStateData.rPrimePrime_FM_M
-        timespan = prescribedTransStateData.times()
-        r_FM_M_Final = r_FM_M[-1, :]
-        rPrime_FM_M_Final = rPrime_FM_M[-1, :]
-
-        # Setup the conservation quantities
-        initialOrbAngMom_N = [[orbAngMom_N[0, 1], orbAngMom_N[0, 2], orbAngMom_N[0, 3]]]
-        finalOrbAngMom = [orbAngMom_N[-1]]
-        initialRotAngMom_N = [[rotAngMom_N[0, 1], rotAngMom_N[0, 2], rotAngMom_N[0, 3]]]
-        finalRotAngMom = [rotAngMom_N[-1]]
-        initialOrbEnergy = [[orbEnergy[0, 1]]]
-        finalOrbEnergy = [orbEnergy[-1]]
-        initialRotEnergy = [[rotEnergy[0, 1]]]
-        finalRotEnergy = [rotEnergy[-1]]
-
+    # Plot results
+    if show_plots:
         # Plot r_FM_F
-        r_FM_M_Ref = posRef * transAxis_M
-        r_FM_M_1_Ref = np.ones(len(timespan)) * r_FM_M_Ref[0]
-        r_FM_M_2_Ref = np.ones(len(timespan)) * r_FM_M_Ref[1]
-        r_FM_M_3_Ref = np.ones(len(timespan)) * r_FM_M_Ref[2]
-
+        r_fm_m_ref = trans_pos_ref * trans_axis_m
+        r_fm_m_1_ref = np.ones(len(timespan)) * r_fm_m_ref[0]
+        r_fm_m_2_ref = np.ones(len(timespan)) * r_fm_m_ref[1]
+        r_fm_m_3_ref = np.ones(len(timespan)) * r_fm_m_ref[2]
         plt.figure()
         plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 0], label=r'$r_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 1], label=r'$r_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 2], label=r'$r_{3}$')
-        plt.plot(timespan * macros.NANO2SEC, r_FM_M_1_Ref, '--', label=r'$r_{1 Ref}$')
-        plt.plot(timespan * macros.NANO2SEC, r_FM_M_2_Ref, '--', label=r'$r_{2 Ref}$')
-        plt.plot(timespan * macros.NANO2SEC, r_FM_M_3_Ref, '--', label=r'$r_{3 Ref}$')
-        plt.title(r'${}^\mathcal{M} r_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.plot(timespan, r_fm_m[:, 0], label=r'$r_{1}$')
+        plt.plot(timespan, r_fm_m[:, 1], label=r'$r_{2}$')
+        plt.plot(timespan, r_fm_m[:, 2], label=r'$r_{3}$')
+        plt.plot(timespan, r_fm_m_1_ref, '--', label=r'$r_{1 Ref}$')
+        plt.plot(timespan, r_fm_m_2_ref, '--', label=r'$r_{2 Ref}$')
+        plt.plot(timespan, r_fm_m_3_ref, '--', label=r'$r_{3 Ref}$')
+        plt.title(r'${}^\mathcal{M} r_{F/M}$ Profiled Trajectory', fontsize=14)
         plt.ylabel('(m)', fontsize=16)
         plt.xlabel('Time (s)', fontsize=16)
         plt.legend(loc='center left', prop={'size': 16})
+        plt.grid(True)
 
         # Plot rPrime_FM_F
         plt.figure()
         plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 0], label='1')
-        plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 1], label='2')
-        plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 2], label='3')
-        plt.title(r'${}^\mathcal{M} rPrime_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.plot(timespan, r_prime_fm_m[:, 0], label='1')
+        plt.plot(timespan, r_prime_fm_m[:, 1], label='2')
+        plt.plot(timespan, r_prime_fm_m[:, 2], label='3')
+        plt.title(r'${}^\mathcal{M} rPrime_{F/M}$ Profiled Trajectory', fontsize=14)
         plt.ylabel('(m/s)', fontsize=16)
         plt.xlabel('Time (s)', fontsize=16)
         plt.legend(loc='upper left', prop={'size': 16})
+        plt.grid(True)
 
-        # Plotting rPrimePrime_FM_M
+        # Plot r_prime_prime_fm_m
         plt.figure()
         plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * rPrimePrime_FM_M[:, 0], label='1')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * rPrimePrime_FM_M[:, 1], label='2')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * rPrimePrime_FM_M[:, 2], label='3')
-        plt.title(r'${}^\mathcal{M} rPrimePrime_{\mathcal{F}/\mathcal{M}}$ Profiled Acceleration', fontsize=14)
+        plt.plot(timespan, r_prime_prime_fm_m[:, 0], label='1')
+        plt.plot(timespan, r_prime_prime_fm_m[:, 1], label='2')
+        plt.plot(timespan, r_prime_prime_fm_m[:, 2], label='3')
+        plt.title(r'${}^\mathcal{M} rPrimePrime_{F/M}$ Profiled Acceleration', fontsize=14)
         plt.ylabel(r'(m/s$^2$)', fontsize=16)
         plt.xlabel('Time (s)', fontsize=16)
         plt.legend(loc='lower left', prop={'size': 16})
+        plt.grid(True)
 
-        # Plot r_BN_N
-        plt.figure()
-        plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, r_BN_N[:, 0], label=r'$r_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, r_BN_N[:, 1], label=r'$r_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, r_BN_N[:, 2], label=r'$r_{3}$')
-        plt.title(r'${}^\mathcal{N} r_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial Trajectory', fontsize=14)
-        plt.ylabel('(m)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
-        plt.legend(loc='center left', prop={'size': 16})
+        # Plot conservation quantities
+        plot_conservation(timespan, orb_ang_mom_n, orb_energy, rot_ang_mom_n, rot_energy)
 
-        # Plot sigma_BN
-        plt.figure()
-        plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, sigma_BN[:, 0], label=r'$\sigma_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, sigma_BN[:, 1], label=r'$\sigma_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, sigma_BN[:, 2], label=r'$\sigma_{3}$')
-        plt.title(r'$\sigma_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial MRP Attitude', fontsize=14)
-        plt.ylabel('', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
-        plt.legend(loc='lower left', prop={'size': 16})
+        plt.show()
 
-        # Plot omega_BN_B
-        plt.figure()
-        plt.clf()
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_BN_B[:, 0], label=r'$\omega_{1}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_BN_B[:, 1], label=r'$\omega_{2}$')
-        plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_BN_B[:, 2], label=r'$\omega_{3}$')
-        plt.title(r'Spacecraft Hub Angular Velocity ${}^\mathcal{B} \omega_{\mathcal{B}/\mathcal{N}}$', fontsize=14)
-        plt.ylabel('(deg/s)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
-        plt.legend(loc='lower left', prop={'size': 16})
+    plt.close("all")
 
-        # Plotting: Conservation quantities
-        plt.figure()
-        plt.clf()
-        plt.plot(orbAngMom_N[:, 0] * macros.NANO2SEC, (orbAngMom_N[:, 1] - orbAngMom_N[0, 1]) / orbAngMom_N[0, 1],
-                 orbAngMom_N[:, 0] * macros.NANO2SEC, (orbAngMom_N[:, 2] - orbAngMom_N[0, 2]) / orbAngMom_N[0, 2],
-                 orbAngMom_N[:, 0] * macros.NANO2SEC, (orbAngMom_N[:, 3] - orbAngMom_N[0, 3]) / orbAngMom_N[0, 3])
-        plt.title('Orbital Angular Momentum Relative Difference', fontsize=14)
-        plt.ylabel('(Nms)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+    # Check conservation quantities
+    check_conservation(orb_ang_mom_n, orb_energy, rot_ang_mom_n, accuracy)
 
-        plt.figure()
-        plt.clf()
-        plt.plot(orbEnergy[:, 0] * macros.NANO2SEC, (orbEnergy[:, 1] - orbEnergy[0, 1]) / orbEnergy[0, 1])
-        plt.title('Orbital Energy Relative Difference', fontsize=14)
-        plt.ylabel('Energy (J)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+def set_spacecraft_hub(sc_object):
+    mass_hub = 800  # [kg]
+    length_hub = 1.0  # [m]
+    width_hub = 1.0  # [m]
+    depth_hub = 1.0  # [m]
+    i_hub_11 = (1 / 12) * mass_hub * (length_hub * length_hub + depth_hub * depth_hub)  # [kg m^2]
+    i_hub_22 = (1 / 12) * mass_hub * (length_hub * length_hub + width_hub * width_hub)  # [kg m^2]
+    i_hub_33 = (1 / 12) * mass_hub * (width_hub * width_hub + depth_hub * depth_hub)  # [kg m^2]
+    sc_object.hub.mHub = mass_hub  # kg
+    sc_object.hub.r_BcB_B = [0.0, 0.0, 0.0]  # [m]
+    sc_object.hub.IHubPntBc_B = [[i_hub_11, 0.0, 0.0],
+                                 [0.0, i_hub_22, 0.0],
+                                 [0.0, 0.0, i_hub_33]]  # [kg m^2] (Hub approximated as a cube)
+    sc_object.hub.r_CN_NInit = [[-4020338.690396649], [7490566.741852513], [5248299.211589362]]
+    sc_object.hub.v_CN_NInit = [[-5199.77710904224], [-3436.681645356935], [1041.576797498721]]
+    sc_object.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]
+    sc_object.hub.sigma_BNInit = [[0.0], [0.0], [0.0]]
 
-        plt.figure()
-        plt.clf()
-        plt.plot(rotAngMom_N[:, 0] * macros.NANO2SEC, (rotAngMom_N[:, 1] - rotAngMom_N[0, 1]),
-                 rotAngMom_N[:, 0] * macros.NANO2SEC, (rotAngMom_N[:, 2] - rotAngMom_N[0, 2]),
-                 rotAngMom_N[:, 0] * macros.NANO2SEC, (rotAngMom_N[:, 3] - rotAngMom_N[0, 3]))
-        plt.title('Rotational Angular Momentum Difference', fontsize=14)
-        plt.ylabel('(Nms)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+def set_prescribed_motion_effector(prescribed_motion_body):
+    mass_prescribed_body = 10  # [kg]
+    length_prescribed_body = 0.1  # [m]
+    width_prescribed_body = 0.1  # [m]
+    depth_prescribed_body = 0.1  # [m]
+    i_prescribed_body_11 = (1 / 12) * mass_prescribed_body * (length_prescribed_body
+                                                              * length_prescribed_body
+                                                              + depth_prescribed_body
+                                                              * depth_prescribed_body)  # [kg m^2]
+    i_prescribed_body_22 = (1 / 12) * mass_prescribed_body * (length_prescribed_body
+                                                              * length_prescribed_body
+                                                              + width_prescribed_body
+                                                              * width_prescribed_body)  # [kg m^2]
+    i_prescribed_body_33 = (1 / 12) * mass_prescribed_body * (width_prescribed_body
+                                                              * width_prescribed_body
+                                                              + depth_prescribed_body
+                                                              * depth_prescribed_body)  # [kg m^2]
+    i_prescribed_body_fc_f = [[i_prescribed_body_11, 0.0, 0.0],
+                              [0.0, i_prescribed_body_22, 0.0],
+                              [0.0, 0.0,
+                               i_prescribed_body_33]]  # [kg m^2] (approximated as a cube)
+    prescribed_motion_body.setMass(mass_prescribed_body)
+    prescribed_motion_body.setIPntFc_F(i_prescribed_body_fc_f)
+    prescribed_motion_body.setR_MB_B([0.0, 0.0, 0.0])
+    prescribed_motion_body.setR_FcF_F([0.0, 0.0, 0.0])
+    prescribed_motion_body.setR_FM_M([0.0, 0.0, 0.0])
+    prescribed_motion_body.setRPrime_FM_M([0.0, 0.0, 0.0])
+    prescribed_motion_body.setRPrimePrime_FM_M([0.0, 0.0, 0.0])
+    prescribed_motion_body.setOmega_FM_F([0.0, 0.0, 0.0])
+    prescribed_motion_body.setOmegaPrime_FM_F([0.0, 0.0, 0.0])
+    prescribed_motion_body.setSigma_FM([0.0, 0.0, 0.0])
+    prescribed_motion_body.setOmega_MB_B([0.0, 0.0, 0.0])
+    prescribed_motion_body.setOmegaPrime_MB_B([0.0, 0.0, 0.0])
+    prescribed_motion_body.setSigma_MB([0.0, 0.0, 0.0])
+    prescribed_motion_body.ModelTag = "prescribedMotionBody"
 
-        plt.figure()
-        plt.clf()
-        plt.plot(rotEnergy[:, 0] * macros.NANO2SEC, (rotEnergy[:, 1] - rotEnergy[0, 1]))
-        plt.title('Total Energy Difference', fontsize=14)
-        plt.ylabel('Energy (J)', fontsize=16)
-        plt.xlabel('Time (s)', fontsize=16)
+def plot_conservation(timespan, orb_ang_mom_n, orb_energy, rot_ang_mom_n, rot_energy):
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, (orb_ang_mom_n[:, 1] - orb_ang_mom_n[0, 1]) / orb_ang_mom_n[0, 1],
+             timespan, (orb_ang_mom_n[:, 2] - orb_ang_mom_n[0, 2]) / orb_ang_mom_n[0, 2],
+             timespan, (orb_ang_mom_n[:, 3] - orb_ang_mom_n[0, 3]) / orb_ang_mom_n[0, 3])
+    plt.title('Orbital Angular Momentum Relative Difference', fontsize=14)
+    plt.ylabel('Relative Difference (Nms)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.grid(True)
 
-        if show_plots:
-            plt.show()
-        plt.close("all")
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, (orb_energy[:, 1] - orb_energy[0, 1]) / orb_energy[0, 1])
+    plt.title('Orbital Energy Relative Difference', fontsize=14)
+    plt.ylabel('Relative Difference (J)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.grid(True)
 
-        # Begin the test analysis
-        finalOrbAngMom = np.delete(finalOrbAngMom, 0, axis=1)  # remove the time column
-        finalRotAngMom = np.delete(finalRotAngMom, 0, axis=1)  # remove the time column
-        finalOrbEnergy = np.delete(finalOrbEnergy, 0, axis=1)  # remove the time column
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, (rot_ang_mom_n[:, 1] - rot_ang_mom_n[0, 1]),
+             timespan, (rot_ang_mom_n[:, 2] - rot_ang_mom_n[0, 2]),
+             timespan, (rot_ang_mom_n[:, 3] - rot_ang_mom_n[0, 3]))
+    plt.title('Rotational Angular Momentum Difference', fontsize=14)
+    plt.ylabel('Difference (Nms)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.grid(True)
 
-        for i in range(0, len(initialOrbAngMom_N)):
-            if not unitTestSupport.isArrayEqualRelative(finalOrbAngMom[i], initialOrbAngMom_N[i], 3, accuracy):
-                testFailCount += 1
-                testMessages.append(
-                    "FAILED: Prescribed Motion integrated test failed orbital angular momentum unit test")
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, (rot_energy[:, 1] - rot_energy[0, 1]))
+    plt.title('Total Energy Difference', fontsize=14)
+    plt.ylabel('Difference (J)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.grid(True)
 
-        for i in range(0, len(initialRotAngMom_N)):
-            if not unitTestSupport.isArrayEqual(finalRotAngMom[i], initialRotAngMom_N[i], 3, accuracy):
-                testFailCount += 1
-                testMessages.append(
-                    "FAILED: Prescribed Motion integrated test failed rotational angular momentum unit test")
+def check_conservation(orb_ang_mom_n, orb_energy, rot_ang_mom_n, accuracy):
+    orb_ang_mom_init = [[orb_ang_mom_n[0, 1], orb_ang_mom_n[0, 2], orb_ang_mom_n[0, 3]]]
+    orb_ang_mom_final = [orb_ang_mom_n[-1]]
+    rot_ang_mom_init = [[rot_ang_mom_n[0, 1], rot_ang_mom_n[0, 2], rot_ang_mom_n[0, 3]]]
+    rot_ang_mom_final = [rot_ang_mom_n[-1]]
+    orb_energy_init = [[orb_energy[0, 1]]]
+    orb_energy_final = [orb_energy[-1]]
 
-        for i in range(0, len(initialOrbEnergy)):
-            if not unitTestSupport.isArrayEqualRelative(finalOrbEnergy[i], initialOrbEnergy[i], 1, accuracy):
-                testFailCount += 1
-                testMessages.append("FAILED: Prescribed Motion integrated test failed orbital energy unit test")
+    orb_ang_mom_final = np.delete(orb_ang_mom_final, 0, axis=1)  # remove the time column
+    rot_ang_mom_final = np.delete(rot_ang_mom_final, 0, axis=1)  # remove the time column
+    orb_energy_final = np.delete(orb_energy_final, 0, axis=1)  # remove the time column
 
-        # Check to ensure the initial velocity converged to the reference velocity
-        rPrime_FM_M_Ref = np.array([0.0, 0.0, 0.0])
-        if not unitTestSupport.isArrayEqual(rPrime_FM_M_Final, rPrime_FM_M_Ref, 3, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + PrescribedTrans.ModelTag + "rPrime_FM_M_Final and rPrime_FM_M_Ref do not match")
-            testMessages.append("rPrime_FM_M_Final: " + str(rPrime_FM_M_Final) + " rPrime_FM_M_Ref: " + str(rPrime_FM_M_Ref))
+    # Orbital angular momentum check
+    np.testing.assert_allclose(orb_ang_mom_init,
+                               orb_ang_mom_final,
+                               atol=accuracy,
+                               verbose=True)
 
-        # Check to ensure the initial position converged to the reference position
-        r_FM_M_Ref = np.array([posRef, 0.0, 0.0])
-        if not unitTestSupport.isArrayEqual(r_FM_M_Final, r_FM_M_Ref, 3, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + PrescribedTrans.ModelTag + "r_FM_M_Final and r_FM_M_Ref do not match")
-            testMessages.append("r_FM_M_Final: " + str(r_FM_M_Final) + " r_FM_M_Ref: " + str(r_FM_M_Ref))
+    # Rotational angular momentum check
+    np.testing.assert_allclose(rot_ang_mom_init,
+                               rot_ang_mom_final,
+                               atol=accuracy,
+                               verbose=True)
 
-        if testFailCount == 0:
-            print("PASSED: " + "prescribedMotion and prescribedLinearTranslation integrated test")
+    # Orbital energy check
+    np.testing.assert_allclose(orb_energy_init,
+                               orb_energy_final,
+                               atol=accuracy,
+                               verbose=True)
 
-    return [testFailCount, ''.join(testMessages)]
-
-#
-# This statement below ensures that the unitTestScript can be run as a
-# stand-along python script
-#
 if __name__ == "__main__":
-    PrescribedMotionTestFunction(
-        True,        # show_plots
-        False,       # rotTest, (True: prescribedRot1DOF integrated test,
-                     #           False: prescribedTrans integrated test)
-         0.0,        # thetaInit [rad]
-         np.pi / 12,    # theta_Ref [rad]
-         0.0,        # posInit [m]
-         0.5,        # posRef [m]
-         1e-8        # accuracy
-       )
+    test_PrescribedMotionStateEffector_Translation(
+        True,  # show_plots
+        0.0,  # trans_pos_init [m]
+        0.1,  # trans_pos_ref [m]
+        1e-8  # accuracy
+    )
+
+    test_PrescribedMotionStateEffector_Rotation(
+        True,  # show_plots
+        0.0,  # theta_init [rad]
+        5.0 * macros.D2R,  # theta_ref [rad]
+        1e-7  # accuracy
+    )
+    

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -1,6 +1,6 @@
 # ISC License
 #
-# Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+# Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -14,41 +14,35 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-
 #
-#   Unit Test Script
-#   Module Name:        prescribedMotion integrated unit test with prescribedRotation1DOF and prescribedLinearTranslation
+#   Integrated Unit Test Script
+#   Module Name:        prescribedMotion
 #   Author:             Leah Kiner
 #   Creation Date:      Jan 10, 2022
+#   Last Updated:       April 15, 2024
 #
 
 import inspect
-import os
-
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import os
 import pytest
-
 from Basilisk.architecture import messaging
 from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import prescribedLinearTranslation
 from Basilisk.simulation import prescribedMotionStateEffector
 from Basilisk.simulation import prescribedRotation1DOF
 from Basilisk.simulation import spacecraft
+from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import unitTestSupport
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
-matplotlib.rc('xtick', labelsize=16)
-matplotlib.rc('ytick', labelsize=16)
-
-# Vary the simulation parameters for pytest
 @pytest.mark.parametrize("rotTest", [True, False])
 @pytest.mark.parametrize("thetaInit", [0, np.pi/18])
 @pytest.mark.parametrize("theta_Ref", [np.pi/36])

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -356,3 +356,197 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t callTime)
     // Call the method to write the output messages
     this->writeOutputStateMessages(callTime);
 }
+
+/*! Setter method for the effector mass.
+ @return void
+ @param mass [kg] Effector mass
+*/
+void PrescribedMotionStateEffector::setMass(const double mass) {
+    this->mass = mass;
+}
+
+/*! Setter method for IPntFc_F.
+ @return void
+ @param IPntFc_F [kg-m^2] Effector's inertia matrix about its center of mass point Fc expressed in F frame components
+*/
+void PrescribedMotionStateEffector::setIPntFc_F(const Eigen::Matrix3d IPntFc_F) {
+    this->IPntFc_F = IPntFc_F;
+}
+
+/*! Setter method for r_FcF_F.
+ @return void
+ @param r_FcF_F [m] Position vector of the effector's center of mass point Fc relative to the effector's body frame origin point F expressed in F frame components
+*/
+void PrescribedMotionStateEffector::setR_FcF_F(const Eigen::Vector3d r_FcF_F) {
+    this->r_FcF_F = r_FcF_F;
+}
+
+/*! Setter method for r_FM_M.
+ @return void
+ @param r_FM_M [m] Position vector of the effector's body frame origin point F relative to the hub-fixed mount frame origin point M expressed in M frame components
+*/
+void PrescribedMotionStateEffector::setR_FM_M(const Eigen::Vector3d r_FM_M) {
+    this->r_FM_M = r_FM_M;
+}
+
+/*! Setter method for rPrime_FM_M.
+ @return void
+ @param rPrime_FM_M [m/s] B frame time derivative of r_FM_M expressed in M frame components
+*/
+void PrescribedMotionStateEffector::setRPrime_FM_M(const Eigen::Vector3d rPrime_FM_M) {
+    this->rPrime_FM_M = rPrime_FM_M;
+}
+
+/*! Setter method for rPrimePrime_FM_M.
+ @return void
+ @param rPrimePrime_FM_M [m/s^2] B frame time derivative of rPrime_FM_M expressed in M frame components
+*/
+void PrescribedMotionStateEffector::setRPrimePrime_FM_M(const Eigen::Vector3d rPrimePrime_FM_M) {
+    this->rPrimePrime_FM_M = rPrimePrime_FM_M;
+}
+
+/*! Setter method for omega_FM_F.
+ @return void
+ @param omega_FM_F [rad/s] Angular velocity of the effector body frame F relative to the hub-fixed mount frame M expressed in F frame components
+*/
+void PrescribedMotionStateEffector::setOmega_FM_F(const Eigen::Vector3d omega_FM_F) {
+    this->omega_FM_F = omega_FM_F;
+}
+
+/*! Setter method for omegaPrime_FM_F.
+ @return void
+ @param omegaPrime_FM_F [rad/s^2] Angular acceleration of the effector body frame F relative to the hub-fixed mount frame M expressed in F frame components
+*/
+void PrescribedMotionStateEffector::setOmegaPrime_FM_F(const Eigen::Vector3d omegaPrime_FM_F) {
+    this->omegaPrime_FM_F = omegaPrime_FM_F;
+}
+
+/*! Setter method for sigma_FM.
+ @return void
+ @param sigma_FM MRP attitude of the effector's body frame F relative to the hub-fixed mount frame M
+*/
+void PrescribedMotionStateEffector::setSigma_FM(const Eigen::MRPd sigma_FM) {
+    this->sigma_FM = sigma_FM;
+}
+
+/*! Setter method for r_MB_B.
+ @return void
+ @param r_MB_B [m] Position vector describing the hub-fixed mount frame origin point M location relative to the hub frame origin point B expressed in B frame components
+*/
+void PrescribedMotionStateEffector::setR_MB_B(const Eigen::Vector3d r_MB_B) {
+    this->r_MB_B = r_MB_B;
+}
+
+/*! Setter method for omega_MB_B.
+ @return void
+ @param omega_MB_B [rad/s] Angular velocity of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
+*/
+void PrescribedMotionStateEffector::setOmega_MB_B(const Eigen::Vector3d omega_MB_B) {
+    this->omega_MB_B = omega_MB_B;
+}
+
+/*! Setter method for omegaPrime_MB_B.
+ @return void
+ @param omegaPrime_MB_B [rad/s^2] Angular acceleration of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
+*/
+void PrescribedMotionStateEffector::setOmegaPrime_MB_B(const Eigen::Vector3d omegaPrime_MB_B) {
+    this->omegaPrime_MB_B = omegaPrime_MB_B;
+}
+/*! Setter method for sigma_MB.
+ @return void
+ @param sigma_MB MRP attitude of the hub-fixed frame M relative to the hub body frame B
+*/
+void PrescribedMotionStateEffector::setSigma_MB(const Eigen::MRPd sigma_MB) {
+    this->sigma_MB = sigma_MB;
+}
+
+/*! Getter method for the effector mass.
+ @return double
+*/
+double PrescribedMotionStateEffector::getMass() const {
+    return this->mass;
+}
+
+/*! Getter method for IPntFc_F.
+ @return const Eigen::Matrix3d
+*/
+const Eigen::Matrix3d PrescribedMotionStateEffector::getIPntFc_F() const {
+    return this->IPntFc_F;
+}
+
+/*! Getter method for r_FcF_F.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getR_FcF_F() const {
+    return this->r_FcF_F;
+}
+
+/*! Getter method for r_FM_M.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getR_FM_M() const {
+    return this->r_FM_M;
+}
+
+/*! Getter method for rPrime_FM_M.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getRPrime_FM_M() const {
+    return this->rPrime_FM_M;
+}
+
+/*! Getter method for rPrimePrime_FM_M.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getRPrimePrime_FM_M() const {
+    return this->rPrimePrime_FM_M;
+}
+
+/*! Getter method for omega_FM_F.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getOmega_FM_F() const {
+    return this->omega_FM_F;
+}
+
+/*! Getter method for omegaPrime_FM_F.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getOmegaPrime_FM_F() const {
+    return this->omegaPrime_FM_F;
+}
+
+/*! Getter method for sigma_FM.
+ @return const Eigen::MRPd
+*/
+const Eigen::MRPd PrescribedMotionStateEffector::getSigma_FM() const {
+    return this->sigma_FM;
+}
+
+/*! Getter method for r_MB_B.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getR_MB_B() const {
+    return this->r_MB_B;
+}
+
+/*! Getter method for omega_MB_B.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getOmega_MB_B() const {
+    return this->omega_MB_B;
+}
+
+/*! Getter method for omegaPrime_MB_B.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d PrescribedMotionStateEffector::getOmegaPrime_MB_B() const {
+    return this->omegaPrime_MB_B;
+}
+
+/*! Getter method for sigma_MB.
+ @return const Eigen::MRPd
+*/
+const Eigen::MRPd PrescribedMotionStateEffector::getSigma_MB() const {
+    return this->sigma_MB;
+}

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -306,6 +306,9 @@ void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
     Eigen::Matrix3d dcm_FN = (this->dcm_BF).transpose() * this->dcm_BN;
     this->sigma_FN = eigenMRPd2Vector3d(eigenC2MRP(dcm_FN));
 
+    // Compute the effector's inertial angular velocity
+    this->omega_FN_F = (this->dcm_BF).transpose() * this->omega_FN_B;
+
     // Compute the effector's inertial position vector
     this->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * this->r_FcB_B;
 

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -22,17 +22,17 @@
 #include "architecture/utilities/macroDefinitions.h"
 #include <string>
 
-/*! This is the constructor, setting variables to default values. */
+/*! The constructor sets the module variables to default values. */
 PrescribedMotionStateEffector::PrescribedMotionStateEffector()
 {
-    // Zero the mass props and mass prop rate contributions
+    // Zero the effector's mass properties and mass property rate contributions
     this->effProps.mEff = 0.0;
     this->effProps.rEff_CB_B.fill(0.0);
     this->effProps.IEffPntB_B.fill(0.0);
     this->effProps.rEffPrime_CB_B.fill(0.0);
     this->effProps.IEffPrimePntB_B.fill(0.0);
 
-    // Initialize the prescribed variables
+    // Initialize the effector's hub-relative states
     this->r_FM_M.setZero();
     this->rPrime_FM_M.setZero();
     this->rPrimePrime_FM_M.setZero();
@@ -41,21 +41,21 @@ PrescribedMotionStateEffector::PrescribedMotionStateEffector()
     this->sigma_FM.setIdentity();
 
     // Initialize the other module variables
+    this->currentSimTimeSec = 0.0;
     this->mass = 0.0;
     this->IPntFc_F.setIdentity();
-    this->r_MB_B.setZero();
     this->r_FcF_F.setZero();
+    this->r_MB_B.setZero();
     this->omega_MB_B.setZero();
     this->omegaPrime_MB_B.setZero();
     this->sigma_MB.setIdentity();
-    this->currentSimTimeSec = 0.0;
-    
+
     // Initialize prescribed states at epoch
     this->rEpoch_FM_M.setZero();
     this->rPrimeEpoch_FM_M.setZero();
     this->omegaEpoch_FM_F.setZero();
 
-    // Set the sigma_FM state name
+    // Set the effector's hub-relative sigma_FM MRP attitude state name
     this->nameOfsigma_FMState = "prescribedMotionsigma_FM" + std::to_string(this->effectorID);
 
     PrescribedMotionStateEffector::effectorID++;
@@ -77,16 +77,14 @@ void PrescribedMotionStateEffector::Reset(uint64_t currentClock)
 {
 }
 
-/*! This method takes the computed states and outputs them to the messaging system.
+/*! This method writes the module output messages to the messaging system.
  @return void
  @param currentClock [ns] Time the method is called
 */
 void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t currentClock)
 {
-
     // Write the prescribed translational motion output message if it is linked
-    if (this->prescribedTranslationOutMsg.isLinked())
-    {
+    if (this->prescribedTranslationOutMsg.isLinked()) {
         PrescribedTranslationMsgPayload prescribedTranslationBuffer = this->prescribedTranslationOutMsg.zeroMsgPayload;
         eigenVector3d2CArray(this->r_FM_M, prescribedTranslationBuffer.r_FM_M);
         eigenVector3d2CArray(this->rPrime_FM_M, prescribedTranslationBuffer.rPrime_FM_M);
@@ -95,8 +93,7 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t currentClo
     }
 
     // Write the prescribed rotational motion output message if it is linked
-    if (this->prescribedRotationOutMsg.isLinked())
-    {
+    if (this->prescribedRotationOutMsg.isLinked()) {
         PrescribedRotationMsgPayload prescribedRotationBuffer = this->prescribedRotationOutMsg.zeroMsgPayload;
         eigenVector3d2CArray(this->omega_FM_F, prescribedRotationBuffer.omega_FM_F);
         eigenVector3d2CArray(this->omegaPrime_FM_F, prescribedRotationBuffer.omegaPrime_FM_F);
@@ -105,12 +102,11 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t currentClo
         this->prescribedRotationOutMsg.write(&prescribedRotationBuffer, this->moduleID, currentClock);
     }
 
-    // Write the config log message if it is linked
-    if (this->prescribedMotionConfigLogOutMsg.isLinked())
-    {
+    // Write the effector config log message if it is linked
+    if (this->prescribedMotionConfigLogOutMsg.isLinked()) {
         SCStatesMsgPayload configLogMsg = this->prescribedMotionConfigLogOutMsg.zeroMsgPayload;
 
-        // Note that the configLogMsg B frame represents the effector body frame (frame F)
+        // Note that the configLogMsg B frame represents the prescribed motion effector body frame (F frame)
         eigenVector3d2CArray(this->r_FcN_N, configLogMsg.r_BN_N);
         eigenVector3d2CArray(this->v_FcN_N, configLogMsg.v_BN_N);
         eigenVector3d2CArray(this->sigma_FN, configLogMsg.sigma_BN);
@@ -119,36 +115,35 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t currentClo
     }
 }
 
-/*! This method allows the effector to have access to the hub states.
+/*! This method gives the prescribed motion effector access the hub inertial states.
  @return void
  @param statesIn Pointer to give the state effector access the hub states
 */
 void PrescribedMotionStateEffector::linkInStates(DynParamManager& statesIn)
 {
-    // Get access to the hub states needed for dynamic coupling
-    this->hubSigma = statesIn.getStateObject("hubSigma");
     this->hubOmega = statesIn.getStateObject("hubOmega");
+    this->hubSigma = statesIn.getStateObject("hubSigma");
     this->inertialPositionProperty = statesIn.getPropertyReference("r_BN_N");
     this->inertialVelocityProperty = statesIn.getPropertyReference("v_BN_N");
 }
 
-/*! This method allows the state effector to register its states with the dynamic parameter manager.
+/*! This method registers the prescribed motion effector hub-relative attitude with the dynamic parameter manager.
  @return void
  @param states Pointer to give the state effector access the hub states
 */
 void PrescribedMotionStateEffector::registerStates(DynParamManager& states)
 {
-        this->sigma_FMState = states.registerState(3, 1, this->nameOfsigma_FMState);
-        Eigen::Vector3d sigma_FM_loc = eigenMRPd2Vector3d(this->sigma_FM);
-        Eigen::Vector3d sigma_FMInitMatrix;
-        sigma_FMInitMatrix(0) = sigma_FM_loc[0];
-        sigma_FMInitMatrix(1) = sigma_FM_loc[1];
-        sigma_FMInitMatrix(2) = sigma_FM_loc[2];
-        this->sigma_FMState->setState(sigma_FMInitMatrix);
+    this->sigma_FMState = states.registerState(3, 1, this->nameOfsigma_FMState);
+    Eigen::Vector3d sigma_FM_loc = eigenMRPd2Vector3d(this->sigma_FM);
+    Eigen::Vector3d sigma_FMInitMatrix;
+    sigma_FMInitMatrix(0) = sigma_FM_loc[0];
+    sigma_FMInitMatrix(1) = sigma_FM_loc[1];
+    sigma_FMInitMatrix(2) = sigma_FM_loc[2];
+    this->sigma_FMState->setState(sigma_FMInitMatrix);
 }
 
-/*! This method allows the state effector to provide its contributions to the mass props and mass prop rates of the
- spacecraft.
+/*! This method provides the effector contributions to the mass props and mass prop rates of
+ the spacecraft.
  @return void
  @param integTime [s] Time the method is called
 */
@@ -173,27 +168,27 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
     // Compute dcm_BF
     this->dcm_BF = this->dcm_BM * this->dcm_FM.transpose();
 
-    // Compute omega_FB_B given the user inputs omega_MB_M and omega_FM_F
+    // Compute omega_FB_B
     this->omega_FM_B = this->dcm_BF * this->omega_FM_F;
     this->omega_FB_B = this->omega_FM_B + this->omega_MB_B;
 
-    // Compute omegaPrime_FB_B given the user inputs
+    // Compute omegaPrime_FB_B
     this->omegaTilde_FB_B = eigenTilde(this->omega_FB_B);
     this->omegaPrime_FM_B = this->dcm_BF * this->omegaPrime_FM_F;
     this->omegaPrime_FB_B = this->omegaPrime_FM_B + this->omegaTilde_FB_B * this->omega_FM_B;
 
-    // Convert the prescribed variables to the B frame
+    // Convert the prescribed translational states to the B frame
     this->r_FM_B = this->dcm_BM * this->r_FM_M;
     this->rPrime_FM_B = this->dcm_BM * this->rPrime_FM_M;
     this->rPrimePrime_FM_B = this->dcm_BM * this->rPrimePrime_FM_M;
 
-    // Compute the effector's CoM with respect to point B
+    // Compute the effector's center of mass with respect to point B
     this->r_FB_B = this->r_FM_B + this->r_MB_B;
     this->r_FcF_B = this->dcm_BF * this->r_FcF_F;
     this->r_FcB_B = this->r_FcF_B + this->r_FB_B;
     this->effProps.rEff_CB_B = this->r_FcB_B;
 
-    // Find the effector inertia about point B
+    // Find the effector's inertia about point B
     this->rTilde_FcB_B = eigenTilde(this->r_FcB_B);
     this->IPntFc_B = this->dcm_BF * this->IPntFc_F * this->dcm_BF.transpose();
     this->effProps.IEffPntB_B = this->IPntFc_B - this->mass * this->rTilde_FcB_B * this->rTilde_FcB_B;
@@ -211,11 +206,11 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
                                      + this->rTilde_FcB_B * rPrimeTilde_FcB_B.transpose());
 }
 
-/*! This method allows the state effector to give its contributions to the matrices needed for the back-sub.
+/*! This method provides the effector's backsubstitution contributions.
  method
  @return void
  @param integTime [s] Time the method is called
- @param backSubContr State effector contribution matrices for back-substitution
+ @param backSubContr State effector contribution matrices for backsubstitution
  @param sigma_BN Current B frame attitude with respect to the inertial frame
  @param omega_BN_B [rad/s] Angular velocity of the B frame with respect to the inertial frame, expressed in B frame
  components
@@ -239,12 +234,13 @@ void PrescribedMotionStateEffector::updateContributions(double integTime,
     Eigen::Matrix3d omegaPrimeTilde_FB_B = eigenTilde(this->omegaPrime_FB_B);
 
     // Compute rPrimePrime_FcB_B
-    this->rPrimePrime_FcB_B = (omegaPrimeTilde_FB_B + this->omegaTilde_FB_B * this->omegaTilde_FB_B) * this->r_FcF_B + this->rPrimePrime_FM_B;
+    this->rPrimePrime_FcB_B = (omegaPrimeTilde_FB_B + this->omegaTilde_FB_B * this->omegaTilde_FB_B) * this->r_FcF_B
+                              + this->rPrimePrime_FM_B;
 
-    // Translation contributions
+    // Backsubstitution RHS translational EOM contribution
     backSubContr.vecTrans = -this->mass * this->rPrimePrime_FcB_B;
 
-    // Rotation contributions
+    // Backsubstitution RHS rotational EOM contribution
     Eigen::Matrix3d IPrimePntFc_B = this->omegaTilde_FB_B * this->IPntFc_B - this->IPntFc_B * this->omegaTilde_FB_B;
     backSubContr.vecRot = -(this->mass * this->rTilde_FcB_B * this->rPrimePrime_FcB_B)
                           - (IPrimePntFc_B + this->omegaTilde_BN_B * this->IPntFc_B) * this->omega_FB_B
@@ -252,7 +248,7 @@ void PrescribedMotionStateEffector::updateContributions(double integTime,
                           - this->mass * this->omegaTilde_BN_B * rTilde_FcB_B * this->rPrime_FcB_B;
 }
 
-/*! This method is for defining the state effector's MRP state derivative
+/*! This method defines the state effector's MRP attitude state derivative
  @return void
  @param integTime [s] Time the method is called
  @param rDDot_BN_N [m/s^2] Acceleration of the vector pointing from the inertial frame origin to the B frame origin,
@@ -268,10 +264,11 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime,
 {
     Eigen::MRPd sigma_FM_loc;
     sigma_FM_loc = (Eigen::Vector3d)this->sigma_FMState->getState();
-    this->sigma_FMState->setDerivative(0.25*sigma_FM_loc.Bmat()*this->omega_FM_F);
+    this->sigma_FMState->setDerivative(0.25 * sigma_FM_loc.Bmat() * this->omega_FM_F);
 }
 
-/*! This method is for calculating the contributions of the effector to the energy and momentum of the spacecraft.
+/*! This method calculates the effector's contributions to the energy and momentum of the
+ spacecraft.
  @return void
  @param integTime [s] Time the method is called
  @param rotAngMomPntCContr_B [kg m^2/s] Contribution of stateEffector to total rotational angular mom
@@ -292,15 +289,15 @@ void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTim
     // Compute rDot_FcB_B
     this->rDot_FcB_B = this->rPrime_FcB_B + this->omegaTilde_BN_B * this->r_FcB_B;
 
-    // Find the rotational angular momentum contribution from hub
+    // Find the rotational angular momentum contribution
     rotAngMomPntCContr_B = this->IPntFc_B * this->omega_FN_B + this->mass * this->rTilde_FcB_B * this->rDot_FcB_B;
 
-    // Find the rotational energy contribution from the hub
+    // Find the rotational energy contribution
     rotEnergyContr = 0.5 * this->omega_FN_B.dot(this->IPntFc_B * this->omega_FN_B)
                      + 0.5 * this->mass * this->rDot_FcB_B.dot(this->rDot_FcB_B);
 }
 
-/*! This method computes the effector states relative to the inertial frame.
+/*! This method computes the prescribed motion state effector states relative to the inertial frame.
  @return void
 */
 void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
@@ -316,7 +313,7 @@ void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
     this->v_FcN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * this->rDot_FcB_B;
 }
 
-/*! This method updates the effector state at the dynamics frequency.
+/*! This method updates the effector's states at the dynamics frequency.
  @return void
  @param currentSimNanos [ns] Time the method is called
 */
@@ -326,8 +323,7 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t currentSimNanos)
     this->currentSimTimeSec = currentSimNanos * NANO2SEC;
 
     // Read the translational input message if it is linked and written
-    if (this->prescribedTranslationInMsg.isLinked() && this->prescribedTranslationInMsg.isWritten())
-    {
+    if (this->prescribedTranslationInMsg.isLinked() && this->prescribedTranslationInMsg.isWritten()) {
         PrescribedTranslationMsgPayload incomingPrescribedTransStates = this->prescribedTranslationInMsg();
         this->r_FM_M = cArray2EigenVector3d(incomingPrescribedTransStates.r_FM_M);
         this->rPrime_FM_M = cArray2EigenVector3d(incomingPrescribedTransStates.rPrime_FM_M);
@@ -339,8 +335,7 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t currentSimNanos)
     }
 
     // Read the rotational input message if it is linked and written
-    if (this->prescribedRotationInMsg.isLinked() && this->prescribedRotationInMsg.isWritten())
-    {
+    if (this->prescribedRotationInMsg.isLinked() && this->prescribedRotationInMsg.isWritten()) {
         PrescribedRotationMsgPayload incomingPrescribedRotStates = this->prescribedRotationInMsg();
         this->omega_FM_F = cArray2EigenVector3d(incomingPrescribedRotStates.omega_FM_F);
         this->omegaPrime_FM_F = cArray2EigenVector3d(incomingPrescribedRotStates.omegaPrime_FM_F);

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -46,7 +46,7 @@ PrescribedMotionStateEffector::PrescribedMotionStateEffector()
     this->IPntFc_F.setIdentity();
     this->r_FcF_F.setZero();
     this->r_MB_B.setZero();
-    this->omega_MB_B.setZero();
+    this->omega_MB_M.setZero();
     this->omegaPrime_MB_B.setZero();
     this->sigma_MB.setIdentity();
 
@@ -170,7 +170,8 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double callTime)
 
     // Compute omega_FB_B
     Eigen::Vector3d omega_FM_B = this->dcm_BF * this->omega_FM_F;
-    this->omega_FB_B = omega_FM_B + this->omega_MB_B;
+    Eigen::Vector3d omega_MB_B = dcm_BM * this->omega_MB_M;
+    this->omega_FB_B = omega_FM_B + omega_MB_B;
 
     // Compute omegaPrime_FB_B
     this->omegaTilde_FB_B = eigenTilde(this->omega_FB_B);
@@ -437,12 +438,12 @@ void PrescribedMotionStateEffector::setR_MB_B(const Eigen::Vector3d r_MB_B) {
     this->r_MB_B = r_MB_B;
 }
 
-/*! Setter method for omega_MB_B.
+/*! Setter method for omega_MB_M.
  @return void
- @param omega_MB_B [rad/s] Angular velocity of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
+ @param omega_MB_M [rad/s] Angular velocity of the hub-fixed mount frame M relative to the hub frame B expressed in M frame components
 */
-void PrescribedMotionStateEffector::setOmega_MB_B(const Eigen::Vector3d omega_MB_B) {
-    this->omega_MB_B = omega_MB_B;
+void PrescribedMotionStateEffector::setOmega_MB_M(const Eigen::Vector3d omega_MB_M) {
+    this->omega_MB_M = omega_MB_M;
 }
 
 /*! Setter method for omegaPrime_MB_B.
@@ -530,11 +531,11 @@ const Eigen::Vector3d PrescribedMotionStateEffector::getR_MB_B() const {
     return this->r_MB_B;
 }
 
-/*! Getter method for omega_MB_B.
+/*! Getter method for omega_MB_M.
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d PrescribedMotionStateEffector::getOmega_MB_B() const {
-    return this->omega_MB_B;
+const Eigen::Vector3d PrescribedMotionStateEffector::getOmega_MB_M() const {
+    return this->omega_MB_M;
 }
 
 /*! Getter method for omegaPrime_MB_B.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -78,81 +78,76 @@ public:
                              Eigen::Vector3d sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;                         //!< Method for computing the effector's backsubstitution contributions
-    void updateEffectorMassProps(double callTime) override;                         //!< Method for providing the effector's contributions to the mass props and mass prop rates of the spacecraft
+    void updateEffectorMassProps(double callTime) override;                         //!< Method for providing the effector's contributions to the mass properties and mass property rates of the spacecraft
     void updateEnergyMomContributions(double callTime,
                                       Eigen::Vector3d & rotAngMomPntCContr_B,
                                       double & rotEnergyContr,
                                       Eigen::Vector3d omega_BN_B) override;         //!< Method for computing the effector's contributions to the energy and momentum of the spacecraft
     void writeOutputStateMessages(uint64_t callTime) override;                      //!< Method for writing the module's output messages
 
-    double currentSimTimeSec;                                                       //!< [s] Current simulation time, updated at the dynamics frequency
-    double mass;                                                                    //!< [kg] Effector mass
-    Eigen::Matrix3d IPntFc_F;                                                       //!< [kg-m^2] Effector inertia about its center of mass point Fc expressed in F frame components
-    Eigen::Vector3d r_FcF_F;                                                        //!< [m] Position of the effector center of mass point Fc relative to point F expressed in F frame components
-    Eigen::Vector3d r_MB_B;                                                         //!< [m] Position of mount M frame origin point M relative to hub frame B origin point B expressed in B frame components
-    Eigen::Vector3d omega_MB_B;                                                     //!< [rad/s] Angular velocity of frame M with respect to frame B expressed in B frame components
-    Eigen::Vector3d omegaPrime_MB_B;                                                //!< [rad/s^2] B frame time derivative of omega_MB_B expressed in B frame components
-    Eigen::MRPd sigma_MB;                                                           //!< MRP attitude of frame M relative to frame B
-
-    // Hub-relative prescribed states of the effector
-    Eigen::Vector3d r_FM_M;                                                         //!< [m] Position of prescribed effector frame origin point F relative to point M expressed in M frame components
-    Eigen::Vector3d rPrime_FM_M;                                                    //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
-    Eigen::Vector3d rPrimePrime_FM_M;                                               //!< [m/s^2] B frame time derivative of rPrime_FM_M expressed in M frame components
-    Eigen::Vector3d omega_FM_F;                                                     //!< [rad/s] Angular velocity of frame F relative to frame M expressed in F frame components
-    Eigen::Vector3d omegaPrime_FM_F;                                                //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components
-    Eigen::MRPd sigma_FM;                                                           //!< MRP attitude of frame F relative to frame M
-    std::string nameOfsigma_FMState;                                                //!< Identifier for the prescribed effector MRP sigma_FM attitude state data container
-
-    ReadFunctor<PrescribedRotationMsgPayload> prescribedRotationInMsg;              //!< Input message for the effector's rotational hub-relative prescribed states
-    ReadFunctor<PrescribedTranslationMsgPayload> prescribedTranslationInMsg;        //!< Input message for the effector's translational hub-relative prescribed states
+    ReadFunctor<PrescribedRotationMsgPayload> prescribedRotationInMsg;              //!< Input message for the effector's hub-relative rotational prescribed states
+    ReadFunctor<PrescribedTranslationMsgPayload> prescribedTranslationInMsg;        //!< Input message for the effector's hub-relative translational prescribed states
     Message<PrescribedRotationMsgPayload> prescribedRotationOutMsg;                 //!< Output message for the effector's hub-relative rotational prescribed states
     Message<PrescribedTranslationMsgPayload> prescribedTranslationOutMsg;           //!< Output message for the effector's hub-relative translational prescribed states
     Message<SCStatesMsgPayload> prescribedMotionConfigLogOutMsg;                    //!< Output config log message for the effector's inertial states
 
 private:
-    static uint64_t effectorID;                                                     //!< ID number of this panel
+    // User-configurable module variables
+    double mass;                                                                    //!< [kg] Effector mass
+    Eigen::Matrix3d IPntFc_F;                                                       //!< [kg-m^2] Effector's inertia matrix about its center of mass point Fc expressed in F frame components
+    Eigen::Vector3d r_FcF_F;                                                        //!< [m] Position vector of the effector's center of mass point Fc relative to the effector's body frame origin point F expressed in F frame components
+    Eigen::Vector3d r_FM_M;                                                         //!< [m] Position vector of the effector's body frame origin point F relative to the hub-fixed mount frame origin point M expressed in M frame components
+    Eigen::Vector3d rPrime_FM_M;                                                    //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
+    Eigen::Vector3d rPrimePrime_FM_M;                                               //!< [m/s^2] B frame time derivative of rPrime_FM_M expressed in M frame components
+    Eigen::Vector3d omega_FM_F;                                                     //!< [rad/s] Angular velocity of the effector body frame F relative to the hub-fixed mount frame M expressed in F frame components
+    Eigen::Vector3d omegaPrime_FM_F;                                                //!< [rad/s^2] Angular acceleration of the effector body frame F relative to the hub-fixed mount frame M expressed in F frame components
+    Eigen::MRPd sigma_FM;                                                           //!< MRP attitude of the effector's body frame F relative to the hub-fixed mount frame M
+    Eigen::Vector3d r_MB_B;                                                         //!< [m] Position vector describing the hub-fixed mount frame origin point M location relative to the hub frame origin point B expressed in B frame components
+    Eigen::Vector3d omega_MB_B;                                                     //!< [rad/s] Angular velocity of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
+    Eigen::Vector3d omegaPrime_MB_B;                                                //!< [rad/s^2] Angular acceleration of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
+    Eigen::MRPd sigma_MB;                                                           //!< MRP attitude of the hub-fixed frame M relative to the hub body frame B
 
-    // Effector prescribed states in body frame components
+    // Other module vectors
+    Eigen::Vector3d r_FcF_B;                                                        //!< [m] Position vector of the effector center of mass point Fc relative to point F expressed in B frame components
+    Eigen::Vector3d r_FcB_B;                                                        //!< [m] Position vector of the effector center of mass point Fc relative to point B expressed in B frame components
+    Eigen::Vector3d rPrime_FcB_B;                                                   //!< [m/s] B frame time derivative of r_FcB_B expressed in B frame components
+    Eigen::Vector3d rDot_FcB_B;                                                     //!< [m/s] Inertial time derivative of r_FcB_B expressed in B frame components
     Eigen::Vector3d rPrimePrime_FM_B;                                               //!< [m/s^2] B frame time derivative of rPrime_FM_B expressed in B frame components
     Eigen::Vector3d omega_FB_B;                                                     //!< [rad/s] Angular velocity of frame F relative to frame B expressed in B frame components
+    Eigen::Vector3d omega_BN_B;                                                     //!< [rad/s] Angular velocity of frame B relative to the inertial frame N expressed in B frame components
+    Eigen::Vector3d omega_FN_B;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame N expressed in B frame components
     Eigen::Vector3d omegaPrime_FB_B;                                                //!< [rad/s^2] B frame time derivative of omega_FB_B expressed in B frame components
 
-    // Other vector quantities
-    Eigen::Vector3d r_FcF_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point F expressed in B frame components
-    Eigen::Vector3d r_FcB_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point B expressed in B frame components
-    Eigen::Vector3d rPrime_FcB_B;                                                   //!< [m/s] B frame time derivative of r_FcB_B expressed in B frame components
-    Eigen::Vector3d omega_BN_B;                                                     //!< [rad/s] Angular velocity of frame B relative to the inertial frame expressed in B frame components
-    Eigen::Vector3d omega_FN_B;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame expressed in B frame components
-    Eigen::Vector3d rDot_FcB_B;                                                     //!< [m/s] Inertial time derivative of r_FcB_B expressed in B frame components
-
-    // DCMs
-    Eigen::Matrix3d dcm_BF;                                                         //!< DCM from frame F to frame B
-    Eigen::Matrix3d dcm_BN;                                                         //!< DCM from inertial frame to frame B
-
-    // Other matrix quantities
-    Eigen::Matrix3d IPntFc_B;                                                       //!< [kg-m^2] Inertia of the effector about its center of mass expressed in B frame components
+    // Matrix quantities
+    Eigen::Matrix3d dcm_BF;                                                         //!< DCM attitude of frame B relative frame F
+    Eigen::Matrix3d dcm_BN;                                                         //!< DCM attitude of frame B relative frame N
+    Eigen::Matrix3d IPntFc_B;                                                       //!< [kg-m^2] Effector inertia matrix about its center of mass point Fc expressed in B frame components
     Eigen::Matrix3d rTilde_FcB_B;                                                   //!< [m] Tilde cross product matrix of r_FcB_B
     Eigen::Matrix3d omegaTilde_BN_B;                                                //!< [rad/s] Tilde cross product matrix of omega_BN_B
     Eigen::Matrix3d omegaTilde_FB_B;                                                //!< [rad/s] Tilde cross product matrix of omega_FB_B
 
     // Effector inertial states
-    Eigen::Vector3d r_FcN_N;                                                        //!< [m] Position of frame F center of mass relative to the inertial frame expressed in inertial frame components
-    Eigen::Vector3d v_FcN_N;                                                        //!< [m/s] Inertial velocity of frame F center of mass relative to the inertial frame expressed in inertial frame components
-    Eigen::Vector3d sigma_FN;                                                       //!< MRP attitude of frame F relative to the inertial frame
-    Eigen::Vector3d omega_FN_F;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame expressed in F frame components
+    Eigen::Vector3d r_FcN_N;                                                        //!< [m] Position vector of the effector center of mass point Fc relative to the inertial frame origin point N expressed in inertial frame N components
+    Eigen::Vector3d v_FcN_N;                                                        //!< [m/s] Velocity vector of the effector center of mass point Fc relative to the inertial frame origin point N expressed in inertial frame N components
+    Eigen::Vector3d sigma_FN;                                                       //!< MRP attitude of the effector body frame F relative to the inertial frame N
+    Eigen::Vector3d omega_FN_F;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame N expressed in F frame components
 
     // Hub inertial states
-    Eigen::MRPd sigma_BN;                                                           //!< Hub MRP attitude relative to the inertial frame
-    StateData *hubSigma;                                                            //!< Hub MRP attitude relative to the inertial frame
-    StateData *hubOmega;                                                            //!< [rad/s] Hub inertial angular velocity expressed in B frame components
-    Eigen::MatrixXd* inertialPositionProperty;                                      //!< [m] r_N Hub inertial position relative to system spice zeroBase/refBase
-    Eigen::MatrixXd* inertialVelocityProperty;                                      //!< [m] v_N Hub inertial velocity relative to system spice zeroBase/refBase
+    Eigen::MRPd sigma_BN;                                                           //!< MRP attitude of the hub body frame B relative to the inertial frame N
+    StateData *hubSigma;                                                            //!< sigma_BN state data
+    StateData *hubOmega;                                                            //!< [rad/s] omega_BN_B state data
+    Eigen::MatrixXd* inertialPositionProperty;                                      //!< [m] r_N Hub inertial position vector relative to system spice zeroBase/refBase
+    Eigen::MatrixXd* inertialVelocityProperty;                                      //!< [m] v_N Hub inertial velocity vector relative to system spice zeroBase/refBase
 
     // Prescribed states at epoch (Dynamics time step)
-    Eigen::Vector3d rEpoch_FM_M;                                                    //!< [m] Position of point F relative to point M expressed in M frame components
-    Eigen::Vector3d rPrimeEpoch_FM_M;                                               //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
-    Eigen::Vector3d omegaEpoch_FM_F;                                                //!< [rad/s] Angular velocity of frame F relative to frame M expressed in F frame components
-    StateData *sigma_FMState;                                                       //!< MRP attitude of frame F relative to frame M
+    Eigen::Vector3d rEpoch_FM_M;                                                    //!< [m] Current r_FM_M at the dynamics time step
+    Eigen::Vector3d rPrimeEpoch_FM_M;                                               //!< [m/s] Current rPrime_FM_M at the dynamics time step
+    Eigen::Vector3d omegaEpoch_FM_F;                                                //!< [rad/s] Current omega_FM_F at the dynamics time step
+    StateData *sigma_FMState;                                                       //!< sigma_FM state data
+
+    double currentSimTimeSec;                                                       //!< [s] Current simulation time, updated at the dynamics time step
+    std::string nameOfsigma_FMState;                                                //!< Identifier for the effector MRP attitude sigma_FM state data container
+    static uint64_t effectorID;                                                     //!< Effector ID
 };
 
 #endif /* PRESCRIBED_MOTION_STATE_EFFECTOR_H */

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -36,26 +36,26 @@ public:
     PrescribedMotionStateEffector();                                                //!< Constructor
     ~PrescribedMotionStateEffector();                                               //!< Destructor
 
-    void Reset(uint64_t currentClock) override;                                     //!< Reset method
-    void UpdateState(uint64_t currentSimNanos) override;                            //!< Method for updating the effector's states
-    void computeDerivatives(double integTime,
+    void Reset(uint64_t callTime) override;                                         //!< Reset method
+    void UpdateState(uint64_t callTime) override;                                   //!< Method for updating the effector's states
+    void computeDerivatives(double callTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
                             Eigen::Vector3d sigma_BN) override;                     //!< Method for computing the effector's MRP attitude state derivative
     void computePrescribedMotionInertialStates();                                   //!< Method for computing the effector's inertial states
     void linkInStates(DynParamManager& states) override;                            //!< Method for giving the effector access to hub states
     void registerStates(DynParamManager& statesIn) override;                        //!< Method for registering the effector's states
-    void updateContributions(double integTime,
+    void updateContributions(double callTime,
                              BackSubMatrices & backSubContr,
                              Eigen::Vector3d sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;                         //!< Method for computing the effector's backsubstitution contributions
-    void updateEffectorMassProps(double integTime) override;                        //!< Method for providing the effector's contributions to the mass props and mass prop rates of the spacecraft
-    void updateEnergyMomContributions(double integTime,
+    void updateEffectorMassProps(double callTime) override;                         //!< Method for providing the effector's contributions to the mass props and mass prop rates of the spacecraft
+    void updateEnergyMomContributions(double callTime,
                                       Eigen::Vector3d & rotAngMomPntCContr_B,
                                       double & rotEnergyContr,
                                       Eigen::Vector3d omega_BN_B) override;         //!< Method for computing the effector's contributions to the energy and momentum of the spacecraft
-    void writeOutputStateMessages(uint64_t currentClock) override;                  //!< Method for writing the module's output messages
+    void writeOutputStateMessages(uint64_t callTime) override;                      //!< Method for writing the module's output messages
 
     double currentSimTimeSec;                                                       //!< [s] Current simulation time, updated at the dynamics frequency
     double mass;                                                                    //!< [kg] Effector mass

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -36,6 +36,34 @@ public:
     PrescribedMotionStateEffector();                                                //!< Constructor
     ~PrescribedMotionStateEffector();                                               //!< Destructor
 
+    void setMass(const double mass);                                                //!< Setter method for the effector mass
+    void setIPntFc_F(const Eigen::Matrix3d IPntFc_F);                               //!< Setter method for IPntFc_F
+    void setR_FcF_F(const Eigen::Vector3d r_FcF_F);                                 //!< Setter method for r_FcF_F
+    void setR_FM_M(const Eigen::Vector3d r_FM_M);                                   //!< Setter method for r_FM_M
+    void setRPrime_FM_M(const Eigen::Vector3d rPrime_FM_M);                         //!< Setter method for rPrime_FM_M
+    void setRPrimePrime_FM_M(const Eigen::Vector3d rPrimePrime_FM_M);               //!< Setter method for rPrimePrime_FM_M
+    void setOmega_FM_F(const Eigen::Vector3d omega_FM_F);                           //!< Setter method for omega_FM_F
+    void setOmegaPrime_FM_F(const Eigen::Vector3d omegaPrime_FM_F);                 //!< Setter method for omegaPrime_FM_F
+    void setSigma_FM(const Eigen::MRPd sigma_FM);                                   //!< Setter method for sigma_FM
+    void setR_MB_B(const Eigen::Vector3d r_MB_B);                                   //!< Setter method for r_MB_B
+    void setOmega_MB_B(const Eigen::Vector3d omega_MB_B);                           //!< Setter method omega_MB_B
+    void setOmegaPrime_MB_B(const Eigen::Vector3d omegaPrime_MB_B);                 //!< Setter method for omegaPrime_MB_B
+    void setSigma_MB(const Eigen::MRPd sigma_MB);                                   //!< Setter method for sigma_MB
+
+    double getMass() const;                                                         //!< Getter method for the effector mass
+    const Eigen::Matrix3d getIPntFc_F() const;                                      //!< Getter method for IPntFc_F
+    const Eigen::Vector3d getR_FcF_F() const;                                       //!< Getter method for r_FcF_F
+    const Eigen::Vector3d getR_FM_M() const;                                        //!< Getter method for r_FM_M
+    const Eigen::Vector3d getRPrime_FM_M() const;                                   //!< Getter method for rPrime_FM_M
+    const Eigen::Vector3d getRPrimePrime_FM_M() const;                              //!< Getter method for rPrimePrime_FM_M
+    const Eigen::Vector3d getOmega_FM_F() const;                                    //!< Getter method for omega_FM_F
+    const Eigen::Vector3d getOmegaPrime_FM_F() const;                               //!< Getter method for omegaPrime_FM_F
+    const Eigen::MRPd getSigma_FM() const;                                          //!< Getter method for sigma_FM
+    const Eigen::Vector3d getR_MB_B() const;                                        //!< Getter method for r_MB_B
+    const Eigen::Vector3d getOmega_MB_B() const;                                    //!< Getter method omega_MB_B
+    const Eigen::Vector3d getOmegaPrime_MB_B() const;                               //!< Getter method for omegaPrime_MB_B
+    const Eigen::MRPd getSigma_MB() const;                                          //!< Getter method for sigma_MB
+
     void Reset(uint64_t callTime) override;                                         //!< Reset method
     void UpdateState(uint64_t callTime) override;                                   //!< Method for updating the effector's states
     void computeDerivatives(double callTime,

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -46,7 +46,7 @@ public:
     void setOmegaPrime_FM_F(const Eigen::Vector3d omegaPrime_FM_F);                 //!< Setter method for omegaPrime_FM_F
     void setSigma_FM(const Eigen::MRPd sigma_FM);                                   //!< Setter method for sigma_FM
     void setR_MB_B(const Eigen::Vector3d r_MB_B);                                   //!< Setter method for r_MB_B
-    void setOmega_MB_B(const Eigen::Vector3d omega_MB_B);                           //!< Setter method omega_MB_B
+    void setOmega_MB_M(const Eigen::Vector3d omega_MB_M);                           //!< Setter method omega_MB_M
     void setOmegaPrime_MB_B(const Eigen::Vector3d omegaPrime_MB_B);                 //!< Setter method for omegaPrime_MB_B
     void setSigma_MB(const Eigen::MRPd sigma_MB);                                   //!< Setter method for sigma_MB
 
@@ -60,7 +60,7 @@ public:
     const Eigen::Vector3d getOmegaPrime_FM_F() const;                               //!< Getter method for omegaPrime_FM_F
     const Eigen::MRPd getSigma_FM() const;                                          //!< Getter method for sigma_FM
     const Eigen::Vector3d getR_MB_B() const;                                        //!< Getter method for r_MB_B
-    const Eigen::Vector3d getOmega_MB_B() const;                                    //!< Getter method omega_MB_B
+    const Eigen::Vector3d getOmega_MB_M() const;                                    //!< Getter method omega_MB_M
     const Eigen::Vector3d getOmegaPrime_MB_B() const;                               //!< Getter method for omegaPrime_MB_B
     const Eigen::MRPd getSigma_MB() const;                                          //!< Getter method for sigma_MB
 
@@ -103,7 +103,7 @@ private:
     Eigen::Vector3d omegaPrime_FM_F;                                                //!< [rad/s^2] Angular acceleration of the effector body frame F relative to the hub-fixed mount frame M expressed in F frame components
     Eigen::MRPd sigma_FM;                                                           //!< MRP attitude of the effector's body frame F relative to the hub-fixed mount frame M
     Eigen::Vector3d r_MB_B;                                                         //!< [m] Position vector describing the hub-fixed mount frame origin point M location relative to the hub frame origin point B expressed in B frame components
-    Eigen::Vector3d omega_MB_B;                                                     //!< [rad/s] Angular velocity of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
+    Eigen::Vector3d omega_MB_M;                                                     //!< [rad/s] Angular velocity of the hub-fixed mount frame M relative to the hub frame B expressed in M frame components
     Eigen::Vector3d omegaPrime_MB_B;                                                //!< [rad/s^2] Angular acceleration of the hub-fixed mount frame M relative to the hub frame B expressed in B frame components
     Eigen::MRPd sigma_MB;                                                           //!< MRP attitude of the hub-fixed frame M relative to the hub body frame B
 

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -85,31 +85,21 @@ private:
     static uint64_t effectorID;                                                     //!< ID number of this panel
 
     // Effector prescribed states in body frame components
-    Eigen::Vector3d r_FM_B;                                                         //!< [m] Position of point F relative to point M expressed in B frame components
-    Eigen::Vector3d rPrime_FM_B;                                                    //!< [m/s] B frame time derivative of position r_FM_B expressed in B frame components
     Eigen::Vector3d rPrimePrime_FM_B;                                               //!< [m/s^2] B frame time derivative of rPrime_FM_B expressed in B frame components
-    Eigen::Vector3d omega_FM_B;                                                     //!< [rad/s] Angular velocity of F frame relative to the M frame expressed in B frame components
-    Eigen::Vector3d omegaPrime_FM_B;                                                //!< [rad/s^2] B frame time derivative of omega_FB_B expressed in B frame components
     Eigen::Vector3d omega_FB_B;                                                     //!< [rad/s] Angular velocity of frame F relative to frame B expressed in B frame components
     Eigen::Vector3d omegaPrime_FB_B;                                                //!< [rad/s^2] B frame time derivative of omega_FB_B expressed in B frame components
 
     // Other vector quantities
     Eigen::Vector3d r_FcF_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point F expressed in B frame components
     Eigen::Vector3d r_FcB_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point B expressed in B frame components
-    Eigen::Vector3d r_FcM_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point M expressed in B frame components
-    Eigen::Vector3d r_FB_B;                                                         //!< [m] Position of point F relative to point B expressed in B frame components
     Eigen::Vector3d rPrime_FcB_B;                                                   //!< [m/s] B frame time derivative of r_FcB_B expressed in B frame components
-    Eigen::Vector3d rPrime_FcM_B;                                                   //!< [m/s] B frame time derivative of r_FcM_B expressed in B frame components
-    Eigen::Vector3d rPrimePrime_FcB_B;                                              //!< [m/s^2] B frame time derivative of rPrime_FcB_B expressed in B frame components
     Eigen::Vector3d omega_BN_B;                                                     //!< [rad/s] Angular velocity of frame B relative to the inertial frame expressed in B frame components
     Eigen::Vector3d omega_FN_B;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame expressed in B frame components
     Eigen::Vector3d rDot_FcB_B;                                                     //!< [m/s] Inertial time derivative of r_FcB_B expressed in B frame components
 
     // DCMs
     Eigen::Matrix3d dcm_BF;                                                         //!< DCM from frame F to frame B
-    Eigen::Matrix3d dcm_BM;                                                         //!< DCM from frame M to frame B
     Eigen::Matrix3d dcm_BN;                                                         //!< DCM from inertial frame to frame B
-    Eigen::Matrix3d dcm_FM;                                                         //!< DCM from frame M to frame F
 
     // Other matrix quantities
     Eigen::Matrix3d IPntFc_B;                                                       //!< [kg-m^2] Inertia of the effector about its center of mass expressed in B frame components

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -20,123 +20,121 @@
 #ifndef PRESCRIBED_MOTION_STATE_EFFECTOR_H
 #define PRESCRIBED_MOTION_STATE_EFFECTOR_H
 
-#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
-#include "architecture/msgPayloadDefC/PrescribedTranslationMsgPayload.h"
 #include "architecture/msgPayloadDefC/PrescribedRotationMsgPayload.h"
-#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/msgPayloadDefC/PrescribedTranslationMsgPayload.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include "architecture/utilities/avsEigenMRP.h"
+#include "architecture/utilities/avsEigenSupport.h"
 
-/*! @brief prescribed motion state effector class */
+/*! @brief Prescribed motion state effector class */
 class PrescribedMotionStateEffector: public StateEffector, public SysModel {
 public:
-    PrescribedMotionStateEffector();
-    ~PrescribedMotionStateEffector();
-    void Reset(uint64_t currentClock) override;                      //!< Method for reset
-    void writeOutputStateMessages(uint64_t currentClock) override;   //!< Method for writing the output messages
-	void UpdateState(uint64_t currentSimNanos) override;             //!< Method for updating the effector states
-    void registerStates(DynParamManager& statesIn) override;         //!< Method for registering the effector's states
-    void linkInStates(DynParamManager& states) override;             //!< Method for giving the effector access to hub states
+    PrescribedMotionStateEffector();                                                //!< Constructor
+    ~PrescribedMotionStateEffector();                                               //!< Destructor
+
+    void Reset(uint64_t currentClock) override;                                     //!< Reset method
+    void UpdateState(uint64_t currentSimNanos) override;                            //!< Method for updating the effector's states
+    void computeDerivatives(double integTime,
+                            Eigen::Vector3d rDDot_BN_N,
+                            Eigen::Vector3d omegaDot_BN_B,
+                            Eigen::Vector3d sigma_BN) override;                     //!< Method for computing the effector's MRP attitude state derivative
+    void computePrescribedMotionInertialStates();                                   //!< Method for computing the effector's inertial states
+    void linkInStates(DynParamManager& states) override;                            //!< Method for giving the effector access to hub states
+    void registerStates(DynParamManager& statesIn) override;                        //!< Method for registering the effector's states
     void updateContributions(double integTime,
                              BackSubMatrices & backSubContr,
                              Eigen::Vector3d sigma_BN,
                              Eigen::Vector3d omega_BN_B,
-                             Eigen::Vector3d g_N) override;          //!< Method for computing the effector's back-substitution contributions
-    void computeDerivatives(double integTime,
-                            Eigen::Vector3d rDDot_BN_N,
-                            Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override;      //!< Method for effector to compute its state derivatives
-    void updateEffectorMassProps(double integTime) override;         //!< Method for calculating the effector mass props and prop rates
+                             Eigen::Vector3d g_N) override;                         //!< Method for computing the effector's backsubstitution contributions
+    void updateEffectorMassProps(double integTime) override;                        //!< Method for providing the effector's contributions to the mass props and mass prop rates of the spacecraft
     void updateEnergyMomContributions(double integTime,
                                       Eigen::Vector3d & rotAngMomPntCContr_B,
                                       double & rotEnergyContr,
-                                      Eigen::Vector3d omega_BN_B) override;    //!< Method for computing the energy and momentum of the effector
-    void computePrescribedMotionInertialStates();       //!< Method for computing the effector's states relative to the inertial frame
+                                      Eigen::Vector3d omega_BN_B) override;         //!< Method for computing the effector's contributions to the energy and momentum of the spacecraft
+    void writeOutputStateMessages(uint64_t currentClock) override;                  //!< Method for writing the module's output messages
 
-    double currentSimTimeSec;                           //!< [s] Current simulation time, updated at the dynamics frequency
-    double mass;                                        //!< [kg] Effector mass
-    Eigen::Matrix3d IPntFc_F;                           //!< [kg-m^2] Inertia of the effector about its center of mass in F frame components
-    Eigen::Vector3d r_MB_B;                             //!< [m] Position of point M relative to point B in B frame components
-    Eigen::Vector3d r_FcF_F;                            //!< [m] Position of the effector center of mass relative to point F in F frame components
-    Eigen::Vector3d omega_MB_B;                         //!< [rad/s] Angular velocity of frame M with respect to frame B in B frame components
-    Eigen::Vector3d omegaPrime_MB_B;                    //!< [rad/s^2] B frame time derivative of omega_MB_B in B frame components
-    Eigen::MRPd sigma_MB;                               //!< MRP attitude of frame M relative to frame B
+    double currentSimTimeSec;                                                       //!< [s] Current simulation time, updated at the dynamics frequency
+    double mass;                                                                    //!< [kg] Effector mass
+    Eigen::Matrix3d IPntFc_F;                                                       //!< [kg-m^2] Effector inertia about its center of mass point Fc expressed in F frame components
+    Eigen::Vector3d r_FcF_F;                                                        //!< [m] Position of the effector center of mass point Fc relative to point F expressed in F frame components
+    Eigen::Vector3d r_MB_B;                                                         //!< [m] Position of mount M frame origin point M relative to hub frame B origin point B expressed in B frame components
+    Eigen::Vector3d omega_MB_B;                                                     //!< [rad/s] Angular velocity of frame M with respect to frame B expressed in B frame components
+    Eigen::Vector3d omegaPrime_MB_B;                                                //!< [rad/s^2] B frame time derivative of omega_MB_B expressed in B frame components
+    Eigen::MRPd sigma_MB;                                                           //!< MRP attitude of frame M relative to frame B
 
-    // Prescribed parameters
-    Eigen::Vector3d r_FM_M;                             //!< [m] Position of point F relative to point M in M frame components
-    Eigen::Vector3d rPrime_FM_M;                        //!< [m/s] B frame time derivative of r_FM_M in M frame components
-    Eigen::Vector3d rPrimePrime_FM_M;                   //!< [m/s^2] B frame time derivative of rPrime_FM_M in M frame components
-    Eigen::Vector3d omega_FM_F;                         //!< [rad/s] Angular velocity of frame F relative to frame M in F frame components
-    Eigen::Vector3d omegaPrime_FM_F;                    //!< [rad/s^2] B frame time derivative of omega_FM_F in F frame components
-    Eigen::MRPd sigma_FM;                               //!< MRP attitude of frame F relative to frame M
-    std::string nameOfsigma_FMState;                    //!< Identifier for the sigma_FM state data container
+    // Hub-relative prescribed states of the effector
+    Eigen::Vector3d r_FM_M;                                                         //!< [m] Position of prescribed effector frame origin point F relative to point M expressed in M frame components
+    Eigen::Vector3d rPrime_FM_M;                                                    //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
+    Eigen::Vector3d rPrimePrime_FM_M;                                               //!< [m/s^2] B frame time derivative of rPrime_FM_M expressed in M frame components
+    Eigen::Vector3d omega_FM_F;                                                     //!< [rad/s] Angular velocity of frame F relative to frame M expressed in F frame components
+    Eigen::Vector3d omegaPrime_FM_F;                                                //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components
+    Eigen::MRPd sigma_FM;                                                           //!< MRP attitude of frame F relative to frame M
+    std::string nameOfsigma_FMState;                                                //!< Identifier for the prescribed effector MRP sigma_FM attitude state data container
 
-    ReadFunctor<PrescribedTranslationMsgPayload> prescribedTranslationInMsg;      //!< Input message for the effector's translational prescribed states
-    ReadFunctor<PrescribedRotationMsgPayload> prescribedRotationInMsg;            //!< Input message for the effector's rotational prescribed states
-    Message<PrescribedTranslationMsgPayload> prescribedTranslationOutMsg;         //!< Output message for the effector's translational prescribed states
-    Message<PrescribedRotationMsgPayload> prescribedRotationOutMsg;               //!< Output message for the effector's rotational prescribed states
-    Message<SCStatesMsgPayload> prescribedMotionConfigLogOutMsg;                  //!< Output config log message for the effector's states
+    ReadFunctor<PrescribedRotationMsgPayload> prescribedRotationInMsg;              //!< Input message for the effector's rotational hub-relative prescribed states
+    ReadFunctor<PrescribedTranslationMsgPayload> prescribedTranslationInMsg;        //!< Input message for the effector's translational hub-relative prescribed states
+    Message<PrescribedRotationMsgPayload> prescribedRotationOutMsg;                 //!< Output message for the effector's hub-relative rotational prescribed states
+    Message<PrescribedTranslationMsgPayload> prescribedTranslationOutMsg;           //!< Output message for the effector's hub-relative translational prescribed states
+    Message<SCStatesMsgPayload> prescribedMotionConfigLogOutMsg;                    //!< Output config log message for the effector's inertial states
 
 private:
-    static uint64_t effectorID;                                         //!< ID number of this panel
+    static uint64_t effectorID;                                                     //!< ID number of this panel
 
-    // Given quantities from user in python
-    Eigen::Matrix3d IPntFc_B;                           //!< [kg-m^2] Inertia of the effector about its center of mass in B frame components
-    Eigen::Vector3d r_FB_B;                             //!< [m] Position of point F relative to point B in B frame components
-    Eigen::Vector3d r_FcF_B;                            //!< [m] Position of the effector center of mass relative to point F in B frame components
-
-    // Prescribed parameters in body frame components
-    Eigen::Vector3d r_FM_B;                             //!< [m] Position of point F relative to point M in B frame components
-    Eigen::Vector3d rPrime_FM_B;                        //!< [m/s] B frame time derivative of position r_FM_B in B frame components
-    Eigen::Vector3d rPrimePrime_FM_B;                   //!< [m/s^2] B frame time derivative of rPrime_FM_B in B frame components
-    Eigen::Vector3d omega_FM_B;                         //!< [rad/s] Angular velocity of F frame relative to the M frame in B frame components
-    Eigen::Vector3d omegaPrime_FM_B;                    //!< [rad/s^2] B frame time derivative of omega_FB_B in B frame components
-    Eigen::Vector3d omega_FB_B;                         //!< [rad/s] Angular velocity of frame F relative to frame B in B frame components
-    Eigen::Vector3d omegaPrime_FB_B;                    //!< [rad/s^2] B frame time derivative of omega_FB_B in B frame components
+    // Effector prescribed states in body frame components
+    Eigen::Vector3d r_FM_B;                                                         //!< [m] Position of point F relative to point M expressed in B frame components
+    Eigen::Vector3d rPrime_FM_B;                                                    //!< [m/s] B frame time derivative of position r_FM_B expressed in B frame components
+    Eigen::Vector3d rPrimePrime_FM_B;                                               //!< [m/s^2] B frame time derivative of rPrime_FM_B expressed in B frame components
+    Eigen::Vector3d omega_FM_B;                                                     //!< [rad/s] Angular velocity of F frame relative to the M frame expressed in B frame components
+    Eigen::Vector3d omegaPrime_FM_B;                                                //!< [rad/s^2] B frame time derivative of omega_FB_B expressed in B frame components
+    Eigen::Vector3d omega_FB_B;                                                     //!< [rad/s] Angular velocity of frame F relative to frame B expressed in B frame components
+    Eigen::Vector3d omegaPrime_FB_B;                                                //!< [rad/s^2] B frame time derivative of omega_FB_B expressed in B frame components
 
     // Other vector quantities
-    Eigen::Vector3d r_FcM_B;                            //!< [m] Position of frame F center of mass relative to point M in B frame components
-    Eigen::Vector3d r_FcB_B;                            //!< [m] Position of frame F center of mass relative to point B in B frame components
-    Eigen::Vector3d rPrime_FcM_B;                       //!< [m/s] B frame time derivative of r_FcM_B in B frame components
-    Eigen::Vector3d rPrime_FcB_B;                       //!< [m/s] B frame time derivative of r_FcB_B in B frame components
-    Eigen::Vector3d rPrimePrime_FcB_B;                  //!< [m/s^2] B frame time derivative of rPrime_FcB_B in B frame components
-    Eigen::Vector3d omega_BN_B;                         //!< [rad/s] Angular velocity of frame B relative to the inertial frame in B frame components
-    Eigen::Vector3d omega_FN_B;                         //!< [rad/s] Angular velocity of frame F relative to the inertial frame in B frame components
-    Eigen::Vector3d rDot_FcB_B;                         //!< [m/s] Inertial time derivative of r_FcB_B in B frame components
-    Eigen::MRPd sigma_BN;                               //!< MRP attitude of frame B relative to the inertial frame
+    Eigen::Vector3d r_FcF_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point F expressed in B frame components
+    Eigen::Vector3d r_FcB_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point B expressed in B frame components
+    Eigen::Vector3d r_FcM_B;                                                        //!< [m] Position of the effector center of mass point Fc relative to point M expressed in B frame components
+    Eigen::Vector3d r_FB_B;                                                         //!< [m] Position of point F relative to point B expressed in B frame components
+    Eigen::Vector3d rPrime_FcB_B;                                                   //!< [m/s] B frame time derivative of r_FcB_B expressed in B frame components
+    Eigen::Vector3d rPrime_FcM_B;                                                   //!< [m/s] B frame time derivative of r_FcM_B expressed in B frame components
+    Eigen::Vector3d rPrimePrime_FcB_B;                                              //!< [m/s^2] B frame time derivative of rPrime_FcB_B expressed in B frame components
+    Eigen::Vector3d omega_BN_B;                                                     //!< [rad/s] Angular velocity of frame B relative to the inertial frame expressed in B frame components
+    Eigen::Vector3d omega_FN_B;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame expressed in B frame components
+    Eigen::Vector3d rDot_FcB_B;                                                     //!< [m/s] Inertial time derivative of r_FcB_B expressed in B frame components
 
     // DCMs
-    Eigen::Matrix3d dcm_BN;                             //!< DCM from inertial frame to frame B
-    Eigen::Matrix3d dcm_BM;                             //!< DCM from frame M to frame B
-    Eigen::Matrix3d dcm_FM;                             //!< DCM from frame M to frame F
-    Eigen::Matrix3d dcm_BF;                             //!< DCM from frame F to frame B
+    Eigen::Matrix3d dcm_BF;                                                         //!< DCM from frame F to frame B
+    Eigen::Matrix3d dcm_BM;                                                         //!< DCM from frame M to frame B
+    Eigen::Matrix3d dcm_BN;                                                         //!< DCM from inertial frame to frame B
+    Eigen::Matrix3d dcm_FM;                                                         //!< DCM from frame M to frame F
 
     // Other matrix quantities
-    Eigen::Matrix3d rTilde_FcB_B;                       //!< [m] Tilde cross product matrix of r_FcB_B
-    Eigen::Matrix3d omegaTilde_BN_B;                    //!< [rad/s] Tilde cross product matrix of omega_BN_B
-    Eigen::Matrix3d omegaTilde_FB_B;                    //!< [rad/s] Tilde cross product matrix of omega_FB_B
+    Eigen::Matrix3d IPntFc_B;                                                       //!< [kg-m^2] Inertia of the effector about its center of mass expressed in B frame components
+    Eigen::Matrix3d rTilde_FcB_B;                                                   //!< [m] Tilde cross product matrix of r_FcB_B
+    Eigen::Matrix3d omegaTilde_BN_B;                                                //!< [rad/s] Tilde cross product matrix of omega_BN_B
+    Eigen::Matrix3d omegaTilde_FB_B;                                                //!< [rad/s] Tilde cross product matrix of omega_FB_B
 
-    // Effector properties relative to the inertial frame
-    Eigen::Vector3d r_FcN_N;                            //!< [m] Position of frame F center of mass relative to the inertial frame in inertial frame components
-    Eigen::Vector3d v_FcN_N;                            //!< [m/s] Inertial velocity of frame F center of mass relative to the inertial frame in inertial frame components
-    Eigen::Vector3d sigma_FN;                           //!< MRP attitude of frame F relative to the inertial frame
-    Eigen::Vector3d omega_FN_F;                         //!< [rad/s] Angular velocity of frame F relative to the inertial frame in F frame components
+    // Effector inertial states
+    Eigen::Vector3d r_FcN_N;                                                        //!< [m] Position of frame F center of mass relative to the inertial frame expressed in inertial frame components
+    Eigen::Vector3d v_FcN_N;                                                        //!< [m/s] Inertial velocity of frame F center of mass relative to the inertial frame expressed in inertial frame components
+    Eigen::Vector3d sigma_FN;                                                       //!< MRP attitude of frame F relative to the inertial frame
+    Eigen::Vector3d omega_FN_F;                                                     //!< [rad/s] Angular velocity of frame F relative to the inertial frame expressed in F frame components
 
-    // Hub states
-    StateData *hubSigma;                                //!< Hub attitude relative to the inertial frame represented by MRP
-    StateData *hubOmega;                                //!< [rad/s] Hub angular velocity in B frame components relative to the inertial frame
-    Eigen::MatrixXd* inertialPositionProperty;          //!< [m] r_N Inertial position relative to system spice zeroBase/refBase
-    Eigen::MatrixXd* inertialVelocityProperty;          //!< [m] v_N Inertial velocity relative to system spice zeroBase/refBase
+    // Hub inertial states
+    Eigen::MRPd sigma_BN;                                                           //!< Hub MRP attitude relative to the inertial frame
+    StateData *hubSigma;                                                            //!< Hub MRP attitude relative to the inertial frame
+    StateData *hubOmega;                                                            //!< [rad/s] Hub inertial angular velocity expressed in B frame components
+    Eigen::MatrixXd* inertialPositionProperty;                                      //!< [m] r_N Hub inertial position relative to system spice zeroBase/refBase
+    Eigen::MatrixXd* inertialVelocityProperty;                                      //!< [m] v_N Hub inertial velocity relative to system spice zeroBase/refBase
 
     // Prescribed states at epoch (Dynamics time step)
-    Eigen::Vector3d rEpoch_FM_M;                        //!< [m] Position of point F relative to point M in M frame components
-    Eigen::Vector3d rPrimeEpoch_FM_M;                   //!< [m/s] B frame time derivative of r_FM_M in M frame components
-    Eigen::Vector3d omegaEpoch_FM_F;                    //!< [rad/s] Angular velocity of frame F relative to frame M in F frame components
-    StateData *sigma_FMState;                           //!< MRP attitude of frame F relative to frame M
-
+    Eigen::Vector3d rEpoch_FM_M;                                                    //!< [m] Position of point F relative to point M expressed in M frame components
+    Eigen::Vector3d rPrimeEpoch_FM_M;                                               //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
+    Eigen::Vector3d omegaEpoch_FM_F;                                                //!< [rad/s] Angular velocity of frame F relative to frame M expressed in F frame components
+    StateData *sigma_FMState;                                                       //!< MRP attitude of frame F relative to frame M
 };
 
 #endif /* PRESCRIBED_MOTION_STATE_EFFECTOR_H */

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
@@ -128,5 +128,3 @@ Make sure to connect the required messages for this module using the kinematic p
 body is to be actuated relative to the spacecraft hub. See the example script :ref:`scenarioDeployingSolarArrays` for
 more information about how to set up hub-relative multi-body prescribed motion using this state effector module and the
 associated kinematic profiler modules.
-
-

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
@@ -14,9 +14,7 @@ be connected to this module's :ref:`PrescribedTranslationMsgPayload` and :ref:`P
 input messages to profile the prescribed body's states as a function of time. These message connections are required
 to provide the prescribed body's states to this dynamics module. Note that either a single profiler can be connected to
 these input messages or two separate profiler modules can be used; where one profiles the prescribed body's
-translational states and the other profiles the prescribed body's rotational states. See the example script
-:ref:`scenarioDeployingSolarArrays` for more information about how to set up hub-relative
-multi-body prescribed motion using this state effector module and the associated kinematic profiler modules.
+translational states and the other profiles the prescribed body's rotational states.
 
 Message Connection Descriptions
 -------------------------------
@@ -130,7 +128,6 @@ default.
 
     unitTestSim.AddModelToTask(unitTaskName, platform)
 
-See the example script :ref:`scenarioDeployingSolarArrays` for more information about how to set up hub-relative
-multi-body prescribed motion using this state effector module and the associated kinematic profiler modules.
+
 
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-197
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR refactors the `prescribedMotion` state effector module. Minor changes are made to the module such as:
1. Adding setter and getter member functions
2. Adding/adjusting comments
3. Minor refactoring of module variables and their calculation
4. Removing variables from the module header file when they can be local to certain member functions
5. Refactoring the module unit test
6. Updating the module documentation

## Verification
The module unit test script is refactored in this PR. The refactor creates two separate unit test scripts
for this module. Instead of using a boolean toggle variable as a pytest parameter to run either the translational or rotational prescribed motion unit test, the script is separated into two separate tests contained within the single unit test file. To reduce code duplication, this refactor also adds shared functions between the scripts that include set_spacecraft_hub(), set_prescribed_motion_body(), plot_conservation(), and check_conservation().

## Documentation
The module documentation is updated to reflect the changes in this PR.

## Future work
N/A
