### PR TITLE
Revert cileimInterface `ImageData` from `using` to plain `struct`

### DIFF
--- a/src/simulation/vizard/cielimInterface/zmqConnector.h
+++ b/src/simulation/vizard/cielimInterface/zmqConnector.h
@@ -28,7 +28,7 @@
 #include "opencv2/core/mat.hpp"
 #include "opencv2/imgcodecs.hpp"
 
-using ImageData = struct {
+struct ImageData{
     int32_t imageBufferLength;
     void *imageBuffer;
 };


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The `using` keyword is handled differently at the linkage stage in GCC (9.5) compared to Clang (and others). It is fair to assume it's comparable to `typedef` but not so. A good discussion of this is contained [here](https://stackoverflow.com/questions/48613758/using-vs-typedef-is-there-a-subtle-lesser-known-difference).

## Verification
CI tests run and pass.

## Documentation
None new and none invalidated.

## Future work
The implementation here of a `struct` is itself not a good choice. Rather, it should be converted to either a class, or something like a std::pair<>. 
