### PR TITLE
Fail conanfile with compile fail

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -373,7 +373,7 @@ if __name__ == "__main__":
     conanCmdString = ''.join(conanCmdString)
     print(statusColor + "Running this conan command:" + endColor)
     print(conanCmdString)
-    os.system(conanCmdString)
+    completedProcess = subprocess.run(conanCmdString, shell=True, check=True)
 
     # run conan build
     if is_running_virtual_env() or platform.system() == "Windows":
@@ -382,4 +382,4 @@ if __name__ == "__main__":
         cmakeCmdString = 'python3 -m conans.conan build . -if ' + buildFolderName
     print(statusColor + "Running cmake:" + endColor)
     print(cmakeCmdString)
-    os.system(cmakeCmdString)
+    completedProcess = subprocess.run(cmakeCmdString, shell=True, check=True)

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -131,16 +131,16 @@ void Spacecraft::readOptionalRefMsg()
         this->hubSigma->setState(eigenMRPd2Vector3d(sigma_BN));
         this->hubOmega_BN_B->setState(omega_BN_B);
     }
-    
+
     if (this->transRefInMsg.isLinked()) {
         Eigen::Vector3d r_RN_N;
         Eigen::Vector3d v_RN_N;
         TransRefMsgPayload transRefMsgBuffer;
         transRefMsgBuffer = this->transRefInMsg();
-        
+
         r_RN_N = cArray2EigenVector3d(transRefMsgBuffer.r_RN_N);
         v_RN_N = cArray2EigenVector3d(transRefMsgBuffer.v_RN_N);
-        
+
         this->hubR_N->setState(r_RN_N);
         this->hubV_N->setState(v_RN_N);
     }


### PR DESCRIPTION
* **Tickets addressed:** MAX-917
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Previously, if the sub process that called `conan.build()` failed (e.g. compilation failed) the sub process return code was ignored and the conanfile execution would return as successful. Of course, this is incorrect behavior.  This PR modifies the sub process call and checks the return code. If the return code is not 0 (success) then an exception is thrown and the `conanfile.py` execution fails. As a nice side effect, because the conanfile.py execution fails, then the encapsulating github action step fails when the build fails (which didn't happen previously). Additionally, os.system is not the recommend method to run a sub process and this PR changes to use `subprocess` package.

## Verification
CI runs successfully. Also a purposeful compilation error was added to `spacecraft.cpp` and the CI run to demonstrate the failing `conanfile.py` execution. See CI run https://github.com/lasp/basilisk/actions/runs/9037970400

## Documentation
None new, none invalidated.

## Future work
None
