### PR TITLE
Remove unused includes

### DIFF
--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -17,7 +17,6 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 */
 #ifndef MESSAGING_H
 #define MESSAGING_H
-#include <memory>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include <vector>
 #include "architecture/messaging/msgHeader.h"

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -38,7 +38,7 @@ private:
     messageType* payloadPointer;    //!< -- pointer to the incoming msg data
     MsgHeader *headerPointer;      //!< -- pointer to the incoming msg header
     bool initialized;               //!< -- flag indicating if the input message is connect to another message
-    
+
 public:
     //!< -- BSK Logging
     BSKLogger bskLogger;            //!< -- bsk logging instance
@@ -125,17 +125,17 @@ public:
 
     //! Check if self has been subscribed to a C message
     uint8_t isSubscribedToC(void *source){
-        
+
         int8_t firstCheck = (this->headerPointer == (MsgHeader*) source);
         MsgHeader* pt = this->headerPointer;
         int8_t secondCheck = (this->payloadPointer == (messageType *) (++pt));
 
         return (this->initialized && firstCheck && secondCheck);
-        
+
     };
     //! Check if self has been subscribed to a Cpp message
     uint8_t isSubscribedTo(Message<messageType> *source){
-        
+
         MsgHeader *dummyMsgPtr;
         int8_t firstCheck = (this->payloadPointer == source->getMsgPointers(&(dummyMsgPtr)));
         int8_t secondCheck = (this->headerPointer == dummyMsgPtr);
@@ -196,7 +196,7 @@ public:
 
     //! Recorder object
     Recorder<messageType> recorder(uint64_t timeDiff = 0){return Recorder<messageType>(this, timeDiff);}
-    
+
     messageType zeroMsgPayload = {};    //!< zero'd copy of the message payload structure
 
     //! check if this msg has been connected to
@@ -295,7 +295,7 @@ public:
     std::vector<uint64_t>& timesWritten(){return this->msgWrittenTimes;}
     //! record method
     std::vector<messageType>& record(){return this->msgRecord;};
-    
+
     //! determine message name
     std::string findMsgName(std::string msgName) {
         size_t locMsg = msgName.find("Payload");

--- a/src/architecture/utilities/BSpline.cpp
+++ b/src/architecture/utilities/BSpline.cpp
@@ -232,12 +232,12 @@ double OutputDataSet::getStates(double T, int derivative, int index)
 
 /*! This function takes the Input structure, performs the BSpline interpolation and outputs the result into Output structure */
 void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output)
-{   
+{
     Output->P = P;
 
-    // N = number of waypoints - 1 
+    // N = number of waypoints - 1
     int N = (int) Input.X1.size() - 1;
-    
+
     // T = time tags; if not specified, it is computed from a cartesian distance assuming a constant velocity norm on average
     Eigen::VectorXd T(N+1);
     double S = 0;
@@ -271,7 +271,7 @@ void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output)
     if (Input.XDot_N_flag == true) {K += 1;}
     if (Input.XDDot_0_flag == true) {K += 1;}
     if (Input.XDDot_N_flag == true) {K += 1;}
-    
+
     // The maximum polynomial order is N + K. If a higher order is requested, print a BSK_ERROR
     if (P > N + K) {
         std::cout << "Error in BSpline.interpolate: \n the desired polynomial order P is too high. Mass matrix A will be singular. \n" ;
@@ -389,7 +389,7 @@ void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output)
     Output->XD2.resize(Num);
     Output->XD3.resize(Num);
     Output->XDD1.resize(Num);
-    Output->XDD2.resize(Num);    
+    Output->XDD2.resize(Num);
     Output->XDD3.resize(Num);
     for (int i = 0; i < Num; i++) {
         basisFunction(t, U, N+K+1, P, &NN[0], &NN1[0], &NN2[0]);
@@ -411,12 +411,12 @@ void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output)
 
 /*! This function takes the Input structure, performs the BSpline LS approximation and outputs the result into Output structure */
 void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Output)
-{   
+{
     Output->P = P;
 
-    // N = number of waypoints - 1 
+    // N = number of waypoints - 1
     int N = (int) Input.X1.size() - 1;
-    
+
     // T = time tags; if not specified, it is computed from a cartesian distance assuming a constant velocity norm on average
     Eigen::VectorXd T(N+1);
     double S = 0;
@@ -443,7 +443,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
     for (int n = 0; n < N+1; n++) {
         uk[n] = T[n] / Ttot;
     }
-    
+
     // The maximum polynomial order is N + K. If a higher order is requested, print a BSK_ERROR
     if (P > Q) {
         std::cout << "Error in BSpline.approximate: \n the desired polynomial order P can't be higher than the number of control points Q. \n" ;
@@ -504,7 +504,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
         n += 1;
         MD(n,0) = NN2[0];
         MD(n,1) = NN2[1];
-        MD(n,2) = NN2[2];        
+        MD(n,2) = NN2[2];
         T1[n] = Input.XDDot_0[0] * pow(Ttot,2);
         T2[n] = Input.XDDot_0[1] * pow(Ttot,2);
         T3[n] = Input.XDDot_0[2] * pow(Ttot,2);
@@ -515,7 +515,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
         n += 1;
         MD(n,K-1) = NN2[Q-2];
         MD(n,K)   = NN2[Q-1];
-        MD(n,K+1) = NN2[Q];        
+        MD(n,K+1) = NN2[Q];
         T1[K-1] = Input.XDDot_N[0] * pow(Ttot,2);
         T2[K]   = Input.XDDot_N[1] * pow(Ttot,2);
         T3[K+1] = Input.XDDot_N[2] * pow(Ttot,2);
@@ -569,7 +569,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
             Rk3[n-1] -= NN[Q-1]*C3_1[K];
         }
     }
-    
+
     // populate LS matrix ND
     Eigen::MatrixXd ND(N-1,Q-K-1);
     for (int n = 0; n < N-1; n++) {
@@ -613,7 +613,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
     Eigen::VectorXd C1_2 = NWN_inv * R1;
     Eigen::VectorXd C2_2 = NWN_inv * R2;
     Eigen::VectorXd C3_2 = NWN_inv * R3;
-    
+
     // build control point vectors C
     Eigen::VectorXd C1(Q+1), C2(Q+1), C3(Q+1);
     n = 0;
@@ -656,7 +656,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
     Output->XD2.resize(Num);
     Output->XD3.resize(Num);
     Output->XDD1.resize(Num);
-    Output->XDD2.resize(Num);    
+    Output->XDD2.resize(Num);
     Output->XDD3.resize(Num);
     for (int i = 0; i < Num; i++) {
         basisFunction(t, U, Q+1, P, &NN[0], &NN1[0], &NN2[0]);
@@ -678,7 +678,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
 
 /*! This function calculates the basis functions NN of order P, and derivatives NN1, NN2, for a given time t and knot vector U */
 void basisFunction(double t, Eigen::VectorXd U, int I, int P, double *NN, double *NN1, double *NN2)
-{   
+{
     Eigen::MatrixXd N(I, P+1);
     Eigen::MatrixXd N1(I, P+1);
     Eigen::MatrixXd N2(I, P+1);

--- a/src/architecture/utilities/BSpline.cpp
+++ b/src/architecture/utilities/BSpline.cpp
@@ -20,7 +20,6 @@
 #include "BSpline.h"
 #include <architecture/utilities/avsEigenSupport.h>
 #include <iostream>
-#include <cstring>
 #include <math.h>
 
 /*! This constructor initializes an Input structure for BSpline interpolation */

--- a/src/architecture/utilities/discretize.cpp
+++ b/src/architecture/utilities/discretize.cpp
@@ -51,7 +51,7 @@ Discretize::~Discretize()
  @param direction
  @return void*/
 void Discretize::setRoundDirection(roundDirection_t direction){
-    
+
     this->roundDirection = direction;
 
     return;
@@ -62,15 +62,15 @@ void Discretize::setRoundDirection(roundDirection_t direction){
  @param undiscretizedVector
  @return vector of discretized values*/
 Eigen::VectorXd Discretize::discretize(Eigen::VectorXd undiscretizedVector){
-    
+
     if (this->carryError){
         undiscretizedVector += this->discErrors;
     }
-    
+
     //discretize the data
     Eigen::VectorXd workingVector = undiscretizedVector.cwiseQuotient(this->LSB);
     workingVector = workingVector.cwiseAbs();
-    
+
     if (this->roundDirection == TO_ZERO){
         for (uint8_t i = 0; i < this->numStates; i++){
             workingVector[i] = floor(workingVector[i]);
@@ -90,8 +90,6 @@ Eigen::VectorXd Discretize::discretize(Eigen::VectorXd undiscretizedVector){
         workingVector[i] = copysign(workingVector[i], undiscretizedVector[i]);
     }
     this->discErrors = undiscretizedVector - workingVector;
-    
+
     return workingVector;
 }
-
-

--- a/src/architecture/utilities/discretize.cpp
+++ b/src/architecture/utilities/discretize.cpp
@@ -18,10 +18,7 @@
  */
 
 #include "discretize.h"
-#include <iostream>
-#include <string>
 #include <math.h>
-#include "linearAlgebra.h"
 
 /*! The constructor initialies the random number generator used for the walks*/
 Discretize::Discretize()

--- a/src/architecture/utilities/gauss_markov.cpp
+++ b/src/architecture/utilities/gauss_markov.cpp
@@ -49,9 +49,9 @@ GaussMarkov::~GaussMarkov()
 {
 }
 
-/*! This method performs almost all of the work for the Gauss Markov random 
-    walk.  It uses the current random walk configuration, propagates the current 
-    state, and then applies appropriate errors to the states to set the current 
+/*! This method performs almost all of the work for the Gauss Markov random
+    walk.  It uses the current random walk configuration, propagates the current
+    state, and then applies appropriate errors to the states to set the current
     error level.
     @return void
 */
@@ -60,7 +60,7 @@ void GaussMarkov::computeNextState()
     Eigen::VectorXd errorVector;
     Eigen::VectorXd ranNums;
     size_t i;
-    
+
     //! - Check for consistent sizes on all of the user-settable matrices.  Quit if they don't match.
     if((this->propMatrix.size() != this->noiseMatrix.size()) ||
        ((uint64_t) this->propMatrix.size() != this->numStates*this->numStates))
@@ -77,7 +77,7 @@ void GaussMarkov::computeNextState()
     //! - Propagate the state forward in time using the propMatrix and the currentState
     errorVector = this->currentState;
     this->currentState = this->propMatrix * errorVector;
-    
+
     //! - Compute the random numbers used for each state.  Note that the same generator is used for all
     ranNums.resize((int64_t) this->numStates);
 
@@ -85,9 +85,9 @@ void GaussMarkov::computeNextState()
     {
         ranNums[i] = this->rNum(rGen);
         if (this->stateBounds[i] > 0.0){
-            
+
             double stateCalc = fabs(this->currentState[i]) > this->stateBounds[i]*1E-10 ? fabs(this->currentState[i]) : this->stateBounds[i];
-            
+
             double boundCheck = (this->stateBounds[i]*2.0 - stateCalc)/stateCalc;
             boundCheck = boundCheck > this->stateBounds[i]*1E-10 ? boundCheck : this->stateBounds[i]*1E-10;
             boundCheck = 1.0/exp(boundCheck*boundCheck*boundCheck);
@@ -103,4 +103,3 @@ void GaussMarkov::computeNextState()
     this->currentState += errorVector;
 
 }
-

--- a/src/architecture/utilities/gauss_markov.cpp
+++ b/src/architecture/utilities/gauss_markov.cpp
@@ -17,7 +17,6 @@
 
  */
 
-#include <iostream>
 #include <math.h>
 #include "gauss_markov.h"
 #include "linearAlgebra.h"

--- a/src/architecture/utilities/linearAlgebra.c
+++ b/src/architecture/utilities/linearAlgebra.c
@@ -21,7 +21,6 @@
 #include "architecture/utilities/bsk_Print.h"
 
 #include <stddef.h>
-#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/architecture/utilities/linearAlgebra.c
+++ b/src/architecture/utilities/linearAlgebra.c
@@ -835,7 +835,7 @@ void mLeastSquaresInverse(void *mx, size_t dim1, size_t dim2, void *result)
     double mxTranspose[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     double mxGrammian[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     double mxGrammianInverse[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
-    
+
     mTranspose(mx, dim1, dim2, mxTranspose);
     mMultM(mxTranspose, dim2, dim1, mx, dim1, dim2, mxGrammian);
     mInverse(mxGrammian, dim2, mxGrammianInverse);
@@ -853,7 +853,7 @@ void mMinimumNormInverse(void *mx, size_t dim1, size_t dim2, void *result)
     double mxTranspose[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     double mxMxTranspose[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     double mxMxTransposeInverse[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
-    
+
     mTranspose(m_mx, dim1, dim2, mxTranspose);
     mMultM(m_mx, dim1, dim2, mxTranspose, dim2, dim1, mxMxTranspose);
     mInverse(mxMxTranspose, dim1, mxMxTransposeInverse);
@@ -1286,7 +1286,7 @@ int mInverse(void *mx, size_t dim, void *result)
     {
         BSK_PRINT(MSG_ERROR,"Linear Algegra library array dimension input is too large.");
     }
-    
+
     if(fabs(det) > DB0_EPS) {
         /* Find adjoint matrix */
         double m_adjoint[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
@@ -2698,4 +2698,3 @@ double safeSqrt(double x) {
         return 0.0;
     return sqrt(x);
 }
-

--- a/src/architecture/utilities/moduleIdGenerator/moduleIdGenerator.cpp
+++ b/src/architecture/utilities/moduleIdGenerator/moduleIdGenerator.cpp
@@ -17,7 +17,6 @@
 
  */
 #include "moduleIdGenerator.h"
-#include <cstring>
 #include <stdio.h>
 
 /*!

--- a/src/architecture/utilities/orbitalMotion.c
+++ b/src/architecture/utilities/orbitalMotion.c
@@ -133,7 +133,7 @@ void    rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *
     m33MultV3(HN, rhoDot_N, rhoDot_H);
     v3Cross(omega_HN_H, rho_H, rhoPrime_H);
     v3Subtract(rhoDot_H, rhoPrime_H, rhoPrime_H);
-    
+
     return;
 }
 

--- a/src/architecture/utilities/orbitalMotion.c
+++ b/src/architecture/utilities/orbitalMotion.c
@@ -26,7 +26,6 @@
 #include "linearAlgebra.h"
 #include "astroConstants.h"
 #include "architecture/utilities/bsk_Print.h"
-#include "rigidBodyKinematics.h"
 
 
 /*!

--- a/src/architecture/utilities/signalCondition.c
+++ b/src/architecture/utilities/signalCondition.c
@@ -20,7 +20,7 @@
 #include "architecture/utilities/signalCondition.h"
 
 
-/*! This method applies the low-pass filter configuration to the newMeas that 
+/*! This method applies the low-pass filter configuration to the newMeas that
     is passed in.  The state is maintained in the LowPassFilterData structure
  @return void
  @param lpData The configuration data and history of the LP filter

--- a/src/architecture/utilities/signalCondition.c
+++ b/src/architecture/utilities/signalCondition.c
@@ -19,9 +19,6 @@
 
 #include "architecture/utilities/signalCondition.h"
 
-#include <math.h>
-#include <stdio.h>
-#include <stdarg.h>
 
 /*! This method applies the low-pass filter configuration to the newMeas that 
     is passed in.  The state is maintained in the LowPassFilterData structure

--- a/src/architecture/utilities/svd.c
+++ b/src/architecture/utilities/svd.c
@@ -18,7 +18,6 @@
  */
 
 #include "svd.h"
-#include <stdlib.h>
 #include "architecture/utilities/linearAlgebra.h"
 #include <math.h>
 #include <stdio.h>

--- a/src/architecture/utilities/svd.c
+++ b/src/architecture/utilities/svd.c
@@ -260,7 +260,7 @@ int svdcmp(double *mx, size_t dim1, size_t dim2, double *w, double *v) {
             w[k] = x;
         }
     }
-    
+
     /*    sort by largest singular value */
     for (i = 0; i < dim2 -  1; i++) {
         max = w[i];
@@ -301,23 +301,23 @@ void solveSVD(double *mx, size_t dim1, size_t dim2, double *x, double *b, double
     double wInvDiag[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     double temp[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     int j;
-    
+
     vSetZero(w, dim2);
     mSetZero(v, dim2, dim2);
     mSetZero(A, dim1, dim2);
     mSetZero(uTranspose, dim1, dim2);
     mSetZero(wInvDiag, dim2, dim2);
     mCopy(mx, dim1, dim2, mxCopy);
-    
+
     svdcmp(mxCopy, dim1, dim2, w, v);
-    
+
     // condition wInvDiag
     for (j = 0; j < dim2;  j++)
     {
         if (w[j] >= minSV)
             wInvDiag[MXINDEX(dim2, j, j)] = 1.0 / w[j];
     }
-    
+
     // compute A
     mTranspose(mxCopy, dim1, dim2, uTranspose);
     mMultM(v, dim2, dim2, wInvDiag, dim2, dim2, temp);

--- a/src/architecture/utilitiesSelfCheck/avsLibrarySelfCheck/avsLibrarySelfCheck.c
+++ b/src/architecture/utilitiesSelfCheck/avsLibrarySelfCheck/avsLibrarySelfCheck.c
@@ -18,7 +18,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 
 #include "architecture/utilities/astroConstants.h"

--- a/src/architecture/utilitiesSelfCheck/avsLibrarySelfCheck/avsLibrarySelfCheck.c
+++ b/src/architecture/utilitiesSelfCheck/avsLibrarySelfCheck/avsLibrarySelfCheck.c
@@ -2367,7 +2367,7 @@ int testRigidBodyKinematics(double accuracy)
         printf("dPRV failed\n");
         errorCount++;
     }
-    
+
     double w[3];
     v3Set(0.0124791041517595, 0.0042760566673861, -0.0043633231299858, v3_1);
     dMRP2Omega(om, v3_1, v3);
@@ -2376,7 +2376,7 @@ int testRigidBodyKinematics(double accuracy)
         printf("dMRP2Omega failed\n");
         errorCount++;
     }
-    
+
     double dw[3];
     v3Set(0.0022991473184427, 0.0035194052312667, -0.0070466757773158, dw);
     ddMRP(om, v3_1, w, dw, v3);

--- a/src/fswAlgorithms/attControl/lowPassFilterTorqueCommand/lowPassFilterTorqueCommand.c
+++ b/src/fswAlgorithms/attControl/lowPassFilterTorqueCommand/lowPassFilterTorqueCommand.c
@@ -24,7 +24,6 @@
 /* modify the path to reflect the new module names */
 #include "fswAlgorithms/attControl/lowPassFilterTorqueCommand/lowPassFilterTorqueCommand.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 #include "math.h"
 

--- a/src/fswAlgorithms/attControl/lowPassFilterTorqueCommand/lowPassFilterTorqueCommand.c
+++ b/src/fswAlgorithms/attControl/lowPassFilterTorqueCommand/lowPassFilterTorqueCommand.c
@@ -18,7 +18,7 @@
  */
 /*
     Control Torque Low Pass Filter Module
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -115,7 +115,7 @@ void Update_lowPassFilterTorqueCommand(lowPassFilterTorqueCommandConfig *configD
         configData->reset = BOOL_FALSE;
 
     }
-    
+
     /*
         regular filter run
      */
@@ -139,10 +139,10 @@ void Update_lowPassFilterTorqueCommand(lowPassFilterTorqueCommandConfig *configD
     }
 
     /*
-        store the output message 
+        store the output message
      */
     v3Copy(configData->LrF[0], controlOut.torqueRequestBody);
     CmdTorqueBodyMsg_C_write(&controlOut, &configData->cmdTorqueOutMsg, moduleID, callTime);
-    
+
     return;
 }

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
@@ -26,7 +26,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/astroConstants.h"
 
 #include <string.h>
 #include <math.h>

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.c
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.c
@@ -24,8 +24,6 @@
 #include "fswAlgorithms/attControl/mrpSteering/mrpSteering.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/astroConstants.h"
-#include <string.h>
 #include <math.h>
 
 /*! self init method

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.c
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.c
@@ -18,7 +18,7 @@
  */
 /*
     MRP_STEERING Module
- 
+
  */
 
 #include "fswAlgorithms/attControl/mrpSteering/mrpSteering.h"
@@ -66,7 +66,7 @@ void Update_mrpSteering(mrpSteeringConfig *configData, uint64_t callTime,
 {
     AttGuidMsgPayload guidCmd;              /* Guidance Message */
     RateCmdMsgPayload outMsg;               /* copy of output message */
-    
+
     /*! - Zero message copies*/
     outMsg = RateCmdMsg_C_zeroMsgPayload();
 

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.c
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.c
@@ -21,7 +21,6 @@
 #include "string.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/svd.h"
-#include <stdio.h>
 
 /*!
  \verbatim embed:rst

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.c
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.c
@@ -69,7 +69,7 @@ void Reset_mtbMomentumManagement(mtbMomentumManagementConfig *configData, uint64
     if (!ArrayMotorTorqueMsg_C_isLinked(&configData->rwMotorTorqueInMsg)){
         _bskLog(configData->bskLogger, BSK_ERROR, "Error: mtbMomentumManagement.rwMotorTorqueInMsg is not connected.");
     }
-    
+
     /*! - Read the input configuration messages.*/
     configData->rwConfigParams = RWArrayConfigMsg_C_read(&configData->rwParamsInMsg);
     configData->mtbConfigParams = MTBArrayConfigMsg_C_read(&configData->mtbParamsInMsg);
@@ -123,7 +123,7 @@ void Update_mtbMomentumManagement(mtbMomentumManagementConfig *configData, uint6
     ArrayMotorTorqueMsgPayload rwMotorTorqueInMsgBuffer = ArrayMotorTorqueMsg_C_read(&configData->rwMotorTorqueInMsg);
     MTBCmdMsgPayload mtbCmdOutputMsgBuffer = MTBCmdMsg_C_zeroMsgPayload();
     ArrayMotorTorqueMsgPayload rwMotorTorqueOutMsgBuffer = rwMotorTorqueInMsgBuffer;
-    
+
     /*! - Compute the wheel speed feedback.*/
     vSubtract(rwSpeedsInMsgBuffer.wheelSpeeds, numRW, configData->wheelSpeedBiases, configData->wheelSpeedError_W);
     vElementwiseMult(configData->rwConfigParams.JsList, numRW, configData->wheelSpeedError_W, configData->hDeltaWheels_W);
@@ -136,7 +136,7 @@ void Update_mtbMomentumManagement(mtbMomentumManagementConfig *configData, uint6
     mMultM(BTilde_B, 3, 3, configData->mtbConfigParams.GtMatrix_B, 3, numMTB, BGt);
     solveSVD(BGt, 3, numMTB, mtbCmdOutputMsgBuffer.mtbDipoleCmds, configData->tauIdealRW_B, 0.00000000001);
     vScale(-1.0, mtbCmdOutputMsgBuffer.mtbDipoleCmds, numMTB, mtbCmdOutputMsgBuffer.mtbDipoleCmds);
-    
+
     /*
      * Saturate dipoles.
      */
@@ -144,32 +144,32 @@ void Update_mtbMomentumManagement(mtbMomentumManagementConfig *configData, uint6
     {
         if (mtbCmdOutputMsgBuffer.mtbDipoleCmds[j] > configData->mtbConfigParams.maxMtbDipoles[j])
             mtbCmdOutputMsgBuffer.mtbDipoleCmds[j] = configData->mtbConfigParams.maxMtbDipoles[j];
-        
+
         if (mtbCmdOutputMsgBuffer.mtbDipoleCmds[j] < -configData->mtbConfigParams.maxMtbDipoles[j])
             mtbCmdOutputMsgBuffer.mtbDipoleCmds[j] = -configData->mtbConfigParams.maxMtbDipoles[j];
     }
-    
+
     /*! - Compute the desired Body torque produced by the torque bars.*/
     mMultV(BGt, 3, numMTB, mtbCmdOutputMsgBuffer.mtbDipoleCmds, configData->tauDesiredMTB_B);
     vScale(-1.0, configData->tauDesiredMTB_B, 3, configData->tauDesiredMTB_B);
-    
+
     /*! - Compute the reaction wheel torque commands.*/
     v3Subtract(configData->tauDesiredMTB_B, configData->tauIdealRW_B, uDelta_B);
     mMinimumNormInverse(Gs, 3, numRW, GsPsuedoInverse);
     mMultV(GsPsuedoInverse, numRW, 3, uDelta_B, uDelta_W);
     vAdd(configData->tauIdealRW_W, numRW, uDelta_W, configData->tauDesiredRW_W);
-    
+
     /*! - Compute the desired Body torque produced by the reaction wheels.*/
     mMultV(Gs, 3, numRW, configData->tauDesiredRW_W, configData->tauDesiredRW_B);
     vScale(-1.0, configData->tauDesiredRW_B, 3, configData->tauDesiredRW_B);
-    
+
     /*
      * Write output messages.
      */
     MTBCmdMsg_C_write(&mtbCmdOutputMsgBuffer, &configData->mtbCmdOutMsg, moduleID, callTime);
     vAdd(configData->tauDesiredRW_W, numRW, rwMotorTorqueOutMsgBuffer.motorTorque, rwMotorTorqueOutMsgBuffer.motorTorque);
     ArrayMotorTorqueMsg_C_write(&rwMotorTorqueOutMsgBuffer, &configData->rwMotorTorqueOutMsg, moduleID, callTime);
-    
+
     return;
 }
 

--- a/src/fswAlgorithms/attControl/prvSteering/prvSteering.c
+++ b/src/fswAlgorithms/attControl/prvSteering/prvSteering.c
@@ -24,8 +24,6 @@
 #include "fswAlgorithms/attControl/prvSteering/prvSteering.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/astroConstants.h"
-#include <string.h>
 #include <math.h>
 
 

--- a/src/fswAlgorithms/attControl/prvSteering/prvSteering.c
+++ b/src/fswAlgorithms/attControl/prvSteering/prvSteering.c
@@ -18,7 +18,7 @@
  */
 /*
     PRV_STEERING Module
- 
+
  */
 
 #include "fswAlgorithms/attControl/prvSteering/prvSteering.h"
@@ -77,10 +77,10 @@ void Update_prvSteering(PrvSteeringConfig *configData, uint64_t callTime,
 
     /* evalute MRP kinematic steering law */
     PRVSteeringLaw(configData, guidCmd.sigma_BR, outMsgBuffer.omega_BastR_B, outMsgBuffer.omegap_BastR_B);
-    
+
     /* Store the output message and pass it to the message bus */
     RateCmdMsg_C_write(&outMsgBuffer, &configData->rateCmdOutMsg, moduleID, callTime);
-    
+
     return;
 }
 
@@ -118,6 +118,6 @@ void PRVSteeringLaw(PrvSteeringConfig *configData, double sigma_BR[3], double om
     value *= (3*configData->K3*phi*phi + configData->K1)/(pow(M_PI_2/configData->omega_max*(configData->K1*phi + configData->K3*phi*phi*phi),2) + 1);
 
     v3Scale(value, e_hat, omega_ast_p);
-    
+
     return;
 }

--- a/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.c
+++ b/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.c
@@ -26,7 +26,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/astroConstants.h"
 
 #include <string.h>
 #include <math.h>

--- a/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.c
+++ b/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.c
@@ -18,7 +18,7 @@
  */
 /*
     rateServoFullNonlinear Module
- 
+
  */
 
 #include "fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.h"
@@ -79,12 +79,12 @@ void Reset_rateServoFullNonlinear(rateServoFullNonlinearConfig *configData, uint
     for (i=0; i < 9; i++){
         configData->ISCPntB_B[i] = sc.ISCPntB_B[i];
     };
-    
+
     configData->rwConfigParams.numRW = 0;
     if (RWArrayConfigMsg_C_isLinked(&configData->rwParamsInMsg)) {
         configData->rwConfigParams = RWArrayConfigMsg_C_read(&configData->rwParamsInMsg);
     }
-    
+
     /* Reset the integral measure of the rate tracking error */
     v3SetZero(configData->z);
 
@@ -111,7 +111,7 @@ void Update_rateServoFullNonlinear(rateServoFullNonlinearConfig *configData, uin
     CmdTorqueBodyMsgPayload controlOut;             /*!< commanded torque output message */
 
     double              dt;                 /* [s] control update period */
-    
+
     double              Lr[3];              /* required control torque vector [Nm] */
     double              omega_BastN_B[3];   /* angular velocity of B^ast relative to inertial N, in body frame components */
     double              omega_BBast_B[3];   /* angular velocity tracking error between actual  body frame B and desired B^ast frame */
@@ -127,10 +127,10 @@ void Update_rateServoFullNonlinear(rateServoFullNonlinearConfig *configData, uin
     double              v3_7[3];
     int                 i;
     double              intLimCheck;
-        
+
     /*! - zero the output message */
     controlOut = CmdTorqueBodyMsg_C_zeroMsgPayload();
-    
+
     /*! - compute control update time */
     if (configData->priorTime == 0) {
         dt = 0.0;
@@ -152,7 +152,7 @@ void Update_rateServoFullNonlinear(rateServoFullNonlinearConfig *configData, uin
             wheelsAvailability = RWAvailabilityMsg_C_read(&configData->rwAvailInMsg);
         }
     }
-    
+
     /*! - compute body rate */
     v3Add(guidCmd.omega_BR_B, guidCmd.omega_RN_B, omega_BN_B);
 
@@ -193,24 +193,23 @@ void Update_rateServoFullNonlinear(rateServoFullNonlinearConfig *configData, uin
     }
     v3Cross(omega_BastN_B, v3_3, v3_4);
     v3Subtract(Lr, v3_4, Lr);
-    
+
     /* Lr +=  - [I](d(omega_B^ast/R)/dt + d(omega_r)/dt - omega x omega_r) */
     v3Cross(omega_BN_B, guidCmd.omega_RN_B, v3_5);
     v3Subtract(guidCmd.domega_RN_B, v3_5, v3_6);
     v3Add(v3_6, rateGuid.omegap_BastR_B, v3_6);
     m33MultV3(RECAST3X3 configData->ISCPntB_B, v3_6, v3_7);
     v3Subtract(Lr, v3_7, Lr);
-    
+
     /* Add external torque: Lr += L */
     v3Add(configData->knownTorquePntB_B, Lr, Lr);
-    
+
     /* Change sign to compute the net positive control torque onto the spacecraft */
     v3Scale(-1.0, Lr, Lr);
-    
+
     /*! - Set output message and pass it to the message bus */
     v3Copy(Lr, controlOut.torqueRequestBody);
     CmdTorqueBodyMsg_C_write(&controlOut, &configData->cmdTorqueOutMsg, moduleID, callTime);
 
     return;
 }
-

--- a/src/fswAlgorithms/attControl/thrMomentumManagement/thrMomentumManagement.c
+++ b/src/fswAlgorithms/attControl/thrMomentumManagement/thrMomentumManagement.c
@@ -22,7 +22,6 @@
  */
 
 #include "fswAlgorithms/attControl/thrMomentumManagement/thrMomentumManagement.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include <string.h>
 

--- a/src/fswAlgorithms/attControl/thrMomentumManagement/thrMomentumManagement.c
+++ b/src/fswAlgorithms/attControl/thrMomentumManagement/thrMomentumManagement.c
@@ -18,7 +18,7 @@
  */
 /*
     Thruster RW Momentum Management
- 
+
  */
 
 #include "fswAlgorithms/attControl/thrMomentumManagement/thrMomentumManagement.h"

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
@@ -62,12 +62,12 @@ void Reset_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime, int64_t module
 
     configData->priorSignalAvailable = 0;
     v3SetZero(configData->dOld);
-    
+
     configData->filtStatus.numObs = 0;
     configData->filtStatus.timeTag = 0.0;
     v3SetZero(configData->filtStatus.state);
     vSetZero(configData->filtStatus.postFitRes, MAX_N_CSS_MEAS);
-    
+
 
     /* Reset the prior time flag state.
      If zero, control time step not evaluated on the first function call */
@@ -76,8 +76,8 @@ void Reset_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime, int64_t module
     return;
 }
 
-/*! This method computes the post-fit residuals for the WLS estimate.  Note that 
-    everything has to have been allocated appropriately as this function operates 
+/*! This method computes the post-fit residuals for the WLS estimate.  Note that
+    everything has to have been allocated appropriately as this function operates
     directly on the arrays.
     @return void
     @param cssMeas The measured values for the CSS sensors
@@ -89,7 +89,7 @@ void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig,
                          double *wlsEst, double *cssResiduals)
 {
     double cssDotProd;
-    
+
     memset(cssResiduals, 0x0, cssConfig->nCSS*sizeof(double));
     /*! The method loops through the sensors and performs: */
     for(uint32_t i=0; i<cssConfig->nCSS; i++)
@@ -101,7 +101,7 @@ void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig,
         cssResiduals[i] = cssMeas[i] - cssDotProd;
         /*! -# This populates the post-fit residuals*/
     }
-    
+
 }
 
 /*! This method computes a least squares fit with the given parameters.  It
@@ -125,7 +125,7 @@ int computeWlsmn(int numActiveCss, double *H, double *W,
     double  m3N[3*MAX_NUM_CSS_SENSORS];
     double  m3N_2[3*MAX_NUM_CSS_SENSORS];
     uint32_t i;
-    
+
     /*! - If we only have one sensor, output best guess (cone of possiblities)*/
     if(numActiveCss == 1) {
         /* Here's a guess.  Do with it what you will. */
@@ -133,7 +133,7 @@ int computeWlsmn(int numActiveCss, double *H, double *W,
             x[i] = H[0*MAX_NUM_CSS_SENSORS+i] * y[0];
         }
     } else if(numActiveCss == 2) { /*! - If we have two, then do a 2x2 fit */
-        
+
         /*!   -# Find minimum norm solution */
         mMultMt(H, 2, 3, H, 2, 3, m22);
         status = m22Inverse(RECAST2x2 m22, RECAST2x2 m22);
@@ -150,7 +150,7 @@ int computeWlsmn(int numActiveCss, double *H, double *W,
         /*!    -# Multiply the LSQ matrix by the obs vector for best fit*/
         mMultV(m3N_2, 3, (size_t) numActiveCss, y, x);
     }
-    
+
     return(status);
 }
 
@@ -174,7 +174,7 @@ void Update_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime,
     double dHatOld[3];                           /* Prior normalized sun heading estimate */
     double  dt;                                  /* [s] Control update period */
     NavAttMsgPayload sunlineOutBuffer;               /* Output Nav message*/
-    
+
     /* Zero output message*/
     sunlineOutBuffer = NavAttMsg_C_zeroMsgPayload();
 
@@ -189,10 +189,10 @@ void Update_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime,
         dt = (callTime - configData->priorTime) * NANO2SEC;
     }
     configData->priorTime = callTime;
-    
+
     /* - Zero the observed active CSS count*/
     configData->numActiveCss = 0;
-    
+
     /*! - Loop over the maximum number of sensors to check for good measurements */
     /*! -# Isolate if measurement is good */
     /*! -# Set body vector for this measurement */
@@ -208,10 +208,10 @@ void Update_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime,
                 configData->cssConfigInBuffer.cssVals[i].nHat_B, &H[configData->numActiveCss*3]);
             y[configData->numActiveCss] = InputBuffer.CosValue[i];
             configData->numActiveCss = configData->numActiveCss + 1;
-            
+
         }
     }
-    
+
     /*! Estimation Steps*/
     configData->filtStatus = SunlineFilterMsg_C_zeroMsgPayload();
 

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
@@ -21,7 +21,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for theCSS WLS estimator.
  @return void

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.c
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.c
@@ -22,7 +22,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for theCSS WLS estimator.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/attDetermination/sunlineEKF/sunlineEKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineEKF/sunlineEKF.c
@@ -22,7 +22,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for theCSS WLS estimator.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/attDetermination/sunlineEKF/sunlineEKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineEKF/sunlineEKF.c
@@ -47,9 +47,9 @@ void SelfInit_sunlineEKF(sunlineEKFConfig *configData, int64_t moduleID)
 void Reset_sunlineEKF(sunlineEKFConfig *configData, uint64_t callTime,
                       int64_t moduleID)
 {
-    
+
     CSSConfigMsgPayload cssConfigInBuffer;
-   
+
     /*! - Zero the local configuration data structures and outputs */
     configData->outputSunline = NavAttMsg_C_zeroMsgPayload();
     mSetZero(configData->cssNHat_B, MAX_NUM_CSS_SENSORS, 3);
@@ -77,29 +77,29 @@ void Reset_sunlineEKF(sunlineEKFConfig *configData, uint64_t callTime,
     }
     /*! - Save the count of sun sensors for later use */
     configData->numCSSTotal = cssConfigInBuffer.nCSS;
-    
+
     /*! - Initialize filter parameters to max values */
     configData->timeTag = callTime*NANO2SEC;
     configData->dt = 0.0;
     configData->numStates = SKF_N_STATES;
     configData->numObs = MAX_N_CSS_MEAS;
-    
+
     /*! - Ensure that all internal filter matrices are zeroed*/
     vSetZero(configData->obs, (size_t) configData->numObs);
     vSetZero(configData->yMeas, (size_t) configData->numObs);
     vSetZero(configData->xBar, configData->numStates);
     mSetZero(configData->covarBar, configData->numStates, configData->numStates);
-    
+
     mSetIdentity(configData->stateTransition, configData->numStates, configData->numStates);
 
     mSetZero(configData->dynMat, configData->numStates, configData->numStates);
     mSetZero(configData->measMat, (size_t) configData->numObs, configData->numStates);
     mSetZero(configData->kalmanGain, configData->numStates, (size_t) configData->numObs);
-    
+
     mSetZero(configData->measNoise, (size_t) configData->numObs, (size_t) configData->numObs);
     mSetIdentity(configData->procNoise,  configData->numStates/2, configData->numStates/2);
     mScale(configData->qProcVal, configData->procNoise, configData->numStates/2, configData->numStates/2, configData->procNoise);
-    
+
     return;
 }
 
@@ -124,7 +124,7 @@ void Update_sunlineEKF(sunlineEKFConfig *configData, uint64_t callTime,
     timeOfMsgWritten = CSSArraySensorMsg_C_timeWritten(&configData->cssDataInMsg);
     isWritten = CSSArraySensorMsg_C_isWritten(&configData->cssDataInMsg);
 
-    /*! - If the time tag from the measured data is new compared to previous step, 
+    /*! - If the time tag from the measured data is new compared to previous step,
           propagate and update the filter*/
     newTimeTag = timeOfMsgWritten * NANO2SEC;
     if(newTimeTag >= configData->timeTag && isWritten)
@@ -132,7 +132,7 @@ void Update_sunlineEKF(sunlineEKFConfig *configData, uint64_t callTime,
         sunlineTimeUpdate(configData, newTimeTag);
         sunlineMeasUpdate(configData, newTimeTag);
     }
-    
+
     /*! - If current clock time is further ahead than the measured time, then
           propagate to this current time-step*/
     newTimeTag = callTime*NANO2SEC;
@@ -142,11 +142,11 @@ void Update_sunlineEKF(sunlineEKFConfig *configData, uint64_t callTime,
         vCopy(configData->xBar, SKF_N_STATES, configData->x);
         mCopy(configData->covarBar, SKF_N_STATES, SKF_N_STATES, configData->covar);
     }
-    
+
     /* Compute post fit residuals once that data has been processed */
     mMultM(configData->measMat, (size_t) configData->numObs, SKF_N_STATES, configData->x, SKF_N_STATES, 1, Hx);
     mSubtract(configData->yMeas, (size_t) configData->numObs, 1, Hx, configData->postFits);
-    
+
     /*! - Write the sunline estimate into the copy of the navigation message structure*/
 	v3Copy(configData->state, configData->outputSunline.vehSunPntBdy);
     v3Normalize(configData->outputSunline.vehSunPntBdy,
@@ -180,22 +180,22 @@ void sunlineTimeUpdate(sunlineEKFConfig *configData, double updateTime)
     double Gamma[SKF_N_STATES][SKF_N_STATES_HALF];
     double qGammaT[SKF_N_STATES_HALF*SKF_N_STATES], gammaQGammaT[SKF_N_STATES*SKF_N_STATES];
     double Id[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    
+
 	configData->dt = updateTime - configData->timeTag;
-    
+
     /*! - Propagate the previous reference states and STM to the current time */
     sunlineDynMatrix(configData->state, configData->dt, configData->dynMat);
     sunlineStateSTMProp(configData->dynMat, configData->dt, configData->state, configData->stateTransition);
 
     /* xbar = Phi*x */
     mMultV(configData->stateTransition, SKF_N_STATES, SKF_N_STATES, configData->x, configData->xBar);
-    
+
     /*! - Update the covariance */
     /*Pbar = Phi*P*Phi^T + Gamma*Q*Gamma^T*/
     mTranspose(configData->stateTransition, SKF_N_STATES, SKF_N_STATES, stmT);
     mMultM(configData->covar, SKF_N_STATES, SKF_N_STATES, stmT, SKF_N_STATES, SKF_N_STATES, covPhiT);
     mMultM(configData->stateTransition, SKF_N_STATES, SKF_N_STATES, covPhiT, SKF_N_STATES, SKF_N_STATES, configData->covarBar);
-    
+
     /*Compute Gamma and add gammaQGamma^T to Pbar. This is the process noise addition*/
 //    double Gamma[6][3]={{configData->dt*configData->dt/2,0,0},{0,configData->dt*configData->dt/2,0},{0,0,configData->dt*configData->dt/2},{configData->dt,0,0},{0,configData->dt,0},{0,0,configData->dt}};
     mSetIdentity(Id, SKF_N_STATES_HALF, SKF_N_STATES_HALF);
@@ -207,7 +207,7 @@ void sunlineTimeUpdate(sunlineEKFConfig *configData, double updateTime)
     mMultMt(configData->procNoise, SKF_N_STATES_HALF, SKF_N_STATES_HALF, Gamma, SKF_N_STATES, SKF_N_STATES_HALF, qGammaT);
     mMultM(Gamma, SKF_N_STATES, SKF_N_STATES_HALF, qGammaT, SKF_N_STATES_HALF, SKF_N_STATES, gammaQGammaT);
     mAdd(configData->covarBar, SKF_N_STATES, SKF_N_STATES, gammaQGammaT, configData->covarBar);
-    
+
 	configData->timeTag = updateTime;
 }
 
@@ -223,18 +223,18 @@ void sunlineTimeUpdate(sunlineEKFConfig *configData, double updateTime)
  */
 void sunlineStateSTMProp(double dynMat[SKF_N_STATES*SKF_N_STATES], double dt, double *stateInOut, double *stateTransition)
 {
-    
+
     double propagatedVel[SKF_N_STATES_HALF];
     double pointUnit[SKF_N_STATES_HALF];
     double unitComp;
     double deltatASTM[SKF_N_STATES*SKF_N_STATES];
-    
+
     /* Set local variables to zero*/
     mSetZero(deltatASTM, SKF_N_STATES, SKF_N_STATES);
     unitComp=0.0;
     vSetZero(pointUnit, SKF_N_STATES_HALF);
     vSetZero(propagatedVel, SKF_N_STATES_HALF);
-    
+
     /*! Begin state update steps */
     /*! - Unitize the current estimate to find direction to restrict motion*/
     v3Normalize(stateInOut, pointUnit);
@@ -245,12 +245,12 @@ void sunlineStateSTMProp(double dynMat[SKF_N_STATES*SKF_N_STATES], double dt, do
     v3Subtract(&(stateInOut[3]), pointUnit, &(stateInOut[3]));
     v3Scale(dt, &(stateInOut[3]), propagatedVel);
     v3Add(stateInOut, propagatedVel, stateInOut);
-    
+
     /*! Begin STM propagation step */
     mSetIdentity(stateTransition, SKF_N_STATES, SKF_N_STATES);
     mScale(dt, dynMat, SKF_N_STATES, SKF_N_STATES, deltatASTM);
     mAdd(stateTransition, SKF_N_STATES, SKF_N_STATES, deltatASTM, stateTransition);
-    
+
     return;
 }
 
@@ -271,43 +271,43 @@ void sunlineDynMatrix(double states[SKF_N_STATES], double dt, double *dynMat)
     double secondterm[3][3], firstterm[3][3];
     double normd2;
     double dFdd[3][3], dFdddot[3][3];
-    
+
     /* dF1dd */
     mSetIdentity(I3, 3, 3);
     dddot = v3Dot(&(states[0]), &(states[3]));
     normd2 = v3Norm(&(states[0]))*v3Norm(&(states[0]));
-    
+
     mScale(normd2, I3, 3, 3, d2I3);
-    
+
     v3OuterProduct(&(states[0]), &(states[3]), douterddot);
     v3OuterProduct(&(states[0]), &(states[0]), douterd);
-    
+
     m33Scale(-2.0, douterd, neg2dd);
     m33Add(d2I3, neg2dd, secondterm);
     m33Scale(dddot/(normd2*normd2), secondterm, secondterm);
-    
+
     m33Scale(1.0/normd2, douterddot, firstterm);
-    
+
     m33Add(firstterm, secondterm, dFdd);
     m33Scale(-1.0, dFdd, dFdd);
-    
+
     /* Populate the first 3x3 matrix of the dynamics matrix*/
     mSetSubMatrix(dFdd, 3, 3, dynMat, SKF_N_STATES, SKF_N_STATES, 0, 0);
-    
+
     /* dF1dddot */
     m33Scale(-1.0/normd2, douterd, ddtnorm2);
     m33Add(I3, ddtnorm2, dFdddot);
-    
+
     /* Populate the second 3x3 matrix */
     mSetSubMatrix(dFdddot, 3, 3, dynMat, SKF_N_STATES, SKF_N_STATES, 0, 3);
-    
+
     /* Only propagate d_dot if dt is greater than zero, if not leave dynMat zeroed*/
     if (dt>1E-10){
         /* dF2dd */
         m33Scale(1.0/dt, dFdd, dFdd);
         /* Populate the third 3x3 matrix of the dynamics matrix*/
         mSetSubMatrix(dFdd, 3, 3, dynMat, SKF_N_STATES, SKF_N_STATES, 3, 0);
-    
+
         /* dF2dddot */
         m33Subtract(dFdddot, I3, dFdddot);
         m33Scale(1.0/dt, dFdddot, dFdddot);
@@ -329,12 +329,12 @@ void sunlineMeasUpdate(sunlineEKFConfig *configData, double updateTime)
 {
     /*! - Compute the valid observations and the measurement model for all observations*/
     sunlineHMatrixYMeas(configData->state, (int) configData->numCSSTotal, configData->cssSensorInBuffer.CosValue, configData->sensorUseThresh, configData->cssNHat_B, configData->CBias, configData->obs, configData->yMeas, &(configData->numObs), configData->measMat);
-    
+
     /*! - Compute the Kalman Gain. */
     sunlineKalmanGain(configData->covarBar, configData->measMat, configData->qObsVal, configData->numObs, configData->kalmanGain);
-    
+
     /* Logic to switch from EKF to CKF. If the covariance is too large, switching references through an EKF could lead to filter divergence in extreme cases. In order to remedy this, past a certain infinite norm of the covariance, we update with a CKF in order to bring down the covariance. */
-    
+
     if (vMaxAbs(configData->covar, SKF_N_STATES*SKF_N_STATES) > configData->eKFSwitch){
     /*! - Compute the update with a CKF */
     sunlineCKFUpdate(configData->xBar, configData->kalmanGain, configData->covarBar, configData->qObsVal, configData->numObs, configData->yMeas, configData->measMat, configData->x,configData->covar);
@@ -343,7 +343,7 @@ void sunlineMeasUpdate(sunlineEKFConfig *configData, double updateTime)
     /*! - Compute the update with a EKF, notice the reference state is added as an argument because it is changed by the filter update */
     sunlineEKFUpdate(configData->kalmanGain, configData->covarBar, configData->qObsVal, configData->numObs, configData->yMeas, configData->measMat, configData->state, configData->x, configData->covar);
     }
-    
+
 }
 
 /*! This method computes the updated with a Classical Kalman Filter
@@ -367,7 +367,7 @@ void sunlineCKFUpdate(double xBar[SKF_N_STATES], double kalmanGain[SKF_N_STATES*
     double eyeKalHCovarBar[SKF_N_STATES*SKF_N_STATES], kalR[SKF_N_STATES*MAX_N_CSS_MEAS];
     double kalT[MAX_N_CSS_MEAS*SKF_N_STATES], kalRKalT[SKF_N_STATES*SKF_N_STATES];
     double noiseMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    
+
     /* Set variables to zero */
     mSetZero(kH, SKF_N_STATES, SKF_N_STATES);
     mSetZero(eyeKalH, SKF_N_STATES, SKF_N_STATES);
@@ -378,17 +378,17 @@ void sunlineCKFUpdate(double xBar[SKF_N_STATES], double kalmanGain[SKF_N_STATES*
     mSetZero(kalT, MAX_N_CSS_MEAS, SKF_N_STATES);
     mSetZero(kalR, SKF_N_STATES, MAX_N_CSS_MEAS);
     mSetZero(eyeKalHCovarBar, SKF_N_STATES, SKF_N_STATES);
-    
+
     /* Set noise matrix given number of observations */
     mSetIdentity(noiseMat, (size_t) numObs, (size_t) numObs);
     mScale(qObsVal, noiseMat, (size_t) numObs, (size_t) numObs, noiseMat);
-    
+
     /*! - Compute innovation, multiply it my Kalman Gain, and add it to xBar*/
     mMultM(hObs, (size_t) numObs, SKF_N_STATES, xBar, SKF_N_STATES, 1, measMatx);
     vSubtract(yObs, (size_t) numObs, measMatx, innov);
     mMultM(kalmanGain, SKF_N_STATES, (size_t) numObs, innov, (size_t) numObs, 1, kInnov);
     vAdd(xBar, SKF_N_STATES, kInnov, x);
-    
+
     /*! - Compute new covariance with Joseph's method*/
     mMultM(kalmanGain, SKF_N_STATES, (size_t) numObs, hObs, (size_t) numObs, SKF_N_STATES, kH);
     mSetIdentity(eye, SKF_N_STATES, SKF_N_STATES);
@@ -396,14 +396,14 @@ void sunlineCKFUpdate(double xBar[SKF_N_STATES], double kalmanGain[SKF_N_STATES*
     mTranspose(eyeKalH, SKF_N_STATES, SKF_N_STATES, eyeKalHT);
     mMultM(eyeKalH, SKF_N_STATES, SKF_N_STATES, covarBar, SKF_N_STATES, SKF_N_STATES, eyeKalHCovarBar);
     mMultM(eyeKalHCovarBar, SKF_N_STATES, SKF_N_STATES, eyeKalHT, SKF_N_STATES, SKF_N_STATES, covar);
-    
+
     /* Add noise to the covariance*/
     mMultM(kalmanGain, SKF_N_STATES, (size_t) numObs, noiseMat, (size_t) numObs, (size_t) numObs, kalR);
     mTranspose(kalmanGain, SKF_N_STATES, (size_t) numObs, kalT);
     mMultM(kalR, SKF_N_STATES, (size_t) numObs, kalT, (size_t) numObs, SKF_N_STATES, kalRKalT);
     mAdd(covar, SKF_N_STATES, SKF_N_STATES, kalRKalT, covar);
-    
-    
+
+
 }
 
 /*! This method computes the updated with a Extended Kalman Filter
@@ -426,7 +426,7 @@ void sunlineEKFUpdate(double kalmanGain[SKF_N_STATES*MAX_N_CSS_MEAS], double cov
     double eyeKalHCovarBar[SKF_N_STATES*SKF_N_STATES], kalR[SKF_N_STATES*MAX_N_CSS_MEAS];
     double kalT[MAX_N_CSS_MEAS*SKF_N_STATES], kalRKalT[SKF_N_STATES*SKF_N_STATES];
     double noiseMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    
+
     /* Set variables to zero */
     mSetZero(kH, SKF_N_STATES, SKF_N_STATES);
     mSetZero(eyeKalH, SKF_N_STATES, SKF_N_STATES);
@@ -437,17 +437,17 @@ void sunlineEKFUpdate(double kalmanGain[SKF_N_STATES*MAX_N_CSS_MEAS], double cov
     mSetZero(kalT, MAX_N_CSS_MEAS, SKF_N_STATES);
     mSetZero(kalR, SKF_N_STATES, MAX_N_CSS_MEAS);
     mSetZero(eyeKalHCovarBar, SKF_N_STATES, SKF_N_STATES);
-    
+
     /* Set noise matrix given number of observations */
     mSetIdentity(noiseMat, (size_t) numObs, (size_t) numObs);
     mScale(qObsVal, noiseMat, (size_t) numObs, (size_t) numObs, noiseMat);
-    
+
     /*! - Update the state error*/
     mMultV(kalmanGain, SKF_N_STATES, (size_t) numObs, yObs, x);
 
     /*! - Change the reference state*/
     vAdd(states, SKF_N_STATES, x, states);
-    
+
     /*! - Compute new covariance with Joseph's method*/
     mMultM(kalmanGain, SKF_N_STATES, (size_t) numObs, hObs, (size_t) numObs, SKF_N_STATES, kH);
     mSetIdentity(eye, SKF_N_STATES, SKF_N_STATES);
@@ -455,18 +455,18 @@ void sunlineEKFUpdate(double kalmanGain[SKF_N_STATES*MAX_N_CSS_MEAS], double cov
     mTranspose(eyeKalH, SKF_N_STATES, SKF_N_STATES, eyeKalHT);
     mMultM(eyeKalH, SKF_N_STATES, SKF_N_STATES, covarBar, SKF_N_STATES, SKF_N_STATES, eyeKalHCovarBar);
     mMultM(eyeKalHCovarBar, SKF_N_STATES, SKF_N_STATES, eyeKalHT, SKF_N_STATES, SKF_N_STATES, covar);
-    
+
     /* Add noise to the covariance*/
     mMultM(kalmanGain, SKF_N_STATES, (size_t) numObs, noiseMat, (size_t) numObs, (size_t) numObs, kalR);
     mTranspose(kalmanGain, SKF_N_STATES, (size_t) numObs, kalT);
     mMultM(kalR, SKF_N_STATES, (size_t) numObs, kalT, (size_t) numObs, SKF_N_STATES, kalRKalT);
     mAdd(covar, SKF_N_STATES, SKF_N_STATES, kalRKalT, covar);
-    
+
 }
 
-/*! This method computes the H matrix, defined by dGdX. As well as computing the 
+/*! This method computes the H matrix, defined by dGdX. As well as computing the
  innovation, difference between the measurements and the expected measurements.
- This methods modifies the numObs, measMat, and yMeas. 
+ This methods modifies the numObs, measMat, and yMeas.
  @return void
  @param states
  @param numCSS The total number of CSS
@@ -484,7 +484,7 @@ void sunlineHMatrixYMeas(double states[SKF_N_STATES], int numCSS, double cssSens
 {
     int i, obsCounter;
     double sensorNormal[3];
-    
+
     v3SetZero(sensorNormal);
 
     obsCounter = 0;
@@ -523,32 +523,30 @@ void sunlineKalmanGain(double covarBar[SKF_N_STATES*SKF_N_STATES], double hObs[M
     double covHT[SKF_N_STATES*MAX_N_CSS_MEAS];
     double hCovar[MAX_N_CSS_MEAS*SKF_N_STATES], hCovarHT[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
     double rMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    
+
     /* Setting all local variables to zero */
     mSetZero(hObsT, SKF_N_STATES, MAX_N_CSS_MEAS);
     mSetZero(covHT, SKF_N_STATES, MAX_N_CSS_MEAS);
     mSetZero(hCovar, MAX_N_CSS_MEAS, SKF_N_STATES);
     mSetZero(hCovarHT, MAX_N_CSS_MEAS, MAX_N_CSS_MEAS);
     mSetZero(rMat, MAX_N_CSS_MEAS, MAX_N_CSS_MEAS);
-    
+
     mTranspose(hObs, (size_t) numObs, SKF_N_STATES, hObsT);
-    
+
     mMultM(covarBar, SKF_N_STATES, SKF_N_STATES, hObsT, SKF_N_STATES, (size_t) numObs, covHT);
     mMultM(hObs, (size_t) numObs, SKF_N_STATES, covarBar, SKF_N_STATES, SKF_N_STATES, hCovar);
     mMultM(hCovar, (size_t) numObs, SKF_N_STATES, hObsT, SKF_N_STATES, (size_t) numObs, hCovarHT);
-    
+
     mSetIdentity(rMat, (size_t) (size_t) numObs, (size_t) numObs);
     mScale(qObsVal, rMat, (size_t) numObs, (size_t) numObs, rMat);
-    
+
     /*! - Add measurement noise */
     mAdd(hCovarHT, (size_t) numObs, (size_t) numObs, rMat, hCovarHT);
-    
+
     /*! - Invert the previous matrix */
     mInverse(hCovarHT, (size_t) numObs, hCovarHT);
-    
+
     /*! - Compute the Kalman Gain */
     mMultM(covHT, SKF_N_STATES, (size_t) numObs, hCovarHT, (size_t) numObs, (size_t) numObs, kalmanGain);
-    
+
 }
-
-

--- a/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.c
+++ b/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.c
@@ -45,7 +45,7 @@ void SelfInit_sunlineEphem(sunlineEphemConfig *configData, int64_t moduleID)
  */
 void Reset_sunlineEphem(sunlineEphemConfig *configData, uint64_t callTime, int64_t moduleID)
 {
-    
+
 }
 
 /*! Updates the sun heading based on ephemeris data. Returns the heading as a unit vector in the body frame.
@@ -64,7 +64,7 @@ void Update_sunlineEphem(sunlineEphemConfig *configData, uint64_t callTime, int6
     EphemerisMsgPayload sunEphemBuffer; /* [-] Input sun ephemeris data */
     NavTransMsgPayload scTransBuffer;   /* [-] Input spacecraft position data */
     NavAttMsgPayload scAttBuffer;       /* [-] Input spacecraft attitude data */
-    
+
     // check if the required input messages are included
     if (!EphemerisMsg_C_isLinked(&configData->sunPositionInMsg)) {
         _bskLog(configData->bskLogger, BSK_ERROR, "Error: sunlineEphem.sunPositionInMsg wasn't connected.");
@@ -88,7 +88,7 @@ void Update_sunlineEphem(sunlineEphemConfig *configData, uint64_t callTime, int6
     MRP2C(scAttBuffer.sigma_BN, BN);
     m33MultV3(BN, r_SB_N_hat, r_SB_B_hat);
     v3Normalize(r_SB_B_hat, r_SB_B_hat);
-    
+
     /*! - store the output message*/
     v3Copy(r_SB_B_hat, outputSunline.vehSunPntBdy);
     NavAttMsg_C_write(&outputSunline, &configData->navStateOutMsg, moduleID, callTime);

--- a/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.c
+++ b/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.c
@@ -19,7 +19,6 @@
 
 #include "sunlineEphem.h"
 #include <string.h>
-#include <math.h>
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.c
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.c
@@ -72,4 +72,3 @@ void Update_attRefCorrection(attRefCorrectionConfig *configData, uint64_t callTi
     // write to the output messages
     AttRefMsg_C_write(&attRefMsgBuffer, &configData->attRefOutMsg, moduleID, callTime);
 }
-

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.c
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.c
@@ -21,7 +21,6 @@
 #include "fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "string.h"
 
 /*!
     This method initializes the output messages for this module.

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.c
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.c
@@ -18,8 +18,6 @@
 
 #include <string.h>
 #include "fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h"
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 

--- a/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.c
+++ b/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.c
@@ -23,7 +23,6 @@
 #include "fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /*! This method initializes the configData for the nominal delta-V maneuver guidance.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.cpp
+++ b/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.cpp
@@ -268,7 +268,7 @@ void ConstrainedAttitudeManeuver::UpdateState(uint64_t CurrentSimNanos)
 
 	dMRP2Omega(sigma_RN, sigmaDot_RN, omega_RN_R);
 	ddMRP2dOmega(sigma_RN, sigmaDot_RN, sigmaDDot_RN, omegaDot_RN_R);
-	
+
 	// create the attitude output message buffer
 	AttRefMsgPayload attMsgBuffer;
 	// zero output message
@@ -449,7 +449,7 @@ void ConstrainedAttitudeManeuver::GenerateGrid(Node startNode, Node goalNode)
 			}
 		}
 	}
-    
+
 	// add start and goal node to grid and connecting them to the neighboring nodes:
 	double ds = 10;
 	double dg = 10;
@@ -510,7 +510,7 @@ void ConstrainedAttitudeManeuver::GenerateGrid(Node startNode, Node goalNode)
 	this->NodesMap[keyG[0]][keyG[1]][keyG[2]] = goalNode;
 	this->keyS[0] = keyS[0]; this->keyS[1] = keyS[1]; this->keyS[2] = keyS[2];
 	this->keyG[0] = keyG[0]; this->keyG[1] = keyG[1]; this->keyG[2] = keyG[2];
-	
+
 }
 
 /*! This method is used inside A* to track the path from goal to start, order it from start to goal and store in class variable path
@@ -570,13 +570,13 @@ void ConstrainedAttitudeManeuver::AStar()
 				}
 			}
 		}
-		
+
 		O.pop(0);
 		O.sort();
 	}
 
 	backtrack(O.list[0]);
-    
+
 	// Uncomment to print path node coordinates
 	/*
 	for (int n = 0; n < this->path.N; n++) {
@@ -628,13 +628,13 @@ void ConstrainedAttitudeManeuver::effortBasedAStar()
 				}
 			}
 		}
-		
+
 		O.pop(0);
 		O.sort();
 	}
 
 	backtrack(O.list[0]);
-    
+
 	// Uncomment to print path node coordinates
 	/*
 	std::cout << "Waypoints: \n";
@@ -709,7 +709,7 @@ void ConstrainedAttitudeManeuver::spline()
 		sDot_s[i] = sigmaDot_start[i];
 		sDot_g[i] = sigmaDot_goal[i];
 	}
-	
+
 	this->Input.setXDot_0(sDot_s);
 	this->Input.setXDot_N(sDot_g);
 	if (this->BSplineType == 0) {
@@ -729,7 +729,7 @@ void ConstrainedAttitudeManeuver::spline()
 void ConstrainedAttitudeManeuver::computeTorque(int n, double I[9], double L[3])
 {
 	double sigma[3], sigmaDot[3], sigmaDDot[3], omega[3], omegaDot[3], L1[3], L2[3], H[3];
-	
+
 	sigma[0]     = this->Output.X1[n];    sigma[1]     = this->Output.X2[n];    sigma[2]     = this->Output.X3[n];
 	sigmaDot[0]  = this->Output.XD1[n];   sigmaDot[1]  = this->Output.XD2[n];   sigmaDot[2]  = this->Output.XD3[n];
 	sigmaDDot[0] = this->Output.XDD1[n];  sigmaDDot[1] = this->Output.XDD2[n];  sigmaDDot[2] = this->Output.XDD3[n];
@@ -748,7 +748,7 @@ double ConstrainedAttitudeManeuver::computeTorqueNorm(int n, double I[9])
 {
 	double L[3];
 	computeTorque(n, this->vehicleConfigMsgBuffer.ISCPntB_B, L);
-	
+
 	return v3Norm(L);
 }
 
@@ -818,7 +818,7 @@ double ConstrainedAttitudeManeuver::returnPathCoord(int index, int nodeCoord)
 }
 
 /*! This helper function returns the coordinates of the 8 symmetrical points to a point in 3D cartesian space. */
-void mirrorFunction(int indices[3], int mirrorIndices[8][3]) 
+void mirrorFunction(int indices[3], int mirrorIndices[8][3])
 {
 	mirrorIndices[0][0] =  indices[0];   mirrorIndices[0][1] =  indices[1];   mirrorIndices[0][2] =  indices[2];
 	mirrorIndices[1][0] = -indices[0];   mirrorIndices[1][1] =  indices[1];   mirrorIndices[1][2] =  indices[2];

--- a/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.cpp
+++ b/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.cpp
@@ -18,9 +18,6 @@
  */
 #include "fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.h"
 #include <map>
-#include <sstream>
-#include <string>
-#include <string.h>
 #include <math.h>
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"

--- a/src/fswAlgorithms/attGuidance/eulerRotation/eulerRotation.c
+++ b/src/fswAlgorithms/attGuidance/eulerRotation/eulerRotation.c
@@ -18,10 +18,10 @@
  */
 /*
  Euler Angle Rotation Guidance Module with Constant Euler Rates
- 
+
  * University of Colorado, Autonomous Vehicle Systems (AVS) Lab
  * Unpublished Copyright (c) 2012-2015 University of Colorado, All Rights Reserved
- 
+
  */
 
 #include "fswAlgorithms/attGuidance/eulerRotation/eulerRotation.h"
@@ -93,7 +93,7 @@ void Update_eulerRotation(eulerRotationConfig *configData, uint64_t callTime, in
         /* - Check the command is new */
         checkRasterCommands(configData);
     }
-    
+
     /* - Compute time step to use in the integration downstream */
     computeTimeStep(configData, callTime);
     /* - Compute output reference frame */
@@ -126,7 +126,7 @@ void checkRasterCommands(eulerRotationConfig *configData)
     {
         v3Copy(configData->cmdSet, configData->angleSet);
         v3Copy(configData->cmdRates, configData->angleRates);
-        
+
         v3Copy(configData->cmdSet, configData->priorCmdSet);
         v3Copy(configData->cmdRates, configData->priorCmdRates);
     }
@@ -159,13 +159,13 @@ void computeEuler321_Binv_derivative(double angleSet[3], double angleRates[3], d
     double c2;
     double s3;
     double c3;
-    
+
     s2 = sin(angleSet[1]);
     c2 = cos(angleSet[1]);
     s3 = sin(angleSet[2]);
     c3 = cos(angleSet[2]);
-    
-    
+
+
     B_inv_deriv[0][0] = -angleRates[1] * c2;
     B_inv_deriv[0][1] = 0;
     B_inv_deriv[0][2] = 0;
@@ -198,14 +198,14 @@ void computeEulerRotationReference(eulerRotationConfig *configData,
     double RR0[3][3];               /*!< [] DCM rotating from R0 to R */
     double R0N[3][3];               /*!< [] DCM rotating from N to R0 */
     double RN[3][3];                /*!< [] DCM rotating from N to R */
-    
+
     MRP2C(sigma_R0N, R0N);
     v3Scale(configData->dt, configData->angleRates, attIncrement);
     v3Add(configData->angleSet, attIncrement, configData->angleSet);
     Euler3212C(configData->angleSet, RR0);
     m33MultM33(RR0, R0N, RN);
     C2MRP(RN, attRefOut->sigma_RN);
-    
+
     /* Compute angular velocity */
     double B_inv[3][3];             /*!< [] matrix related Euler angle rates to angular velocity vector components */
     double omega_RR0_R[3];          /*!< [r/s] angular velocity vector between R and R0 frame in R frame components */
@@ -214,7 +214,7 @@ void computeEulerRotationReference(eulerRotationConfig *configData,
     m33MultV3(B_inv, configData->angleRates, omega_RR0_R);
     m33tMultV3(RN, omega_RR0_R, omega_RR0_N);
     v3Add(omega_R0N_N, omega_RR0_N, attRefOut->omega_RN_N);
- 
+
     /* Compute angular acceleration */
     double B_inv_deriv[3][3];       /*!< [] time derivatie of matrix relating EA rates to omegas */
     double domega_RR0_R[3];         /*!< [r/s] inertial derivative of omega_RR0_R in R frame components */

--- a/src/fswAlgorithms/attGuidance/eulerRotation/eulerRotation.c
+++ b/src/fswAlgorithms/attGuidance/eulerRotation/eulerRotation.c
@@ -25,9 +25,7 @@
  */
 
 #include "fswAlgorithms/attGuidance/eulerRotation/eulerRotation.h"
-#include <string.h>
 #include <math.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 #include "architecture/utilities/macroDefinitions.h"
 
 /* Support files.  Be sure to use the absolute path relative to Basilisk directory. */

--- a/src/fswAlgorithms/attGuidance/hillPoint/hillPoint.c
+++ b/src/fswAlgorithms/attGuidance/hillPoint/hillPoint.c
@@ -24,8 +24,6 @@
 
 #include "fswAlgorithms/attGuidance/hillPoint/hillPoint.h"
 #include <string.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /* Support files.  Be sure to use the absolute path relative to Basilisk directory. */
 #include "architecture/utilities/linearAlgebra.h"

--- a/src/fswAlgorithms/attGuidance/hillPoint/hillPoint.c
+++ b/src/fswAlgorithms/attGuidance/hillPoint/hillPoint.c
@@ -18,7 +18,7 @@
  */
 /*
     Hill Point Module
- 
+
  */
 
 
@@ -103,34 +103,34 @@ void computeHillPointingReference(hillPointConfig *configData,
                                   double celBdyVelocityVector[3],
                                   AttRefMsgPayload *attRefOut)
 {
-    
+
     double  relPosVector[3];
     double  relVelVector[3];
     double  dcm_RN[3][3];            /* DCM from inertial to reference frame */
     double  dcm_NR[3][3];            /* DCM from reference to inertial frame */
-    
+
     double  rm;                      /* orbit radius */
     double  h[3];                    /* orbit angular momentum vector */
     double  hm;                      /* module of the orbit angular momentum vector */
-    
+
     double  dfdt;                    /* rotational rate of the orbit frame */
     double  ddfdt2;                  /* rotational acceleration of the frame */
     double  omega_RN_R[3];           /* reference angular velocity vector in Reference frame R components */
     double  domega_RN_R[3];          /* reference angular acceleration vector in Reference frame R components */
-    
+
     /*! - Compute relative position and velocity of the spacecraft with respect to the main celestial body */
     v3Subtract(r_BN_N, celBdyPositonVector, relPosVector);
     v3Subtract(v_BN_N, celBdyVelocityVector, relVelVector);
-    
+
     /*! - Compute RN */
     v3Normalize(relPosVector, dcm_RN[0]);
     v3Cross(relPosVector, relVelVector, h);
     v3Normalize(h, dcm_RN[2]);
     v3Cross(dcm_RN[2], dcm_RN[0], dcm_RN[1]);
-    
+
     /*! - Compute R-frame orientation */
     C2MRP(dcm_RN, attRefOut->sigma_RN);
-    
+
     /*! - Compute R-frame inertial rate and acceleration */
     rm = v3Norm(relPosVector);
     hm = v3Norm(h);
@@ -153,5 +153,5 @@ void computeHillPointingReference(hillPointConfig *configData,
     m33Transpose(dcm_RN, dcm_NR);
     m33MultV3(dcm_NR, omega_RN_R, attRefOut->omega_RN_N);
     m33MultV3(dcm_NR, domega_RN_R, attRefOut->domega_RN_N);
-    
+
 }

--- a/src/fswAlgorithms/attGuidance/inertial3D/inertial3D.c
+++ b/src/fswAlgorithms/attGuidance/inertial3D/inertial3D.c
@@ -23,16 +23,12 @@
 
 /* modify the path to reflect the new module names */
 #include "fswAlgorithms/attGuidance/inertial3D/inertial3D.h"
-#include <string.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 
 
 
 /* Pull in support files from other modules.  Be sure to use the absolute path relative to Basilisk directory. */
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 
 
 /*!

--- a/src/fswAlgorithms/attGuidance/inertial3D/inertial3D.c
+++ b/src/fswAlgorithms/attGuidance/inertial3D/inertial3D.c
@@ -81,7 +81,7 @@ void Update_inertial3D(inertial3DConfig *configData, uint64_t callTime, int64_t 
     with zero angular rate and acceleration vectors
  @return void
  @param configData The configuration data associated with the null space control
- @param attRefOut Output message 
+ @param attRefOut Output message
  */
 void computeInertialPointingReference(inertial3DConfig *configData, AttRefMsgPayload *attRefOut)
 {

--- a/src/fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.c
+++ b/src/fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.c
@@ -26,8 +26,6 @@
 
 /* modify the path to reflect the new module names */
 #include "fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.h"
-#include <string.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 #include "architecture/utilities/macroDefinitions.h"
 
 

--- a/src/fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.c
+++ b/src/fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.c
@@ -18,7 +18,7 @@
  */
 /*
     Inertial 3D Spin Module
- 
+
  * University of Colorado, Autonomous Vehicle Systems (AVS) Lab
  * Unpublished Copyright (c) 2012-2015 University of Colorado, All Rights Reserved
 
@@ -77,7 +77,7 @@ void Update_inertial3DSpin(inertial3DSpinConfig *configData, uint64_t callTime, 
 {
     /*! - Read input message */
     AttRefMsgPayload attRefInMsgBuffer;
-    
+
     if (AttRefMsg_C_isLinked(&configData->attRefInMsg)) {
         attRefInMsgBuffer = AttRefMsg_C_read(&configData->attRefInMsg);
     } else {
@@ -93,7 +93,7 @@ void Update_inertial3DSpin(inertial3DSpinConfig *configData, uint64_t callTime, 
     } else {
         dt = (callTime - configData->priorTime) * NANO2SEC;
     }
-    
+
     /*! - Generate inertial 3D Spinning Reference */
     configData->attRefOutBuffer = AttRefMsg_C_zeroMsgPayload();
     computeReference_inertial3DSpin(configData,
@@ -116,19 +116,19 @@ void computeReference_inertial3DSpin(inertial3DSpinConfig *configData,
 {
     double omega_RN_N[3];
     double domega_RN_N[3];
-    
+
     /*! Compute angular rate */
     double dcm_RN[3][3];   /* DCM from inertial frame N to generated ref frame R */
     double omega_RR0_N[3]; /* angular rate of the generated ref R wrt the base ref R0 in inertial N components */
     MRP2C(configData->sigma_RN, dcm_RN);
     m33tMultV3(dcm_RN, omega_RR0_R0, omega_RR0_N);
     v3Add(omega_R0N_N, omega_RR0_N, omega_RN_N);
-    
+
     /*! Compute angular acceleration */
     double v3Temp[3]; /* temporary 3x1 array */
     v3Cross(omega_R0N_N, omega_RR0_N, v3Temp);
     v3Add(v3Temp, domega_R0N_N, domega_RN_N);
-    
+
     /*! Integrate Attitude */
     double B[3][3]; /* MRP rate matrix */
     double omega_RN_R[3]; /* inertial angular rate of ref R in R frame components */
@@ -138,7 +138,7 @@ void computeReference_inertial3DSpin(inertial3DSpinConfig *configData,
     m33MultV3(B, omega_RN_R, v3Temp);
     v3Add(configData->sigma_RN, v3Temp, configData->sigma_RN);
     MRPswitch(configData->sigma_RN, 1.0, configData->sigma_RN);
-    
+
     /*! Copy output in AttRefMsgPayload struct */
     v3Copy(configData->sigma_RN, configData->attRefOutBuffer.sigma_RN);
     v3Copy(omega_RN_N, configData->attRefOutBuffer.omega_RN_N);

--- a/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
+++ b/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
@@ -22,7 +22,6 @@
 #include "string.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <math.h>
 

--- a/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
+++ b/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
@@ -71,7 +71,7 @@ void Reset_locationPointing(locationPointingConfig *configData, uint64_t callTim
 
     v3SetZero(configData->sigma_BR_old);
     configData->time_old = callTime;
-    
+
     /* compute an Eigen axis orthogonal to sHatBdyCmd */
     if (v3Norm(configData->pHat_B)  < 0.1) {
       char info[MAX_LOGGING_LENGTH];
@@ -178,7 +178,7 @@ void Update_locationPointing(locationPointingConfig *configData, uint64_t callTi
     // compute sigma_RN
     v3Scale(-1.0, sigma_BR, sigma_RB);
     addMRP(scAttInMsgBuffer.sigma_BN, sigma_RB, attRefOutMsgBuffer.sigma_RN);
-    
+
     /* use sigma_BR to compute d(sigma_BR)/dt if at least two data points */
     if (configData->init < 1) {
         // module update time
@@ -190,7 +190,7 @@ void Update_locationPointing(locationPointingConfig *configData, uint64_t callTi
 
         // calculate BinvMRP
         BinvMRP(sigma_BR, Binv);
-        
+
         // compute omega_BR_B
         v3Scale(4.0, sigmaDot_BR, sigmaDot_BR);
         m33MultV3(Binv, sigmaDot_BR, attGuidOutMsgBuffer.omega_BR_B);
@@ -220,4 +220,3 @@ void Update_locationPointing(locationPointingConfig *configData, uint64_t callTi
     AttGuidMsg_C_write(&attGuidOutMsgBuffer, &configData->attGuidOutMsg, moduleID, callTime);
     AttRefMsg_C_write(&attRefOutMsgBuffer, &configData->attRefOutMsg, moduleID, callTime);
 }
-

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.c
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.c
@@ -22,9 +22,6 @@
  */
 
 #include "fswAlgorithms/attGuidance/mrpRotation/mrpRotation.h"
-#include <string.h>
-#include <math.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 #include "architecture/utilities/macroDefinitions.h"
 
 /* Support files.  Be sure to use the absolute path relative to Basilisk directory. */

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.c
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.c
@@ -18,7 +18,7 @@
  */
 /*
  MRP Rotation Guidance Module with a Constant Body Rate Vector
- 
+
  */
 
 #include "fswAlgorithms/attGuidance/mrpRotation/mrpRotation.h"
@@ -59,7 +59,7 @@ void Reset_mrpRotation(mrpRotationConfig *configData, uint64_t callTime, int64_t
 
     v3SetZero(configData->priorCmdSet);
     v3SetZero(configData->priorCmdRates);
-     
+
 }
 
 /*! @brief This method takes the input attitude reference frame, and and superimposes the dynamics MRP
@@ -92,7 +92,7 @@ void Update_mrpRotation(mrpRotationConfig *configData, uint64_t callTime, int64_
         /* - Check the command is new */
         checkRasterCommands(configData);
     }
-    
+
     /*! - Compute time step to use in the integration downstream */
     computeTimeStep(configData, callTime);
 
@@ -187,11 +187,11 @@ void computeMRPRotationReference(mrpRotationConfig *configData,
     MRP2C(configData->mrpSet, RR0);
     m33MultM33(RR0, R0N, RN);
     C2MRP(RN, attRefOut->sigma_RN);
-    
+
     /*! - Compute angular velocity of R/N */
     m33tMultV3(RN, configData->omega_RR0_R, omega_RR0_N);
     v3Add(omega_R0N_N, omega_RR0_N, attRefOut->omega_RN_N);
- 
+
     /*! - Compute angular acceleration of R/N */
     v3Cross(omega_R0N_N, omega_RR0_N, domega_RR0_N);
     v3Add(domega_RR0_N, domega_R0N_N, attRefOut->domega_RN_N);

--- a/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.c
+++ b/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.c
@@ -22,7 +22,6 @@
 #include "fswAlgorithms/attGuidance/opNavPoint/opNavPoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/astroConstants.h"
 
 /*! This method initializes the configData for the opNav attitude guidance.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.c
+++ b/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.c
@@ -107,7 +107,7 @@ void Update_opNavPoint(OpNavPointConfig *configData, uint64_t callTime,
     opNavMsg = OpNavMsg_C_read(&configData->opnavDataInMsg);
     localImuDataInBuffer = NavAttMsg_C_read(&configData->imuInMsg);
     cameraSpecs = CameraConfigMsg_C_read(&configData->cameraConfigInMsg);
-    
+
     if (configData->lastTime==0){
         configData->lastTime=callTime*1E-9;
         v3SetZero(configData->currentHeading_N);
@@ -179,6 +179,6 @@ void Update_opNavPoint(OpNavPointConfig *configData, uint64_t callTime,
 
     /* write the Guidance output message */
     AttGuidMsg_C_write(&configData->attGuidanceOutBuffer, &configData->attGuidanceOutMsg, moduleID, callTime);
-    
+
     return;
 }

--- a/src/fswAlgorithms/attGuidance/rasterManager/rasterManager.c
+++ b/src/fswAlgorithms/attGuidance/rasterManager/rasterManager.c
@@ -18,10 +18,10 @@
  */
 /*
  Inertial 3D Spin Module
- 
+
  * University of Colorado, Autonomous Vehicle Systems (AVS) Lab
  * Unpublished Copyright (c) 2012-2015 University of Colorado, All Rights Reserved
- 
+
  */
 
 #include "fswAlgorithms/attGuidance/rasterManager/rasterManager.h"
@@ -76,12 +76,8 @@ void Update_rasterManager(rasterManagerConfig *configData, uint64_t callTime, in
                configData->attOutSet.rate[2]);
         _bskLog(configData->bskLogger, BSK_INFORMATION, info);
     }
-    
+
     AttStateMsg_C_write(&configData->attOutSet, &configData->attStateOutMsg, moduleID, callTime);
 
     return;
 }
-
-
-
-

--- a/src/fswAlgorithms/attGuidance/rasterManager/rasterManager.c
+++ b/src/fswAlgorithms/attGuidance/rasterManager/rasterManager.c
@@ -27,9 +27,6 @@
 #include "fswAlgorithms/attGuidance/rasterManager/rasterManager.h"
 #include <string.h>
 #include <stdio.h>
-#include <math.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /* Support files.  Be sure to use the absolute path relative to Basilisk directory. */
 #include "architecture/utilities/linearAlgebra.h"

--- a/src/fswAlgorithms/attGuidance/simpleDeadband/simpleDeadband.c
+++ b/src/fswAlgorithms/attGuidance/simpleDeadband/simpleDeadband.c
@@ -23,13 +23,7 @@
 
 /* modify the path to reflect the new module names */
 #include "fswAlgorithms/attGuidance/simpleDeadband/simpleDeadband.h"
-#include <string.h>
 #include <math.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/macroDefinitions.h"
-
-/* update this include to reflect the required module input messages */
-#include "fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h"
 
 
 

--- a/src/fswAlgorithms/attGuidance/simpleDeadband/simpleDeadband.c
+++ b/src/fswAlgorithms/attGuidance/simpleDeadband/simpleDeadband.c
@@ -18,7 +18,7 @@
  */
 /*
     Attitude Tracking simple Module
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -77,10 +77,10 @@ void Update_simpleDeadband(simpleDeadbandConfig *configData, uint64_t callTime, 
     /*! - Evaluate average simple in attitude and rates */
     configData->attError = 4.0 * atan(v3Norm(configData->attGuidOut.sigma_BR));
     configData->rateError = v3Norm(configData->attGuidOut.omega_BR_B);
-    
+
     /*! - Check whether control should be ON or OFF */
     applyDBLogic_simpleDeadband(configData);
-    
+
     /*! - Write output guidance message and update module knowledge of control status*/
     AttGuidMsg_C_write(&configData->attGuidOut, &configData->attGuidOutMsg, moduleID, callTime);
     return;
@@ -96,7 +96,7 @@ void applyDBLogic_simpleDeadband(simpleDeadbandConfig *configData)
 {
     uint32_t areErrorsBelowUpperThresh = (configData->attError < configData->outerAttThresh && configData->rateError < configData->outerRateThresh);
     uint32_t areErrorsBelowLowerThresh = (configData->attError < configData->innerAttThresh && configData->rateError < configData->innerRateThresh);
-    
+
     if (areErrorsBelowUpperThresh)
     {
         if ((areErrorsBelowLowerThresh == 1) || ((areErrorsBelowLowerThresh == 0) && configData->wasControlOff))
@@ -110,7 +110,3 @@ void applyDBLogic_simpleDeadband(simpleDeadbandConfig *configData)
         }
     } else { configData->wasControlOff = 0; }
 }
-
-
-
-

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.c
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.c
@@ -33,7 +33,7 @@
 void SelfInit_sunSafePoint(sunSafePointConfig *configData, int64_t moduleID)
 {
     AttGuidMsg_C_init(&configData->attGuidanceOutMsg);
-    
+
 }
 
 
@@ -115,7 +115,7 @@ void Update_sunSafePoint(sunSafePointConfig *configData, uint64_t callTime,
         configData->sunAngleErr = safeAcos(ctSNormalized);
 
         /*
-            Compute the heading error relative to the sun direction vector 
+            Compute the heading error relative to the sun direction vector
          */
         if (configData->sunAngleErr < configData->smallAngle) {
             /* sun heading and desired body axis are essentially aligned.  Set attitude error to zero. */
@@ -150,6 +150,6 @@ void Update_sunSafePoint(sunSafePointConfig *configData, uint64_t callTime,
 
     /* write the Guidance output message */
     AttGuidMsg_C_write(&configData->attGuidanceOutBuffer, &configData->attGuidanceOutMsg, moduleID, callTime);
-    
+
     return;
 }

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.c
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.c
@@ -22,7 +22,6 @@
 #include "fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/astroConstants.h"
 
 /*! This method initializes the configData for the sun safe attitude guidance.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/attGuidance/sunSafePointCpp/sunSafePointCpp.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePointCpp/sunSafePointCpp.cpp
@@ -19,7 +19,6 @@
 
 #include "sunSafePointCpp.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <math.h>

--- a/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.c
+++ b/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.c
@@ -26,14 +26,11 @@
 #include "fswAlgorithms/attGuidance/velocityPoint/velocityPoint.h"
 #include <string.h>
 #include <math.h>
-#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /* Support files.  Be sure to use the absolute path relative to Basilisk directory. */
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/orbitalMotion.h"
-#include "architecture/utilities/astroConstants.h"
 
 
 /*! self init method

--- a/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.c
+++ b/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.c
@@ -17,9 +17,9 @@
 
  */
 /*
- 
+
  Velocity Pointing Guidance Module
- 
+
  */
 
 
@@ -83,7 +83,7 @@ void Update_velocityPoint(velocityPointConfig *configData, uint64_t callTime, in
     }
     navData = NavTransMsg_C_read(&configData->transNavInMsg);
 
-    
+
     /*! - Compute and store output message */
     computeVelocityPointingReference(configData,
                                      navData.r_BN_N,
@@ -91,7 +91,7 @@ void Update_velocityPoint(velocityPointConfig *configData, uint64_t callTime, in
                                      primPlanet.r_BdyZero_N,
                                      primPlanet.v_BdyZero_N,
                                      &attRefOut);
-    
+
     AttRefMsg_C_write(&attRefOut, &configData->attRefOutMsg, moduleID, callTime);
 
     return;
@@ -106,13 +106,13 @@ void computeVelocityPointingReference(velocityPointConfig *configData,
                                       AttRefMsgPayload *attRefOut)
 {
     double  dcm_RN[3][3];            /* DCM from inertial to reference frame */
-    
+
     double  r[3];                    /* relative position vector of the spacecraft with respect to the orbited planet */
     double  v[3];                    /* relative velocity vector of the spacecraft with respect to the orbited planet  */
     double  h[3];                    /* orbit angular momentum vector */
     double  rm;                      /* orbit radius */
     double  hm;                      /* module of the orbit angular momentum vector */
-    
+
     double  dfdt;                    /* rotational rate of the orbit frame */
     double  ddfdt2;                  /* rotational acceleration of the frame */
     double  omega_RN_R[3];           /* reference angular velocity vector in Reference frame R components */
@@ -122,7 +122,7 @@ void computeVelocityPointingReference(velocityPointConfig *configData,
     double  temp33[3][3];
     double  temp;
     double  denom;
-    
+
     /* zero the reference rate and acceleration vectors */
     v3SetZero(omega_RN_R);
     v3SetZero(domega_RN_R);
@@ -130,16 +130,16 @@ void computeVelocityPointingReference(velocityPointConfig *configData,
     /* Compute relative position and velocity of the spacecraft with respect to the main celestial body */
     v3Subtract(r_BN_N, celBdyPositonVector, r);
     v3Subtract(v_BN_N, celBdyVelocityVector, v);
-    
+
     /* Compute RN */
     v3Normalize(v, dcm_RN[1]);
     v3Cross(r, v, h);
     v3Normalize(h, dcm_RN[2]);
     v3Cross(dcm_RN[1], dcm_RN[2], dcm_RN[0]);
-    
+
     /* Compute R-frame orientation */
     C2MRP(dcm_RN, attRefOut->sigma_RN);
-    
+
     /* Compute R-frame inertial rate and acceleration */
     rm = v3Norm(r);
     hm = v3Norm(h);

--- a/src/fswAlgorithms/attGuidance/waypointReference/waypointReference.cpp
+++ b/src/fswAlgorithms/attGuidance/waypointReference/waypointReference.cpp
@@ -19,8 +19,6 @@
 #include "fswAlgorithms/attGuidance/waypointReference/waypointReference.h"
 #include <sstream>
 #include <string>
-#include <string.h>
-#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"

--- a/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.c
+++ b/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.c
@@ -21,8 +21,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for the nominal delta-V maneuver guidance.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.c
+++ b/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.c
@@ -51,8 +51,8 @@ void Reset_dvGuidance(dvGuidanceConfig *configData, uint64_t callTime,
     return;
 }
 
-/*! This method takes its own internal variables and creates an output attitude 
-    command to use for burn execution.  It also flags whether the burn should 
+/*! This method takes its own internal variables and creates an output attitude
+    command to use for burn execution.  It also flags whether the burn should
     be happening or not.
  @return void
  @param configData The configuration data associated with the delta-V maneuver guidance
@@ -106,7 +106,6 @@ void Update_dvGuidance(dvGuidanceConfig *configData, uint64_t callTime,
 
     /*! - Write the output message */
     AttRefMsg_C_write(&attCmd, &configData->attRefOutMsg, moduleID, callTime);
-    
+
     return;
 }
-

--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.c
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.c
@@ -135,5 +135,3 @@ void Update_dvExecuteGuidance(dvExecuteGuidanceConfig *configData, uint64_t call
 
     return;
 }
-
-

--- a/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.c
+++ b/src/fswAlgorithms/dvGuidance/dvExecuteGuidance/dvExecuteGuidance.c
@@ -22,7 +22,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for the nominal delta-V maneuver guidance.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/effectorInterfaces/errorConversion/dvAttEffect.c
+++ b/src/fswAlgorithms/effectorInterfaces/errorConversion/dvAttEffect.c
@@ -38,8 +38,8 @@ void SelfInit_dvAttEffect(dvAttEffectConfig *configData, int64_t moduleID)
     {
         THRArrayOnTimeCmdMsg_C_init(&configData->thrGroups[i].thrOnTimeOutMsg);
     }
- 
-    
+
+
 }
 
 /*! This method resets the module.
@@ -79,13 +79,13 @@ void Update_dvAttEffect(dvAttEffectConfig *configData, uint64_t callTime,
 
     /*! - Read the input requested torque from the feedback controller*/
     cntrRequest = CmdTorqueBodyMsg_C_read(&configData->cmdTorqueBodyInMsg);
-    
+
     for(i=0; i<configData->numThrGroups; i=i+1)
     {
         computeSingleThrustBlock(&(configData->thrGroups[i]), callTime,
             &cntrRequest, moduleID);
     }
-    
+
     return;
 }
 
@@ -97,16 +97,16 @@ CmdTorqueBodyMsgPayload *contrReq, int64_t moduleID)
     effPairs sortPairs[MAX_EFF_CNT];
     uint32_t i;
     double localRequest[3];
-    
+
     v3Copy(contrReq->torqueRequestBody, localRequest);      /* to generate a positive torque onto the spacecraft */
     mMultV(thrData->thrOnMap, thrData->numEffectors, 3,
            localRequest, unSortOnTime);
-    
+
     for(i=0; i<thrData->numEffectors; i=i+1)
     {
         unSortOnTime[i] = unSortOnTime[i] + thrData->nomThrustOn;
     }
-    
+
     for(i=0; i<thrData->numEffectors; i=i+1)
     {
         if(unSortOnTime[i] < thrData->minThrustRequest)
@@ -114,7 +114,7 @@ CmdTorqueBodyMsgPayload *contrReq, int64_t moduleID)
             unSortOnTime[i] = 0.0;
         }
     }
-    
+
     for(i=0; i<thrData->numEffectors; i++)
     {
         unSortPairs[i].onTime = unSortOnTime[i];

--- a/src/fswAlgorithms/effectorInterfaces/errorConversion/dvAttEffect.c
+++ b/src/fswAlgorithms/effectorInterfaces/errorConversion/dvAttEffect.c
@@ -21,7 +21,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for the sun safe ACS control.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/effectorInterfaces/errorConversion/sunSafeACS.c
+++ b/src/fswAlgorithms/effectorInterfaces/errorConversion/sunSafeACS.c
@@ -65,6 +65,6 @@ void Update_sunSafeACS(sunSafeACSConfig *configData, uint64_t callTime,
     cntrRequest = CmdTorqueBodyMsg_C_read(&configData->cmdTorqueBodyInMsg);
     computeSingleThrustBlock(&(configData->thrData), callTime,
                              &cntrRequest, moduleID);
-    
+
     return;
 }

--- a/src/fswAlgorithms/effectorInterfaces/errorConversion/sunSafeACS.c
+++ b/src/fswAlgorithms/effectorInterfaces/errorConversion/sunSafeACS.c
@@ -18,10 +18,8 @@
  */
 
 #include "fswAlgorithms/effectorInterfaces/errorConversion/sunSafeACS.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for the sun safe ACS control.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
@@ -21,7 +21,6 @@
 /* modify the path to reflect the new module names */
 #include "hingedRigidBodyPIDMotor.h"
 #include "string.h"
-#include <math.h>
 
 /* Support files */
 #include "architecture/utilities/macroDefinitions.h"

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.c
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.c
@@ -22,7 +22,6 @@
 
 /*! Import other required files */
 #include <math.h>
-#include <stdlib.h>
 #include <stdbool.h>
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.c
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.c
@@ -22,7 +22,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
-#include <math.h>
 
 /*!
  \verbatim embed:rst

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.c
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.c
@@ -95,8 +95,8 @@ void Reset_rwNullSpace(rwNullSpaceConfig *configData, uint64_t callTime,
 
 }
 
-/*! This method takes the input reaction wheel commands as well as the observed 
-    reaction wheel speeds and balances the commands so that the overall vehicle 
+/*! This method takes the input reaction wheel commands as well as the observed
+    reaction wheel speeds and balances the commands so that the overall vehicle
 	momentum is minimized.
  @return void
  @param configData The configuration data associated with the null space control
@@ -113,7 +113,7 @@ void Update_rwNullSpace(rwNullSpaceConfig *configData, uint64_t callTime,
                                                        the control and null motion torques */
 	double dVector[MAX_EFF_CNT];                   /* [Nm]  null motion wheel speed control array */
     double DeltaOmega[MAX_EFF_CNT];                /* [r/s] difference in RW speeds */
-    
+
     /* zero all output message containers prior to evaluation */
     finalControl = ArrayMotorTorqueMsg_C_zeroMsgPayload();
 
@@ -135,7 +135,7 @@ void Update_rwNullSpace(rwNullSpaceConfig *configData, uint64_t callTime,
     /* compute the RW null space motor torque solution to reduce the wheel speeds */
 	mMultV(configData->tau, configData->numWheels, configData->numWheels,
 		dVector, finalControl.motorTorque);
-    
+
     /* add the null motion RW torque solution to the RW feedback control torque solution */
 	vAdd(finalControl.motorTorque, configData->numWheels,
 		cntrRequest.motorTorque, finalControl.motorTorque);

--- a/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.c
+++ b/src/fswAlgorithms/effectorInterfaces/stepperMotorProfiler/stepperMotorProfiler.c
@@ -18,7 +18,6 @@
 
 #include "stepperMotorProfiler.h"
 #include <stdbool.h>
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.c
@@ -23,8 +23,6 @@
 
 #include "fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <stdio.h>
-#include <string.h>
 
 
 

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.c
@@ -18,7 +18,7 @@
  */
 /*
     Thrust Firing Remainder
- 
+
  */
 
 #include "fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.h"
@@ -147,7 +147,7 @@ void Update_thrFiringRemainder(thrFiringRemainderConfig *configData, uint64_t ca
 
 		/*! - Set the output data for each thruster */
 		thrOnTimeOut.OnTimeRequest[i] = onTime[i];
-		
+
 	}
 
     /*! - write the moduel output message */

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.c
@@ -23,7 +23,6 @@
 
 #include "fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <stdio.h>
 #include <string.h>
 
 

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.c
@@ -18,7 +18,7 @@
  */
 /*
     Thrust Firing Schmitt
- 
+
  */
 
 #include "fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.h"

--- a/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
@@ -18,7 +18,7 @@
  */
 /*
     FSW MODULE thrMomentumDumping
- 
+
  */
 
 #include "fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.h"

--- a/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
@@ -25,7 +25,6 @@
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include <string.h>
-#include <stdio.h>
 
 
 /*!

--- a/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.c
@@ -20,9 +20,7 @@
 #include "fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
-#include <math.h>
 
 /*! This method initializes the configData for the thruster-based RW desat module.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.c
@@ -104,7 +104,7 @@ void Update_thrustRWDesat(thrustRWDesatConfig *configData, uint64_t callTime,
 	double currentMatch;          /* Assessment of the current match */
     double fireValue;             /* Amount of time to fire the jet for */
 	THRArrayOnTimeCmdMsgPayload outputData;    /* Local output firings */
-  
+
     /*! - If we haven't met the cooldown threshold, do nothing */
 	if ((callTime - configData->previousFiring)*1.0E-9 <
 		configData->thrFiringPeriod)
@@ -114,12 +114,12 @@ void Update_thrustRWDesat(thrustRWDesatConfig *configData, uint64_t callTime,
 
     /*! - Read the input rwheel speeds from the reaction wheels*/
     rwSpeeds = RWSpeedMsg_C_read(&configData->rwSpeedInMsg);
-    
+
     /*! - Accumulate the total momentum vector we want to apply (subtract speed vectors)*/
 	v3SetZero(observedSpeedVec);
 	for (i = 0; i < configData->numRWAs; i++)
 	{
-		v3Scale(rwSpeeds.wheelSpeeds[i], &(configData->rwAlignMap[i * 3]), 
+		v3Scale(rwSpeeds.wheelSpeeds[i], &(configData->rwAlignMap[i * 3]),
 			singleSpeedVec);
 		v3Subtract(observedSpeedVec, singleSpeedVec, observedSpeedVec);
 	}
@@ -130,9 +130,9 @@ void Update_thrustRWDesat(thrustRWDesatConfig *configData, uint64_t callTime,
 		return;
 	}
 
-    /*! - Iterate through the list of thrusters and find the "best" match for the 
-          observed momentum vector that does not continue to perturb the velocity 
-          in the same direction as previous aggregate firings.  Only do this once we have 
+    /*! - Iterate through the list of thrusters and find the "best" match for the
+          observed momentum vector that does not continue to perturb the velocity
+          in the same direction as previous aggregate firings.  Only do this once we have
 		  removed the specified momentum accuracy from the current direction.*/
 	selectedThruster = -1;
 	bestMatch = 0.0;
@@ -157,9 +157,9 @@ void Update_thrustRWDesat(thrustRWDesatConfig *configData, uint64_t callTime,
 				configData->currDMDir);
 		}
 	}
-    
+
     /*! - Zero out the thruster commands prior to setting the selected thruster.
-          Only apply thruster firing if the best match is non-zero.  Find the thruster 
+          Only apply thruster firing if the best match is non-zero.  Find the thruster
 		  that best matches the current specified direction.
     */
     outputData = THRArrayOnTimeCmdMsg_C_zeroMsgPayload();
@@ -178,7 +178,7 @@ void Update_thrustRWDesat(thrustRWDesatConfig *configData, uint64_t callTime,
 			bestMatch = fireValue - currentMatch;
 		}
 	}
-    /*! - If we have a valid match: 
+    /*! - If we have a valid match:
           - Set firing based on the best counter to the observed momentum.
           - Saturate based on the maximum allowable firing
           - Accumulate impulse and the total firing
@@ -203,4 +203,3 @@ void Update_thrustRWDesat(thrustRWDesatConfig *configData, uint64_t callTime,
 
     return;
 }
-

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/thrusterPlatformState.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/thrusterPlatformState.c
@@ -18,7 +18,6 @@
  */
 
 #include "thrusterPlatformState.h"
-#include <math.h>
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/thrusterPlatformState.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/thrusterPlatformState.c
@@ -95,4 +95,3 @@ void Update_thrusterPlatformState(thrusterPlatformStateConfig *configData, uint6
     /*! write output thruster config msg */
     THRConfigMsg_C_write(&thrusterConfigBOut, &configData->thrusterConfigBOutMsg, moduleID, callTime);
 }
-

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.c
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.c
@@ -18,7 +18,7 @@
  */
 /*
     FSW Electrostatic Tractor Control
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -79,12 +79,12 @@ void Reset_etSphericalControl(etSphericalControlConfig *configData, uint64_t cal
         _bskLog(configData->bskLogger, BSK_ERROR, "Error: etSphericalControl.eForceInMsg wasn't connected.");
     }
     // check if input parameters are valid
-    
+
     // L_r must be a positive value
     if (configData->L_r <= 0.0) {
         _bskLog(configData->bskLogger, BSK_ERROR, "Error in etSphericalControl: L_r must be set to a positive value.");
     }
-    
+
     // m_T and m_D must be positive and non-zero
     if (VehicleConfigMsg_C_read(&configData->servicerVehicleConfigInMsg).massSC <= 0.0) {
         _bskLog(configData->bskLogger, BSK_ERROR, "Error in etSphericalControl: servicer mass must be set to a positive value.");
@@ -127,7 +127,7 @@ void Update_etSphericalControl(etSphericalControlConfig *configData, uint64_t ca
     // out
     CmdForceInertialMsgPayload forceInertialOutMsgBuffer;
     CmdForceBodyMsgPayload forceBodyOutMsgBuffer;
-    
+
     // - always zero the output buffer first
     forceInertialOutMsgBuffer = CmdForceInertialMsg_C_zeroMsgPayload();
     forceBodyOutMsgBuffer = CmdForceBodyMsg_C_zeroMsgPayload();
@@ -139,10 +139,10 @@ void Update_etSphericalControl(etSphericalControlConfig *configData, uint64_t ca
     servicerVehicleConfigInMsgBuffer = VehicleConfigMsg_C_read(&configData->servicerVehicleConfigInMsg);
     debrisVehicleConfigInMsgBuffer = VehicleConfigMsg_C_read(&configData->debrisVehicleConfigInMsg);
     eForceInMsgBuffer = CmdForceInertialMsg_C_read(&configData->eForceInMsg);
-    
+
     // - calculate control force
     calc_RelativeMotionControl(configData, servicerTransInMsgBuffer, debrisTransInMsgBuffer, servicerAttInMsgBuffer, servicerVehicleConfigInMsgBuffer, debrisVehicleConfigInMsgBuffer, eForceInMsgBuffer, &forceInertialOutMsgBuffer, &forceBodyOutMsgBuffer);
-    
+
     // - write the module output messages
     CmdForceInertialMsg_C_write(&forceInertialOutMsgBuffer, &configData->forceInertialOutMsg, moduleID, callTime);
     CmdForceBodyMsg_C_write(&forceBodyOutMsgBuffer, &configData->forceBodyOutMsg, moduleID, callTime);
@@ -172,7 +172,7 @@ void calc_RelativeMotionControl(etSphericalControlConfig *configData, NavTransMs
                                 CmdForceBodyMsgPayload *forceBodyOutMsgBuffer)
 {
     // relative motion control according to "Relative Motion Control For Two-Spacecraft Electrostatic Orbit Corrections" https://doi.org/10.2514/1.56118
-    
+
     // DCMs
     double dcm_HN[3][3]; // [HN] from inertial frame to Hill frame
     double dcm_NH[3][3]; // [NH] from Hill frame to inertial frame
@@ -236,7 +236,7 @@ void calc_RelativeMotionControl(etSphericalControlConfig *configData, NavTransMs
     rv2elem(mu, servicerTransInMsgBuffer.r_BN_N, servicerTransInMsgBuffer.v_BN_N, &elements);
     double a = elements.a;
     double n = sqrt(mu/a/a/a); // mean motion
-    
+
     double Fvector[3];
     v3Set(1./4.*L*(n*n*(-6.*cos(2.*theta)*cos(phi)*cos(phi)+5.*cos(2.*phi)+1.)+4.*thetaDot*cos(phi)*cos(phi)*(2.*n+thetaDot)+4.*phiDot*phiDot),
           (3.*n*n*sin(theta)*cos(theta)+2.*phiDot*tan(phi)*(n+thetaDot))-2.*LDot/L*(n+thetaDot),
@@ -270,7 +270,7 @@ void calc_RelativeMotionControl(etSphericalControlConfig *configData, NavTransMs
     v3Subtract(PK, Fvector, PKF);
     double u_S[3]; // feedback control acceleration
     m33MultV3( GmatrixInv, PKF, u_S);   // u_S = [G]^-1*(-[P]*XDot-[K]*(X-X_r)-[F])
-    
+
     // control thrust force
     double m_T; // mass of servicer
     double m_D; // mass of debris
@@ -291,6 +291,6 @@ void calc_RelativeMotionControl(etSphericalControlConfig *configData, NavTransMs
     m33MultV3(dcm_TN, T_N, T_T);
     v3Copy(T_N, forceInertialOutMsgBuffer->forceRequestInertial);
     v3Copy(T_T, forceBodyOutMsgBuffer->forceRequestBody);
-    
+
     return;
 }

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.c
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.c
@@ -25,14 +25,12 @@
 #include "etSphericalControl.h"
 
 #include <math.h>
-#include <stdlib.h>
 #include <string.h>
 
 /*
  Pull in support files from other modules.  Be sure to use the absolute path relative to Basilisk directory.
  */
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/orbitalMotion.h"
 #include "architecture/utilities/rigidBodyKinematics.h"

--- a/src/fswAlgorithms/formationFlying/hillStateConverter/hillStateConverter.c
+++ b/src/fswAlgorithms/formationFlying/hillStateConverter/hillStateConverter.c
@@ -68,9 +68,9 @@ void Update_hillStateConverter(HillStateConverterConfig *configData, uint64_t ca
     HillRelStateMsgPayload hillStateOut;
     chiefStateIn = NavTransMsg_C_read(&configData->chiefStateInMsg);
     depStateIn = NavTransMsg_C_read(&configData->depStateInMsg);
-    
+
     hillStateOut = HillRelStateMsg_C_zeroMsgPayload();
-    
+
     /*! - Add the module specific code */
     rv2hill(chiefStateIn.r_BN_N, chiefStateIn.v_BN_N,
             depStateIn.r_BN_N,  depStateIn.v_BN_N,

--- a/src/fswAlgorithms/formationFlying/hillStateConverter/hillStateConverter.c
+++ b/src/fswAlgorithms/formationFlying/hillStateConverter/hillStateConverter.c
@@ -19,10 +19,8 @@
 
 /* modify the path to reflect the new module names */
 #include "hillStateConverter.h"
-#include "string.h"
 
 // Internal utilities
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/orbitalMotion.h"
 
 

--- a/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.c
+++ b/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.c
@@ -20,11 +20,9 @@
 #include "meanOEFeedback.h"
 
 #include <math.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/orbitalMotion.h"
 #include "architecture/utilities/rigidBodyKinematics.h"

--- a/src/fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.c
@@ -18,12 +18,10 @@
  */
 
 #include <string.h>
-#include <math.h>
 #include "fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/astroConstants.h"
 
 /*! This method initializes the configData for the spacecraft pointing module
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.c
@@ -72,14 +72,14 @@ void Reset_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t cal
     v3Normalize(A_z_B, dcm_AB[2]);
     C2MRP(dcm_AB, sigma_AB);
     v3Scale(-1, sigma_AB, configData->sigma_BA);
-    
+
     /* Set initial values of the sigma and omega of the previous timestep to zero. */
     v3SetZero(configData->old_sigma_RN);
     v3SetZero(configData->old_omega_RN_N);
-    
+
     /* Set the numerical error flag to zero. */
     configData->i = 0;
-    
+
     return;
 }
 
@@ -130,7 +130,7 @@ void Update_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t ca
 
     /* Find the vector that points from the deputy spacecraft to the chief spacecraft. */
     v3Subtract(chiefTransMsg.r_BN_N, deputyTransMsg.r_BN_N, rho_N);
-    
+
     /* Build a coordinate system around the vector that points from the deputy to the chief and
         and determine the orientation of this R-frame with respect to the N-frame. */
     v3Normalize(rho_N, dcm_RN[0]);
@@ -161,44 +161,44 @@ void Update_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t ca
     /* Find the timestep of the simulation. */
     dt = (callTime - configData->priorTime) * NANO2SEC;
     configData->priorTime = callTime;
-        
+
     /* sigma_dot_RN is calculated by dividing the difference in sigma by the timestep. */
     v3Scale((1.0/dt), delta_sigma_RN, sigma_dot_RN);
-        
+
     /* Due to the fact that sigma_dot_RN is actually the average increase in sigma over the timeperiod between t-1 and t,
        it turned out that the bevaviour of the simulation significantly improves in case the average of the B-matrix of old_sigma_RN
        and new_sigma_RN is taken, as well as the average of 1/((1+sigma^2)^2) (see Schaub and Junkins eq. 3.163). */
     old_sigma_RN_squared = configData->old_sigma_RN[0]*configData->old_sigma_RN[0] + configData->old_sigma_RN[1]*configData->old_sigma_RN[1] + configData->old_sigma_RN[2]*configData->old_sigma_RN[2];
     sigma_RN_squared = sigma_RN[0]*sigma_RN[0] + sigma_RN[1]*sigma_RN[1] + sigma_RN[2]*sigma_RN[2];
-        
+
     m33Set(1.0 - old_sigma_RN_squared + 2.0*configData->old_sigma_RN[0]*configData->old_sigma_RN[0], 2.0*(configData->old_sigma_RN[0]*configData->old_sigma_RN[1] - configData->old_sigma_RN[2]), 2.0*(configData->old_sigma_RN[0]*configData->old_sigma_RN[2] + configData->old_sigma_RN[1]),
         2.0*(configData->old_sigma_RN[1]*configData->old_sigma_RN[0] + configData->old_sigma_RN[2]), 1.0 - old_sigma_RN_squared + 2.0*configData->old_sigma_RN[1]*configData->old_sigma_RN[1], 2.0*(configData->old_sigma_RN[1]*configData->old_sigma_RN[2] - configData->old_sigma_RN[0]),
         2.0*(configData->old_sigma_RN[2]*configData->old_sigma_RN[0] - configData->old_sigma_RN[1]), 2.0*(configData->old_sigma_RN[2]*configData->old_sigma_RN[1] + configData->old_sigma_RN[0]), 1.0 - old_sigma_RN_squared + 2.0*configData->old_sigma_RN[2]*configData->old_sigma_RN[2],
         old_B_sigma_RN);
-        
+
     m33Set(1.0 - sigma_RN_squared + 2.0*sigma_RN[0]*sigma_RN[0], 2.0*(sigma_RN[0]*sigma_RN[1] - sigma_RN[2]), 2.0*(sigma_RN[0]*sigma_RN[2] +         sigma_RN[1]),
         2.0*(sigma_RN[1]*sigma_RN[0] + sigma_RN[2]), 1.0 - sigma_RN_squared + 2.0*sigma_RN[1]*sigma_RN[1], 2.0*(sigma_RN[1]*sigma_RN[2] - sigma_RN[0]),
         2.0*(sigma_RN[2]*sigma_RN[0] - sigma_RN[1]), 2.0*(sigma_RN[2]*sigma_RN[1] + sigma_RN[0]), 1.0 - sigma_RN_squared + 2.0*sigma_RN[2]*sigma_RN[2],
         B_sigma_RN);
-        
+
     /* Taking the average between entries of the old sigma matrix and the new sigma matrix. */
     m33Set((old_B_sigma_RN[0][0] + B_sigma_RN[0][0])/2, (old_B_sigma_RN[0][1] + B_sigma_RN[0][1])/2, (old_B_sigma_RN[0][2] + B_sigma_RN[0][2])/2,
            (old_B_sigma_RN[1][0] + B_sigma_RN[1][0])/2, (old_B_sigma_RN[1][1] + B_sigma_RN[1][1])/2, (old_B_sigma_RN[1][2] + B_sigma_RN[1][2])/2,
            (old_B_sigma_RN[2][0] + B_sigma_RN[2][0])/2, (old_B_sigma_RN[2][1] + B_sigma_RN[2][1])/2, (old_B_sigma_RN[2][2] + B_sigma_RN[2][2])/2,
            B_sigma_RN);
-        
+
     /* Find the angular velocity of the R-frame with respect to the N-frame according to Schaub and Junkin's chapter about MRPs. */
     m33Transpose(B_sigma_RN, B_trans);
     average_scale = 0.5*(1.0/((1.0 + sigma_RN_squared)*(1.0 + sigma_RN_squared)) + 1.0/((1.0 + old_sigma_RN_squared)*(1.0 + old_sigma_RN_squared)));
     m33Scale(average_scale, B_trans, B_sigma_RN_inv);
     m33MultV3(B_sigma_RN_inv, sigma_dot_RN, omega_RN_R);
     v3Scale(4.0, omega_RN_R, omega_RN_R);
-        
+
     /* Convert omega_RN_R to omega_RN_N. */
     v3Scale(-1, sigma_RN, sigma_NR);
     MRP2C(sigma_NR, dcm_NR);
     m33MultV3(dcm_NR, omega_RN_R, omega_RN_N);
-    
+
     /* Determine domega_RN_N. */
     v3Subtract(omega_RN_N, configData->old_omega_RN_N, delta_omega_RN_N);
     v3Scale((1.0/dt), delta_omega_RN_N, domega_RN_N);
@@ -206,7 +206,7 @@ void Update_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t ca
 
     /* Copy the sigma_RN variable to the old_sigma_RN variable. */
     v3Copy(sigma_RN, configData->old_sigma_RN);
-    
+
     /* Due to the numerical method used the first result from omega and the first two results of domega are incorrect.
         For this reason, these values are set to zero. Take into account that the first data point is an initialization
         datapoint. This is equal to zero for all parameters. So the actual simulation only starts after this first initialization
@@ -218,7 +218,7 @@ void Update_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t ca
         v3SetZero(domega_RN_N);
         configData->i += 1;
     }
-    
+
     /* One of the requirements for this module is that the user should be able to fill in a vector within the B-frame that points at
         the antenna. For this reason it is necessary to add the orientation of the B-frame with respect to the A-frame to the R-frame
         orientation with respect to the N-frame (add sigma_BA to sigma_RN). This results in the orientation of the R1-frame with respect
@@ -228,7 +228,7 @@ void Update_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t ca
     v3Copy(sigma_R1N, configData->attReferenceOutBuffer.sigma_RN);
     v3Copy(omega_RN_N, configData->attReferenceOutBuffer.omega_RN_N);
     v3Copy(domega_RN_N, configData->attReferenceOutBuffer.domega_RN_N);
-    
+
     /* write the Guidance output message */
     AttRefMsg_C_write(&configData->attReferenceOutBuffer, &configData->attReferenceOutMsg, moduleID, callTime);
     return;

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <math.h>
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 
 

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
@@ -66,7 +66,7 @@ void Reset_spacecraftReconfig(spacecraftReconfigConfig *configData, uint64_t cal
 
     // zero the burn info buffer
     configData->burnArrayInfoOutMsgBuffer = ReconfigBurnArrayInfoMsg_C_zeroMsgPayload();
-  
+
     configData->prevCallTime    = 0;
     configData->tCurrent        = 0.0;
     configData->thrustOnFlag    = 0;
@@ -146,7 +146,7 @@ void Update_spacecraftReconfig(spacecraftReconfigConfig *configData, uint64_t ca
 void UpdateManeuver(spacecraftReconfigConfig *configData, NavTransMsgPayload chiefTransMsgBuffer,
                      NavTransMsgPayload deputyTransMsgBuffer, AttRefMsgPayload attRefInMsgBuffer,
                      THRArrayConfigMsgPayload thrustConfigMsgBuffer, VehicleConfigMsgPayload vehicleConfigMsgBuffer,
-                     AttRefMsgPayload *attRefOutMsgBuffer, THRArrayOnTimeCmdMsgPayload *thrustOnMsgBuffer, 
+                     AttRefMsgPayload *attRefOutMsgBuffer, THRArrayOnTimeCmdMsgPayload *thrustOnMsgBuffer,
                      uint64_t callTime, int64_t moduleID)
 {
     /* conversion from r,v to classical orbital elements */
@@ -188,7 +188,7 @@ void UpdateManeuver(spacecraftReconfigConfig *configData, NavTransMsgPayload chi
         }
     }else if(configData->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 1) {
         double t_left = configData->burnArrayInfoOutMsgBuffer.burnArray[1].t - configData->tCurrent; // remaining time until second burn
-        if(configData->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 && 
+        if(configData->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 &&
            configData->tCurrent < (configData->burnArrayInfoOutMsgBuffer.burnArray[0].t+configData->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters))){
             // in this case, first burn is still executed, so first burn attitude is set as target
             v3Copy(configData->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN, attRefOutMsgBuffer->sigma_RN);
@@ -212,11 +212,11 @@ void UpdateManeuver(spacecraftReconfigConfig *configData, NavTransMsgPayload chi
         }
     }else if(configData->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 1){
         double t_left = configData->burnArrayInfoOutMsgBuffer.burnArray[2].t - configData->tCurrent; // remaining time until third burn
-        if(configData->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 2 && 
+        if(configData->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 2 &&
            configData->tCurrent < (configData->burnArrayInfoOutMsgBuffer.burnArray[1].t+configData->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters))){
             // in this case, second burn is still executed, so second burn attitude is set as target
             v3Copy(configData->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN, attRefOutMsgBuffer->sigma_RN);
-        }else if(configData->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 && 
+        }else if(configData->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 &&
            configData->tCurrent < (configData->burnArrayInfoOutMsgBuffer.burnArray[0].t+configData->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters))){
             // in this case, first burn is still executed, so first burn attitude is set as target
             v3Copy(configData->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN, attRefOutMsgBuffer->sigma_RN);
@@ -254,7 +254,7 @@ void UpdateManeuver(spacecraftReconfigConfig *configData, NavTransMsgPayload chi
                 *attRefOutMsgBuffer = attRefInMsgBuffer;
             }else{
                 v3Copy(configData->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN, attRefOutMsgBuffer->sigma_RN);
-            }  
+            }
         }else if(configData->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2){
             if(configData->tCurrent > (configData->burnArrayInfoOutMsgBuffer.burnArray[0].t+configData->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters)) &&
                configData->attRefInIsLinked){
@@ -272,7 +272,7 @@ void UpdateManeuver(spacecraftReconfigConfig *configData, NavTransMsgPayload chi
     if(configData->tCurrent > configData->resetPeriod){
         Reset_spacecraftReconfig(configData, callTime, moduleID);
     }
-    
+
     return;
 }
 
@@ -462,7 +462,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     /* R frame represents a frame where scheduled thrusct direction is aligned with +Z axis */
     /* dcm_TR is used to align scheduled thrust direction with configured thruster direction */
     /* by multiplying two dcms dcm_TR and dcm_RN, target attitude is calculated */
-    
+
     /* calculate dcm_TR (this is common in three burns) */
     double thruster_dir[3];
     double ep_vec[3];
@@ -482,7 +482,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     double ep_TR[4] = {cos(acos_dv/2.0),ep_vec[0]*sin(acos_dv/2.0),ep_vec[1]*sin(acos_dv/2.0),ep_vec[2]*sin(acos_dv/2.0)};
     double dcm_TR[3][3];
     EP2C(ep_TR,dcm_TR);
-    
+
     /* calculate sigma_dvrtp_RN */
     // calculate dcm_RN
     double M_d_dvrtp = M_d + configData->burnArrayInfoOutMsgBuffer.burnArray[0].t*n;
@@ -519,7 +519,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     double dcm_TN_dvrtp[3][3];
     m33MultM33(dcm_TR,dcm_RN_dvrtp,dcm_TN_dvrtp);
     C2MRP(dcm_TN_dvrtp, configData->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN);
-    
+
     /* calculate sigma_dvrta_RN */
     double M_d_dvrta = M_d + configData->burnArrayInfoOutMsgBuffer.burnArray[1].t*n;
     double E_d_dvrta = M2E(M_d_dvrta, oe_d.e);
@@ -555,7 +555,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     double dcm_TN_dvrta[3][3];
     m33MultM33(dcm_TR,dcm_RN_dvrta,dcm_TN_dvrta);
     C2MRP(dcm_TN_dvrta, configData->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN);
-    
+
     /* calculate sigma_dvn_RN */
     double M_d_dvn = M_d + configData->burnArrayInfoOutMsgBuffer.burnArray[2].t*n;
     double E_d_dvn = M2E(M_d_dvn, oe_d.e);

--- a/src/fswAlgorithms/imageProcessing/centerRadiusCNN/centerRadiusCNN.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerRadiusCNN/centerRadiusCNN.cpp
@@ -24,7 +24,6 @@
  */
 
 /* modify the path to reflect the new module names */
-#include <string.h>
 #include "centerRadiusCNN.h"
 #include <opencv2/dnn/dnn.hpp>
 #include <fstream>

--- a/src/fswAlgorithms/imageProcessing/houghCircles/houghCircles.cpp
+++ b/src/fswAlgorithms/imageProcessing/houghCircles/houghCircles.cpp
@@ -22,7 +22,7 @@
     Note:   This module takes an image and writes out the circles that are found in the image by OpenCV's HoughCricle Transform.
     Author: Thibaud Teil
     Date:   February 13, 2019
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -66,7 +66,7 @@ void HoughCircles::Reset(uint64_t CurrentSimNanos)
     }
 }
 
-/*! This module reads an OpNav image and extracts circle information from its content using OpenCV's HoughCircle Transform. It performs a greyscale, a bur, and a threshold on the image to facilitate circle-finding. 
+/*! This module reads an OpNav image and extracts circle information from its content using OpenCV's HoughCircle Transform. It performs a greyscale, a bur, and a threshold on the image to facilitate circle-finding.
  @return void
  @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
  */
@@ -114,7 +114,7 @@ void HoughCircles::UpdateState(uint64_t CurrentSimNanos)
     cv::cvtColor( imageCV, imageCV, cv::COLOR_BGR2GRAY);
     cv::threshold(imageCV, imageCV, 15, 255, cv::THRESH_BINARY_INV);
     cv::blur(imageCV, blurred, cv::Size(this->blurrSize,this->blurrSize) );
-    
+
     std::vector<cv::Vec4f> circles;
     /*! - Apply the Hough Transform to find the circles*/
     cv::HoughCircles( blurred, circles, cv::HOUGH_GRADIENT, this->dpValue, this->houghMinDist, this->cannyThresh,this->voteThresh, this->houghMinRadius, this->houghMaxRadius );
@@ -136,10 +136,9 @@ void HoughCircles::UpdateState(uint64_t CurrentSimNanos)
         circleBuffer.valid = 1;
         circleBuffer.planetIds[0] = 2;
     }
-    
+
     this->opnavCirclesOutMsg.write(&circleBuffer, this->moduleID, CurrentSimNanos);
 
 //    free(imageBuffer.imagePointer);
     return;
 }
-

--- a/src/fswAlgorithms/imageProcessing/houghCircles/houghCircles.cpp
+++ b/src/fswAlgorithms/imageProcessing/houghCircles/houghCircles.cpp
@@ -26,7 +26,6 @@
  */
 
 /* modify the path to reflect the new module names */
-#include <string.h>
 #include "houghCircles.h"
 
 

--- a/src/fswAlgorithms/imageProcessing/limbFinding/limbFinding.cpp
+++ b/src/fswAlgorithms/imageProcessing/limbFinding/limbFinding.cpp
@@ -26,7 +26,6 @@
  */
 
 /* modify the path to reflect the new module names */
-#include <string.h>
 #include "limbFinding.h"
 
 

--- a/src/fswAlgorithms/imageProcessing/limbFinding/limbFinding.cpp
+++ b/src/fswAlgorithms/imageProcessing/limbFinding/limbFinding.cpp
@@ -22,7 +22,7 @@
     Note:   This module takes an image and writes out a message containing all the pixel points that are on the limb.
     Author: Thibaud Teil
     Date:   September 16, 2019
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -79,7 +79,7 @@ void LimbFinding::UpdateState(uint64_t CurrentSimNanos)
         dirName = this->saveDir + std::to_string(CurrentSimNanos*1E-9) + ".jpg";
     }
     else{dirName = "./"+ std::to_string(CurrentSimNanos*1E-9) + ".jpg";}
-    
+
     /*! - Read in the bitmap*/
     if(this->imageInMsg.isLinked())
     {
@@ -122,7 +122,7 @@ void LimbFinding::UpdateState(uint64_t CurrentSimNanos)
         limbMsg.valid = 1;
         limbMsg.planetIds = 2;
     }
-    
+
     limbMsg.timeTag = (double) this->sensorTimeTag;
     limbMsg.cameraID = imageBuffer.cameraID;
 
@@ -130,4 +130,3 @@ void LimbFinding::UpdateState(uint64_t CurrentSimNanos)
 
     return;
 }
-

--- a/src/fswAlgorithms/opticalNavigation/faultDetection/faultDetection.c
+++ b/src/fswAlgorithms/opticalNavigation/faultDetection/faultDetection.c
@@ -91,7 +91,7 @@ void Update_faultDetection(FaultDetectionData *configData, uint64_t callTime, in
     MRP2C(attInfo.sigma_BN, dcm_BN);
     m33MultM33(dcm_CB, dcm_BN, dcm_NC);
     m33Transpose(dcm_NC, dcm_NC);
-    
+
     /*! Begin fault detection logic */
     /*! - If none of the message contain valid nav data, unvalidate the nav and populate a zero message */
     if (opNavIn1.valid == 0 && opNavIn2.valid == 0){
@@ -128,12 +128,12 @@ void Update_faultDetection(FaultDetectionData *configData, uint64_t callTime, in
         /*! -- Dissimilar mode compares the two measurements: if the mean +/- 3-sigma covariances overlap use the nominal nav solution */
         double faultDirection[3];
         double faultNorm;
-        
+
         /*! Get the direction and norm between the the two measurements in camera frame*/
         v3Subtract(opNavIn2.r_BN_C, opNavIn1.r_BN_C, faultDirection);
         faultNorm = v3Norm(faultDirection);
         v3Normalize(faultDirection, faultDirection);
-        
+
         /*! If the difference between vectors is beyond the covariances, detect a fault and use secondary */
         if (faultNorm > configData->sigmaFault*sqrt((vNorm(opNavIn1.covar_C, 9) + vNorm(opNavIn2.covar_C, 9)))){
             opNavMsgOut = opNavIn2;
@@ -150,7 +150,7 @@ void Update_faultDetection(FaultDetectionData *configData, uint64_t callTime, in
         else if (configData->faultMode==0){
             double P1invX1[3], P2invX2[3], X_C[3], P_C[3][3], P_B[3][3], P_N[3][3];
             double P1inv[3][3], P2inv[3][3];
-            
+
             /*! The covariance merge is given by P = (P1^{-1} + P2^{-1})^{-1} */
             m33Inverse(RECAST3X3 opNavIn1.covar_C, P1inv);
             m33Inverse(RECAST3X3 opNavIn2.covar_C, P2inv);
@@ -163,7 +163,7 @@ void Update_faultDetection(FaultDetectionData *configData, uint64_t callTime, in
             v3Add(P1invX1, P2invX2, X_C);
             m33MultV3(P_C, X_C, X_C);
             v3Copy(X_C, opNavMsgOut.r_BN_C);
-            
+
             /*! Bring all the measurements and covariances into their respective frames */
             m33MultV3(dcm_NC, X_C, opNavMsgOut.r_BN_N);
             mCopy(P_C, 3, 3, opNavMsgOut.covar_C);
@@ -181,7 +181,7 @@ void Update_faultDetection(FaultDetectionData *configData, uint64_t callTime, in
         OpNavMsg_C_write(&opNavMsgOut, &configData->opNavOutMsg, moduleID, callTime);
     }
 
-    
+
     return;
 
 }

--- a/src/fswAlgorithms/opticalNavigation/faultDetection/faultDetection.c
+++ b/src/fswAlgorithms/opticalNavigation/faultDetection/faultDetection.c
@@ -19,7 +19,6 @@
 
 #include <math.h>
 #include <string.h>
-#include <stdlib.h>
 #include "faultDetection.h"
 
 

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.c
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.c
@@ -18,7 +18,6 @@
  */
 
 #include <string.h>
-#include <stdlib.h>
 #include <math.h>
 #include "pixelLineBiasUKF.h"
 #include "architecture/utilities/ukfUtilities.h"

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.c
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.c
@@ -1,12 +1,12 @@
 /*
  ISC License
- 
+
  Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
- 
+
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,7 +14,7 @@
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
  */
 
 #include <string.h>
@@ -58,7 +58,7 @@ void Reset_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTim
     size_t i;
     int32_t badUpdate=0; /* Negative badUpdate is faulty, */
     double tempMatrix[PIXLINE_N_STATES*PIXLINE_N_STATES];
-    
+
     /*! - Initialize filter parameters to max values */
     configData->timeTag = callTime*NANO2SEC;
     configData->dt = 0.0;
@@ -67,7 +67,7 @@ void Reset_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTim
     configData->numObs = PIXLINE_N_MEAS;
     configData->firstPassComplete = 0;
     configData->planetId = configData->planetIdInit;
-    
+
     /*! - Ensure that all internal filter matrices are zeroed*/
     vSetZero(configData->obs, configData->numObs);
     vSetZero(configData->wM, configData->countHalfSPs * 2 + 1);
@@ -77,13 +77,13 @@ void Reset_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTim
              configData->numStates);
     mSetZero(configData->sQnoise, configData->numStates, configData->numStates);
     mSetZero(configData->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS);
-    
+
     /*! - Set lambda/gamma to standard value for unscented kalman filters */
     configData->lambdaVal = configData->alpha*configData->alpha*
     (configData->numStates + configData->kappa) - configData->numStates;
     configData->gamma = sqrt(configData->numStates + configData->lambdaVal);
-    
-    
+
+
     /*! - Set the wM/wC vectors to standard values for unscented kalman filters*/
     configData->wM[0] = configData->lambdaVal / (configData->numStates +
                                                  configData->lambdaVal);
@@ -94,7 +94,7 @@ void Reset_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTim
         configData->wM[i] = 1.0 / 2.0*1.0 / (configData->numStates + configData->lambdaVal);
         configData->wC[i] = configData->wM[i];
     }
-    
+
     vCopy(configData->stateInit, configData->numStates, configData->state);
     v6Scale(1E-3, configData->state, configData->state); // Convert to km
     /*! - User a cholesky decomposition to obtain the sBar and sQnoise matrices for use in filter at runtime*/
@@ -104,21 +104,21 @@ void Reset_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTim
     mCopy(configData->covarInit, configData->numStates, configData->numStates,
           configData->covar);
     vScale(1E-6, configData->covar, PIXLINE_DYN_STATES*PIXLINE_N_STATES + PIXLINE_DYN_STATES, configData->covar); // Convert to km
-    
+
     mSetZero(tempMatrix, configData->numStates, configData->numStates);
     badUpdate += ukfCholDecomp(configData->sBar, (int) configData->numStates,
                                (int) configData->numStates, tempMatrix);
-    
+
     badUpdate += ukfCholDecomp(configData->qNoise, (int) configData->numStates,
                                (int) configData->numStates, configData->sQnoise);
-    
+
     mCopy(tempMatrix, configData->numStates, configData->numStates,
           configData->sBar);
     mTranspose(configData->sQnoise, configData->numStates,
                configData->numStates, configData->sQnoise);
-    
+
     configData->timeTagOut = configData->timeTag;
-    
+
     if (badUpdate <0){
         _bskLog(configData->bskLogger, BSK_WARNING, "Reset method contained bad update");
     }
@@ -144,7 +144,7 @@ void Update_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTi
     NavTransMsgPayload outputRelOD;
     OpNavCirclesMsgPayload inputCircles;
     configData->moduleId = (int) moduleId;
-    
+
     computePostFits = 0;
     v3SetZero(configData->postFits);
 
@@ -178,12 +178,12 @@ void Update_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTi
         pixelLineBiasUKFTimeUpdate(configData, newTimeTag);
     }
 
-    
+
     /*! - The post fits are y - ybar if a measurement was read, if observations are zero, do not compute post fit residuals*/
     if(computePostFits == 1){
         /*! - Compute Post Fit Residuals, first get Y (eq 22) using the states post fit*/
         pixelLineBiasUKFMeasModel(configData);
-        
+
         /*! - Compute the value for the yBar parameter (equation 23)*/
         vSetZero(yBar, configData->numObs);
         for(i=0; i<configData->countHalfSPs*2+1; i++)
@@ -195,8 +195,8 @@ void Update_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTi
         }
         mSubtract(configData->obs, PIXLINE_N_MEAS, 1, yBar, configData->postFits);
     }
-    
-   
+
+
     /*! - Write the relative OD estimate into the copy of the navigation message structure*/
     v3Copy(configData->state, outputRelOD.r_BN_N);
     outputRelOD.timeTag = configData->timeTag;
@@ -205,7 +205,7 @@ void Update_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTi
     v3Scale(1E3, outputRelOD.v_BN_N, outputRelOD.v_BN_N); // Convert to m
     outputRelOD.timeTag = configData->timeTagOut;
     NavTransMsg_C_write(&outputRelOD, &configData->navStateOutMsg, moduleId, callTime);
-    
+
     /*! - Populate the filter states output buffer and write the output message*/
     opNavOutBuffer.timeTag = configData->timeTag;
     memmove(opNavOutBuffer.covar, configData->covar,
@@ -215,7 +215,7 @@ void Update_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTi
     v6Scale(1E3, opNavOutBuffer.state, opNavOutBuffer.state); // Convert to m
     vScale(1E6, opNavOutBuffer.covar, PIXLINE_DYN_STATES*PIXLINE_N_STATES+PIXLINE_DYN_STATES, opNavOutBuffer.covar); // Convert to m
     PixelLineFilterMsg_C_write(&opNavOutBuffer, &configData->filtDataOutMsg, moduleId, callTime);
-    
+
     return;
 }
 
@@ -228,14 +228,14 @@ void Update_pixelLineBiasUKF(PixelLineBiasUKFConfig *configData, uint64_t callTi
  */
 void relODStateProp(PixelLineBiasUKFConfig *configData, double *stateInOut, double dt)
 {
-    
+
     double muPlanet;
     double k1[PIXLINE_DYN_STATES], k2[PIXLINE_DYN_STATES], k3[PIXLINE_DYN_STATES], k4[PIXLINE_DYN_STATES];
     double states1[PIXLINE_DYN_STATES], states2[PIXLINE_DYN_STATES], states3[PIXLINE_DYN_STATES];
     if(configData->planetId ==1){muPlanet = MU_EARTH;} //in km
     if(configData->planetId ==2){muPlanet = MU_MARS;} //in km
     if(configData->planetId ==3){muPlanet = MU_JUPITER;} //in km
-    
+
     /*! Start RK4 */
     /*! - Compute k1 */
     pixelLineBiasUKFTwoBodyDyn(stateInOut, muPlanet, &k1[0]);
@@ -257,12 +257,12 @@ void relODStateProp(PixelLineBiasUKFConfig *configData, double *stateInOut, doub
     vScale(2./3., k2, PIXLINE_DYN_STATES, k2); // k2 is now k2/3
     vScale(1./3., k3, PIXLINE_DYN_STATES, k3); // k3 is now k2/3
     vScale(1./6., k4, PIXLINE_DYN_STATES, k4); // k4 is now k2/6
-    
+
     vAdd(stateInOut, PIXLINE_DYN_STATES, k1, stateInOut);
     vAdd(stateInOut, PIXLINE_DYN_STATES, k2, stateInOut);
     vAdd(stateInOut, PIXLINE_DYN_STATES, k3, stateInOut);
     vAdd(stateInOut, PIXLINE_DYN_STATES, k4, stateInOut);
-    
+
     return;
 }
 
@@ -276,7 +276,7 @@ void pixelLineBiasUKFTwoBodyDyn(double state[PIXLINE_DYN_STATES], double muPlane
 {
     double rNorm;
     double dvdt[3];
-    
+
     rNorm = v3Norm(state);
     v3Copy(&state[3], stateDeriv);
     v3Copy(state, dvdt);
@@ -301,12 +301,12 @@ int pixelLineBiasUKFTimeUpdate(PixelLineBiasUKFConfig *configData, double update
     double *spPtr; //sigma point intermediate varaible
     double procNoise[PIXLINE_N_STATES*PIXLINE_N_STATES]; //process noise
     int32_t badUpdate=0;
-    
+
     configData->dt = updateTime - configData->timeTag;
     vCopy(configData->state, configData->numStates, configData->statePrev);
     mCopy(configData->sBar, configData->numStates, configData->numStates, configData->sBarPrev);
     mCopy(configData->covar, configData->numStates, configData->numStates, configData->covarPrev);
-    
+
     /*! - Read the planet ID from the message*/
     if(configData->planetId == 0)
     {
@@ -366,7 +366,7 @@ int pixelLineBiasUKFTimeUpdate(PixelLineBiasUKFConfig *configData, double update
         vScale(sqrt(configData->wC[i+1]), aRow, configData->numStates, aRow);
         memcpy((void *)&AT[i*configData->numStates], (void *)aRow,
                configData->numStates*sizeof(double));
-        
+
     }
     /*! - Pop the sQNoise matrix on to the end of AT prior to getting QR decomposition*/
     memcpy(&AT[2 * configData->countHalfSPs*configData->numStates],
@@ -375,19 +375,19 @@ int pixelLineBiasUKFTimeUpdate(PixelLineBiasUKFConfig *configData, double update
     /*! - QR decomposition (only R computed!) of the AT matrix provides the new sBar matrix*/
     ukfQRDJustR(AT, (int) (2 * configData->countHalfSPs + configData->numStates),
                 (int) configData->countHalfSPs, rAT);
-    
+
     mCopy(rAT, configData->numStates, configData->numStates, sBarT);
     mTranspose(sBarT, configData->numStates, configData->numStates,
                configData->sBar);
-    
+
     /*! - Shift the sBar matrix over by the xBar vector using the appropriate weight
      like in equation 21 in design document.*/
     vScale(-1.0, configData->xBar, configData->numStates, xErr);
     vAdd(xErr, configData->numStates, &configData->SP[0], xErr);
     badUpdate += ukfCholDownDate(configData->sBar, xErr, configData->wC[0],
                                  (int) configData->numStates, sBarUp);
-    
-    
+
+
     /*! - Save current sBar matrix, covariance, and state estimate off for further use*/
     mCopy(sBarUp, configData->numStates, configData->numStates, configData->sBar);
     mTranspose(configData->sBar, configData->numStates, configData->numStates,
@@ -396,7 +396,7 @@ int pixelLineBiasUKFTimeUpdate(PixelLineBiasUKFConfig *configData, double update
            configData->covar, configData->numStates, configData->numStates,
            configData->covar);
     vCopy(&(configData->SP[0]), configData->numStates, configData->state);
-    
+
     if (badUpdate<0){
         pixelLineBiasUKFCleanUpdate(configData);
         return(-1);}
@@ -430,7 +430,7 @@ void pixelLineBiasUKFMeasModel(PixelLineBiasUKFConfig *configData)
     pY = 2.*tan(configData->cameraSpecs.fieldOfView/2.0);
     X = pX/configData->cameraSpecs.resolution[0];
     Y = pY/configData->cameraSpecs.resolution[1];
-    
+
     if(configData->circlesInBuffer.planetIds[0] > 0){
         if(configData->circlesInBuffer.planetIds[0] ==1){
             planetRad = REQ_EARTH;//in km
@@ -442,26 +442,26 @@ void pixelLineBiasUKFMeasModel(PixelLineBiasUKFConfig *configData)
             planetRad = REQ_JUPITER;//in km
         }
     }
-    
+
     for(j=0; j<configData->countHalfSPs*2+1; j++)
     {
         double centers[2], r_N_bar[3], radius=0;
         v2SetZero(centers);
         v3SetZero(r_N_bar);
-        
+
         v3Copy(&configData->SP[j*configData->numStates], r_N_bar);
         rNorm = v3Norm(r_N_bar);
-        
+
         m33MultV3(dcm_CN, r_N_bar, r_C);
         v3Scale(-1./r_C[2], r_C, r_C);
-        
+
         /*! - Find pixel size using camera specs */
         reCentered[0] = r_C[0]/X;
         reCentered[1] = r_C[1]/Y;
-        
+
         centers[0] = reCentered[0] + configData->cameraSpecs.resolution[0]/2 - 0.5;
         centers[1] = reCentered[1] + configData->cameraSpecs.resolution[1]/2 - 0.5;
-        
+
         denom = planetRad/rNorm;
         radius = tan(safeAsin(denom)) / X;
         if (j==0){
@@ -482,7 +482,7 @@ void pixelLineBiasUKFMeasModel(PixelLineBiasUKFConfig *configData)
     /*! - yMeas matrix was set backwards deliberately so we need to transpose it through*/
     mTranspose(configData->yMeas, PIXLINE_N_MEAS, configData->countHalfSPs*2+1,
                configData->yMeas);
-    
+
 }
 
 /*! This method performs the measurement update for the kalman filter.
@@ -502,13 +502,13 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
     double sy[PIXLINE_N_MEAS*PIXLINE_N_MEAS]; // Chol of covariance
     double updMat[PIXLINE_N_MEAS*PIXLINE_N_MEAS], pXY[PIXLINE_N_STATES*PIXLINE_N_MEAS], Umat[PIXLINE_N_STATES*PIXLINE_N_MEAS]; // Intermediate variable, covariance eq 26, U eq 28
     int32_t badUpdate=0;
-    
+
     vCopy(configData->state, configData->numStates, configData->statePrev);
     mCopy(configData->sBar, configData->numStates, configData->numStates, configData->sBarPrev);
     mCopy(configData->covar, configData->numStates, configData->numStates, configData->covarPrev);
     /*! - Compute the valid observations and the measurement model for all observations*/
     pixelLineBiasUKFMeasModel(configData);
-    
+
     /*! - Compute the value for the yBar parameter (note that this is equation 23 in the
      time update section of the reference document*/
     vSetZero(yBar, configData->numObs);
@@ -519,7 +519,7 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
         vScale(configData->wM[i], tempYVec, configData->numObs, tempYVec);
         vAdd(yBar, configData->numObs, tempYVec, yBar);
     }
-    
+
     /*! - Populate the matrix that we perform the QR decomposition on in the measurement
      update section of the code.  This is based on the differenence between the yBar
      parameter and the calculated measurement models.  Equation 24 in driving doc. */
@@ -535,7 +535,7 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
         memcpy(&(AT[i*configData->numObs]), tempYVec,
                configData->numObs*sizeof(double));
     }
-    
+
     /*! - This is the square-root of the Rk matrix which we treat as the Cholesky
      decomposition of the observation variance matrix constructed for our number
      of observations*/
@@ -549,7 +549,7 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
      current Sy matrix*/
     ukfQRDJustR(AT, (int) (2*configData->countHalfSPs+configData->numObs),
                 (int) configData->numObs, rAT);
-    
+
     mCopy(rAT, configData->numObs, configData->numObs, syT);
     mTranspose(syT, configData->numObs, configData->numObs, sy);
     /*! - Shift the matrix over by the difference between the 0th SP-based measurement
@@ -558,11 +558,11 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
     vAdd(tempYVec, configData->numObs, &(configData->yMeas[0]), tempYVec);
     badUpdate += ukfCholDownDate(sy, tempYVec, configData->wC[0],
                                  (int) configData->numObs, updMat);
-    
+
     /*! - Shifted matrix represents the Sy matrix */
     mCopy(updMat, configData->numObs, configData->numObs, sy);
     mTranspose(sy, configData->numObs, configData->numObs, syT);
-    
+
     /*! - Construct the Pxy matrix (equation 26) which multiplies the Sigma-point cloud
      by the measurement model cloud (weighted) to get the total Pxy matrix*/
     mSetZero(pXY, configData->numStates, configData->numObs);
@@ -578,20 +578,20 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
                kMat);
         mAdd(pXY, configData->numStates, configData->numObs, kMat, pXY);
     }
-    
+
     /*! - Then we need to invert the SyT*Sy matrix to get the Kalman gain factor.  Since
      The Sy matrix is lower triangular, we can do a back-sub inversion instead of
      a full matrix inversion.  That is the ukfUInv and ukfLInv calls below.  Once that
      multiplication is done (equation 27), we have the Kalman Gain.*/
     ukfUInv(syT, (int) configData->numObs, (int) configData->numObs, syInv);
-    
+
     mMultM(pXY, configData->numStates, configData->numObs, syInv,
            configData->numObs, configData->numObs, kMat);
     ukfLInv(sy, (int) configData->numObs, (int) configData->numObs, syInv);
     mMultM(kMat, configData->numStates, configData->numObs, syInv,
            configData->numObs, configData->numObs, kMat);
-    
-    
+
+
     /*! - Difference the yBar and the observations to get the observed error and
      multiply by the Kalman Gain to get the state update.  Add the state update
      to the state to get the updated state value (equation 27).*/
@@ -616,14 +616,14 @@ int pixelLineBiasUKFMeasUpdate(PixelLineBiasUKFConfig *configData)
         mCopy(sBarT, configData->numStates, configData->numStates,
               configData->sBar);
     }
-    
+
     /*! - Compute equivalent covariance based on updated sBar matrix*/
     mTranspose(configData->sBar, configData->numStates, configData->numStates,
                configData->covar);
     mMultM(configData->sBar, configData->numStates, configData->numStates,
            configData->covar, configData->numStates, configData->numStates,
            configData->covar);
-    
+
     if (badUpdate<0){
         pixelLineBiasUKFCleanUpdate(configData);
         return(-1);}
@@ -643,7 +643,7 @@ void pixelLineBiasUKFCleanUpdate(PixelLineBiasUKFConfig *configData){
     vCopy(configData->statePrev, configData->numStates, configData->state);
     mCopy(configData->sBarPrev, configData->numStates, configData->numStates, configData->sBar);
     mCopy(configData->covarPrev, configData->numStates, configData->numStates, configData->covar);
-    
+
     /*! - Reset the wM/wC vectors to standard values for unscented kalman filters*/
     configData->wM[0] = configData->lambdaVal / (configData->numStates +
                                                  configData->lambdaVal);
@@ -655,7 +655,6 @@ void pixelLineBiasUKFCleanUpdate(PixelLineBiasUKFConfig *configData){
                                              configData->lambdaVal);
         configData->wC[i] = configData->wM[i];
     }
-    
+
     return;
 }
-

--- a/src/fswAlgorithms/opticalNavigation/pixelLineConverter/pixelLineConverter.c
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineConverter/pixelLineConverter.c
@@ -19,7 +19,6 @@
 
 #include <math.h>
 #include <string.h>
-#include <stdlib.h>
 #include "pixelLineConverter.h"
 
 

--- a/src/fswAlgorithms/opticalNavigation/pixelLineConverter/pixelLineConverter.c
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineConverter/pixelLineConverter.c
@@ -76,7 +76,7 @@ void Update_pixelLineConverter(PixelLineConvertData *configData, uint64_t callTi
     cameraSpecs = CameraConfigMsg_C_read(&configData->cameraConfigInMsg);
     circlesIn = OpNavCirclesMsg_C_read(&configData->circlesInMsg);
     attInfo = NavAttMsg_C_read(&configData->attInMsg);
-    
+
     if (circlesIn.valid == 0){
         opNavMsgOut.valid = 0;
         OpNavMsg_C_write(&opNavMsgOut, &configData->opNavOutMsg, moduleID, callTime);
@@ -112,7 +112,7 @@ void Update_pixelLineConverter(PixelLineConvertData *configData, uint64_t callTi
     v3Set(rtilde_C[0], rtilde_C[1], 1.0, rHat_BN_C);
     v3Scale(-1, rHat_BN_C, rHat_BN_C);
     v3Normalize(rHat_BN_C, rHat_BN_C);
-    
+
     m33MultV3(dcm_NC, rHat_BN_C, rHat_BN_N);
     m33tMultV3(dcm_CB, rHat_BN_C, rHat_BN_B);
 
@@ -129,10 +129,10 @@ void Update_pixelLineConverter(PixelLineConvertData *configData, uint64_t callTi
             planetRad = REQ_JUPITER;//in km
             opNavMsgOut.planetID = configData->planetTarget;
         }
-        
+
         denom = sin(atan(X*circlesIn.circlesRadii[0]));
         rNorm = planetRad/denom; //in km
-        
+
         /*! - Compute the uncertainty */
         x_map = planetRad/denom*(X);
         y_map = planetRad/denom*(Y);
@@ -151,7 +151,7 @@ void Update_pixelLineConverter(PixelLineConvertData *configData, uint64_t callTi
         mtMultM(dcm_CB, 3, 3, covar_In_C, 3, 3, covar_In_B);
         mMultM(covar_In_B, 3, 3, dcm_CB, 3, 3, covar_In_B);
     }
-    
+
     /*! - write output message */
     v3Scale(rNorm*1E3, rHat_BN_N, opNavMsgOut.r_BN_N); //in m
     v3Scale(rNorm*1E3, rHat_BN_C, opNavMsgOut.r_BN_C); //in m

--- a/src/fswAlgorithms/opticalNavigation/relativeODuKF/relativeODuKF.c
+++ b/src/fswAlgorithms/opticalNavigation/relativeODuKF/relativeODuKF.c
@@ -1,12 +1,12 @@
 /*
  ISC License
- 
+
  Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
- 
+
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,7 +14,7 @@
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
  */
 
 #include <string.h>
@@ -52,7 +52,7 @@ void Reset_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
     size_t i;
     int32_t badUpdate=0; /* Negative badUpdate is faulty, */
     double tempMatrix[ODUKF_N_STATES*ODUKF_N_STATES];
-    
+
     /*! - Initialize filter parameters to max values */
     configData->timeTag = callTime*NANO2SEC;
     configData->dt = 0.0;
@@ -61,7 +61,7 @@ void Reset_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
     configData->numObs = 3;
     configData->firstPassComplete = 0;
     configData->planetId = configData->planetIdInit;
-    
+
     /*! - Ensure that all internal filter matrices are zeroed*/
     vSetZero(configData->obs, configData->numObs);
     vSetZero(configData->wM, configData->countHalfSPs * 2 + 1);
@@ -71,13 +71,13 @@ void Reset_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
              configData->numStates);
     mSetZero(configData->sQnoise, configData->numStates, configData->numStates);
     mSetZero(configData->measNoise, ODUKF_N_MEAS, ODUKF_N_MEAS);
-    
+
     /*! - Set lambda/gamma to standard value for unscented kalman filters */
     configData->lambdaVal = configData->alpha*configData->alpha*
     (configData->numStates + configData->kappa) - configData->numStates;
     configData->gamma = sqrt(configData->numStates + configData->lambdaVal);
-    
-    
+
+
     /*! - Set the wM/wC vectors to standard values for unscented kalman filters*/
     configData->wM[0] = configData->lambdaVal / (configData->numStates +
                                                  configData->lambdaVal);
@@ -88,7 +88,7 @@ void Reset_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
         configData->wM[i] = 1.0 / 2.0*1.0 / (configData->numStates + configData->lambdaVal);
         configData->wC[i] = configData->wM[i];
     }
-    
+
     vCopy(configData->stateInit, configData->numStates, configData->state);
     v6Scale(1E-3, configData->state, configData->state); // Convert to km
     /*! - User a cholesky decomposition to obtain the sBar and sQnoise matrices for use in filter at runtime*/
@@ -98,21 +98,21 @@ void Reset_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
     mCopy(configData->covarInit, configData->numStates, configData->numStates,
           configData->covar);
     vScale(1E-6, configData->covar, ODUKF_N_STATES*ODUKF_N_STATES, configData->covar); // Convert to km
-    
+
     mSetZero(tempMatrix, configData->numStates, configData->numStates);
     badUpdate += ukfCholDecomp(configData->sBar, (int) configData->numStates,
                                (int) configData->numStates, tempMatrix);
-    
+
     badUpdate += ukfCholDecomp(configData->qNoise, (int) configData->numStates,
                                (int) configData->numStates, configData->sQnoise);
-    
+
     mCopy(tempMatrix, configData->numStates, configData->numStates,
           configData->sBar);
     mTranspose(configData->sQnoise, configData->numStates,
                configData->numStates, configData->sQnoise);
-    
+
     configData->timeTagOut = configData->timeTag;
-    
+
     if (badUpdate <0){
         _bskLog(configData->bskLogger, BSK_WARNING, "relODuKF: Reset method contained bad update");
     }
@@ -142,7 +142,7 @@ void Update_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
     OpNavFilterMsgPayload opNavOutBuffer; /* [-] Output filter info*/
     NavTransMsgPayload outputRelOD;
     OpNavMsgPayload inputRelOD;
-    
+
     computePostFits = 0;
     v3SetZero(configData->postFits);
     outputRelOD = NavTransMsg_C_zeroMsgPayload();
@@ -173,12 +173,12 @@ void Update_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
         relODuKFTimeUpdate(configData, newTimeTag);
     }
 
-    
+
     /*! - The post fits are y - ybar if a measurement was read, if observations are zero, do not compute post fit residuals*/
     if(computePostFits == 1){
         /*! - Compute Post Fit Residuals, first get Y (eq 22) using the states post fit*/
         relODuKFMeasModel(configData);
-        
+
         /*! - Compute the value for the yBar parameter (equation 23)*/
         vSetZero(yBar, configData->numObs);
         for(i=0; i<configData->countHalfSPs*2+1; i++)
@@ -190,8 +190,8 @@ void Update_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
         }
         mSubtract(configData->obs, ODUKF_N_MEAS, 1, yBar, configData->postFits);
     }
-    
-   
+
+
     /*! - Write the relative OD estimate into the copy of the navigation message structure*/
     v3Copy(configData->state, outputRelOD.r_BN_N);
     outputRelOD.timeTag = configData->timeTag;
@@ -199,9 +199,9 @@ void Update_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
     v3Copy(&configData->state[3], outputRelOD.v_BN_N);
     v3Scale(1E3, outputRelOD.v_BN_N, outputRelOD.v_BN_N); // Convert to m
     outputRelOD.timeTag = configData->timeTagOut;
-    
+
     NavTransMsg_C_write(&outputRelOD, &configData->navStateOutMsg, moduleId, callTime);
-    
+
     /*! - Populate the filter states output buffer and write the output message*/
     opNavOutBuffer.timeTag = configData->timeTag;
     memmove(opNavOutBuffer.covar, configData->covar,
@@ -213,7 +213,7 @@ void Update_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
     vScale(1E6, opNavOutBuffer.covar, ODUKF_N_STATES*ODUKF_N_STATES, opNavOutBuffer.covar); // Convert to m
 
     OpNavFilterMsg_C_write(&opNavOutBuffer, &configData->filtDataOutMsg, moduleId, callTime);
-    
+
     return;
 }
 
@@ -226,14 +226,14 @@ void Update_relODuKF(RelODuKFConfig *configData, uint64_t callTime,
  */
 void relODStateProp(RelODuKFConfig *configData, double *stateInOut, double dt)
 {
-    
+
     double muPlanet;
     double k1[ODUKF_N_STATES], k2[ODUKF_N_STATES], k3[ODUKF_N_STATES], k4[ODUKF_N_STATES];
     double states1[ODUKF_N_STATES], states2[ODUKF_N_STATES], states3[ODUKF_N_STATES];
     if(configData->planetId ==1){muPlanet = MU_EARTH;} //in km
     if(configData->planetId ==2){muPlanet = MU_MARS;} //in km
     if(configData->planetId ==3){muPlanet = MU_JUPITER;} //in km
-    
+
     /*! Start RK4 */
     /*! - Compute k1 */
     relODuKFTwoBodyDyn(stateInOut, muPlanet, &k1[0]);
@@ -255,12 +255,12 @@ void relODStateProp(RelODuKFConfig *configData, double *stateInOut, double dt)
     vScale(2./3., k2, ODUKF_N_STATES, k2); // k2 is now k2/3
     vScale(1./3., k3, ODUKF_N_STATES, k3); // k3 is now k2/3
     vScale(1./6., k4, ODUKF_N_STATES, k4); // k4 is now k2/6
-    
+
     vAdd(stateInOut, ODUKF_N_STATES, k1, stateInOut);
     vAdd(stateInOut, ODUKF_N_STATES, k2, stateInOut);
     vAdd(stateInOut, ODUKF_N_STATES, k3, stateInOut);
     vAdd(stateInOut, ODUKF_N_STATES, k4, stateInOut);
-    
+
     return;
 }
 
@@ -274,7 +274,7 @@ void relODuKFTwoBodyDyn(double state[ODUKF_N_STATES], double muPlanet, double *s
 {
     double rNorm;
     double dvdt[3];
-    
+
     rNorm = v3Norm(state);
     v3Copy(&state[3], stateDeriv);
     v3Copy(state, dvdt);
@@ -299,12 +299,12 @@ int relODuKFTimeUpdate(RelODuKFConfig *configData, double updateTime)
     double *spPtr; //sigma point intermediate varaible
     double procNoise[ODUKF_N_STATES*ODUKF_N_STATES]; //process noise
     int32_t badUpdate=0;
-    
+
     configData->dt = updateTime - configData->timeTag;
     vCopy(configData->state, configData->numStates, configData->statePrev);
     mCopy(configData->sBar, configData->numStates, configData->numStates, configData->sBarPrev);
     mCopy(configData->covar, configData->numStates, configData->numStates, configData->covarPrev);
-    
+
     /*! - Read the planet ID from the message*/
     if(configData->planetId == 0)
     {
@@ -364,7 +364,7 @@ int relODuKFTimeUpdate(RelODuKFConfig *configData, double updateTime)
         vScale(sqrt(configData->wC[i+1]), aRow, configData->numStates, aRow);
         memcpy((void *)&AT[(size_t)i*configData->numStates], (void *)aRow,
                configData->numStates*sizeof(double));
-        
+
     }
     /*! - Pop the sQNoise matrix on to the end of AT prior to getting QR decomposition*/
     memcpy(&AT[2 * configData->countHalfSPs*configData->numStates],
@@ -373,19 +373,19 @@ int relODuKFTimeUpdate(RelODuKFConfig *configData, double updateTime)
     /*! - QR decomposition (only R computed!) of the AT matrix provides the new sBar matrix*/
     ukfQRDJustR(AT, (int) (2 * configData->countHalfSPs + configData->numStates),
                 (int) configData->countHalfSPs, rAT);
-    
+
     mCopy(rAT, configData->numStates, configData->numStates, sBarT);
     mTranspose(sBarT, configData->numStates, configData->numStates,
                configData->sBar);
-    
+
     /*! - Shift the sBar matrix over by the xBar vector using the appropriate weight
      like in equation 21 in design document.*/
     vScale(-1.0, configData->xBar, configData->numStates, xErr);
     vAdd(xErr, configData->numStates, &configData->SP[0], xErr);
     badUpdate += ukfCholDownDate(configData->sBar, xErr, configData->wC[0],
                                  (int) configData->numStates, sBarUp);
-    
-    
+
+
     /*! - Save current sBar matrix, covariance, and state estimate off for further use*/
     mCopy(sBarUp, configData->numStates, configData->numStates, configData->sBar);
     mTranspose(configData->sBar, configData->numStates, configData->numStates,
@@ -394,7 +394,7 @@ int relODuKFTimeUpdate(RelODuKFConfig *configData, double updateTime)
            configData->covar, configData->numStates, configData->numStates,
            configData->covar);
     vCopy(&(configData->SP[0]), configData->numStates, configData->state);
-    
+
     if (badUpdate<0){
         relODuKFCleanUpdate(configData);
         return(-1);}
@@ -419,11 +419,11 @@ void relODuKFMeasModel(RelODuKFConfig *configData)
             configData->yMeas[i*((int) configData->countHalfSPs*2+1) + j] =
             configData->SP[i + j*ODUKF_N_STATES];
     }
-    
+
     /*! - yMeas matrix was set backwards deliberately so we need to transpose it through*/
     mTranspose(configData->yMeas, ODUKF_N_MEAS, configData->countHalfSPs*2+1,
                configData->yMeas);
-    
+
 }
 
 /*! This method performs the measurement update for the kalman filter.
@@ -443,13 +443,13 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
     double sy[3*3]; // Chol of covariance
     double updMat[3*3], pXY[ODUKF_N_STATES*3], Umat[ODUKF_N_STATES*3]; // Intermediate variable, covariance eq 26, U eq 28
     int32_t badUpdate=0;
-    
+
     vCopy(configData->state, configData->numStates, configData->statePrev);
     mCopy(configData->sBar, configData->numStates, configData->numStates, configData->sBarPrev);
     mCopy(configData->covar, configData->numStates, configData->numStates, configData->covarPrev);
     /*! - Compute the valid observations and the measurement model for all observations*/
     relODuKFMeasModel(configData);
-    
+
     /*! - Compute the value for the yBar parameter (note that this is equation 23 in the
      time update section of the reference document*/
     vSetZero(yBar, configData->numObs);
@@ -460,7 +460,7 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
         vScale(configData->wM[i], tempYVec, configData->numObs, tempYVec);
         vAdd(yBar, configData->numObs, tempYVec, yBar);
     }
-    
+
     /*! - Populate the matrix that we perform the QR decomposition on in the measurement
      update section of the code.  This is based on the differenence between the yBar
      parameter and the calculated measurement models.  Equation 24 in driving doc. */
@@ -476,7 +476,7 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
         memcpy(&(AT[i*configData->numObs]), tempYVec,
                configData->numObs*sizeof(double));
     }
-    
+
     /*! - This is the square-root of the Rk matrix which we treat as the Cholesky
      decomposition of the observation variance matrix constructed for our number
      of observations*/
@@ -490,7 +490,7 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
      current Sy matrix*/
     ukfQRDJustR(AT, (int) (2*configData->countHalfSPs+configData->numObs),
                 (int) configData->numObs, rAT);
-    
+
     mCopy(rAT, configData->numObs, configData->numObs, syT);
     mTranspose(syT, configData->numObs, configData->numObs, sy);
     /*! - Shift the matrix over by the difference between the 0th SP-based measurement
@@ -499,11 +499,11 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
     vAdd(tempYVec, configData->numObs, &(configData->yMeas[0]), tempYVec);
     badUpdate += ukfCholDownDate(sy, tempYVec, configData->wC[0],
                                  (int) configData->numObs, updMat);
-    
+
     /*! - Shifted matrix represents the Sy matrix */
     mCopy(updMat, configData->numObs, configData->numObs, sy);
     mTranspose(sy, configData->numObs, configData->numObs, syT);
-    
+
     /*! - Construct the Pxy matrix (equation 26) which multiplies the Sigma-point cloud
      by the measurement model cloud (weighted) to get the total Pxy matrix*/
     mSetZero(pXY, configData->numStates, configData->numObs);
@@ -519,20 +519,20 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
                kMat);
         mAdd(pXY, configData->numStates, configData->numObs, kMat, pXY);
     }
-    
+
     /*! - Then we need to invert the SyT*Sy matrix to get the Kalman gain factor.  Since
      The Sy matrix is lower triangular, we can do a back-sub inversion instead of
      a full matrix inversion.  That is the ukfUInv and ukfLInv calls below.  Once that
      multiplication is done (equation 27), we have the Kalman Gain.*/
     ukfUInv(syT, (int) configData->numObs, (int) configData->numObs, syInv);
-    
+
     mMultM(pXY, configData->numStates, configData->numObs, syInv,
            configData->numObs, configData->numObs, kMat);
     ukfLInv(sy, (int) configData->numObs, (int) configData->numObs, syInv);
     mMultM(kMat, configData->numStates, configData->numObs, syInv,
            configData->numObs, configData->numObs, kMat);
-    
-    
+
+
     /*! - Difference the yBar and the observations to get the observed error and
      multiply by the Kalman Gain to get the state update.  Add the state update
      to the state to get the updated state value (equation 27).*/
@@ -554,14 +554,14 @@ int relODuKFMeasUpdate(RelODuKFConfig *configData)
         mCopy(sBarT, configData->numStates, configData->numStates,
               configData->sBar);
     }
-    
+
     /*! - Compute equivalent covariance based on updated sBar matrix*/
     mTranspose(configData->sBar, configData->numStates, configData->numStates,
                configData->covar);
     mMultM(configData->sBar, configData->numStates, configData->numStates,
            configData->covar, configData->numStates, configData->numStates,
            configData->covar);
-    
+
     if (badUpdate<0){
         relODuKFCleanUpdate(configData);
         return(-1);}
@@ -581,7 +581,7 @@ void relODuKFCleanUpdate(RelODuKFConfig *configData){
     vCopy(configData->statePrev, configData->numStates, configData->state);
     mCopy(configData->sBarPrev, configData->numStates, configData->numStates, configData->sBar);
     mCopy(configData->covarPrev, configData->numStates, configData->numStates, configData->covar);
-    
+
     /*! - Reset the wM/wC vectors to standard values for unscented kalman filters*/
     configData->wM[0] = configData->lambdaVal / (configData->numStates +
                                                  configData->lambdaVal);
@@ -593,7 +593,6 @@ void relODuKFCleanUpdate(RelODuKFConfig *configData){
                                              configData->lambdaVal);
         configData->wC[i] = configData->wM[i];
     }
-    
+
     return;
 }
-

--- a/src/fswAlgorithms/opticalNavigation/relativeODuKF/relativeODuKF.c
+++ b/src/fswAlgorithms/opticalNavigation/relativeODuKF/relativeODuKF.c
@@ -18,7 +18,6 @@
  */
 
 #include <string.h>
-#include <stdlib.h>
 #include <math.h>
 #include "relativeODuKF.h"
 #include "architecture/utilities/ukfUtilities.h"

--- a/src/fswAlgorithms/opticalNavigation/visualOdometry/visualOdometry.cpp
+++ b/src/fswAlgorithms/opticalNavigation/visualOdometry/visualOdometry.cpp
@@ -19,7 +19,6 @@
 
 #include "fswAlgorithms/opticalNavigation/visualOdometry/visualOdometry.h"
 #include <cmath>
-#include <array>
 
 VisualOdometry::VisualOdometry() = default;
 

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
@@ -18,10 +18,7 @@
 */
 
 #include "fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include <iostream>
-#include <cstring>
 #include <math.h>
 
 /*! This is the constructor for the module class.  It sets default variable

--- a/src/fswAlgorithms/rwConfigData/rwConfigData.c
+++ b/src/fswAlgorithms/rwConfigData/rwConfigData.c
@@ -24,8 +24,6 @@
 /* modify the path to reflect the new module names */
 #include "fswAlgorithms/rwConfigData/rwConfigData.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/macroDefinitions.h"
-#include "rwConfigData.h"
 #include <string.h>
 
 /*

--- a/src/fswAlgorithms/rwConfigData/rwConfigData.c
+++ b/src/fswAlgorithms/rwConfigData/rwConfigData.c
@@ -18,7 +18,7 @@
  */
 /*
     FSW MODULE Template
- 
+
  */
 
 /* modify the path to reflect the new module names */

--- a/src/fswAlgorithms/sensorInterfaces/IMUSensorData/imuComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/IMUSensorData/imuComm.c
@@ -20,7 +20,6 @@
 #include "fswAlgorithms/sensorInterfaces/IMUSensorData/imuComm.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <string.h>
 
 /*! This method initializes the configData for theIMU sensor interface.
  It checks to ensure that the inputs are sane and then creates the

--- a/src/fswAlgorithms/sensorInterfaces/IMUSensorData/imuComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/IMUSensorData/imuComm.c
@@ -31,7 +31,7 @@
 void SelfInit_imuProcessTelem(IMUConfigData *configData, int64_t moduleID)
 {
     IMUSensorBodyMsg_C_init(&configData->imuSensorOutMsg);
-    
+
 }
 
 
@@ -70,8 +70,8 @@ void Update_imuProcessTelem(IMUConfigData *configData, uint64_t callTime, int64_
               configData->outMsgBuffer.DRFrameBody);
     m33MultV3(RECAST3X3 configData->dcm_BP, LocalInput.AngVelPlatform,
               configData->outMsgBuffer.AngVelBody);
-    
+
     IMUSensorBodyMsg_C_write(&configData->outMsgBuffer, &configData->imuSensorOutMsg, moduleID, callTime);
-    
+
     return;
 }

--- a/src/fswAlgorithms/sensorInterfaces/STSensorData/stComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/STSensorData/stComm.c
@@ -71,6 +71,6 @@ void Update_stProcessTelem(STConfigData *configData, uint64_t callTime, int64_t 
     configData->attOutBuffer.timeTag = localInput.timeTag;
 
     STAttMsg_C_write(&configData->attOutBuffer, &configData->stAttOutMsg, moduleID, callTime);
-    
+
     return;
 }

--- a/src/fswAlgorithms/sensorInterfaces/STSensorData/stComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/STSensorData/stComm.c
@@ -21,7 +21,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <string.h>
 
 /*! This method initializes the configData for the ST sensor interface.
  @return void

--- a/src/fswAlgorithms/sensorInterfaces/TAMSensorData/tamComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/TAMSensorData/tamComm.c
@@ -55,7 +55,7 @@ void Reset_tamProcessTelem(tamConfigData* configData, uint64_t callTime, int64_t
 
     return;
 }
-    
+
 /*! This method takes the sensor data from the magnetometers and
  converts that information to the format used by the TAM nav.
  @return void
@@ -75,6 +75,6 @@ void Update_tamProcessTelem(tamConfigData *configData, uint64_t callTime, int64_
 
     /*! - Write aggregate output into output message */
     TAMSensorBodyMsg_C_write(&configData->tamLocalOutput, &configData->tamOutMsg, moduleID, callTime);
-    
+
     return;
 }

--- a/src/fswAlgorithms/sensorInterfaces/TAMSensorData/tamComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/TAMSensorData/tamComm.c
@@ -20,8 +20,6 @@
 #include "fswAlgorithms/sensorInterfaces/TAMSensorData/tamComm.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include <string.h>
 #include <math.h>
 
 /*! This method initializes the configData for the TAM sensor interface.

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
@@ -21,8 +21,6 @@
 #include "fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include <iostream>
-#include <cstring>
 #include <math.h>
 
 /*! This is the constructor for the module class.  It sets default variable

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
@@ -453,4 +453,3 @@ void SmallBodyNavEKF::writeMessages(uint64_t CurrentSimNanos){
     SmallBodyNavMsg_C_write(&smallBodyNavOutMsgBuffer, &this->smallBodyNavOutMsgC, this->moduleID, CurrentSimNanos);
     EphemerisMsg_C_write(&asteroidEphemerisOutMsgBuffer, &this->asteroidEphemerisOutMsgC, this->moduleID, CurrentSimNanos);
 }
-

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
@@ -73,7 +73,7 @@ void SmallBodyNavUKF::Reset(uint64_t CurrentSimNanos)
     if (!this->asteroidEphemerisInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "SmallBodyNavUKF.asteroidEphemerisInMsg was not linked.");
     }
-    
+
     /* compute UT weights to be used in the UT */
     this->wm_sigma(0) = this->kappa / (this->kappa + this->numStates);
     this->wc_sigma(0) = this->wm_sigma(0) + 1 - pow(this->alpha,2) + this->beta;
@@ -102,22 +102,22 @@ void SmallBodyNavUKF::readMessages(){
 void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
     /* Read angular velocity of the small body fixed frame */
     this->omega_AN_A = cArray2EigenVector3d(this->asteroidEphemerisInMsgBuffer.omega_BN_B);
-    
+
     /* Declare matrix to store sigma points spread */
     Eigen::MatrixXd X_sigma_k;
     Eigen::MatrixXd X_sigma_dot_k;
-    
+
     /* Set sigma points related matrices and vectors to zero */
     X_sigma_k.setZero(this->numStates, this->numSigmas);
     X_sigma_dot_k.setZero(this->numStates, this->numSigmas);
-    
+
     /* Compute square root matrix of covariance */
     Eigen::MatrixXd Psqrt_k;
     Psqrt_k = this->P_k.llt().matrixL();
-    
+
     /* Assign mean to central sigma point */
     X_sigma_k.col(0) = this->x_hat_k;
-    
+
     /* Loop to generate remaining sigma points */
     for (int i = 0; i < this->numStates; i++) {
         /* Generate sigma points */
@@ -126,7 +126,7 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
         X_sigma_k.col(numStates+i+1) = x_hat_k
             + sqrt(this->numStates + this->kappa) * Psqrt_k.col(i);
     }
-    
+
     /* Loop to propagate sigma points and compute mean */
     Eigen::VectorXd x_sigma_k;
     Eigen::VectorXd x_sigma_dot_k;
@@ -139,7 +139,7 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
     for (int i = 0; i < this->numSigmas; i++) {
         /* Extract sigma point */
         x_sigma_k = X_sigma_k.col(i);
-        
+
         /* Compute dynamics derivative */
         r_sigma_k << x_sigma_k.segment(0,3);
         v_sigma_k << x_sigma_k.segment(3,3);
@@ -149,14 +149,14 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
                                      - this->omega_AN_A.cross(this->omega_AN_A.cross(r_sigma_k))
                                      - this->mu_ast*r_sigma_k/pow(r_sigma_k.norm(), 3)
                                      + a_sigma_k;
-        
+
         /* Use Euler integration to propagate */
         this->X_sigma_k1_.col(i) = x_sigma_k + x_sigma_dot_k*(CurrentSimNanos-prevTime)*NANO2SEC;
-        
+
         /* Compute average */
         this->x_hat_k1_ = this->x_hat_k1_ + this->wm_sigma(i)*this->X_sigma_k1_.col(i);
     }
-    
+
     /* Loop to compute covariance */
     Eigen::VectorXd x_sigma_dev_k1_;
     x_sigma_dev_k1_.setZero(this->numStates);
@@ -164,11 +164,11 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
     for (int i = 0; i < numSigmas; i++) {
         /* Compute deviation of sigma from the mean */
         x_sigma_dev_k1_ = this->X_sigma_k1_.col(i) - this->x_hat_k1_;
-        
+
         /* Add the deviation to the covariance */
         this->P_k1_ = this->P_k1_ + this->wc_sigma(i)*x_sigma_dev_k1_*x_sigma_dev_k1_.transpose();
     }
-    
+
     /* Add process noise covariance */
     this->P_k1_ = this->P_k1_ + this->P_proc;
 }
@@ -180,10 +180,10 @@ void SmallBodyNavUKF::measurementUT(){
     /* Compute square root matrix of covariance */
     Eigen::MatrixXd Psqrt_k1_;
     Psqrt_k1_ = P_k1_.llt().matrixL();
-    
+
     /* Assign mean to central sigma point */
     this->X_sigma_k1_.col(0) = this->x_hat_k1_;
-    
+
     /* Loop to generate remaining sigma points */
     for (int i = 0; i < this->numStates; i++) {
         /* Generate sigma points */
@@ -192,7 +192,7 @@ void SmallBodyNavUKF::measurementUT(){
         this->X_sigma_k1_.col(this->numStates+i+1) = this->x_hat_k1_
             + sqrt(this->numStates + this->kappa) * Psqrt_k1_.col(i);
     }
-    
+
     /* Loop to propagate sigma points and compute mean */
     Eigen::VectorXd x_sigma_k1_;
     x_sigma_k1_.setZero(this->numStates);
@@ -200,14 +200,14 @@ void SmallBodyNavUKF::measurementUT(){
     for (int i = 0; i < this->numSigmas; i++) {
         /* Extract sigma point */
         x_sigma_k1_ = this->X_sigma_k1_.col(i);
-        
+
         /* Assign correlation between state and measurement */
         this->Y_sigma_k1_.col(i) = x_sigma_k1_.segment(0,3);
-        
+
         /* Compute average */
         this->y_hat_k1_ = this->y_hat_k1_ + this->wm_sigma(i)*this->Y_sigma_k1_.col(i);
     }
-    
+
     /* Loop to compute measurements covariance and cross-correlation */
     Eigen::VectorXd x_sigma_dev_k1_;
     Eigen::VectorXd y_sigma_dev_k1_;
@@ -219,17 +219,17 @@ void SmallBodyNavUKF::measurementUT(){
         /* Compute deviation of measurement sigma from the mean */
         x_sigma_dev_k1_ = this->X_sigma_k1_.col(i) - this->x_hat_k1_;
         y_sigma_dev_k1_ = this->Y_sigma_k1_.col(i) - this->y_hat_k1_;
-        
+
         /* Add the deviation to the measurement and cross-correlation covariances*/
         this->R_k1_ = this->R_k1_ + this->wc_sigma(i)*y_sigma_dev_k1_*y_sigma_dev_k1_.transpose();
         this->H = this->H + this->wc_sigma(i)*x_sigma_dev_k1_*y_sigma_dev_k1_.transpose();
     }
-    
+
     /* Extract dcm of the small body, it transforms from inertial to small body fixed frame */
     double dcm_AN_array[3][3];
     MRP2C(asteroidEphemerisInMsgBuffer.sigma_BN, dcm_AN_array);
     this->dcm_AN = cArray2EigenMatrix3d(*dcm_AN_array);
-    
+
     /* Add process noise covariance */
     this->R_k1_ = this->R_k1_ + this->dcm_AN * this->R_meas * this->dcm_AN.transpose();
 }
@@ -241,24 +241,24 @@ void SmallBodyNavUKF::kalmanUpdate(){
     /* Read attitude MRP of the small body fixed frame w.r.t. inertial */
     Eigen::Vector3d sigma_AN;
     sigma_AN = cArray2EigenVector3d(asteroidEphemerisInMsgBuffer.sigma_BN);
-    
+
     /* Subtract the asteroid position from the spacecraft position */
     Eigen::VectorXd y_k1;
     y_k1.setZero(this->numMeas);
     y_k1.segment(0, 3) = this->dcm_AN*(cArray2EigenVector3d(navTransInMsgBuffer.r_BN_N) -  cArray2EigenVector3d(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
-    
+
     /* Compute Kalman gain */
     this->K = this->H*this->R_k1_.inverse();
-    
+
     /* Compute the Kalman innovation */
     Eigen::VectorXd w_k1;
     w_k1.setZero(this->numStates);
     w_k1 = this->K * (y_k1 - this->y_hat_k1_);
-    
+
     /* Update state estimation and covariance */
     this->x_hat_k1 = this->x_hat_k1_ + w_k1;
     this->P_k1 = this->P_k1_ - this->K * this->R_k1_ * this->K.transpose();
-    
+
     /* Assign the state estimate and covariance to k for the next iteration */
     this->x_hat_k = this->x_hat_k1;
     this->P_k = this->P_k1;
@@ -270,14 +270,14 @@ void SmallBodyNavUKF::kalmanUpdate(){
 void SmallBodyNavUKF::writeMessages(uint64_t CurrentSimNanos){
     /* Create output msg buffers */
     SmallBodyNavUKFMsgPayload smallBodyNavUKFOutMsgBuffer;
-    
+
     /* Zero the output message buffers before assigning values */
     smallBodyNavUKFOutMsgBuffer = this->smallBodyNavUKFOutMsg.zeroMsgPayload;
-    
+
     /* Assign values to the small body navigation output message */
     eigenMatrixXd2CArray(this->x_hat_k1, smallBodyNavUKFOutMsgBuffer.state);
     eigenMatrixXd2CArray(this->P_k1, *smallBodyNavUKFOutMsgBuffer.covar);
-    
+
     /* Write to the C++-wrapped output messages */
     this->smallBodyNavUKFOutMsg.write(&smallBodyNavUKFOutMsgBuffer, this->moduleID, CurrentSimNanos);
 

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
@@ -21,8 +21,6 @@
 #include "fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include <iostream>
-#include <cstring>
 #include <math.h>
 
 /*! This is the constructor for the module class.  It sets default variable

--- a/src/fswAlgorithms/transDetermination/chebyPosEphem/chebyPosEphem.c
+++ b/src/fswAlgorithms/transDetermination/chebyPosEphem/chebyPosEphem.c
@@ -76,13 +76,13 @@ void Reset_chebyPosEphem(ChebyPosEphemData *configData, uint64_t callTime,
                 currRec->velChebyCoeff[k*n+j] *= 1.0/currRec->ephemTimeRad;
             }
         }
-        
+
     }
-    
+
 }
 
 /*! This method takes the current time and computes the state of the object
-    using that time and the stored Chebyshev coefficients.  If the time provided 
+    using that time and the stored Chebyshev coefficients.  If the time provided
     is outside the specified range, the position vectors rail high/low appropriately.
  @return void
  @param configData The configuration data associated with the ephemeris model
@@ -104,7 +104,7 @@ void Update_chebyPosEphem(ChebyPosEphemData *configData, uint64_t callTime, int6
 
     currentEphTime = callTime*NANO2SEC;
     currentEphTime += localCorr.ephemerisTime - localCorr.vehicleClockTime;
-    
+
     configData->coeffSelector = 0;
     for(i=0; i<MAX_CHEB_RECORDS; i++)
     {
@@ -115,7 +115,7 @@ void Update_chebyPosEphem(ChebyPosEphemData *configData, uint64_t callTime, int6
             break;
         }
     }
-   
+
     currRec = &(configData->ephArray[configData->coeffSelector]);
     currentScaledValue = (currentEphTime - currRec->ephemTimeMid)
         /currRec->ephemTimeRad;
@@ -123,9 +123,9 @@ void Update_chebyPosEphem(ChebyPosEphemData *configData, uint64_t callTime, int6
     {
         currentScaledValue = currentScaledValue/fabs(currentScaledValue);
     }
-    
+
     configData->outputState.timeTag = callTime*NANO2SEC;
-    
+
     for(i=0; i<3; i++)
     {
         configData->outputState.r_BdyZero_N[i] = calculateChebyValue(
@@ -134,11 +134,11 @@ void Update_chebyPosEphem(ChebyPosEphemData *configData, uint64_t callTime, int6
         configData->outputState.v_BdyZero_N[i] = calculateChebyValue(
             &(currRec->velChebyCoeff[i*currRec->nChebCoeff]),
             currRec->nChebCoeff, currentScaledValue);
-        
+
     }
-    
+
     EphemerisMsg_C_write(&configData->outputState, &configData->posFitOutMsg, moduleID, callTime);
-    
+
     return;
 
 }

--- a/src/fswAlgorithms/transDetermination/chebyPosEphem/chebyPosEphem.c
+++ b/src/fswAlgorithms/transDetermination/chebyPosEphem/chebyPosEphem.c
@@ -23,7 +23,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include <math.h>
 #include <string.h>
-#include <stdlib.h>
 
 /*! This method creates the output navigation message (translation only) for
     the ephemeris model

--- a/src/fswAlgorithms/transDetermination/dvAccumulation/dvAccumulation.c
+++ b/src/fswAlgorithms/transDetermination/dvAccumulation/dvAccumulation.c
@@ -21,7 +21,6 @@
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include <string.h>
-#include <stdlib.h>
 #include "architecture/utilities/bsk_Print.h"
 
 

--- a/src/fswAlgorithms/transDetermination/dvAccumulation/dvAccumulation.c
+++ b/src/fswAlgorithms/transDetermination/dvAccumulation/dvAccumulation.c
@@ -160,7 +160,7 @@ void Update_dvAccumulation(DVAccumulationData *configData, uint64_t callTime, in
     double frameDV_B[3];            /* [m/s] The DV of an integrated acc measurement */
     AccDataMsgPayload inputAccData;     /* [-] Input message container */
     NavTransMsgPayload outputData;      /* [-] The local storage of the outgoing message data */
-    
+
     /*! - zero output message container */
     outputData = NavTransMsg_C_zeroMsgPayload();
 
@@ -168,7 +168,7 @@ void Update_dvAccumulation(DVAccumulationData *configData, uint64_t callTime, in
     inputAccData = AccDataMsg_C_read(&configData->accPktInMsg);
 
     /*! - stack data in time order */
-    
+
     dvAccumulation_QuickSort(&(inputAccData.accPkts[0]), 0, MAX_ACC_BUF_PKT-1); /* measTime is the array we want to sort. We're sorting the time calculated for each measurement taken from the accelerometer in order in terms of time. */
 
     /*! - Ensure that the computed dt doesn't get huge.*/
@@ -199,7 +199,7 @@ void Update_dvAccumulation(DVAccumulationData *configData, uint64_t callTime, in
     }
 
     /*! - Create output message */
-    
+
     outputData.timeTag = configData->previousTime*NANO2SEC;
     v3Copy(configData->vehAccumDV_B, outputData.vehAccumDV);
 

--- a/src/fswAlgorithms/transDetermination/ephemDifference/ephemDifference.c
+++ b/src/fswAlgorithms/transDetermination/ephemDifference/ephemDifference.c
@@ -17,11 +17,7 @@
 
  */
 
-#include <math.h>
-#include <string.h>
-#include <stdlib.h>
 #include "fswAlgorithms/transDetermination/ephemDifference/ephemDifference.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 
 /*! @brief This method creates the output ephemeris messages for each body.

--- a/src/fswAlgorithms/transDetermination/ephemDifference/ephemDifference.c
+++ b/src/fswAlgorithms/transDetermination/ephemDifference/ephemDifference.c
@@ -92,7 +92,7 @@ void Update_ephemDifference(EphemDifferenceData *configData, uint64_t callTime, 
         v3Subtract(tmpEphStore.v_BdyZero_N,
                    tmpBaseEphem.v_BdyZero_N,
                    tmpEphStore.v_BdyZero_N);
-        
+
         EphemerisMsg_C_write(&tmpEphStore, &configData->changeBodies[i].ephOutMsg, moduleID, callTime);
     }
     return;

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.c
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.c
@@ -17,11 +17,7 @@
 
  */
 
-#include <math.h>
-#include <string.h>
-#include <stdlib.h>
 #include "fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 
 /*! This method creates the output navigation message (translation only) for

--- a/src/fswAlgorithms/transDetermination/navAggregate/navAggregate.c
+++ b/src/fswAlgorithms/transDetermination/navAggregate/navAggregate.c
@@ -18,7 +18,6 @@
  */
 
 #include "navAggregate.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include <string.h>
 #include <stdio.h>

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.c
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.c
@@ -19,14 +19,9 @@
 
 #include "fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.h"
 #include "fswAlgorithms/transDetermination/_GeneralModuleFiles/ephemerisUtilities.h"
-#include "fswAlgorithms/transDetermination/chebyPosEphem/chebyPosEphem.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/orbitalMotion.h"
-#include "architecture/utilities/astroConstants.h"
 #include <math.h>
-#include <string.h>
-#include <stdlib.h>
 
 /*! This method creates the output navigation message (translation only) for 
     the ephemeris model

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.c
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.c
@@ -23,7 +23,7 @@
 #include "architecture/utilities/orbitalMotion.h"
 #include <math.h>
 
-/*! This method creates the output navigation message (translation only) for 
+/*! This method creates the output navigation message (translation only) for
     the ephemeris model
  @return void
  @param configData The configuration data associated with the ephemeris model
@@ -51,7 +51,7 @@ void Reset_oeStateEphem(OEStateEphemData *configData, uint64_t callTime,
 }
 
 /*! This method takes the current time and computes the state of the object
-    using that time and the stored Chebyshev coefficients.  If the time provided 
+    using that time and the stored Chebyshev coefficients.  If the time provided
     is outside the specified range, the position vectors rail high/low appropriately.
  @return void
  @param configData The configuration data associated with the ephemeris model

--- a/src/fswAlgorithms/vehicleConfigData/vehicleConfigData.c
+++ b/src/fswAlgorithms/vehicleConfigData/vehicleConfigData.c
@@ -20,7 +20,6 @@
 #include "architecture/utilities/macroDefinitions.h"
 #include "fswAlgorithms/vehicleConfigData/vehicleConfigData.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include <string.h>
 
 /*! This method initializes the configData for the veh config algorithm.
     It initializes the output message in the messaging system.

--- a/src/fswAlgorithms/vehicleConfigData/vehicleConfigData.c
+++ b/src/fswAlgorithms/vehicleConfigData/vehicleConfigData.c
@@ -46,7 +46,7 @@ void Reset_vehicleConfigData(VehConfigInputData *configData, uint64_t callTime, 
 
     /*! - Copy over the inertia */
     m33Copy(RECAST3X3 configData->ISCPntB_B, RECAST3X3 localConfigData.ISCPntB_B);
-    
+
     /*! - Copy over the mass */
     localConfigData.massSC = configData->massSC;
 

--- a/src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.cpp
+++ b/src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.cpp
@@ -18,8 +18,6 @@
  */
 #include "moduleTemplates/cppModuleTemplate/cppModuleTemplate.h"
 #include <iostream>
-#include <cstring>
-#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 
 /*! This is the constructor for the module class.  It sets default variable

--- a/src/simulation/deviceInterface/encoder/encoder.cpp
+++ b/src/simulation/deviceInterface/encoder/encoder.cpp
@@ -61,11 +61,11 @@ void Encoder::Reset(uint64_t CurrentSimNanos)
     }
 
     // reset the previous time
-    this->prevTime = CurrentSimNanos;     
+    this->prevTime = CurrentSimNanos;
 
     // zero the RW wheel output message buffer //
     this->rwSpeedConverted = this->rwSpeedOutMsg.zeroMsgPayload;
-    
+
     // Loop through the RW to set some internal parameters to default
     for (int i = 0; i < MAX_EFF_CNT; i++)
     {
@@ -74,7 +74,7 @@ void Encoder::Reset(uint64_t CurrentSimNanos)
         // set the remaining clicks to zero
         this->remainingClicks[i] = 0.0;
     }
-    
+
     return;
 }
 
@@ -102,7 +102,7 @@ void Encoder::writeOutputMessages(uint64_t CurrentClock)
 /*! This method applies an encoder to the reaction wheel speeds.
 */
 void Encoder::encode(uint64_t CurrentSimNanos)
-{    
+{
     double timeStep;
     double numberClicks;
     double clicksPerRadian;

--- a/src/simulation/deviceInterface/encoder/encoder.cpp
+++ b/src/simulation/deviceInterface/encoder/encoder.cpp
@@ -17,10 +17,7 @@
 
  */
 #include "simulation/deviceInterface/encoder/encoder.h"
-#include <iostream>
-#include <cstring>
 #include <math.h>
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/macroDefinitions.h"
 
 /*! This is the constructor for the module class.  It sets default variable

--- a/src/simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.cpp
+++ b/src/simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.cpp
@@ -84,4 +84,3 @@ void HingedBodyLinearProfiler::UpdateState(uint64_t CurrentSimNanos)
     //!<  write to the output messages
     this->hingedRigidBodyReferenceOutMsg.write(&hingedRigidBodyReferenceOutMsgBuffer, this->moduleID, CurrentSimNanos);
 }
-

--- a/src/simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.cpp
+++ b/src/simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.cpp
@@ -21,7 +21,6 @@
 #include "simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <iostream>
-#include <cstring>
 
 /*! This is the constructor for the module class.  It sets default variable
     values and initializes the various parts of the model */

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
@@ -59,7 +59,7 @@ void MotorVoltageInterface::readInputMessages()
 
     // read the incoming array of voltages
     this->inputVoltageBuffer = this->motorVoltageInMsg();
-    
+
     return;
 }
 
@@ -147,5 +147,3 @@ void MotorVoltageInterface::UpdateState(uint64_t CurrentSimNanos)
 
     return;
 }
-
-

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
@@ -19,7 +19,6 @@
 #include "simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.h"
 
 #include <iostream>
-#include <cstring>
 
 /*! This is the constructor for the motor voltgage interface.  It sets default variable
     values and initializes the various parts of the model */

--- a/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.cpp
+++ b/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.cpp
@@ -20,7 +20,6 @@
 #include "singleAxisProfiler.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <cmath>
 

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
@@ -82,17 +82,17 @@ void BoreAngCalc::ReadInputs()
         this->localPlanet = this->celBodyInMsg();
         celBodyMsgGood = this->celBodyInMsg.isWritten();
     }
-    
+
     this->inputsGood = this->scStateInMsg.isWritten() && (celBodyMsgGood || this->useInertialHeading);
 }
 
-/*! This method computes the vector specified in the input file in the LVLH 
-    reference frame of the spacecraft above the target celestial body.  This 
+/*! This method computes the vector specified in the input file in the LVLH
+    reference frame of the spacecraft above the target celestial body.  This
     is used later to compute how far off that vector is in an angular sense.
     @return void
 */
 void BoreAngCalc::computeCelestialAxisPoint()
-{             
+{
     // Convert planet and body data to Eigen variables
     Eigen::Vector3d r_BN_N = cArray2EigenVector3d(this->localState.r_BN_N); // spacecraft's inertial position
     Eigen::Vector3d v_BN_N = cArray2EigenVector3d(this->localState.v_BN_N); // spacecraft''s inertial velocity
@@ -140,7 +140,7 @@ void BoreAngCalc::computeCelestialOutputData()
     }
 }
 
-/*! This method computes the output structure for messaging. The miss angle is 
+/*! This method computes the output structure for messaging. The miss angle is
     computed using the body heading and the provided inertial heading
     @return void
 */
@@ -169,9 +169,9 @@ void BoreAngCalc::UpdateState(uint64_t CurrentSimNanos)
 {
     //! - Read the input message and convert it over appropriately depending on switch
     ReadInputs();
-   
+
     if(this->inputsGood)
-    { 
+    {
         if (this->useCelestialHeading)
         {
             this->computeCelestialAxisPoint();
@@ -181,7 +181,7 @@ void BoreAngCalc::UpdateState(uint64_t CurrentSimNanos)
             this->computeInertialOutputData();
         }
     }
-    
+
     //! Write out the current output for current time
     WriteOutputMessages(CurrentSimNanos);
 }

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
@@ -19,7 +19,6 @@
 
 #include "simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 
 //! The constructor.  Note that you have to overwrite the message names.
 BoreAngCalc::BoreAngCalc()

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.cpp
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.cpp
@@ -84,7 +84,7 @@ void OrbElemConvert::WriteOutputMessages(uint64_t CurrentClock)
         v3Copy(this->r_N, spiceMsg.PositionVector);
         v3Copy(this->v_N, spiceMsg.VelocityVector);
         this->spiceStateOutMsg.write(&spiceMsg, this->moduleID, CurrentClock);
-    }    
+    }
 }
 
 /*! The name kind of says it all right?  Converts CurrentElem to pos/vel.

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.cpp
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.cpp
@@ -17,7 +17,6 @@
 
  */
 #include "simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.h"
-#include <cstring>
 #include <iostream>
 #include "architecture/utilities/linearAlgebra.h"
 

--- a/src/simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.cpp
+++ b/src/simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.cpp
@@ -63,7 +63,7 @@ void ExtPulsedTorque::readInputMessages()
 
 /*! This method is used to compute the RHS forces and torques.
     Note:   the module can set any of these three vecors, or a subset.  Regarding the external force, the
-            matrix represnetations in the body (B) and inerial (N) frame components are treated as 2 
+            matrix represnetations in the body (B) and inerial (N) frame components are treated as 2
             separate vectors.  Only set both if you mean to, as both vectors will be included.
  */
 void ExtPulsedTorque::computeForceTorque(double integTime, double timeStep)
@@ -93,5 +93,3 @@ void ExtPulsedTorque::UpdateState(uint64_t CurrentSimNanos)
 {
     return;
 }
-
-

--- a/src/simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.cpp
+++ b/src/simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.cpp
@@ -18,8 +18,6 @@
  */
 #include "simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.h"
 #include <iostream>
-#include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /*! This is the constructor.  It sets some default initializers that can be
  overriden by the user.*/

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -179,7 +179,7 @@ void HingedRigidBodyStateEffector::updateEffectorMassProps(double integTime)
     return;
 }
 
-/*! This method allows the HRB state effector to give its contributions to the matrices needed for the back-sub 
+/*! This method allows the HRB state effector to give its contributions to the matrices needed for the back-sub
  method */
 void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
@@ -313,7 +313,7 @@ void HingedRigidBodyStateEffector::UpdateState(uint64_t CurrentSimNanos)
     this->computePanelInertialStates();
 
     this->writeOutputStateMessages(CurrentSimNanos);
-    
+
     return;
 }
 

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -19,10 +19,6 @@
 
 #include "hingedRigidBodyStateEffector.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
-#include <iostream>
 #include <string>
 
 /*! This is the constructor, setting variables to default values */

--- a/src/simulation/dynamics/RadiationPressure/radiationPressure.cpp
+++ b/src/simulation/dynamics/RadiationPressure/radiationPressure.cpp
@@ -17,7 +17,6 @@
 
  */
 
-#include <iostream>
 #include "simulation/dynamics/RadiationPressure/radiationPressure.h"
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"

--- a/src/simulation/dynamics/RadiationPressure/radiationPressure.cpp
+++ b/src/simulation/dynamics/RadiationPressure/radiationPressure.cpp
@@ -35,7 +35,7 @@ RadiationPressure::RadiationPressure()
     this->forceExternal_N.setZero();
     this->forceExternal_B.setZero();
     this->torqueExternalPntB_B.setZero();
-    
+
     CallCounts = 0;
     return;
 }
@@ -70,7 +70,7 @@ void RadiationPressure::linkInStates(DynParamManager& states)
     this->hubR_N = states.getStateObject("hubPosition");
 }
 
-/*! This method is used to read the incoming ephmeris and 
+/*! This method is used to read the incoming ephmeris and
  spacecraft state messages. The data is stored in the associated
  buffer structure.
  @return void
@@ -88,7 +88,7 @@ void RadiationPressure::readInputMessages()
 }
 
 /*! This method computes the dynamic effect due to solar raidation pressure.
- It is an inherited method from the DynamicEffector class and 
+ It is an inherited method from the DynamicEffector class and
  is designed to be called by the simulation dynamics engine.
  @return void
  @param integTime Current simulation integration time
@@ -103,7 +103,7 @@ void RadiationPressure::computeForceTorque(double integTime, double timeStep)
     Eigen::Vector3d r_N = (Eigen::Vector3d)this->hubR_N->getState();
     Eigen::Vector3d sun_r_N(this->sunEphmInBuffer.PositionVector);
     Eigen::Vector3d s_N = sun_r_N - r_N;
-    
+
     if (this->srpModel == SRP_CANNONBALL_MODEL) {
         this->computeCannonballModel(s_N);
         this->forceExternal_N = this->forceExternal_N * this->sunVisibilityFactor.shadowFactor;
@@ -187,13 +187,13 @@ void RadiationPressure::computeLookupModel(Eigen::Vector3d s_B)
     double sunDist = s_B.norm();
     Eigen::Vector3d sHat_B = s_B/sunDist;
     Eigen::Vector3d tmpLookupSHat_B(0,0,0);
-    
+
     if (!this->stateRead) {
         this->forceExternal_B.setZero();
         this->torqueExternalPntB_B.setZero();
         return;
     }
-    
+
     // Find the lookup entry that most closely aligns with the current sHat_B direction
     // Look up force is expected to be evaluated at 1AU.
     // Therefore, we must scale the force by its distance from the sun squared.
@@ -209,7 +209,7 @@ void RadiationPressure::computeLookupModel(Eigen::Vector3d s_B)
             currentDotProduct = tmpDotProduct;
         }
     }
-    
+
     this->forceExternal_B = this->lookupForce_B[currentIdx]*pow(AU*1000/sunDist, 2);
     this->torqueExternalPntB_B = this->lookupTorque_B[currentIdx]*pow(AU*1000/sunDist, 2);
 }

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -84,7 +84,7 @@ void ThrusterDynamicEffector::writeOutputMessages(uint64_t CurrentClock)
         tmpThruster.thrustForce = v3Norm(it->ThrustOps.opThrustForce_B);
         v3Copy(it->ThrustOps.opThrustForce_B, tmpThruster.thrustForce_B);
         v3Copy(it->ThrustOps.opThrustTorquePntB_B, tmpThruster.thrustTorquePntB_B);
-        
+
         this->thrusterOutMsgs[idx]->write(&tmpThruster, this->moduleID, CurrentClock);
 
         idx ++;
@@ -100,7 +100,7 @@ bool ThrusterDynamicEffector::ReadInputs()
 {
     uint64_t i;
     bool dataGood;
-    
+
     if (this->cmdsInMsg.isLinked()) {
         //! - read the incoming command array
         this->incomingCmdBuffer = this->cmdsInMsg();
@@ -124,7 +124,7 @@ bool ThrusterDynamicEffector::ReadInputs()
         *CmdPtr = this->incomingCmdBuffer.OnTimeRequest[i];
     }
     return(true);
-    
+
 }
 
 /*! This method is used to read the new commands vector and set the thruster
@@ -164,7 +164,7 @@ void ThrusterDynamicEffector::ConfigureThrustRequests(double currentTime)
         //! After we have assigned the firing to the internal thruster, zero the command request.
         *CmdIt = 0.0;
     }
-    
+
 }
 
 /*! This method is used to update the location and orientation of the thrusters
@@ -252,7 +252,7 @@ void ThrusterDynamicEffector::computeForceTorque(double integTime, double timeSt
     Eigen::Matrix3d	axesWeightMatrix;
     Eigen::Vector3d BM1, BM2, BM3;
     double mDotNozzle;
-    
+
     //! - Zero out the structure force/torque for the thruster set
     this->forceExternal_B.setZero();
     this->forceExternal_N.setZero();
@@ -264,7 +264,7 @@ void ThrusterDynamicEffector::computeForceTorque(double integTime, double timeSt
     // Loop variables
     std::vector<THRSimConfig>::iterator it;
     THROperation* ops;
-    
+
     //! - Iterate through all of the thrusters to aggregate the force/torque in the system
     int index;
     for(it = this->thrusterData.begin(), index = 0; it != this->thrusterData.end(); it++, index++)
@@ -293,11 +293,11 @@ void ThrusterDynamicEffector::computeForceTorque(double integTime, double timeSt
         tmpThrustMag *= (1. + it->thrusterMagDisp);
         SingleThrusterForce = tmpThrustMag * thrustDirection_B;
         this->forceExternal_B += SingleThrusterForce;
-        
+
         //! - Compute the point B relative torque and aggregate into the composite body torque
         SingleThrusterTorque = thrustLocation_B.cross(SingleThrusterForce) + ops->ThrustFactor * it->MaxSwirlTorque * thrustDirection_B;
         this->torqueExternalPntB_B += SingleThrusterTorque;
-        
+
 		if (!it->updateOnly) {
 			//! - Add the mass depletion force contribution
 			mDotNozzle = 0.0;
@@ -372,7 +372,7 @@ void ThrusterDynamicEffector::addThruster(THRSimConfig* newThruster, Message<SCS
 
 
 void ThrusterDynamicEffector::computeStateContribution(double integTime){
-    
+
     std::vector<THRSimConfig>::iterator it;
     THROperation *ops;
     double mDotSingle=0.0;
@@ -420,7 +420,7 @@ void ThrusterDynamicEffector::ComputeThrusterFire(THRSimConfig *CurrentThruster,
     double prevValidThrFactor = 0.0;
     double prevValidIspFactor = 0.0;
     double prevValidDelta = 0.0;
-    
+
     //! - Iterate through the on-ramp for the thruster data to find where we are in ramp
     for(it = CurrentThruster->ThrusterOnRamp.begin();
         it != CurrentThruster->ThrusterOnRamp.end(); it++)
@@ -444,7 +444,7 @@ void ThrusterDynamicEffector::ComputeThrusterFire(THRSimConfig *CurrentThruster,
         prevValidDelta = it->TimeDelta;
     }
     //! - If we did not find the current time in the on-ramp, then we are at steady-state
-    
+
     ops->ThrustOnSteadyTime += (currentTime - ops->PreviousIterTime);
     ops->totalOnTime += (currentTime - ops->PreviousIterTime);
     ops->PreviousIterTime = currentTime;
@@ -466,7 +466,7 @@ void ThrusterDynamicEffector::ComputeThrusterShut(THRSimConfig *CurrentThruster,
 {
     std::vector<THRTimePair>::iterator it;
     THROperation *ops = &(CurrentThruster->ThrustOps);
-    
+
     //! - Set the current off-ramp time based on the previous clock time and now
     if(ops->ThrustOffRampTime == 0.0 &&
        CurrentThruster->ThrusterOffRamp.size() > 0)
@@ -524,7 +524,7 @@ double ThrusterDynamicEffector::thrFactorToTime(THRSimConfig *thrData,
     double rampTime = it->TimeDelta;
     double rampDirection = std::copysign(1.0,
                                          it->ThrustFactor - thrData->ThrustOps.ThrustFactor);
-    
+
     //! - Initialize the time computation functiosn based on ramp direction
     double prevValidThrFactor = rampDirection < 0 ? 1.0 : 0.0;
     double prevValidDelta = 0.0;
@@ -541,7 +541,7 @@ double ThrusterDynamicEffector::thrFactorToTime(THRSimConfig *thrData,
             prevValidDelta = it->TimeDelta;
             continue;
         }
-        
+
         //! - Linearly interpolate between the points, check for numerical garbage, and return clean interpolation
         rampTime = (it->TimeDelta - prevValidDelta)/(it->ThrustFactor -
                                                      prevValidThrFactor) * (thrData->ThrustOps.ThrustFactor -
@@ -549,7 +549,7 @@ double ThrusterDynamicEffector::thrFactorToTime(THRSimConfig *thrData,
         rampTime = rampTime < 0.0 ? 0.0 : rampTime;
         break;
     }
-    
+
     return(rampTime);
 }
 

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -17,18 +17,12 @@
 
  */
 
-#include <cstring>
 #include <iostream>
-#include <cmath>
 
 #include "thrusterDynamicEffector.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/astroConstants.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include <cstring>
-#include <iostream>
-#include <cmath>
 
 /*! The Constructor.*/
 ThrusterDynamicEffector::ThrusterDynamicEffector()

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -80,7 +80,7 @@ void ThrusterStateEffector::Reset(uint64_t CurrentSimNanos)
 
     // Reset the mas flow value
     this->mDotTotal = 0.0;
-    
+
     return;
 }
 
@@ -93,7 +93,7 @@ bool ThrusterStateEffector::ReadInputs()
     // Initialize local variables
     uint64_t i;
     bool dataGood;
-    
+
     // Check if the message has been linked
     if (this->cmdsInMsg.isLinked()) {
         //! - Read the incoming command array
@@ -118,7 +118,7 @@ bool ThrusterStateEffector::ReadInputs()
         *CmdPtr = this->incomingCmdBuffer.OnTimeRequest[i];
     }
     return(true);
-    
+
 }
 
 /*! This method is here to write the output message structure into the specified
@@ -185,8 +185,8 @@ void ThrusterStateEffector::ConfigureThrustRequests()
     return;
 }
 
-/*! This method is used to update the location and orientation of the thrusters 
-* at every UpdateState call when the thrusters are attached to a body other than 
+/*! This method is used to update the location and orientation of the thrusters
+* at every UpdateState call when the thrusters are attached to a body other than
 * the hub.
  @return void
  */
@@ -311,7 +311,7 @@ void ThrusterStateEffector::registerStates(DynParamManager& states)
             this->kappaInit[i] = 0.0;
         }
         kappaInitMatrix(i, 0) = this->kappaInit[i];
-    }  
+    }
     this->kappaState->setState(kappaInitMatrix);
 
     return;
@@ -348,7 +348,7 @@ void ThrusterStateEffector::computeDerivatives(double integTime, Eigen::Vector3d
         ops->ThrustFactor = this->kappaState->state(i, 0);
     }
     this->kappaState->setDerivative(kappaDot);
-   
+
     return;
 }
 
@@ -365,7 +365,7 @@ void ThrusterStateEffector::calcForceTorqueOnBody(double integTime, Eigen::Vecto
     // Auxiliary variables to convert direction and location from F to B
     Eigen::Vector3d thrustDirection_B;
     Eigen::Vector3d thrustLocation_B;
-    
+
     // Expelled momentum variables
     Eigen::Matrix3d BMj;
     Eigen::Matrix3d	axesWeightMatrix;

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -17,9 +17,7 @@
 
  */
 
-#include <cstring>
 #include <iostream>
-#include <cmath>
 
 #include "thrusterStateEffector.h"
 #include "architecture/utilities/linearAlgebra.h"

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -535,7 +535,7 @@ void VSCMGStateEffector::Reset(uint64_t CurrenSimNanos)
 }
 
 /*! This method is here to write the output message structure into the specified
- message.  
+ message.
  @param CurrentClock The current time used for time-stamping the message
  @return void
  */
@@ -770,4 +770,3 @@ void VSCMGStateEffector::AddVSCMG(VSCMGConfigMsgPayload *NewVSCMG)
     msg = new Message<VSCMGConfigMsgPayload>;
     this->vscmgOutMsgs.push_back(msg);
 }
-

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -19,7 +19,6 @@
 
 
 #include "vscmgStateEffector.h"
-#include <cstring>
 #include <iostream>
 #include <cmath>
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
@@ -38,7 +38,7 @@ double computeDtInSeconds(uint64_t lhs, uint64_t rhs)
 } // namespace
 
 GravBodyData::GravBodyData()
-    : gravityModel{std::make_shared<PointMassGravityModel>()}, 
+    : gravityModel{std::make_shared<PointMassGravityModel>()},
       localPlanet{std::invoke([]() {
           SpicePlanetStateMsgPayload payload{};
           m33SetIdentity(payload.J20002Pfix); // Initialize rotation matrix to identity
@@ -176,7 +176,7 @@ void GravityEffector::prependSpacecraftNameToStates()
 void GravityEffector::registerProperties(DynParamManager& statesIn)
 {
     static const Eigen::Vector3d zeroVector3d = Eigen::Vector3d::Zero();
-    
+
     this->gravProperty = statesIn.createProperty(this->vehicleGravityPropName, zeroVector3d);
     this->inertialPositionProperty =
         statesIn.createProperty(this->inertialPositionPropName, zeroVector3d);

--- a/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
@@ -20,7 +20,6 @@
 #include <functional>
 
 #include "gravityEffector.h"
-#include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
 

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -83,7 +83,7 @@ DualHingedRigidBodyStateEffector::~DualHingedRigidBodyStateEffector()
         free(this->dualHingedRigidBodyOutMsgs.at(c));
         free(this->dualHingedRigidBodyConfigLogOutMsgs.at(c));
     }
-    
+
     this->effectorID = 1;    /* reset the panel ID*/
     return;
 }
@@ -252,7 +252,7 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime, Bac
     this->matrixGDHRB.row(1) = -(this->IPntS2_S2(1,1)*this->sHat22_P.transpose() - this->mass2*this->d2*this->sHat23_P.transpose()*this->rTildeS2P_P);
 
     this->vectorVDHRB(0) =  -(this->IPntS1_S1(0,0) - this->IPntS1_S1(2,2))*this->omega_PN_S1(2)*this->omega_PN_S1(0)
-                            + this->u1 - this->k1*this->theta1 - this->c1*this->theta1Dot + this->k2*this->theta2 + this->c2*this->theta2Dot + this->sHat12_P.dot(gravTorquePan1PntH1) + this->l1*this->sHat13_P.dot(gravForcePan2) - 
+                            + this->u1 - this->k1*this->theta1 - this->c1*this->theta1Dot + this->k2*this->theta2 + this->c2*this->theta2Dot + this->sHat12_P.dot(gravTorquePan1PntH1) + this->l1*this->sHat13_P.dot(gravForcePan2) -
                             this->mass1*this->d1*this->sHat13_P.transpose()*(2*this->omegaTildePNLoc_P*this->rPrimeS1P_P + this->omegaTildePNLoc_P*this->omegaTildePNLoc_P*this->r_S1P_P)
                             - this->mass2*this->l1*this->sHat13_P.transpose()*(2*this->omegaTildePNLoc_P*this->rPrimeS2P_P + this->omegaTildePNLoc_P*this->omegaTildePNLoc_P*this->r_S2P_P + this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P + this->d2*(this->theta1Dot + this->theta2Dot)*(this->theta1Dot + this->theta2Dot)*this->sHat21_P); //still missing torque and force terms - SJKC
 
@@ -267,13 +267,13 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime, Bac
                     + (this->mass1*this->d1*this->sHat13_P + this->mass2*this->l1*this->sHat13_P + this->mass2*this->d2*this->sHat23_P)*this->matrixEDHRB.row(0)*this->vectorVDHRB + this->mass2*this->d2*this->sHat23_P*this->matrixEDHRB.row(1)*this->vectorVDHRB);
 
     // - Define rotational matrice contributions (Eq 96 in paper)
-    
+
     backSubContr.matrixC = (this->IPntS1_S1(1,1)*this->sHat12_P + this->mass1*this->d1*this->rTildeS1P_P*this->sHat13_P + this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->l1*this->rTildeS2P_P*this->sHat13_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(0)*this->matrixFDHRB
                     + (this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(1)*this->matrixFDHRB;
-    
+
     backSubContr.matrixD = (this->IPntS1_S1(1,1)*this->sHat12_P + this->mass1*this->d1*this->rTildeS1P_P*this->sHat13_P + this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->l1*this->rTildeS2P_P*this->sHat13_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(0)*this->matrixGDHRB
                     +(this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(1)*this->matrixGDHRB;
-    
+
     backSubContr.vecRot = -(this->theta1Dot*this->IPntS1_S1(1,1)*this->omegaTildePNLoc_P*this->sHat12_P
                     + this->mass1*this->omegaTildePNLoc_P*this->rTildeS1P_P*this->rPrimeS1P_P + this->mass1*this->d1*this->theta1Dot*this->theta1Dot*this->rTildeS1P_P*this->sHat11_P + (this->theta1Dot+this->theta2Dot)*this->IPntS2_S2(1,1)*this->omegaTildePNLoc_P*this->sHat22_P + this->mass2*this->omegaTildePNLoc_P*this->rTildeS2P_P*this->rPrimeS2P_P
                     + this->mass2*this->rTildeS2P_P*(this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P + this->d2*(this->theta1Dot+this->theta2Dot)*(this->theta1Dot+this->theta2Dot)*this->sHat21_P) + (this->IPntS1_S1(1,1)*this->sHat12_P + this->mass1*this->d1*this->rTildeS1P_P*this->sHat13_P + this->IPntS2_S2(1,1)*this->sHat22_P
@@ -320,7 +320,7 @@ void DualHingedRigidBodyStateEffector::updateEnergyMomContributions(double integ
     // - Get the current omega state
     Eigen::Vector3d omegaLocal_PN_P;
     omegaLocal_PN_P = this->omega_BN_BState->getState();
-    
+
     // - Find rotational angular momentum contribution from hub
     Eigen::Vector3d omega_S1P_P;
     Eigen::Vector3d omega_S2P_P;
@@ -340,7 +340,7 @@ void DualHingedRigidBodyStateEffector::updateEnergyMomContributions(double integ
     rDot_S2P_P = this->rPrimeS2P_P + omegaLocal_PN_P.cross(this->r_S2P_P);
     rotAngMomPntCContr_P = IPntS1_P*omega_S1N_P + this->mass1*this->r_S1P_P.cross(rDot_S1P_P)
                             + IPntS2_P*omega_S2N_P + this->mass2*this->r_S2P_P.cross(rDot_S2P_P);
-    
+
     // - Find rotational energy contribution from the hub
     double rotEnergyContrS1;
     double rotEnergyContrS2;
@@ -351,7 +351,7 @@ void DualHingedRigidBodyStateEffector::updateEnergyMomContributions(double integ
                         + 0.5*this->mass2*rDot_S2P_P.dot(rDot_S2P_P)
                         + 0.5*this->k2*this->theta2*this->theta2;
     rotEnergyContr = rotEnergyContrS1 + rotEnergyContrS2;
-    
+
     return;
 }
 

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -19,10 +19,7 @@
 
 
 #include "dualHingedRigidBodyStateEffector.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
-#include <iostream>
 #include <string>
 
 DualHingedRigidBodyStateEffector::DualHingedRigidBodyStateEffector()

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -104,10 +104,10 @@ void FacetDragDynamicEffector::updateDragDir(){
     Eigen::MRPd sigmaBN;
     sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
     Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
-    
+
     this->v_B = dcm_BN*this->hubVelocity->getState(); // [m/s] sc velocity
     this->v_hat_B = this->v_B / this->v_B.norm();
-    
+
     return;
 }
 
@@ -117,7 +117,7 @@ dependence and lift forces.
 void FacetDragDynamicEffector::plateDrag(){
 	Eigen::Vector3d facetDragForce, facetDragTorque;
 	Eigen::Vector3d totalDragForce, totalDragTorque;
-    
+
 	//! - Zero out the structure force/torque for the drag set
     double projectedArea = 0.0;
     double projectionTerm = 0.0;
@@ -125,7 +125,7 @@ void FacetDragDynamicEffector::plateDrag(){
 	totalDragTorque.setZero();
     this->forceExternal_B.setZero();
     this->torqueExternalPntB_B.setZero();
-    
+
 	for(size_t i = 0; i < this->numFacets; i++){
 	    projectionTerm = this->scGeometry.facetNormals_B[i].dot(this->v_hat_B);
 		projectedArea = this->scGeometry.facetAreas[i] * projectionTerm;

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -17,7 +17,6 @@
 
  */
 
-#include <iostream>
 #include "facetDragDynamicEffector.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/astroConstants.h"

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -20,7 +20,6 @@
 #include "facetSRPDynamicEffector.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include <cmath>
 
 const double speedLight = 299792458.0;  // [m/s] Speed of light

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
@@ -65,7 +65,7 @@ void HingedRigidBodyMotor::UpdateState(uint64_t CurrentSimNanos)
     double refTheta;
     double refThetaDot;
     double torque;
-    
+
     HingedRigidBodyMsgPayload hingedBodyStateSensedInMsgBuffer;  //!< local copy of message buffer for reference
     HingedRigidBodyMsgPayload hingedBodyStateReferenceInMsgBuffer;  //!< local copy of message buffer for measurement
     ArrayMotorTorqueMsgPayload motorTorqueOutMsgBuffer;  //!< local copy of message buffer for motor torque
@@ -86,8 +86,7 @@ void HingedRigidBodyMotor::UpdateState(uint64_t CurrentSimNanos)
     //! calculate motor torque
     torque = -1 * this->K * (sensedTheta - refTheta) - this->P * (sensedThetaDot - refThetaDot);
     motorTorqueOutMsgBuffer.motorTorque[0] = torque;
-    
+
     //! write to the output messages
     this->motorTorqueOutMsg.write(&motorTorqueOutMsgBuffer, this->moduleID, CurrentSimNanos);
 }
-

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
@@ -20,7 +20,6 @@
 
 #include "simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h"
 #include <iostream>
-#include <cstring>
 
 /*! This is the constructor for the module class.  It sets default variable
     values and initializes the various parts of the model */

--- a/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
+++ b/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
@@ -53,18 +53,18 @@ void MsmForceTorque::Reset(uint64_t CurrentSimNanos)
             bskLogger.bskLog(BSK_ERROR, "MsmForceTorque.scStateInMsgs[%d] was not linked.", c);
         }
     }
-    
+
     for (long unsigned int c=0; c < this->voltInMsgs.size(); c++) {
         if (!this->voltInMsgs.at(c).isLinked()) {
             bskLogger.bskLog(BSK_ERROR, "MsmForceTorque.voltInMsgs[%d] was not linked.", c);
         }
     }
-    
+
     this->numSat = (uint32_t) this->scStateInMsgs.size();
     if (this->numSat < 2) {
         bskLogger.bskLog(BSK_ERROR, "MsmForceTorque must have 2 or more spacecraft components added. You added %lu.", this->numSat);
     }
-    
+
     /* determine number of spheres being modeled */
     this->numSpheres = 0;
     for (long unsigned int c=0; c < this->numSat; c++) {
@@ -73,7 +73,7 @@ void MsmForceTorque::Reset(uint64_t CurrentSimNanos)
     if (this->numSpheres == 0) {
         bskLogger.bskLog(BSK_ERROR, "MsmForceTorque does not have any spheres added?");
     }
-    
+
     return;
 }
 
@@ -85,18 +85,18 @@ void MsmForceTorque::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg
 {
     /* add the message reader to the vector of input spacecraft state messages */
     this->scStateInMsgs.push_back(tmpScMsg->addSubscriber());
-    
+
     /* increase the vector of voltage input message readers */
     ReadFunctor<VoltMsgPayload> inVoltMsg;
     this->voltInMsgs.push_back(inVoltMsg);
-    
+
     /* store MSM sphere radii and location information */
     if (radii.size() != r_SB_B.size()) {
         bskLogger.bskLog(BSK_ERROR, "MsmForceTorque:addSpacecraftToModel() The vector of MSM radii and positions must have the same size, they have sizes %lu and %lu.", radii.size(), r_SB_B.size());
     }
     this->radiiList.push_back(radii);
     this->r_SB_BList.push_back(r_SB_B);
-    
+
     this->volt.push_back(0);
     Eigen::Vector3d zero;
     zero << 0.0, 0.0, 0.0;
@@ -104,12 +104,12 @@ void MsmForceTorque::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg
     Eigen::MRPd zeroMRP;
     zeroMRP = zero;
     this->sigma_BNList.push_back(zeroMRP);
-        
+
     /* create output message objects */
     Message<CmdTorqueBodyMsgPayload> *msgTorque;
     msgTorque = new Message<CmdTorqueBodyMsgPayload>;
     this->eTorqueOutMsgs.push_back(msgTorque);
-    
+
     Message<CmdForceInertialMsgPayload> *msgForce;
     msgForce = new Message<CmdForceInertialMsgPayload>;
     this->eForceOutMsgs.push_back(msgForce);
@@ -127,11 +127,11 @@ void MsmForceTorque::readMessages()
     VoltMsgPayload voltInMsgBuffer;          //!< local copy of voltage input message buffer
     SCStatesMsgPayload scStateInMsgsBuffer;     //!< local copy of spacecraft state input message buffer
     long unsigned int c;                        //!< spacecraft loop counter
-    
+
     for (c = 0; c < this->numSat; c++) {
         voltInMsgBuffer = this->voltInMsgs.at(c)();
         this->volt.at(c) = voltInMsgBuffer.voltage;
-        
+
         scStateInMsgsBuffer = this->scStateInMsgs.at(c)();
         this->r_BN_NList.at(c) = cArray2EigenVector3d(scStateInMsgsBuffer.r_BN_N);
         this->sigma_BNList.at(c) = cArray2EigenVector3d(scStateInMsgsBuffer.sigma_BN);
@@ -146,7 +146,7 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
 {
     // read the input messages
     this->readMessages();
-    
+
     // compute the electrostatic forces and torques
     Eigen::MatrixXd S;                          //!< [1/m] Elastance matrix divided by kc
     Eigen::VectorXd V;                          //!< [V] vector of sphere voltages
@@ -163,7 +163,7 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
     ChargeMsmMsgPayload chargeMsmMsgBuffer;     //!< [] MSM charge message buffer
 
     kc = 8.99e9;
-    
+
     /* size matrices */
     S.resize(this->numSpheres, this->numSpheres);
     V.resize(this->numSpheres);
@@ -177,7 +177,7 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
             r_SN_NList.push_back(r_BN_N + dcm_NB * this->r_SB_BList.at(c).at(k));
         }
     }
-    
+
     /*
      setup elastance matrix
      */
@@ -200,7 +200,7 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
             }
         }
     }
-    
+
     /* solve for sphere charges */
     q = S.llt().solve(V);
 
@@ -217,17 +217,17 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
 
         netForce_N.setZero();
         netTorque_B.setZero();
-        
+
         dcm_BN = this->sigma_BNList.at(c).toRotationMatrix().transpose();
-        
+
         // set the body sphere end counter
         i1 = i0 + this->radiiList.at(c).size();
-        
+
         // zero output message buffer
         forceMsgBuffer = this->eForceOutMsgs.at(c)->zeroMsgPayload;
         torqueMsgBuffer = this->eTorqueOutMsgs.at(c)->zeroMsgPayload;
         chargeMsmMsgBuffer = this->chargeMsmOutMsgs.at(c)->zeroMsgPayload;
-        
+
         // loop over current body spheres
         for (long unsigned int j=i0; j<i1; j++) {
             force_N.setZero();
@@ -246,11 +246,11 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
             }
             // add to total force acting on spacecraft
             netForce_N += force_N;
-            
+
             // add to total torque acting on spacecraft
             netTorque_B += this->r_SB_BList.at(c).at(j-i0).cross(dcm_BN * force_N);
         }
-        
+
         // store net force and torque acting on body
         eigenVector3d2CArray(netForce_N, forceMsgBuffer.forceRequestInertial);
         this->eForceOutMsgs.at(c)->write(&forceMsgBuffer, this->moduleID, CurrentSimNanos);
@@ -264,5 +264,5 @@ void MsmForceTorque::UpdateState(uint64_t CurrentSimNanos)
         // set the body sphere start counter
         i0 = i1;
     }
-    
+
 }

--- a/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
+++ b/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
@@ -20,7 +20,6 @@
 
 #include "simulation/dynamics/msmForceTorque/msmForceTorque.h"
 #include <iostream>
-#include <cstring>
 
 /*! This is the constructor for the module class.  It sets default variable
     values and initializes the various parts of the model */

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -37,7 +37,7 @@ ReactionWheelStateEffector::ReactionWheelStateEffector()
 
     this->nameOfReactionWheelOmegasState = "reactionWheelOmegas";
     this->nameOfReactionWheelThetasState = "reactionWheelThetas";
-    
+
     return;
 }
 
@@ -79,7 +79,7 @@ void ReactionWheelStateEffector::registerStates(DynParamManager& states)
         omegasForInit(RWItp - this->ReactionWheelData.begin(), 0) = RWIt->Omega;
         this->numRW++;
     }
-    
+
 	this->OmegasState = states.registerState((uint32_t) this->numRW, 1, this->nameOfReactionWheelOmegasState);
 
 	if (numRWJitter > 0) {
@@ -104,7 +104,7 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.IEffPntB_B.setZero();
     this->effProps.rEffPrime_CB_B.setZero();
     this->effProps.IEffPrimePntB_B.setZero();
-    
+
     int thetaCount = 0;
     std::vector<RWConfigMsgPayload *>::iterator RWItp;
     RWConfigMsgPayload *RWIt;
@@ -565,4 +565,3 @@ void ReactionWheelStateEffector::UpdateState(uint64_t CurrentSimNanos)
     WriteOutputMessages(CurrentSimNanos);
 //
 }
-

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <iostream>
 #include <cmath>
-#include "architecture/utilities/avsEigenSupport.h"
 
 ReactionWheelStateEffector::ReactionWheelStateEffector()
 {

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
@@ -18,7 +18,6 @@
 
 #include "stepperMotor.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 
 /*! This method performs a complete reset of the module.  Local module variables that retain

--- a/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
+++ b/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
@@ -19,11 +19,8 @@
 
 #include "msisAtmosphere.h"
 #include "architecture/utilities/astroConstants.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/geodeticConversion.h"
-#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /*! This method initializes some basic parameters for the module.
  @return void

--- a/src/simulation/environment/dentonFluxModel/dentonFluxModel.cpp
+++ b/src/simulation/environment/dentonFluxModel/dentonFluxModel.cpp
@@ -99,7 +99,7 @@ void DentonFluxModel::Reset(uint64_t CurrentSimNanos)
         bskLogger.bskLog(BSK_ERROR,
                          "DentonFluxModel: Kp index must be between 0o and 9o. Indices 0- and 9+ do not exist.");
     }
-    
+
     // convert energies to log10 values
     for (int k = 0; k < MAX_NUM_ENERGIES; k++)
     {
@@ -109,7 +109,7 @@ void DentonFluxModel::Reset(uint64_t CurrentSimNanos)
 
     // Define Energy Array
     double step = (40000 - 1)/this->numOutputEnergies;
-    
+
     // start at 100eV
     // (fluxes of smaller energies are unreliable due to contamination with secondary electrons and photoelectrons,
     // according to Denton)
@@ -144,7 +144,7 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
     scStateInMsgBuffer = this->scStateInMsg();
     sunSpiceInMsgBuffer = this->sunStateInMsg();
     earthSpiceInMsgBuffer = this->earthStateInMsg();
-    
+
     // Define output (array if we open more than 2 files)
     double finalElec;
     double finalIon;
@@ -154,7 +154,7 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
     double r_SE_N[3];       /* sun position relative to Earth in N frame components */
     v3Subtract(scStateInMsgBuffer.r_BN_N, earthSpiceInMsgBuffer.PositionVector, r_BE_N);
     v3Subtract(sunSpiceInMsgBuffer.PositionVector, earthSpiceInMsgBuffer.PositionVector, r_SE_N);
-    
+
     // Check that spacecraft is located in GEO regime (otherwise Denton flux data not valid)
     double r_GEO = 42000e3; // GEO orbit radius
     double tol = 4000e3; // tolerance how far spacecraft can be away from GEO
@@ -166,17 +166,17 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
 
     // Find local lime from spacecraft and Earth state messages
     calcLocalTime(r_BE_N, r_SE_N);
-    
+
     // For loop to calculate each element of output flux vectors
     for (int i = 0; i < this->numOutputEnergies; i++)
     {
         // Convert energies to log10
         double logInputEnergy = log(this->inputEnergies[i]);
-                
+
         // ELECTRONS: Find nearest neighbors in energy
         int eHigherIndex = 0;
         int eLowerIndex = 0;
-        
+
         for (int j = 0; j < MAX_NUM_ENERGIES; j++)
         {
             if (this->logEnElec[j] > logInputEnergy)
@@ -195,11 +195,11 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
                 break;
             }
         }
-        
+
         // IONS: Find nearest neighbors in energy
         int iHigherIndex = 0;
         int iLowerIndex = 0;
-        
+
         for (int m = 0; m < MAX_NUM_ENERGIES; m++)
         {
             if (this->logEnProt[m] > logInputEnergy)
@@ -218,16 +218,16 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
                 break;
             }
         }
-        
+
         int localTimeFloor = floor(this->localTime);
         int localTimeCeil = ceil(this->localTime);
-        
+
         // Initialize flux variables
         double flux11 = 0.0;
         double flux12 = 0.0;
         double flux13 = 0.0;
         double flux14 = 0.0;
-        
+
         // ELECTRON: Gather four nearest *MEAN* flux values
         flux11 = this->mean_e_flux[this->kpIndexCounter][eLowerIndex][localTimeFloor];
         flux12 = this->mean_e_flux[this->kpIndexCounter][eHigherIndex][localTimeFloor];
@@ -238,7 +238,7 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
         finalElec = bilinear(localTimeFloor, localTimeCeil, logEnElec[eLowerIndex], logEnElec[eHigherIndex],
                              logInputEnergy, flux11, flux12, flux13, flux14);
         finalElec = pow(10.0, finalElec);
-        
+
         // ION: Gather four nearest *MEAN* flux values
         flux11 = this->mean_i_flux[this->kpIndexCounter][iLowerIndex][localTimeFloor];
         flux12 = this->mean_i_flux[this->kpIndexCounter][iHigherIndex][localTimeFloor];
@@ -249,13 +249,13 @@ void DentonFluxModel::UpdateState(uint64_t CurrentSimNanos)
         finalIon = bilinear(localTimeFloor, localTimeCeil, logEnProt[iLowerIndex], logEnProt[iHigherIndex],
                             logInputEnergy, flux11, flux12, flux13, flux14);
         finalIon = pow(10.0, finalIon);
-        
+
         // Store the output message (differential flux in units of [m^-2 s^-1 sr^-2 eV^-1])
         fluxOutMsgBuffer.meanElectronFlux[i] = finalElec * 1e4;
         fluxOutMsgBuffer.meanIonFlux[i] = finalIon * 1e4;
         fluxOutMsgBuffer.energies[i] = inputEnergies[i];
     }
-    
+
     // Write to the output message
     this->fluxOutMsg.write(&fluxOutMsgBuffer, this->moduleID, CurrentSimNanos);
 }
@@ -273,7 +273,7 @@ void DentonFluxModel::calcLocalTime(double r_SE_N[3], double r_BE_N[3])
     double r_SE_N_hat[2];       /* unit vector from Earth to Sun */
     v2Normalize(r_BE_N, r_BE_N_hat);
     v2Normalize(r_SE_N, r_SE_N_hat);
-    
+
     // Determine Local Time: Using atan2()
     double x = v2Dot(r_BE_N_hat, r_SE_N_hat);
     double y = r_BE_N_hat[0]*r_SE_N_hat[1] - r_BE_N_hat[1]*r_SE_N_hat[0];
@@ -287,9 +287,9 @@ void DentonFluxModel::calcLocalTime(double r_SE_N[3], double r_BE_N[3])
     {
         this->localTime = 12.00 + (theta / (2.*M_PI))*24;
     }
-    
+
     return;
-    
+
 }
 
 /*! Bilinear interpolation method
@@ -325,13 +325,13 @@ void DentonFluxModel::readDentonDataFile(std::string fileName,
                                          double data[MAX_NUM_KPS][MAX_NUM_ENERGIES][MAX_NUM_LOCAL_TIMES])
 {
     double temp = 0.0;
-    
+
     // Input file stream object
     std::ifstream inputFile;
-    
+
     // Read data from file:
     inputFile.open(this->dataPath + fileName);
-    
+
     // Read information into array: Data includes information about mean, standard deviation,
     // median and percentiles (7 types of values in total). Only mean is relevant for this module
     if (inputFile.is_open()) {
@@ -346,16 +346,16 @@ void DentonFluxModel::readDentonDataFile(std::string fileName,
                     } else {
                         inputFile >> temp;
                     }
-                    
+
                 }
             }
         }
     } else {
         bskLogger.bskLog(BSK_ERROR, ("Could not open " + this->dataPath + fileName).c_str());
     }
-    
+
     // Close file
     inputFile.close();
-    
+
     return;
 }

--- a/src/simulation/environment/dentonFluxModel/dentonFluxModel.cpp
+++ b/src/simulation/environment/dentonFluxModel/dentonFluxModel.cpp
@@ -19,8 +19,6 @@
 
 #include "simulation/environment/dentonFluxModel/dentonFluxModel.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/astroConstants.h"
-#include <iostream>
 #include <fstream>
 #include <cmath>
 

--- a/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
+++ b/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
@@ -20,7 +20,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <string.h>
 
 EphemerisConverter::EphemerisConverter()
 {

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -233,4 +233,3 @@ void GroundMapping::UpdateState(uint64_t CurrentSimNanos)
     // Write output messages
     this->WriteMessages(CurrentSimNanos);
 }
-

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -23,7 +23,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <iostream>
-#include <cstring>
 #include <math.h>
 
 /*! This is the constructor for the module class.  It sets default variable

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.cpp
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.cpp
@@ -18,12 +18,10 @@
  */
 #include "simulation/environment/planetEphemeris/planetEphemeris.h"
 #include <iostream>
-#include <sstream>
 #include <string.h>
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/avsEigenSupport.h"
 
 
 /*! This constructor initializes the variables.

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -161,7 +161,7 @@ void SpiceInterface::Reset(uint64_t CurrenSimNanos)
 void SpiceInterface::initTimeData()
 {
     double EpochDelteET;
-    
+
     /* set epoch information.  If provided, then the epoch message information should be used.  */
     if (this->epochInMsg.isLinked()) {
         // Read in the epoch message and set the internal time structure
@@ -194,14 +194,14 @@ void SpiceInterface::initTimeData()
 void SpiceInterface::computeGPSData()
 {
     double JDDifference;
-    
+
     //! - The difference between the epochs in julian date terms is the total
     JDDifference = this->J2000Current - this->JDGPSEpoch;
     //! - Scale the elapsed by a week's worth of seconds to get week
     this->GPSWeek = (uint16_t) (JDDifference/(7*86400));
     //! - Subtract out the GPS week scaled up to seconds to get time in week
     this->GPSSeconds = JDDifference - this->GPSWeek*7*86400;
-    
+
     //! - Maximum GPS week is 1024 so get rollovers and subtract out those weeks
     this->GPSRollovers = this->GPSWeek/1024;
     this->GPSWeek = (uint16_t)(this->GPSWeek-this->GPSRollovers*1024);
@@ -224,7 +224,7 @@ void SpiceInterface::writeOutputMessages(uint64_t CurrentClock)
     OutputData.GPSWeek = this->GPSWeek;
     OutputData.GPSRollovers = this->GPSRollovers;
     this->spiceTimeOutMsg.write(&OutputData, this->moduleID, CurrentClock);
-    
+
     //! - Iterate through all of the planets that are on and write their outputs
     for (long unsigned int c=0; c<this->planetStateOutMsgs.size(); c++)
     {
@@ -264,7 +264,7 @@ void SpiceInterface::UpdateState(uint64_t CurrentSimNanos)
 {
     //! - Increment the J2000 elapsed time based on init value and Current sim
     this->J2000Current = this->J2000ETInit + CurrentSimNanos*NANO2SEC;
-    
+
     //! - Compute the current Julian Date string and cast it over to the double
     et2utc_c(this->J2000Current, "J", 14, this->charBufferSize - 1, reinterpret_cast<SpiceChar*>
              (this->spiceBuffer));
@@ -373,9 +373,9 @@ void SpiceInterface::addSpacecraftNames(std::vector<std::string> spacecraftNames
 void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spiceData)
 {
     std::vector<SpicePlanetStateMsgPayload>::iterator planit;
-    
+
     /*! - Loop over the vector of Spice objects and compute values.
-     
+
      -# Call the Ephemeris file (spkezr)
      -# Copy out the position and velocity values (default in km)
      -# Convert the pos/vel over to meters.
@@ -387,7 +387,7 @@ void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spic
         double lighttime;
         double localState[6];
         std::string planetFrame = "";
-        
+
         spkezr_c(planit->PlanetName, this->J2000Current, this->referenceBase.c_str(),
             "NONE", this->zeroBase.c_str(), localState, &lighttime);
         v3Copy(&localState[0], planit->PositionVector);
@@ -413,13 +413,13 @@ void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spic
         {
             //pxform_c ( referenceBase.c_str(), planetFrame.c_str(), J2000Current,
             //    planit->second.J20002Pfix);
-            
+
             double aux[6][6];
-            
+
             sxform_c(this->referenceBase.c_str(), planetFrame.c_str(), this->J2000Current, aux); //returns attitude of planet (i.e. IAU_EARTH) wrt "j2000". note j2000 is actually ICRF in Spice.
-            
+
             m66Get33Matrix(0, 0, aux, planit->J20002Pfix);
-            
+
             m66Get33Matrix(1, 0, aux, planit->J20002Pfix_dot);
         }
         c++;
@@ -438,7 +438,7 @@ int SpiceInterface::loadSpiceKernel(char *kernelName, const char *dataPath)
 {
     char *fileName = new char[this->charBufferSize];
     SpiceChar *name = new SpiceChar[this->charBufferSize];
-    
+
     //! - The required calls come from the SPICE documentation.
     //! - The most critical call is furnsh_c
     strcpy(name, "REPORT");
@@ -446,7 +446,7 @@ int SpiceInterface::loadSpiceKernel(char *kernelName, const char *dataPath)
     strcpy(fileName, dataPath);
     strcat(fileName, kernelName);
     furnsh_c(fileName);
-    
+
     //! - Check to see if we had trouble loading a kernel and alert user if so
     strcpy(name, "DEFAULT");
     erract_c("SET", this->charBufferSize, name);
@@ -470,7 +470,7 @@ int SpiceInterface::unloadSpiceKernel(char *kernelName, const char *dataPath)
 {
     char *fileName = new char[this->charBufferSize];
     SpiceChar *name = new SpiceChar[this->charBufferSize];
-    
+
     //! - The required calls come from the SPICE documentation.
     //! - The most critical call is furnsh_c
     strcpy(name, "REPORT");

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -17,7 +17,6 @@
 
  */
 #include "simulation/environment/spiceInterface/spiceInterface.h"
-#include <iostream>
 #include <sstream>
 #include "../libs/cspice/include/SpiceUsr.h"
 #include <string.h>

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
@@ -32,7 +32,7 @@ PinholeCamera::PinholeCamera()
 {
     /* Set focal direction to be +z axis in camera frame */
     this->eC_C << 0, 0, 1;
-    
+
     /* Set no lighting conditions by default  */
     this->maskSun = -MPI_2;
 }
@@ -54,7 +54,7 @@ void PinholeCamera::Reset(uint64_t CurrentSimNanos)
 {
     /* Get number of landmarks */
     this->n = int(this->r_LP_P.size());
-    
+
     /* Check that required input messages are connected */
     if (!this->scStateInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "PinholeCamera.scStateInMsg was not linked.");
@@ -62,7 +62,7 @@ void PinholeCamera::Reset(uint64_t CurrentSimNanos)
     if (!this->ephemerisInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "PinholeCamera.ephemerisInMsg was not linked.");
     }
-    
+
     /* Compute field of view */
     this->FOVx = 2 * atan2(this->nxPixel*this->wPixel, 2*this->f);
     this->FOVy = 2 * atan2(this->nyPixel*this->wPixel, 2*this->f);
@@ -96,22 +96,22 @@ void PinholeCamera::loopLandmarks()
     Eigen::Vector3d rLmk, nLmk;
     Eigen::Vector2i pLmk;
     bool flagFOV, flagLighting;
-    
+
     /* Preallocate visibility status and landmark pixels */
     this->isvisibleLmk.setZero(this->n);
     this->pixelLmk.setZero(this->n, 2);
-    
+
     /* Loop through landmarks */
     for (int i = 0; i < this->n; i++){
         /* Extract ith landmark position and its normal */
         rLmk = this->r_LP_P[i];
         nLmk = this->nL_P[i];
-        
+
         /* Compute pixel and check visbility/lighting conditions */
         pLmk = this->computePixel(rLmk);
         flagFOV = this->checkFOV(pLmk, rLmk, nLmk);
         flagLighting = this->checkLighting(nLmk);
-        
+
         /* Add pixel */
         if (flagFOV && flagLighting){
             this->pixelLmk.row(i) = pLmk;
@@ -129,7 +129,7 @@ bool PinholeCamera::checkLighting(Eigen::Vector3d nLmk)
     /* Compute Sun's incident angle */
     double angleSun;
     angleSun = M_PI_2 - safeAcos(nLmk.dot(this->e_SP_P) / (this->e_SP_P.norm()*nLmk.norm()));
-    
+
     /* Check if the landmark is illuminated */
     bool flagLighting;
     flagLighting = false;
@@ -137,7 +137,7 @@ bool PinholeCamera::checkLighting(Eigen::Vector3d nLmk)
         /* Set lighting condition to true */
         flagLighting = true;
     }
-    
+
     return flagLighting;
 }
 
@@ -151,7 +151,7 @@ bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::
     Eigen::Vector3d dr, eLmk_P;
     dr = this->r_BP_P - rLmk;
     eLmk_P = dr / dr.norm();
-    
+
     /* Define output and angles to check
      angleFOV1 checks if landmarks are in front of the camera
      angleFOV2 checks if the reflected light (landmark normal) is captured by camera
@@ -161,7 +161,7 @@ bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::
     double angleFOV1, angleFOV2;
     angleFOV1 = M_PI_2 - safeAcos(-this->eC_P.dot(eLmk_P) / (this->eC_P.norm()*eLmk_P.norm()));
     angleFOV2 = M_PI_2 - safeAcos(-this->eC_P.dot(nLmk) / (this->eC_P.norm()*nLmk.norm()));
-    
+
     /* If both angles are positive */
     if (angleFOV1 > 0 && angleFOV2 > 0){
         /* Check if landmark actually falls within camera field of view*/
@@ -170,7 +170,7 @@ bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::
             flagFOV = true;
         }
     }
-    
+
     return flagFOV;
 }
 
@@ -183,13 +183,13 @@ Eigen::Vector2i PinholeCamera::computePixel(Eigen::Vector3d rLmk)
      in camera frame */
     Eigen::Vector3d dr;
     dr = this->dcm_CB * this->dcm_BP * (rLmk - this->r_BP_P);
-    
+
     /* Compute pixel location */
     double u, v;
     Eigen::Vector2i p;
     u = this->f * dr(0) / (dr(2) * this->wPixel);
     v = this->f * dr(1) / (dr(2) * this->wPixel);
-                
+
     /* Apply pixelization */
     if (u > 0){
         p(0) = int(ceil(u));
@@ -209,7 +209,7 @@ Eigen::Vector2i PinholeCamera::computePixel(Eigen::Vector3d rLmk)
     else{
         p(1) = 1;
     }
-    
+
     return p;
 }
 
@@ -221,12 +221,12 @@ void PinholeCamera::processInputs()
     double dcm_PN_array[3][3];
     MRP2C(this->ephemerisPlanet.sigma_BN, dcm_PN_array);
     this->dcm_PN = cArray2EigenMatrix3d(*dcm_PN_array);
-    
+
     /* Compute planet to Sun line e_SP on the planet rotating frame P */
     Eigen::Vector3d r_PS_N;
     r_PS_N = cArray2EigenVector3d(this->ephemerisPlanet.r_BdyZero_N);
     this->e_SP_P = this->dcm_PN * (-r_PS_N / r_PS_N.norm());
-    
+
     /* Compute spacecraft position in the planet rotating frame P */
     this->r_BP_P = this->dcm_PN * (cArray2EigenVector3d(this->spacecraftState.r_BN_N) -  cArray2EigenVector3d(this->ephemerisPlanet.r_BdyZero_N));
 
@@ -234,7 +234,7 @@ void PinholeCamera::processInputs()
     double dcm_BN_array[3][3];
     MRP2C(this->spacecraftState.sigma_BN, dcm_BN_array);
     this->dcm_BP = cArray2EigenMatrix3d(*dcm_BN_array) * this->dcm_PN.transpose();
-    
+
     /* Camera focal direction in planet frame */
     this->eC_P = (this->dcm_CB * this->dcm_BP).transpose()*this->eC_C;
 }
@@ -256,7 +256,7 @@ void PinholeCamera::writeOutputMessages(uint64_t CurrentClock)
     for (int i = 0; i < this->n; i++){
         /* Zero the output message buffers */
         this->landmarkMsgBuffer.at(i) = this->landmarkOutMsgs.at(i)->zeroMsgPayload;
-        
+
         /* Fill landmark output messages */
         this->landmarkMsgBuffer.at(i).isVisible = this->isvisibleLmk(i);
         eigenMatrixXi2CArray(this->pixelLmk.row(i), this->landmarkMsgBuffer.at(i).pL);
@@ -273,14 +273,14 @@ void PinholeCamera::UpdateState(uint64_t CurrentSimNanos)
 {
     /* Read messages */
     this->readInputMessages();
-    
+
     /* Process planet ephemeris, spacecraft position
      and orientation */
     this->processInputs();
-    
+
     /* Loop through landmarks */
     this->loopLandmarks();
-    
+
     /* Write message */
     this->writeOutputMessages(CurrentSimNanos);
 }
@@ -295,22 +295,22 @@ void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mr
     /* Obtain number of samples in the batch to be processed */
     int nBatch;
     nBatch = int(rBatch_BP_P.rows());
-    
+
     /* Preallocate batches of pixel landmarks and visibility status. These
      are the variables the user should extract */
     this->pixelBatchLmk.setZero(nBatch, 2*this->n);
     this->isvisibleBatchLmk.setZero(nBatch, this->n);
-    
+
     /* Define direction cosine matrix and MRP of the spacecraft body
      frame w.r.t. the planet frame */
     double dcm_BP_array[3][3];
     double mrp_BP[3];
-    
+
     /* Print initialization */
     if (show_progress){
         std::cout << "--- Initialization of loop through " << nBatch << " samples ---" << '\n';
     }
-    
+
     /* Loop through batch */
     for (int i = 0; i < nBatch; i++){
         /* Print progress after each 5% of the batch is completed */
@@ -319,29 +319,29 @@ void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mr
                 std::cout << i / (int(nBatch/100)) << "% completed" << '\n';
             }
         }
-        
+
         /* Extract spacecraft position and Sun's unit-vector in
          planet frame */
         this->r_BP_P = rBatch_BP_P.row(i).transpose();
         this->e_SP_P = eBatch_SP_P.row(i).transpose();
-        
+
         /* Compute spacecraft dcm w.r.t. planet frame */
         eigenMatrixXd2CArray(mrpBatch_BP.row(i).transpose(), mrp_BP);
         MRP2C(mrp_BP, dcm_BP_array);
         this->dcm_BP = cArray2EigenMatrix3d(*dcm_BP_array);
-        
+
         /* Compute camera focal direction in planet frame */
         this->eC_P = (this->dcm_CB * this->dcm_BP).transpose()*this->eC_C;
-        
+
         /* Loop through landmarks */
         this->loopLandmarks();
-        
+
         /* Fill batches of pixel landmarks and visibility status */
         this->pixelBatchLmk.block(i, 0, 1, this->n) = this->pixelLmk.col(0).transpose();
         this->pixelBatchLmk.block(i, this->n, 1, this->n) = this->pixelLmk.col(1).transpose();
         this->isvisibleBatchLmk.row(i) = this->isvisibleLmk;
     }
-    
+
     /* Declare initialization */
     if (show_progress){
         std::cout << "--- Batch has been processed ---" << '\n';

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
@@ -23,7 +23,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <iostream>
 #include <math.h>
-#include "architecture/utilities/linearAlgebra.h"
 
 
 /*! @brief Creates an instance of the PinholeCamera class with a prescribed focal direction in camera frame and -90º of Sun's mask angle (that is, no lighting constraint).

--- a/src/simulation/navigation/planetHeading/planetHeading.cpp
+++ b/src/simulation/navigation/planetHeading/planetHeading.cpp
@@ -20,7 +20,6 @@
 #include "planetHeading.h"
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include <iostream>
 
 /*! Customer constructor just sets the spacecraftSTateInMsg by default*/
 PlanetHeading::PlanetHeading()

--- a/src/simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.cpp
+++ b/src/simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.cpp
@@ -17,7 +17,6 @@
 
 */
 
-#include "architecture/utilities/macroDefinitions.h"
 #include "simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.h"
 #include "string.h"
 

--- a/src/simulation/power/_GeneralModuleFiles/powerNodeBase.cpp
+++ b/src/simulation/power/_GeneralModuleFiles/powerNodeBase.cpp
@@ -18,10 +18,8 @@
  */
 
 #include "architecture/utilities/astroConstants.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "powerNodeBase.h"
-#include <string.h>
 
 /*! This method initializes the messaging parameters to either empty strings for message names or -1 for message IDs.
  @return void

--- a/src/simulation/power/simpleSolarPanel/simpleSolarPanel.cpp
+++ b/src/simulation/power/simpleSolarPanel/simpleSolarPanel.cpp
@@ -2,15 +2,10 @@
 // Created by andrew on 7/12/19.
 //
 #include <math.h>
-#include <iostream>
-#include <cstring>
-#include <algorithm>
 #include "simpleSolarPanel.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/avsEigenMRP.h"
 
 SimpleSolarPanel::SimpleSolarPanel(){

--- a/src/simulation/power/simpleSolarPanel/simpleSolarPanel.cpp
+++ b/src/simulation/power/simpleSolarPanel/simpleSolarPanel.cpp
@@ -72,7 +72,7 @@ bool SimpleSolarPanel::customReadMessages()
     {
         this->stateCurrent = this->stateInMsg();
     }
-    //! - Read in optional sun eclipse input message 
+    //! - Read in optional sun eclipse input message
     if(this->sunEclipseInMsg.isLinked()) {
         EclipseMsgPayload sunVisibilityFactor;          // sun visiblity input message
         sunVisibilityFactor = this->sunEclipseInMsg();

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -27,7 +27,6 @@
  */
 
 /* modify the path to reflect the new module names */
-#include <Eigen/Dense>
 #include <string.h>
 #include "camera.h"
 #include "architecture/utilities/rigidBodyKinematics.h"

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -23,7 +23,7 @@
     as well as provides a template for image corruption
     Author: Thibaud Teil
     Date:   October 03, 2019
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -63,12 +63,12 @@ void Camera::Reset(uint64_t currentSimNanos)
 void Camera::hsvAdjust(const cv::Mat& mSrc, cv::Mat &mDst){
     cv::Mat localHsv;
     cvtColor(mSrc, localHsv, cv::COLOR_BGR2HSV);
-    
+
     for (int j = 0; j < mSrc.rows; j++) {
         for (int i = 0; i < mSrc.cols; i++) {
             // Saturation is hsv.at<Vec3b>(j, i)[1] range: [0-255]
             // Value is hsv.at<Vec3b>(j, i)[2] range: [0-255]
-            
+
             // convert radians to degrees and multiply by 2
             // user assumes range hue range is 0-2pi and not 0-180
             int input_degrees = (int) (this->hsv[0] * R2D);
@@ -136,7 +136,7 @@ void Camera::addGaussianNoise(const cv::Mat& mSrc, cv::Mat &mDst, double Mean, d
     cv::Mat mGaussian_noise = cv::Mat(mSrc.size(), CV_16SC3);
     /*!  Generates random noise in a normal distribution.*/
     randn(mGaussian_noise, cv::Scalar::all(Mean), cv::Scalar::all(StdDev));
-    
+
     mSrc.convertTo(mSrc_16SC, CV_16SC3);
     /*!  Adds the noise layer to the image layer with a weighted add to prevent overflowing the pixels.*/
     addWeighted(mSrc_16SC, 1.0, mGaussian_noise, 1.0, 0.0, mSrc_16SC);
@@ -155,38 +155,38 @@ void Camera::addSaltPepper(const cv::Mat& mSrc, cv::Mat &mDst, float pa, float p
     /*! These lines will make the hot and dead pixels different every time.*/
     // uint64 initValue = time(0);
     // RNG rng(initValue);
-    
+
     /*! This line makes the hot and dead pixels the same frame to frame.*/
     cv::RNG rng;
-    
+
     /*!  Determines the amount of hot/dead pixels based on the input probabilities.*/
     int amount1 = (int) (mSrc.rows * mSrc.cols * pa);
     int amount2 = (int) (mSrc.rows * mSrc.cols * pb);
-    
+
     cv::Mat mSaltPepper = cv::Mat(mSrc.size(), mSrc.type());
     mSrc.convertTo(mSaltPepper, mSrc.type());
-    
+
     cv::Vec3b black;
     black.val[0] = 0;
     black.val[1] = 0;
     black.val[2] = 0;
-    
+
     cv::Vec3b white;
     white.val[0] = 255;
     white.val[1] = 255;
     white.val[2] = 255;
-    
+
     /*!  Chooses random pixels to be stuck or dead in the amount calculated previously.*/
     for(int counter = 0; counter < amount1; counter++){
         mSaltPepper.at<cv::Vec3b>(rng.uniform(0, mSaltPepper.rows),
                                   rng.uniform(0, mSaltPepper.cols)) = black;
     }
-    
+
     for(int counter = 0; counter < amount2; counter++){
         mSaltPepper.at<cv::Vec3b>(rng.uniform(0, mSaltPepper.rows),
                                   rng.uniform(0, mSaltPepper.cols)) = white;
     }
-    
+
     mSaltPepper.convertTo(mDst, mSrc.type());
 }
 
@@ -203,23 +203,23 @@ void Camera::addCosmicRay(const cv::Mat& mSrc, cv::Mat &mDst, float probThreshho
     /*! Uses the current sim time and the random offset to ensure a different ray every time.*/
     uint64 initValue = this->localCurrentSimNanos;
     cv::RNG rng((uint64) (initValue + time(0) + randOffset));
-    
+
     float prob = (float) (rng.uniform(0.0, 1.0));
     if (prob > probThreshhold) {
         cv::Mat mCosmic = cv::Mat(mSrc.size(), mSrc.type());
         mSrc.convertTo(mCosmic, mSrc.type());
-    
+
         /*!  Chooses a random point on the image. Then chooses a second random point within 50 pixels
          * in either direction.*/
         int x = rng.uniform(0, mCosmic.rows);
         int y = rng.uniform(0, mCosmic.cols);
         int deltax = rng.uniform(-maxSize/2, maxSize/2);
         int deltay = rng.uniform(-maxSize/2, maxSize/2);
-        
+
         cv::Point p1 = cv::Point(x, y);
         cv::Point p2 = cv::Point(x + deltax, y + deltay);
         line(mCosmic, p1, p2, cv::Scalar(255, 255, 255), 1, cv::LINE_8);
-    
+
         mCosmic.convertTo(mDst, mSrc.type());
     }
 }
@@ -293,7 +293,7 @@ void Camera::applyFilters(cv::Mat &mSource, cv::Mat &mDst){
     if(this->cosmicRays > 0){
         this->addCosmicRayBurst(mFilters, mFilters, std::round(this->cosmicRays));
     }
-    
+
     mFilters.convertTo(mDst, mSource.type());
 }
 
@@ -330,10 +330,10 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraMsg.ppFocalLength = this->ppFocalLength;
     cameraMsg.ppFocusDistance = this->ppFocusDistance;
     cameraMsg.ppMaxBlurSize = this->ppMaxBlurSize;
-    
+
     /*! - Update the camera config data no matter if an image is present*/
     this->cameraConfigOutMsg.write(&cameraMsg, this->moduleID, currentSimNanos);
-    
+
     cv::Mat imageCV;
     cv::Mat blurred;
     if (this->saveDir != ""){
@@ -360,7 +360,7 @@ void Camera::UpdateState(uint64_t currentSimNanos)
         std::vector<unsigned char> vectorBuffer((char*)imageBuffer.imagePointer,
                                                 (char*)imageBuffer.imagePointer + imageBuffer.imageBufferLength);
         imageCV = cv::imdecode(vectorBuffer, cv::IMREAD_COLOR);
-        
+
         this->applyFilters(imageCV, blurred);
         if (this->saveImages == 1){
             if (!cv::imwrite(localPath, blurred)) {
@@ -386,7 +386,7 @@ void Camera::UpdateState(uint64_t currentSimNanos)
         this->pointImageOut = malloc(imageOut.imageBufferLength*sizeof(char));
         memcpy(this->pointImageOut, &buf[0], imageOut.imageBufferLength*sizeof(char));
         imageOut.imagePointer = this->pointImageOut;
-        
+
         this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
     }
     else{

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
@@ -80,17 +80,17 @@ void CoarseSunSensor::setUnitDirectionVectorWithPerturbation(double cssThetaPert
 {
     double tempPhi = this->phi + cssPhiPerturb;
     double tempTheta = this->theta + cssThetaPerturb;
-    
+
     //! - Rotation from individual photo diode sensor frame (S) to css platform frame (P)
     Eigen::Vector3d sensorV3_P; // sensor diode normal in platform frame
     sensorV3_P.fill(0.0);
-    
+
     /*! azimuth and elevation rotations of vec transpose(1,0,0) where vec is the unit normal
      of the photo diode*/
     sensorV3_P[0] = cos(tempPhi) * cos(tempTheta);
     sensorV3_P[1] = cos(tempPhi) * sin(tempTheta);
     sensorV3_P[2] = sin(tempPhi);
-    
+
     //! Rotation from P frame to body frame (B)
     this->nHat_B = this->dcm_PB.transpose() * sensorV3_P;
 }
@@ -131,20 +131,20 @@ void CoarseSunSensor::Reset(uint64_t CurrentSimNanos)
     nMatrix.resize(1,1);
     pMatrix.resize(1,1);
     bounds.resize(1,1);
-    
+
     this->noiseModel.setRNGSeed(this->RNGSeed);
-    
+
     nMatrix(0,0) = this->senNoiseStd*1.5;
     this->noiseModel.setNoiseMatrix(nMatrix);
-    
+
     bounds(0,0) = this->walkBounds;
     this->noiseModel.setUpperBounds(bounds);
-    
+
     pMatrix(0,0) = 1.;
     this->noiseModel.setPropMatrix(pMatrix);
 
-    
-    
+
+
     // Fault Noise Model
     Eigen::VectorXd nMatrixFault;
     Eigen::VectorXd pMatrixFault;
@@ -157,11 +157,11 @@ void CoarseSunSensor::Reset(uint64_t CurrentSimNanos)
 
     nMatrixFault(0,0) = this->faultNoiseStd*1.5; // sensor noise standard dev
     this->faultNoiseModel.setNoiseMatrix(nMatrixFault);
-    
+
     boundsFault(0,0) = 2.0; // walk bounds
     this->faultNoiseModel.setUpperBounds(boundsFault);
 
-    pMatrixFault(0,0) = 1.0; // propagation matrix 
+    pMatrixFault(0,0) = 1.0; // propagation matrix
     this->faultNoiseModel.setPropMatrix(pMatrixFault);
 
     Eigen::MatrixXd satBounds;
@@ -200,38 +200,38 @@ void CoarseSunSensor::readInputMessages()
     }
 }
 
-/*! This method computes the sun-vector heading information in the vehicle 
+/*! This method computes the sun-vector heading information in the vehicle
  body frame.*/
 void CoarseSunSensor::computeSunData()
 {
     Eigen::Vector3d Sc2Sun_Inrtl;
     Eigen::Vector3d sHat_N;
     Eigen::Matrix3d dcm_BN;
-    
+
     Eigen::Vector3d r_BN_N_eigen;
     Eigen::Vector3d sunPos;
     Eigen::MRPd sigma_BN_eigen;
-    
+
     //! - Get the position from spacecraft to Sun
-    
+
     //! - Read Message data to eigen
     r_BN_N_eigen = cArray2EigenVector3d(this->stateCurrent.r_BN_N);
     sunPos = cArray2EigenVector3d(this->sunData.PositionVector);
     sigma_BN_eigen = cArray2EigenMRPd(this->stateCurrent.sigma_BN);
-    
-    
+
+
     //! - Find sun heading unit vector
     Sc2Sun_Inrtl = sunPos -  r_BN_N_eigen;
     sHat_N = Sc2Sun_Inrtl / Sc2Sun_Inrtl.norm();
-    
+
     //! - Get the inertial to body frame transformation information and convert sHat to body frame
     dcm_BN = sigma_BN_eigen.toRotationMatrix().transpose();
     this->sHat_B = dcm_BN * sHat_N;
-    
+
     //! - compute sun distance factor
     double r_Sun_Sc = Sc2Sun_Inrtl.norm();
     this->sunDistanceFactor = pow(AU*1000., 2.)/pow(r_Sun_Sc, 2.);
-    
+
 }
 
 /*! This method computes the true sensed values for the sensor */
@@ -252,8 +252,8 @@ void CoarseSunSensor::computeTrueOutput()
     } else {
         kellyFit = 1.0;
     }
-    this->trueValue *= kellyFit; 
-    
+    this->trueValue *= kellyFit;
+
     // apply sun distance factor (adjust based on flux at current distance from sun)
     this->trueValue *= this->sunDistanceFactor;
 
@@ -261,11 +261,11 @@ void CoarseSunSensor::computeTrueOutput()
     this->trueValue *= this->sunVisibilityFactor.shadowFactor;
 
     // Adding albedo value (if defined by the user)
-    if (this->albedoValue > 0.0){        
+    if (this->albedoValue > 0.0){
         this->trueValue += this->albedoValue;}
 }
 
-/*! This method takes the true observed cosine value and converts 
+/*! This method takes the true observed cosine value and converts
  it over to an errored value.  It applies noise to the truth. */
 void CoarseSunSensor::applySensorErrors()
 {
@@ -281,27 +281,27 @@ void CoarseSunSensor::applySensorErrors()
     }
 
     this->sensedValue = this->trueValue + sensorError;
-    
+
     //Apply faults values here.
     this->faultNoiseModel.computeNextState();
-    
+
     if(this->faultState == CSSFAULT_OFF){
         this->sensedValue = 0.0;
     } else if (this->faultState == CSSFAULT_STUCK_MAX){
         this->sensedValue = 1.0;
     } else if (this->faultState == CSSFAULT_STUCK_CURRENT){
-        this->sensedValue = this->pastValue; 
+        this->sensedValue = this->pastValue;
     } else if (this->faultState == CSSFAULT_STUCK_RAND){
         this->sensedValue = this->faultNoiseModel.getCurrentState().coeff(0,0);
-        this->faultState = CSSFAULT_STUCK_CURRENT; 
+        this->faultState = CSSFAULT_STUCK_CURRENT;
     } else if (this->faultState == CSSFAULT_RAND){
         this->sensedValue = this->faultNoiseModel.getCurrentState().coeff(0,0);
     } else { // Nominal
 
     }
 
-    this->pastValue = this->sensedValue; 
-    
+    this->pastValue = this->sensedValue;
+
 }
 
 void CoarseSunSensor::scaleSensorValues()
@@ -318,7 +318,7 @@ void CoarseSunSensor::applySaturation()
     eigenMatrixXd2CArray(sensedEigen, &this->sensedValue);
 }
 
-/*! This method writes the output message.  The output message contains the 
+/*! This method writes the output message.  The output message contains the
  current output of the CSS converted over to some discrete "counts" to
  emulate ADC conversion of S/C.
  @param Clock The current simulation time*/
@@ -352,7 +352,7 @@ void CoarseSunSensor::writeOutputMessages(uint64_t Clock)
     }
 }
 
-/*! This method is called at a specified rate by the architecture.  It makes the 
+/*! This method is called at a specified rate by the architecture.  It makes the
  calls to compute the current sun information and write the output message for
  the rest of the model.
  @param CurrentSimNanos The current simulation time from the architecture*/
@@ -374,7 +374,7 @@ void CoarseSunSensor::UpdateState(uint64_t CurrentSimNanos)
     this->writeOutputMessages(CurrentSimNanos);
 }
 
-/*! The default constructor for the constellation really just clears the 
+/*! The default constructor for the constellation really just clears the
  sensor list.*/
 CSSConstellation::CSSConstellation()
 {
@@ -423,7 +423,7 @@ void CSSConstellation::UpdateState(uint64_t CurrentSimNanos)
         it->scaleSensorValues();
         it->applySaturation();
         it->writeOutputMessages(CurrentSimNanos);
-        
+
         this->outputBuffer.CosValue[itp - this->sensorList.begin()] = it->sensedValue;
 
     }

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
@@ -22,8 +22,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/astroConstants.h"
 #include <math.h>
-#include <iostream>
-#include <cstring>
 #include <algorithm>
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/macroDefinitions.h"

--- a/src/simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.cpp
+++ b/src/simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.cpp
@@ -19,8 +19,6 @@
 
 
 #include "simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.h"
-#include <iostream>
-#include <cstring>
 #include <cmath>
 #include <stdint.h>
 #include <random>

--- a/src/simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.cpp
+++ b/src/simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.cpp
@@ -27,7 +27,7 @@
 HingedRigidBodyMotorSensor::HingedRigidBodyMotorSensor()
 {
 
-    
+
     this->rGen.seed((unsigned int)this->RNGSeed); //! RNGSeed is an attribute of all modules
 
     this->thetaNoiseStd = 0.0;
@@ -82,7 +82,7 @@ void HingedRigidBodyMotorSensor::UpdateState(uint64_t CurrentSimNanos)
     double workingTheta;            //! [rad] discretized panel angle
     double workingThetaDot;         //! [rad/s] discretized panel angle rate
     double remainder;               //! [] remainder between sensed state and discretized state
-    
+
     HingedRigidBodyMsgPayload hingedRigidBodyMotorSensorInMsgBuffer;  //! local copy of message buffer
     HingedRigidBodyMsgPayload hingedRigidBodyMotorSensorOutMsgBuffer;  //! local copy of message buffer
 
@@ -117,7 +117,7 @@ void HingedRigidBodyMotorSensor::UpdateState(uint64_t CurrentSimNanos)
             workingTheta += this->thetaLSB * copysign(1.0,sensedTheta);
         }
         sensedTheta = workingTheta;
-        
+
     }
     if(this->thetaDotLSB > 0.0)
     {
@@ -128,7 +128,7 @@ void HingedRigidBodyMotorSensor::UpdateState(uint64_t CurrentSimNanos)
             workingThetaDot += this->thetaDotLSB * copysign(1.0,sensedThetaDot);
         }
         sensedThetaDot = workingThetaDot;
-        
+
     }
 
     //! write to the output messages
@@ -136,4 +136,3 @@ void HingedRigidBodyMotorSensor::UpdateState(uint64_t CurrentSimNanos)
     hingedRigidBodyMotorSensorOutMsgBuffer.thetaDot = sensedThetaDot;
     this->hingedRigidBodyMotorSensorOutMsg.write(&hingedRigidBodyMotorSensorOutMsgBuffer, this->moduleID, CurrentSimNanos);
 }
-

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -18,14 +18,9 @@
  */
 #include "simulation/sensors/imuSensor/imuSensor.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include <math.h>
-#include <iostream>
 #include <cstring>
-#include <random>
 #include "architecture/utilities/gauss_markov.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <inttypes.h>
 

--- a/src/simulation/sensors/magnetometer/magnetometer.cpp
+++ b/src/simulation/sensors/magnetometer/magnetometer.cpp
@@ -175,4 +175,3 @@ void Magnetometer::UpdateState(uint64_t CurrentSimNanos)
     //! - Write output data
     this->writeOutputMessages(CurrentSimNanos);
 }
-

--- a/src/simulation/sensors/magnetometer/magnetometer.cpp
+++ b/src/simulation/sensors/magnetometer/magnetometer.cpp
@@ -19,14 +19,8 @@
 
 #include "simulation/sensors/magnetometer/magnetometer.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/astroConstants.h"
 #include <math.h>
-#include <iostream>
-#include <cstring>
-#include <algorithm>
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/avsEigenMRP.h"
 
 /*! This is the constructor, setting variables to default values. */

--- a/src/simulation/sensors/simpleMassProps/simpleMassProps.cpp
+++ b/src/simulation/sensors/simpleMassProps/simpleMassProps.cpp
@@ -86,7 +86,7 @@ void SimpleMassProps::computeMassProperties()
         for (uint64_t j = 0; j < 3; j++) {
             this->vehicleConfigMsgBuffer.ISCPntB_B[3*i + j] = this->scMassPropsMsgBuffer.ISC_PntB_B[i][j];
         }
-    }   
+    }
 
     // transfer the center of mass
     v3Copy(this->scMassPropsMsgBuffer.c_B, this->vehicleConfigMsgBuffer.CoM_B);

--- a/src/simulation/sensors/simpleMassProps/simpleMassProps.cpp
+++ b/src/simulation/sensors/simpleMassProps/simpleMassProps.cpp
@@ -18,8 +18,6 @@
  */
 #include "simulation/sensors/simpleMassProps/simpleMassProps.h"
 #include <iostream>
-#include <cstring>
-#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 
 /*! This is the constructor for the module class. */

--- a/src/simulation/sensors/simpleVoltEstimator/simpleVoltEstimator.cpp
+++ b/src/simulation/sensors/simpleVoltEstimator/simpleVoltEstimator.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <cstring>
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /*! This is the constructor for the simple voltage estimator module.  It sets default variable
     values and initializes the various parts of the model */

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -21,8 +21,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <iostream>
-#include <cstring>
-#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/gauss_markov.h"
 
 StarTracker::StarTracker()

--- a/src/simulation/thermal/motorThermal/motorThermal.cpp
+++ b/src/simulation/thermal/motorThermal/motorThermal.cpp
@@ -26,7 +26,7 @@ MotorThermal::MotorThermal()
 {
     this->currentTemperature = -273.15;     //!< current temperature defaults to absolute zero
     this->ambientTemperature = 0.0;         //!< ambient temperature defaults to 0 Celsius
-    this->ambientThermalResistance = -1.0;  //!< ambient thermal resistance  
+    this->ambientThermalResistance = -1.0;  //!< ambient thermal resistance
     this->motorHeatCapacity = -1.0;         //!< motor heat capacity
     this->efficiency = 1.0;                 //!< default efficiency is 1.0
 }

--- a/src/simulation/thermal/motorThermal/motorThermal.cpp
+++ b/src/simulation/thermal/motorThermal/motorThermal.cpp
@@ -17,9 +17,6 @@
 
  */
 #include "simulation/thermal/motorThermal/motorThermal.h"
-#include <iostream>
-#include <cstring>
-#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include <math.h>
 

--- a/src/simulation/thermal/sensorThermal/sensorThermal.cpp
+++ b/src/simulation/thermal/sensorThermal/sensorThermal.cpp
@@ -1,11 +1,6 @@
 #include <math.h>
-#include <iostream>
-#include <cstring>
-#include <algorithm>
 #include "sensorThermal.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/avsEigenMRP.h"

--- a/src/simulation/thermal/sensorThermal/sensorThermal.cpp
+++ b/src/simulation/thermal/sensorThermal/sensorThermal.cpp
@@ -84,7 +84,7 @@ void SensorThermal::readMessages()
     //! Read vehicle state ephemeris message
     this->stateCurrent = this->stateInMsg();
 
-    //! - Read in optional sun eclipse input message 
+    //! - Read in optional sun eclipse input message
     if(this->sunEclipseInMsg.isLinked()) {
         EclipseMsgPayload sunVisibilityFactor;          // sun visiblity input message
         sunVisibilityFactor = this->sunEclipseInMsg();
@@ -108,7 +108,7 @@ void SensorThermal::UpdateState(uint64_t CurrentSimNanos)
 
     //! - Read in messages
     this->readMessages();
-    
+
     //! - Evaluate model
     this->evaluateThermalModel(CurrentSimNanos*NANO2SEC);
 
@@ -195,5 +195,3 @@ void SensorThermal::evaluateThermalModel(uint64_t CurrentSimSeconds) {
 
     return;
 }
-
-

--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
@@ -1,10 +1,10 @@
 /*
  Copyright (c) 2016, Autonomous Vehicle Systems Lab, Univeristy of Colorado at Boulder
- 
+
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -12,7 +12,7 @@
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
  */
 
 
@@ -117,7 +117,7 @@ void DataFileToViz::Reset(uint64_t CurrentSimNanos)
         this->fileHandle.close();
         bskLogger.bskLog(BSK_INFORMATION, "DataFileToViz:\nclosed the file: %s.", this->dataFileName.c_str());
     }
-    
+
     /* open the data file*/
     this->fileHandle.open(this->dataFileName);
     if (this->fileHandle.fail()) {

--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
@@ -22,7 +22,6 @@
 #include "architecture/utilities/avsEigenSupport.h"
 #include <sstream>
 #include <string>
-#include <string.h>
 
 /*! DataFileToViz Constructor
  */

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -20,7 +20,6 @@
 #include <cstdio>
 
 #include "vizInterface.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <google/protobuf/io/coded_stream.h>

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1,10 +1,10 @@
 /*
  Copyright (c) 2016, Autonomous Vehicle Systems Lab, Univeristy of Colorado at Boulder
- 
+
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -12,7 +12,7 @@
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
  */
 
 #include <fstream>
@@ -38,11 +38,11 @@ VizInterface::VizInterface()
     this->FrameNumber= -1;
 
     this->firstPass = 0;
-    
+
     this->comProtocol = "tcp";
     this->comAddress = "localhost";
     this->comPortNumber = "5556";
-    
+
     return;
 }
 
@@ -307,7 +307,7 @@ void VizInterface::ReadBSKMessages()
                 }
             }
         }
-        
+
         /* read in transceiver state values */
         {
             for (size_t idx=0;idx< (size_t) scIt->transceiverList.size(); idx++) {
@@ -332,7 +332,7 @@ void VizInterface::ReadBSKMessages()
                 }
             }
         }
-        
+
         /* read in generic storage state values */
         {
             for (size_t idx=0;idx< (size_t) scIt->genericStorageList.size(); idx++) {
@@ -588,7 +588,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             for (int i=0; i<4; i++){
                 vizSettings->add_defaultthrustercolor(this->settings.defaultThrusterColor[i]);
             }
-        } 
+        }
 
         vizSettings->set_defaultthrusterplumelifescalar(this->settings.defaultThrusterPlumeLifeScalar);
         vizSettings->set_orbitlinesegments(this->settings.orbitLineSegments);
@@ -793,7 +793,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                         for (int i=0; i<4; i++) {
                             thr->add_color(scIt->thrInfo[idx].color[i]);
                         }
-                    } 
+                    }
                     for (int i=0; i<3; i++){
                         thr->add_position(scIt->thrOutputMessage[idx].thrusterLocation[i]);
                         thr->add_thrustvector(scIt->thrOutputMessage[idx].thrusterDirection[i]);
@@ -856,7 +856,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                 el->set_showgridlines(scIt->ellipsoidList[idx]->showGridLines);
             }
 
-            
+
             // Write transceiver messages
             for (size_t idx =0; idx < (size_t) scIt->transceiverList.size(); idx++) {
                 vizProtobufferMessage::VizMessage::Transceiver* tr = scp->add_transceivers();
@@ -1050,7 +1050,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             zmq_msg_t receive_buffer;
             zmq_msg_init(&receive_buffer);
             zmq_msg_recv (&receive_buffer, requester_socket, 0);
-            
+
             /*! - send protobuffer raw over zmq_socket */
             void* serialized_message = malloc(byteCount);
             message->SerializeToArray(serialized_message, (int) byteCount);
@@ -1063,7 +1063,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
 
             void* header_message = malloc(10 * sizeof(char));
             memcpy(header_message, "SIM_UPDATE", 10);
-            
+
             zmq_msg_init_data(&request_header, header_message, 10, message_buffer_deallocate, NULL);
             zmq_msg_init(&empty_frame1);
             zmq_msg_init(&empty_frame2);
@@ -1093,7 +1093,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                 zmq_msg_send(&request_life, this->requester_socket, 0);
                 return;
             }
-            
+
         }
         /*!  Write protobuffer to file */
         if (!this->saveFile  || !message->SerializeToOstream(this->outputStream)) {


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Basilisk code base is has many unused includes. This is wasted effort during compilation as the compiler often parses the include only to then never make use of that effort. This PR simply removes all unused includes. 

## Verification
CI runs successfully and by inspection the only changes should be removed includes.

## Documentation
None new, none invalidated.

## Future work
A tool like IWUYU should be added to prevent developers from merging code with unused includes.
