### PR TITLE
Feature/834 com cob offset

### DIFF
--- a/src/architecture/msgPayloadDefCpp/OpNavCOMMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/OpNavCOMMsgPayload.h
@@ -1,0 +1,42 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef COMOPNAVMSG_H
+#define COMOPNAVMSG_H
+
+//!@brief Center of mass optical navigation measurement message
+/*! This message is output by the center of brightness converter module and contains the center of mass (COM) after
+ * offsetting the center of brightness (COB) using the phase angle correction.
+ */
+typedef struct
+//@cond DOXYGEN_IGNORE
+OpNavCOMMsgPayload
+//@endcond
+{
+    uint64_t timeTag; //!< --[ns] Current vehicle time-tag associated with measurements
+    bool valid; //!< -- Quality of measurement
+    int64_t cameraID; //!< -- [-] ID of the camera that took the image
+    double centerOfMass[2]; //!< -- [-] Center x, y of bright pixels
+    double offsetFactor; //!< -- [-] COM/COB offset factor as a fraction of object radius
+    int32_t objectPixelRadius; //!< -- [-] radius of object in pixels
+    double phaseAngle; //!< -- [rad] angle between Sun-Object-Camera
+    double sunDirection; //!< -- [rad] Sun direction in the image
+}OpNavCOMMsgPayload;
+
+#endif /* COMOPNAVMSG_H */

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/_UnitTest/test_cobConverter.py
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/_UnitTest/test_cobConverter.py
@@ -28,64 +28,91 @@ from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
-'''
-Main method that is writen in the module to map the state from pixel space to position
-'''
-def mapState(state, inputCamera):
-    # Compute pixel pitch divided by focal length (often denoted d_x and d_y)
-    sensorWidth_focal_ratio = 2.*np.tan(inputCamera.fieldOfView*inputCamera.resolution[0]/inputCamera.resolution[1]/2.0)
-    sensorHeight_focal_ratio = 2.*np.tan(inputCamera.fieldOfView/2.0)
-    d_x = sensorWidth_focal_ratio/inputCamera.resolution[0]
-    d_y = sensorHeight_focal_ratio/inputCamera.resolution[1]
+noCorr = cobConverter.PhaseAngleCorrectionMethod_NoCorrection
+binary = cobConverter.PhaseAngleCorrectionMethod_Binary
+lambertian = cobConverter.PhaseAngleCorrectionMethod_Lambertian
 
-    rHat_BN_C = np.zeros(3)
-    rHat_BN_C[0] = (state[0] - inputCamera.resolution[0]/2 + 0.5)*d_x
-    rHat_BN_C[1] = (state[1] - inputCamera.resolution[1]/2 + 0.5)*d_y
-    rHat_BN_C[2] = 1.0
+
+def mapState(state, input_camera):
+    """Main method that is writen in the module to map the state from pixel space to position"""
+    K = compute_camera_calibration_matrix(input_camera)
+    Kinv = np.linalg.inv(K)
+
+    rHat_BN_C = Kinv @ np.array([state[0], state[1], 1])
+    rHat_BN_C = -rHat_BN_C / np.linalg.norm(rHat_BN_C)
 
     return rHat_BN_C
 
-'''
-Secondary method to map the covariance in pixel space to position
-'''
-def mapCovar(pixels, inputCamera):
-    if pixels >0:
-        scaleFactor = np.sqrt(pixels)/6.28
+
+def mapCovar(pixels, input_camera):
+    """Secondary method to map the covariance in pixel space to position"""
+    K = compute_camera_calibration_matrix(input_camera)
+    d_x = K[0, 0]
+    d_y = K[1, 1]
+    X = 1 / d_x
+    Y = 1 / d_y
+
+    if pixels > 0:
+        scale_factor = np.sqrt(pixels) / (2 * np.pi)
     else:
-        scaleFactor = 1
-    # Compute pixel pitch divided by focal length (often denoted d_x and d_y)
-    sensorWidth_focal_ratio = 2.*np.tan(inputCamera.fieldOfView*inputCamera.resolution[0]/inputCamera.resolution[1]/2.0)
-    sensorHeight_focal_ratio = 2.*np.tan(inputCamera.fieldOfView/2.0)
-    d_x = sensorWidth_focal_ratio/inputCamera.resolution[0]
-    d_y = sensorHeight_focal_ratio/inputCamera.resolution[1]
+        scale_factor = 1  # prevent division by zero
 
-    covar = np.zeros([3,3])
-    covar[0,0] = d_x**2
-    covar[1,1] = d_y**2
-    covar[2,2] = 1
+    covar = np.zeros([3, 3])
+    covar[0, 0] = X ** 2
+    covar[1, 1] = Y ** 2
+    covar[2, 2] = 1
 
-    return 1/scaleFactor*covar
+    return 1 / scale_factor * covar
 
