### PR TITLE
Add conan cache to windows using github actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -104,6 +104,8 @@ jobs:
       security-events: write
     env:
       MPLBACKEND: agg
+      CONAN_USER_HOME: C:\Users\runneradmin\
+      CONAN_USER_HOME_SHORT: None
     steps:
       - name: Checkout code
         uses: nschloe/action-checkout-with-lfs-cache@v1
@@ -113,6 +115,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/requirements.txt'
+      - name: Cache conan packages
+        id: cache-conan
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-conan-packages
+        with:
+          path: C:\Users\runneradmin\.conan
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
       - name: Choco help
         uses: crazy-max/ghaction-chocolatey@v3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,7 +46,7 @@ jobs:
           path: ~/.conan
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
       - name: Cache pip modules
         id: cache-pip
         uses: actions/cache@v4


### PR DESCRIPTION
* **Tickets addressed:** maxgnc-895
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
This branch moves all dependency files created on windows github runners to ```C:\users\runneradmin\.conan```, and caches this folder between CI runs. There is no change outside of github actions.
This branch also touches the linux build as it is more descriptive of which keys it accepts when grabbing caches

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->

No new tests added, there should be no change in output, just how CI is ran.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->

No documentation added

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None currently, maybe if cache sizes increase we will need to move away from github's cache