### PR TITLE
Add cielim to vizinterface build toggle

### DIFF
--- a/src/cmake/bskTargetExcludeBuildOptions.cmake
+++ b/src/cmake/bskTargetExcludeBuildOptions.cmake
@@ -1,6 +1,6 @@
 option(BUILD_VIZINTERFACE "Build VizInterface Module" ON)
 if(NOT BUILD_VIZINTERFACE)
-  list(APPEND EXCLUDED_BSK_TARGETS "vizInterface")
+  list(APPEND EXCLUDED_BSK_TARGETS "vizInterface" "cielimInterface")
 endif()
 
 option(BUILD_OPNAV "Build OpNav Modules" OFF)


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Cielim interface is added to the vizInterface build toggle.

## Verification
CI will compile cielim interface

## Documentation
NA

## Future work
When the messaging system is redeveloped, the data marshalling done by cielim (protobufs) will no longer you the kitchen sink vizInterface protobuf definition. This will decouple cielim from the vizInterface.