-@pytest.mark.parametrize("cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels",
-    [([512, 512], [1., 0.3, 0.1], [0.6, 1., 0.1], [152, 251], 75)
-    ,([128, 345], [0, 0, 0], [0, 0, 0], [251, 120], 100)
-    ,([742, 512], [-1., -0.3, -0.1], [-0.6, -1., -0.1], [0, 0], 0)
-    ,([2048, 2048], [-1., -0.3, -0.1], [-0.6, -1., -0.1], [1021, 1891], 1000)
-    ])
 
-def test_cob_converter(show_plots, cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels):
-    [testResults, testMessage] = cobConverterTestFunction(show_plots,
-                                                          cameraResolution,
-                                                          sigma_CB,
-                                                          sigma_BN,
-                                                          centerOfBrightness,
-                                                          numberOfPixels)
-    assert testResults < 1, testMessage
+def compute_camera_calibration_matrix(input_camera):
+    """Secondary method to compute camera calibration matrix"""
+    # camera parameters
+    alpha = 0.
+    resX = input_camera.resolution[0]
+    resY = input_camera.resolution[1]
+    pX = 2. * np.tan(input_camera.fieldOfView / 2.0)
+    pY = 2. * np.tan(input_camera.fieldOfView * resY / resX / 2.0)
+    dX = resX / pX
+    dY = resY / pY
+    up = resX / 2.
+    vp = resY / 2.
+    # build camera calibration matrix
+    K = np.array([[dX, alpha, up], [0., dY, vp], [0., 0., 1.]])
 
-""" Test the center of brightness converter module. """
-def cobConverterTestFunction(show_plots, cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels):
-    testFailCount = 0
-    testMessages = []
+    return K
+
+
+def phase_angle_correction(alpha, method):
+    """Secondary method to compute the phase angle correction for COB/COM offset"""
+    if method == binary:
+        gamma = 4 / (3 * np.pi) * (1 - np.cos(alpha))
+    elif method == lambertian:
+        gamma = 3 * np.pi / 16 * ((np.cos(alpha) + 1.0) * np.sin(alpha)) / \
+                (np.sin(alpha) + (np.pi - alpha) * np.cos(alpha))
+    else:
+        gamma = 0.0
+
+    return gamma
+
+
+@pytest.mark.parametrize("method", [noCorr, binary, lambertian])
+@pytest.mark.parametrize("cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels, sunDirection",
+                         [([512, 512], [1., 0.3, 0.1], [0.6, 1., 0.1], [152, 251], 75, [-1., -1., 0.]),
+                          ([128, 345], [0, 0, 0], [0, 0, 0], [120, 251], 100, [0., -1., 0.]),
+                          ([742, 512], [-1., -0.3, -0.1], [-0.6, -1., -0.1], [0, 0], 0, [0., 1., 0.]),
+                          ([2048, 2048], [-1., -0.3, -0.1], [-0.6, -1., -0.1], [1021, 1891], 1000, [0., 1., 1.]),
+                          ([1024, 1024], [-1., 0.3, 0.1], [0.6, 1., -0.1], [521, 891], 800, [1., 0., 0.]),
+                          ([875, 987], [1., 0.3, 0.1], [0.6, 1., 0.1], [321, 191], 375, [1., 0.5, 0.3])
+                          ])
+def test_cob_converter(show_plots, cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels,
+                       sunDirection, method):
+    cob_converter_test_function(show_plots, cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels,
+                                sunDirection, method)
+
+
+def cob_converter_test_function(show_plots, cameraResolution, sigma_CB, sigma_BN, centerOfBrightness, numberOfPixels,
+                                sunDirection, method):
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -93,18 +120,22 @@ def cobConverterTestFunction(show_plots, cameraResolution, sigma_CB, sigma_BN, c
     testProcessRate = macros.sec2nano(0.5)
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
-    module = cobConverter.CobConverter()
+    module = cobConverter.CobConverter(method)
+    R_object = 25. * 1e3
+    module.setRadius(R_object)
     unitTestSim.AddModelToTask(unitTaskName, module, module)
 
     # Create the input messages.
     inputCamera = messaging.CameraConfigMsgPayload()
     inputCob = messaging.OpNavCOBMsgPayload()
     inputAtt = messaging.NavAttMsgPayload()
+    inputEphem = messaging.EphemerisMsgPayload()
 
     # Set camera parameters
-    inputCamera.fieldOfView = 2.0 * np.arctan(10*1e-3 / 2.0 / (1.*1e-3) )  # 2*arctan(size/2 / focal)
+    inputCamera.fieldOfView = np.deg2rad(20.0)
     inputCamera.resolution = cameraResolution
     inputCamera.sigma_CB = sigma_CB
+    inputCamera.ppFocalLength = 0.10
     camInMsg = messaging.CameraConfigMsg().write(inputCamera)
     module.cameraConfigInMsg.subscribeTo(camInMsg)
 
@@ -112,57 +143,128 @@ def cobConverterTestFunction(show_plots, cameraResolution, sigma_CB, sigma_BN, c
     inputCob.centerOfBrightness = centerOfBrightness
     inputCob.pixelsFound = numberOfPixels
     inputCob.timeTag = 12345
+    inputCob.valid = (numberOfPixels > 0)
     cobInMsg = messaging.OpNavCOBMsg().write(inputCob)
     module.opnavCOBInMsg.subscribeTo(cobInMsg)
 
+    vehSunPntN = np.array(sunDirection) / np.linalg.norm(np.array(sunDirection))  # unit vector from SC to Sun
+    dcm_BN = rbk.MRP2C(sigma_BN)
     # Set body attitude relative to inertial
     inputAtt.sigma_BN = sigma_BN
+    inputAtt.vehSunPntBdy = dcm_BN @ vehSunPntN
     attInMsg = messaging.NavAttMsg().write(inputAtt)
     module.navAttInMsg.subscribeTo(attInMsg)
 
-    dataLog = module.opnavUnitVecOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    r_BdyZero_N = np.array([-500. * 1e3, 0., 0.])
+    # Set ephemeris message of spacecraft relative to object
+    inputEphem.r_BdyZero_N = r_BdyZero_N
+    ephemInMsg = messaging.EphemerisMsg().write(inputEphem)
+    module.ephemInMsg.subscribeTo(ephemInMsg)
+
+    dataLogUnitVecCOB = module.opnavUnitVecCOBOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogUnitVecCOB)
+    dataLogUnitVecCOM = module.opnavUnitVecCOMOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogUnitVecCOM)
+    dataLogCOM = module.opnavCOMOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLogCOM)
 
     unitTestSim.InitializeSimulation()
     unitTestSim.ConfigureStopTime(testProcessRate)
     unitTestSim.ExecuteSimulation()
 
     # Truth Values
