### PR TITLE
Feature/852 simple nav gyro

### DIFF
--- a/src/simulation/navigation/simpleNav/simpleNav.cpp
+++ b/src/simulation/navigation/simpleNav/simpleNav.cpp
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Copyright (c) 2024, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -55,6 +55,7 @@ public:
     Message<NavAttMsgPayload> attOutMsg;        //!< attitude navigation output msg
     Message<NavTransMsgPayload> transOutMsg;    //!< translation navigation output msg
     Message<EphemerisMsgPayload> scEphemOutMsg;    //!< translation navigation output msg
+    Message<AccDataMsgPayload> accelDataOutMsg; //!< accelerometer and gyro data output msg
     bool crossTrans;                  //!< -- Have position error depend on velocity
     bool crossAtt;                    //!< -- Have attitude depend on attitude rate
     NavAttMsgPayload trueAttState;        //!< -- attitude nav state without errors
@@ -62,6 +63,7 @@ public:
     NavTransMsgPayload trueTransState;    //!< -- translation nav state without errors
     NavTransMsgPayload estTransState;     //!< -- translation nav state including errors
     EphemerisMsgPayload spacecraftEphemerisState;    //!< -- full spacecraft ephemeris state with errors
+    AccDataMsgPayload accelDataState;  //!< accelerometer and gyro data payload
     SCStatesMsgPayload inertialState; //!< -- input inertial state from Star Tracker
     SpicePlanetStateMsgPayload sunState;  //!< -- input Sun state
     BSKLogger bskLogger;              //!< -- BSK Logging

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Copyright (c) 2024, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -21,6 +21,7 @@
 #define SIMPLE_NAV_H
 
 #include <vector>
+#include <random>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/gauss_markov.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -28,6 +28,8 @@
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
 #include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/AccPktDataMsgPayload.h"
+#include "architecture/msgPayloadDefC/AccDataMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 #include <Eigen/Dense>
 #include "architecture/messaging/messaging.h"

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -49,6 +49,14 @@ public:
     void writeOutputMessages(uint64_t Clock);
 
 public:
+    double gyroStandardDeviation=1E-5;    //!< Standard deviation for each rate component
+    double accelStandardDeviation=1E-8;    //!< Standard deviation for each acceleration component
+    double gyroBias=0 ;    //!<  Bias for each rate component
+    double accelBias=0;    //!<  Bias for each acceleration component
+    double gyroErrors[3*MAX_ACC_BUF_PKT]; //!<  Errors to apply to each gyro measurement
+    double accelErrors[3*MAX_ACC_BUF_PKT]; //!<  Errors to apply to each accelerometer measurement
+    int numberOfGyroBuffers=100;       //!< Number of gyro measurements per timestep
+    int gyroFrequencyPerSecond=500;       //!< Number of gyro measurements per second
     Eigen::MatrixXd PMatrix;          //!< -- Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
     Eigen::VectorXd walkBounds;       //!< -- "3-sigma" errors to permit for states
     Eigen::VectorXd navErrors;        //!< -- Current navigation errors applied to truth

--- a/src/simulation/navigation/simpleNav/simpleNav.i
+++ b/src/simulation/navigation/simpleNav/simpleNav.i
@@ -41,6 +41,8 @@ struct NavTransMsg_C;
 struct SpicePlanetStateMsg_C;
 %include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
 struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/AccDataMsgPayload.h"
+struct AccDataMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/simulation/navigation/simpleNav/simpleNav.i
+++ b/src/simulation/navigation/simpleNav/simpleNav.i
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Copyright (c) 2024, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/navigation/simpleNav/simpleNav.rst
+++ b/src/simulation/navigation/simpleNav/simpleNav.rst
@@ -38,6 +38,9 @@ not come from a noisy sensor but from a ground-based estimation process.
     * - scEphemOutMsg
       - :ref:`EphemerisMsgPayload`
       - spacecraft ephemeris output msg
+    * - scEphemOutMsg
+      - :ref:`accelDataOutMsg`
+      - spacecraft accelerometer and gyro output msg
     * - scStateInMsg
       - :ref:`SCStatesMsgPayload`
       - spacecraft state input msg


### PR DESCRIPTION
* **Tickets addressed:** bsk-852
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Update simple nav to write out the accelerometer packet message (containing acceleration and rate information). This change allows for a user to set a cadence of gyro measurements per time step (100 measurements per time step for instance) and set gyro biases and standard deviations

## Verification
The unit test contains data to check the time output by the message (mean time for all the measurements) and the statistics on the noise

## Documentation
Updated given new message

## Future work
The module needs a healthy refactoring
