### PR TITLE
Add pre-commit workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,8 +8,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - id: file_changes
+        uses: tj-actions/changed-files@v44
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}
   build-linux:
     name: Build Linux
+    needs: pre-commit
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -82,6 +93,7 @@ jobs:
 
   build-windows:
     name: Build Windows
+    needs: pre-commit
     runs-on: windows-2019
     strategy:
       matrix:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,8 +11,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - id: file_changes
         uses: tj-actions/changed-files@v44
       - uses: pre-commit/action@v3.0.1
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cache conan packages
         id: cache-conan
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: Cache pip modules
         id: cache-pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-pip-modules
         with:
@@ -75,7 +75,7 @@ jobs:
           source .venv/bin/activate
           cd src && pytest -n 2 -m "not scenarioTest" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
       - name: "Upload pytest test results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
@@ -85,7 +85,7 @@ jobs:
         working-directory: ./dist3
         run: ctest --gtest_output "json:../ctest/ctest-results-linux-${{ matrix.python-version }}.json"
       - name: "Upload Google Test CTest results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ctest-results-${{ matrix.python-version }}
           path: ctest/ctest-results-${{ matrix.python-version }}.json


### PR DESCRIPTION
* **Tickets addressed:** maxgnc-885
* **Review:** By file
* **Merge strategy:** Merge (no squash)  


## Description

Adds a new job to pull-request.yml that fetches all of the names of the files that have been changed then feeds those files into pre-commit. The tests that run on Windows and Linux have been set to wait for the pre-commit job to pass before starting.

## Verification

These changes are verified by sending in files that need to be changed by pre-commit and expecting a stoppage of tests along with sending files that have already been checked by pre-commit and expecting a pass.

## Documentation

No documentation added or invalidated.

## Future work

Consider making the other tests start up as pre-commit is running and cancelling them early if pre-commit fails.