-    state = [inputCob.centerOfBrightness[0], inputCob.centerOfBrightness[1]]
-    pixels = inputCob.pixelsFound
-
-    r_Cexp = mapState(state, inputCamera)
-    covar_Cexp = mapCovar(pixels, inputCamera)
-
+    if numberOfPixels > 0:
+        valid_COB_true = 1
+    else:
+        valid_COB_true = 0
+    cob_true = [inputCob.centerOfBrightness[0], inputCob.centerOfBrightness[1]]
+    num_pixels = inputCob.pixelsFound
     dcm_CB = rbk.MRP2C(inputCamera.sigma_CB)
     dcm_BN = rbk.MRP2C(inputAtt.sigma_BN)
     dcm_NC = np.dot(dcm_CB, dcm_BN).T
 
-    r_Nexp = np.dot(dcm_NC, r_Cexp)
-    covar_Nexp = np.dot(dcm_NC, np.dot(covar_Cexp, dcm_NC.T)).flatten()
-    timTagExp = inputCob.timeTag
+    # Center of Brightness Unit Vector
+    rhat_COB_C_true = mapState(cob_true, inputCamera)
+    covar_COB_C_true = mapCovar(num_pixels, inputCamera)
+    rhat_COB_N_true = np.dot(dcm_NC, rhat_COB_C_true) * valid_COB_true  # multiple by validity to get zero vector if bad
+    covar_COB_N_true = np.dot(dcm_NC, np.dot(covar_COB_C_true, dcm_NC.T)).flatten() * valid_COB_true
+    timeTag_true_ns = inputCob.timeTag * valid_COB_true
+    timeTag_true = timeTag_true_ns * macros.NANO2SEC
 
-    outputR = dataLog.rhat_BN_N
-    outputCovar = dataLog.covar_N
-    outputTime = dataLog.timeTag
+    # Center of Mass Message and Unit Vector
+    alpha = np.arccos(np.dot(r_BdyZero_N.T / np.linalg.norm(r_BdyZero_N), vehSunPntN))  # phase angle
+    gamma = phase_angle_correction(alpha, method)  # COB/COM offset factor
+    shat_C = dcm_NC.T @ vehSunPntN
+    phi = np.arctan2(shat_C[1], shat_C[0])  # sun direction in image plane
+    K = compute_camera_calibration_matrix(inputCamera)
+    dX = K[0, 0]
+    Kx = dX / inputCamera.ppFocalLength
+    Rc = R_object * Kx * inputCamera.ppFocalLength / np.linalg.norm(r_BdyZero_N)  # object radius in pixels
+    com_true = [None] * 2  # COM location in image
+    com_true[0] = cob_true[0] - gamma * Rc * np.cos(phi) * valid_COB_true
+    com_true[1] = cob_true[1] - gamma * Rc * np.sin(phi) * valid_COB_true
+    rhat_COM_C_true = mapState(com_true, inputCamera)
+    if valid_COB_true and (method == binary or method == lambertian):
+        valid_COM_true = True
+        rhat_COM_N_true = np.dot(dcm_NC, rhat_COM_C_true)
+    else:
+        valid_COM_true = False
+        rhat_COM_N_true = rhat_COB_N_true
 
-    tollerance = 1e-10
-    for i in range(len(outputR[-1, 1:])):
-        if np.abs(r_Nexp[i] - outputR[-1, i]) > tollerance and np.isnan(outputR.any()):
-            testFailCount += 1
-            testMessages.append("Position Check in cobConvert")
+    # module output
+    rhat_COB_N = dataLogUnitVecCOB.rhat_BN_N[0]
+    covar_COB_N = dataLogUnitVecCOB.covar_N[0]
+    time_COB = dataLogUnitVecCOB.timeTag[0]
+    com = dataLogCOM.centerOfMass[0]
+    time_COM_ns = dataLogCOM.timeTag[0]
+    valid_COM = dataLogCOM.valid[0]
+    rhat_COM_N = dataLogUnitVecCOM.rhat_BN_N[0]
 
-    for i in range(len(outputCovar[-1, 0:])):
-        if np.abs((covar_Nexp[i] - outputCovar[-1, i])) > tollerance and np.isnan(outputTime.any()):
-            testFailCount += 1
-            testMessages.append("Covar Check in cobConvert")
+    # make sure module output data is correct
+    tolerance = 1e-10
+    np.testing.assert_allclose(rhat_COB_N,
+                               rhat_COB_N_true,
+                               rtol=0,
+                               atol=tolerance,
+                               err_msg='Variable: rhat_COB_N',
+                               verbose=True)
 
-    if np.abs((timTagExp - outputTime[-1])/timTagExp) > tollerance and np.isnan(outputTime.any()):
-        testFailCount += 1
-        testMessages.append("Time Check in cobConvert")
+    np.testing.assert_allclose(covar_COB_N,
+                               covar_COB_N_true,
+                               rtol=0,
+                               atol=tolerance,
+                               err_msg='Variable: covar_COB_N',
+                               verbose=True)
 
-    return [testFailCount, ''.join(testMessages)]
+    np.testing.assert_allclose(time_COB,
+                               timeTag_true,
+                               rtol=0,
+                               atol=tolerance,
+                               err_msg='Variable: time_COB',
+                               verbose=True)
+    np.testing.assert_allclose(com,
+                               com_true,
+                               rtol=0,
+                               atol=tolerance,
+                               err_msg='Variable: com',
+                               verbose=True)
+    np.testing.assert_allclose(time_COM_ns,
+                               timeTag_true_ns,
+                               rtol=0,
+                               atol=tolerance,
+                               err_msg='Variable: time_COM_ns',
+                               verbose=True)
+    np.testing.assert_equal(valid_COM,
+                            valid_COM_true,
+                            err_msg='Variable: valid_COM',
+                            verbose=True)
+    np.testing.assert_allclose(rhat_COM_N,
+                               rhat_COM_N_true,
+                               rtol=0,
+                               atol=tolerance,
+                               err_msg='Variable: rhat_COM_N',
+                               verbose=True)
 
 
 if __name__ == '__main__':
-    test_cob_converter(False, [512, 512], [1., 0.3, 0.1], [0.6, 1., 0.1], [152, 251], 75)
+    test_cob_converter(False, [512, 512], [1.0, 0.3, 0.1], [0.6, 1.0, 0.1], [152, 251], 75, [-1.0, -1.0, 0.0], binary)

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -110,8 +110,7 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
         covar_C(1,1) = pow(Y,2);
         covar_C(2,2) = 1;
         /*! - define and rotate covariance using number of pixels found */
-        double scaleFactor;
-        scaleFactor = sqrt(cobMsgBuffer.pixelsFound)/(6.28); // division by 2pi
+        double scaleFactor = sqrt(cobMsgBuffer.pixelsFound)/(2*M_PI);
         covar_C *= 1./scaleFactor;
         Eigen::Matrix3d covar_N, covar_B;
         covar_N = dcm_NC * covar_C * dcm_NC.transpose();

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -40,6 +40,9 @@ void CobConverter::Reset(uint64_t CurrentSimNanos)
     if (!this->navAttInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "CobConverter.navAttInMsg wasn't connected.");
     }
+    if (!this->ephemInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "CobConverter.ephemInMsg wasn't connected.");
+    }
 }
 
 /*! During an update, this module transforms pixel values for the center of brightness into a unit vector
@@ -52,9 +55,14 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
     CameraConfigMsgPayload cameraSpecs = this->cameraConfigInMsg();
     OpNavCOBMsgPayload cobMsgBuffer = this->opnavCOBInMsg();
     NavAttMsgPayload navAttBuffer = this->navAttInMsg();
+    EphemerisMsgPayload ephemBuffer = this->ephemInMsg();
 
     OpNavUnitVecMsgPayload uVecCOBMsgBuffer;
     uVecCOBMsgBuffer = this->opnavUnitVecCOBOutMsg.zeroMsgPayload;
+    OpNavUnitVecMsgPayload uVecCOMMsgBuffer;
+    uVecCOMMsgBuffer = this->opnavUnitVecCOMOutMsg.zeroMsgPayload;
+    OpNavCOMMsgPayload comMsgBuffer;
+    comMsgBuffer = this->opnavCOMOutMsg.zeroMsgPayload;
 
     if (cobMsgBuffer.valid && cobMsgBuffer.pixelsFound != 0){
         /*! - Extract rotations from relevant messages */

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -58,14 +58,14 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
 
     if (cobMsgBuffer.valid && cobMsgBuffer.pixelsFound != 0){
         /*! - Extract rotations from relevant messages */
-        Eigen::Matrix3d dcm_CB, dcm_BN, dcm_NC;
-        double CB[3][3], BN[3][3];
+        double CB[3][3];
+        double BN[3][3];
         MRP2C(cameraSpecs.sigma_CB, CB);
-        dcm_CB = c2DArray2EigenMatrix3d(CB);
+        Eigen::Matrix3d dcm_CB = c2DArray2EigenMatrix3d(CB);
         MRP2C(navAttBuffer.sigma_BN, BN);
-        dcm_BN = c2DArray2EigenMatrix3d(BN);
+        Eigen::Matrix3d dcm_BN = c2DArray2EigenMatrix3d(BN);
 
-        dcm_NC = dcm_BN.transpose() * dcm_CB.transpose();
+        Eigen::Matrix3d dcm_NC = dcm_BN.transpose() * dcm_CB.transpose();
 
         /*! - camera parameters */
         double alpha = 0;
@@ -112,9 +112,8 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
         /*! - define and rotate covariance using number of pixels found */
         double scaleFactor = sqrt(cobMsgBuffer.pixelsFound)/(2*M_PI);
         covar_C *= 1./scaleFactor;
-        Eigen::Matrix3d covar_N, covar_B;
-        covar_N = dcm_NC * covar_C * dcm_NC.transpose();
-        covar_B = dcm_CB.transpose() * covar_C * dcm_CB;
+        Eigen::Matrix3d covar_N = dcm_NC * covar_C * dcm_NC.transpose();
+        Eigen::Matrix3d covar_B = dcm_CB.transpose() * covar_C * dcm_CB;
 
         /*! - output messages */
         eigenMatrix3d2CArray(covar_N, uVecCOBMsgBuffer.covar_N);

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -51,8 +51,10 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
 {
     CameraConfigMsgPayload cameraSpecs = this->cameraConfigInMsg();
     OpNavCOBMsgPayload cobMsgBuffer = this->opnavCOBInMsg();
-    OpNavUnitVecMsgPayload uVecMsgBuffer = this->opnavUnitVecOutMsg.zeroMsgPayload;
     NavAttMsgPayload navAttBuffer = this->navAttInMsg();
+
+    OpNavUnitVecMsgPayload uVecCOBMsgBuffer;
+    uVecCOBMsgBuffer = this->opnavUnitVecCOBOutMsg.zeroMsgPayload;
 
     if (cobMsgBuffer.valid && cobMsgBuffer.pixelsFound != 0){
         /*! - Extract rotations from relevant messages */
@@ -101,18 +103,18 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
         Eigen::Matrix3d covar_N, covar_B;
         covar_N = dcm_NC * covar_C * dcm_NC.transpose();
         covar_B = dcm_CB.transpose() * covar_C * dcm_CB;
-        /*! - write output message */
-        eigenMatrix3d2CArray(covar_N, uVecMsgBuffer.covar_N);
-        eigenMatrix3d2CArray(covar_C, uVecMsgBuffer.covar_C);
-        eigenMatrix3d2CArray(covar_B, uVecMsgBuffer.covar_B);
-        eigenVector3d2CArray(rhat_BN_N, uVecMsgBuffer.rhat_BN_N);
-        eigenVector3d2CArray(rhat_BN_C, uVecMsgBuffer.rhat_BN_C);
-        eigenVector3d2CArray(rhat_BN_B, uVecMsgBuffer.rhat_BN_B);
 
-        uVecMsgBuffer.timeTag = (double) cobMsgBuffer.timeTag;
-        uVecMsgBuffer.valid = true;
+        /*! - output messages */
+        eigenMatrix3d2CArray(covar_N, uVecCOBMsgBuffer.covar_N);
+        eigenMatrix3d2CArray(covar_C, uVecCOBMsgBuffer.covar_C);
+        eigenMatrix3d2CArray(covar_B, uVecCOBMsgBuffer.covar_B);
+        eigenVector3d2CArray(rhat_BN_N, uVecCOBMsgBuffer.rhat_BN_N);
+        eigenVector3d2CArray(rhat_BN_C, uVecCOBMsgBuffer.rhat_BN_C);
+        eigenVector3d2CArray(rhat_BN_B, uVecCOBMsgBuffer.rhat_BN_B);
+        uVecCOBMsgBuffer.timeTag = (double) cobMsgBuffer.timeTag * NANO2SEC;
+        uVecCOBMsgBuffer.valid = true;
     }
 
-    this->opnavUnitVecOutMsg.write(&uVecMsgBuffer, this->moduleID, CurrentSimNanos);
+    this->opnavUnitVecCOBOutMsg.write(&uVecCOBMsgBuffer, this->moduleID, CurrentSimNanos);
 
 }

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -19,7 +19,10 @@
 
 #include "cobConverter.h"
 
-CobConverter::CobConverter() = default;
+CobConverter::CobConverter(PhaseAngleCorrectionMethod method)
+{
+    phaseAngleCorrectionMethod = method;
+}
 
 CobConverter::~CobConverter() = default;
 

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -53,8 +53,8 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
     OpNavCOBMsgPayload cobMsgBuffer = this->opnavCOBInMsg();
     OpNavUnitVecMsgPayload uVecMsgBuffer = this->opnavUnitVecOutMsg.zeroMsgPayload;
     NavAttMsgPayload navAttBuffer = this->navAttInMsg();
-    
-    if (cobMsgBuffer.valid){
+
+    if (cobMsgBuffer.valid && cobMsgBuffer.pixelsFound != 0){
         /*! - Extract rotations from relevant messages */
         Eigen::Matrix3d dcm_CB, dcm_BN, dcm_NC;
         double CB[3][3], BN[3][3];

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.cpp
@@ -138,5 +138,19 @@ void CobConverter::UpdateState(uint64_t CurrentSimNanos)
     }
 
     this->opnavUnitVecCOBOutMsg.write(&uVecCOBMsgBuffer, this->moduleID, CurrentSimNanos);
+}
 
+/*! Set the object radius
+    @param double radiusInput [m]
+    @return void
+    */
+void CobConverter::setRadius(const double radius){
+    this->objectRadius = radius;
+}
+
+/*! Get the object radius
+    @return double radius [m]
+    */
+double CobConverter::getRadius() const {
+    return this->objectRadius;
 }

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
@@ -38,10 +38,12 @@
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
 
+enum class PhaseAngleCorrectionMethod {NoCorrection, Lambertian, Binary};
+
 /*! @brief visual limb finding module */
 class CobConverter: public SysModel {
 public:
-    CobConverter();
+    CobConverter(PhaseAngleCorrectionMethod method);
     ~CobConverter();
 
     void UpdateState(uint64_t CurrentSimNanos);
@@ -58,6 +60,9 @@ public:
 
     uint64_t sensorTimeTag;
     BSKLogger bskLogger;
+
+private:
+    PhaseAngleCorrectionMethod phaseAngleCorrectionMethod;
 };
 
 #endif

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
@@ -27,7 +27,9 @@
 
 #include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/OpNavCOBMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/OpNavCOMMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/OpNavUnitVecMsgPayload.h"
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
@@ -47,9 +49,12 @@ public:
 
 public:
     Message<OpNavUnitVecMsgPayload> opnavUnitVecCOBOutMsg;
+    Message<OpNavUnitVecMsgPayload> opnavUnitVecCOMOutMsg;
+    Message<OpNavCOMMsgPayload> opnavCOMOutMsg;
     ReadFunctor<OpNavCOBMsgPayload> opnavCOBInMsg;
     ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg;
     ReadFunctor<NavAttMsgPayload> navAttInMsg;
+    ReadFunctor<EphemerisMsgPayload> ephemInMsg;
 
     uint64_t sensorTimeTag;
     BSKLogger bskLogger;

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
@@ -41,12 +41,12 @@ class CobConverter: public SysModel {
 public:
     CobConverter();
     ~CobConverter();
-    
+
     void UpdateState(uint64_t CurrentSimNanos);
     void Reset(uint64_t CurrentSimNanos);
-    
+
 public:
-    Message<OpNavUnitVecMsgPayload> opnavUnitVecOutMsg;
+    Message<OpNavUnitVecMsgPayload> opnavUnitVecCOBOutMsg;
     ReadFunctor<OpNavCOBMsgPayload> opnavCOBInMsg;
     ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg;
     ReadFunctor<NavAttMsgPayload> navAttInMsg;

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.h
@@ -49,6 +49,9 @@ public:
     void UpdateState(uint64_t CurrentSimNanos);
     void Reset(uint64_t CurrentSimNanos);
 
+    void setRadius(const double radius);
+    double getRadius() const;
+
 public:
     Message<OpNavUnitVecMsgPayload> opnavUnitVecCOBOutMsg;
     Message<OpNavUnitVecMsgPayload> opnavUnitVecCOMOutMsg;
@@ -63,6 +66,7 @@ public:
 
 private:
     PhaseAngleCorrectionMethod phaseAngleCorrectionMethod;
+    double objectRadius{};
 };
 
 #endif

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.i
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.i
@@ -36,9 +36,12 @@ from Basilisk.architecture.swig_common_model import *
 struct CameraConfigMsg_C;
 %include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
 
 %include "architecture/msgPayloadDefCpp/OpNavUnitVecMsgPayload.h"
 %include "architecture/msgPayloadDefCpp/OpNavCOBMsgPayload.h"
+%include "architecture/msgPayloadDefCpp/OpNavCOMMsgPayload.h"
 
 
 %pythoncode %{

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.rst
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverter.rst
@@ -1,8 +1,17 @@
 Executive Summary
 -----------------
 
-Module reads in a message containing the pixel data extracted from the center of brightness measurement and transforms
-into a position measurement. The written message contains a heading (unit vector) and a covariance (measurement noise).
+Module reads in a message containing the pixel data extracted from the center of brightness (COB) measurement and
+transforms into a position measurement. The written message contains a heading (unit vector) and a covariance
+(measurement noise).
+
+Additionally, the center of mass (COM) can be estimated using a Sun phase angle correction. In this case, another unit
+vector message is written containing the heading and covariance for the COM, as well as a message containing information
+about the COM offset.
+
+The center of mass correction can be applied using the "Lambertian" or "Binary" method. If no correction should be
+performed, the method needs to be "NoCorrection". The Lambertian method assumes that the body is a sphere with
+lambertian reflectance, while the Binary method assumes a brightness of either 1 or 0 in the image of the body.
 
 Message Connection Descriptions
 -------------------------------
@@ -25,10 +34,19 @@ provides information on what this message is used for:
       - Input enter of brightness message written out by the image processing module
     * - navAttInMsg
       - :ref:`NavAttMsgPayload`
-      - Input avigation message containing the spacecraft attitude in the inertial frame
-    * - opnavUnitVecOutMsg
+      - Input navigation message containing the spacecraft attitude in the inertial frame
+    * - ephemInMsg
+      - :ref:`EphemerisMsgPayload`
+      - Input ephemeris message containing the spacecraft position in the inertial frame
+    * - opnavUnitVecCOBOutMsg
       - :ref:`OpNavUnitVecMsgPayload`
-      - Output unit vector containing the heading vector and covariance in multiple frames for filtering
+      - Output unit vector containing the heading vector of the COB and covariance in multiple frames for filtering
+    * - opnavUnitVecCOMOutMsg
+      - :ref:`OpNavUnitVecMsgPayload`
+      - Output unit vector containing the heading vector of the COM and covariance in multiple frames for filtering
+    * - opnavCOMOutMsg
+      - :ref:`OpNavCOMMsgPayload`
+      - Output message containing information about the COM offset due to the phase angle correction
 
 Detailed Module Description
 ---------------------------
@@ -43,41 +61,72 @@ After reading the input center of brightness message which contains the pixel lo
 of brightness and the number of pixels that were found, the module reads the camera parameters and uses
 them to compute all necessary optics values.
 
-The main relation used between all of the camera values is:
+The main relations used between all of the camera values can be found in `this paper by J. A. Christian
+<https://doi.org/10.1109/ACCESS.2021.3051914>`__.
+
+With this, the unit vector in the camera frame from focal point to center of brightness in the image plane is found by
+(equivalent to setting z=1):
 
 .. math::
 
-    \tan \left(\frac{\mathrm{fov}}{2}\right) &= \frac{H}{2f}\\
-    2 \tan \left(\frac{\mathrm{fov}}{2}\right) &= d_x * \mathrm{Res}
+    \mathbf{r}_{COB}^C &= [K]^{-1} \mathbf{\bar{u}}_{COB}
 
-where :math:`\mathrm{fov}` represents the field of view, :math:`f` is the focal length,
-:math:`d_{x}` is the ratio of pixel pitch to focal length, :math:`\mathrm{Res}` is the resolution, and
-:math:`H` is the full sensor size.
+where :math:`\mathbf{\bar{u}}_{COB} = [\mathrm{cob}_x, \mathrm{cob}_y, 1]^T` with the pixel coordinates of the center of
+brightmess :math:`\mathrm{cob}_x` and :math:`\mathrm{cob}_y`, :math:`[K]` is the camera calibration matrix and
+:math:`\mathbf{r}_{COB}^N` is the unit vector describing the physical heading to the target in the camera frame.
 
-With this, the equations computed find the unit vector in the camera frame from focal point to
-center of brightness in the image plane (equivalent to setting z=1):
-
-.. math::
-
-    r_x &= (\mathrm{cob}_x - c_x + \frac{1}{2})*d_x \\
-    r_y &= (\mathrm{cob}_y - c_y + \frac{1}{2})*d_y \\
-    r_z &= 1
-
-where :math:`\mathrm{cob}` are the pixel coordinates of the center of brightmess, :math:`c` are the pixel coordinates
-for the center of the image (where the camera boresight intersects the detector), and the  :math:`r` vector is the
-unit vector describing the physical heading to the target in the camera frame.
-
-The covariance is found using the numer of detected pixels and the camera parameters, given by:
+The covariance is found using the number of detected pixels and the camera parameters, given by:
 
 .. math::
 
     P = \frac{2 \ pi}{\sqrt{\mathrm{numPixels}}} \left( \begin{bmatrix} d_x^2 & 0 & 0 \\ 0 & d_y^2 & 0
     \\ 0 & 0 & 1 \end{bmatrix}\right)
 
+where :math:`d_x` and :math:`d_y` are the first and second diagonal elements of the camera calibration matrix
+:math:`[K]`.
+
 By reading the camera orientation and the current body attitude in the inertial frame, the final step is to rotate
 the covariance and heading vector in all the relevant frames for modules downstream. This is done simply by
-converting MRPs to DCMs and performing the matrix mulitplication.
-If the incoming image is not valid, the module writes and empty message.
+converting MRPs to DCMs and performing the matrix multiplication.
+If the incoming image is not valid, the module writes empty messages.
+
+If a COM correction is to be performed, the offset factor :math:`\gamma` due to the Sun phase angle correction is
+obtained for a phase angle :math:`\alpha` using
+
+.. math::
+
+    \gamma = \frac{4}{3 \pi} (1 - \cos\alpha)
+
+for the Binary method or
+
+.. math::
+
+    \gamma = \frac{3 \pi}{16} \left[ \frac{(\cos\alpha + 1) \sin\alpha}{\sin\alpha + (\pi - \alpha) \cos\alpha} \right]
+
+for the Lambertian method. If no correction is to be performed, then :math:`\gamma = 0`. The correction for the COM
+location is performed according to `this paper by S. Bhaskaran <https://doi.org/10.1109/AERO.1998.687921>`__. First, the
+object radius :math:`R` in meters is converted to the object radius in pixel units :math:`R_c` by
+
+.. math::
+
+    R_c = \frac{R K_x f}{\rho}
+
+where :math:`K_x = d_x/f`, :math:`f` is the focal length in meters, and :math:`\rho` is the distance from the
+body center to the spacecraft in meters. Using the sun direction in the image plane :math:`\phi`, the COM location in
+pixel space is then computed using
+
+.. math::
+
+    \mathrm{com}_x = \mathrm{cob}_x - \gamma R_c \cos\phi \\
+    \mathrm{com}_y = \mathrm{cob}_y - \gamma R_c \sin\phi
+
+Finally, similar to the COB unit vector, the COM unit vector is obtained by
+
+.. math::
+
+    \mathbf{r}_{COM}^C &= [K]^{-1} \mathbf{\bar{u}}_{COM}
+
+where :math:`\mathbf{\bar{u}}_{COM} = [\mathrm{com}_x, \mathrm{com}_y, 1]^T`.
 
 User Guide
 ----------
@@ -87,19 +136,23 @@ This section is to outline the steps needed to setup a center of brightness conv
 
     from Basilisk.fswAlgorithms import cobConverter
 
-#. Create an instantiation of converter class::
+#. Create an instantiation of converter class. The COM/COB correction method needs to be specified::
 
-    module = cobConverter.CobConverter()
+    module = cobConverter.CobConverter(cobConverter.PhaseAngleCorrectionMethod_NoCorrection)  # no correction
+    # module = cobConverter.CobConverter(cobConverter.PhaseAngleCorrectionMethod_Lambertian)  # Lambertian method
+    # module = cobConverter.CobConverter(cobConverter.PhaseAngleCorrectionMethod_Binary)  # Binary method
 
-#. There are no parameters to set directly in this module
+#. The object radius in units of meters for the phase angle correction is set by::
+
+    module.setRadius(R_object)
 
 #. Subscribe to the messages::
 
     module.cameraConfigInMsg.subscribeTo(camInMsg)
     module.opnavCOBInMsg.subscribeTo(cobInMsg)
     module.navAttInMsg.subscribeTo(attInMsg)
+    module.ephemInMsg.subscribeTo(ephemInMsg)
 
-#. Add model to task with some dataLog::
+#. Add model to task::
 
-    sim.AddModelToTask(taskName, dataLog)
-
+    sim.AddModelToTask(taskName, module)


### PR DESCRIPTION
* **Tickets addressed:** MAXGNC-834
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The cobConverter module was updated to include the center of mass (COM) offset estimation due to the phase angle correction. In addition to the unit vector pointing to the center of brightness (COB), the module now outputs another message containing the unit vector pointing to the center of mass (COM) as well as an output message containing more information about the COM computation. The noise (covariance matrix) for the COM unit vector is the same as for the COB unit vector.

The module now requires an input parameter to specify which method should be used to compute the phase angle correction ("NoCorrection" needs to be chosen to not apply any correction).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
The UnitTest was updated accordingly.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
The documentation was updated accordingly.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
