### PR TITLE
Feature/833 cob windowing

### DIFF
--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -78,6 +78,11 @@ void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
         }
     }
 
+    this->computeWindow(imageCV);
+    if (this->validWindow) {
+        this->applyWindow(imageCV);
+    }
+
     std::vector<cv::Vec2i> locations = this->extractBrightPixels(imageCV);
 
     /*!- If no lit pixels are found do not validate the image as a measurement */

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -90,12 +90,12 @@ void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
         Eigen::Vector2d cobCoordinates;
         cobCoordinates = this->weightedCenterOfBrightness(locations);
 
-        cobBuffer.valid = 1;
+        cobBuffer.valid = true;
         cobBuffer.timeTag = this->sensorTimeTag;
         cobBuffer.cameraID = imageBuffer.cameraID;
         cobBuffer.centerOfBrightness[0] = cobCoordinates[0];
         cobBuffer.centerOfBrightness[1] = cobCoordinates[1];
-        cobBuffer.pixelsFound = locations.size();
+        cobBuffer.pixelsFound = static_cast<int32_t> (locations.size());
     }
 
     this->opnavCOBOutMsg.write(&cobBuffer, this->moduleID, CurrentSimNanos);

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -72,7 +72,7 @@ void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
     std::string dirName;
     /*! - Save image to prescribed path if requested */
     if (this->saveImages) {
-        dirName = this->saveDir + std::to_string(CurrentSimNanos * 1E-9) + ".png";
+        dirName = this->saveDir + std::to_string((double) CurrentSimNanos * NANO2SEC) + ".png";
         if (!cv::imwrite(dirName, imageCV)) {
             bskLogger.bskLog(BSK_WARNING, "CenterOfBrightness: wasn't able to save images.");
         }

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -138,6 +138,31 @@ Eigen::Vector2d CenterOfBrightness::weightedCenterOfBrightness(std::vector<cv::V
     return coordinates;
 }
 
+/*! This method computes the points of the window used for windowing
+ @return void
+ @param image openCV matrix of the input image
+ */
+void CenterOfBrightness::computeWindow(cv::Mat const &image)
+{
+    // if any of the window parameters is 0 (not specified), window is the same as image dimensions and won't be applied
+    if (this->windowCenter.isZero() || this->windowWidth == 0 || this->windowHeight == 0) {
+        this->windowPointTopLeft[0] = 0;
+        this->windowPointTopLeft[1] = 0;
+        this->windowPointBottomRight[0] = image.size().width;
+        this->windowPointBottomRight[1] = image.size().height;
+    } else {
+        this->windowPointTopLeft[0] = this->windowCenter[0] - this->windowWidth/2;
+        this->windowPointTopLeft[1] = this->windowCenter[1] - this->windowHeight/2;
+        this->windowPointBottomRight[0] = this->windowCenter[0] + this->windowWidth/2;
+        this->windowPointBottomRight[1] = this->windowCenter[1] + this->windowHeight/2;
+        this->validWindow = true;
+    }
+    assert(windowPointTopLeft[0] >= 0);
+    assert(windowPointTopLeft[1] >= 0);
+    assert(windowPointBottomRight[0] <= image.size().width);
+    assert(windowPointBottomRight[1] <= image.size().height);
+}
+
 /*! Set the mask center for windowing
     @param Eigen::Vector2i center [px]
     @return void

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -92,7 +92,7 @@ void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
         cobBuffer.centerOfBrightness[1] = cobCoordinates[1];
         cobBuffer.pixelsFound = locations.size();
     }
-    
+
     this->opnavCOBOutMsg.write(&cobBuffer, this->moduleID, CurrentSimNanos);
 
 }
@@ -136,4 +136,41 @@ Eigen::Vector2d CenterOfBrightness::weightedCenterOfBrightness(std::vector<cv::V
     }
     coordinates /= weightSum;
     return coordinates;
+}
+
+/*! Set the mask center for windowing
+    @param Eigen::Vector2i center [px]
+    @return void
+    */
+void CenterOfBrightness::setWindowCenter(const Eigen::VectorXi& center)
+{
+    this->windowCenter = center;
+}
+
+/*! Get the mask center for windowing
+    @return Eigen::Vector2i center [px]
+    */
+Eigen::VectorXi CenterOfBrightness::getWindowCenter() const
+{
+    return this->windowCenter;
+}
+
+/*! Set the mask size for windowing
+    @param int32_t width [px]
+    @param int32_t height [px]
+    @return void
+    */
+void CenterOfBrightness::setWindowSize(const int32_t width, const int32_t height)
+{
+    this->windowWidth = width;
+    this->windowHeight = height;
+}
+
+/*! Get the mask center for windowing
+    @return Eigen::Vector2i size [px]
+    */
+Eigen::VectorXi CenterOfBrightness::getWindowSize() const
+{
+    Eigen::VectorXi center = {this->windowWidth, this->windowHeight};
+    return center;
 }

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -138,6 +138,49 @@ Eigen::Vector2d CenterOfBrightness::weightedCenterOfBrightness(std::vector<cv::V
     return coordinates;
 }
 
+/*! This method applies the window for windowing by setting anything outside the window to black.
+ @return void
+ @param image cv::Mat of the input image
+ */
+void CenterOfBrightness::applyWindow (cv::Mat const &image) const
+{
+    /*! Create a window and ignore anything outside of it (make it black).
+     * Point in opencv is column, row. x goes left-to-right, y goes top-to-bottom ([0,0] is top left corner).
+     * Window mask is inclusive (edge of mask should be considered in COB), so must add/subtract one pixel. */
+    /*! - Left edge removal */
+    if (this->windowPointTopLeft[0] > 0) {
+        cv::rectangle(image,
+                      cv::Point(0, 0),
+                      cv::Point(this->windowPointTopLeft[0]-1, image.size().height),
+                      cv::Scalar(0),
+                      -1);
+    }
+    /*! - Right edge removal */
+    if (this->windowPointBottomRight[0] < image.size().width) {
+        cv::rectangle(image,
+                      cv::Point(this->windowPointBottomRight[0]+1, 0),
+                      cv::Point(image.size().width, image.size().height),
+                      cv::Scalar(0),
+                      -1);
+    }
+    /*! - Top edge removal */
+    if (this->windowPointTopLeft[1] > 0) {
+        cv::rectangle(image,
+                      cv::Point(this->windowPointTopLeft[0]-1, 0),
+                      cv::Point(this->windowPointBottomRight[0]+1, this->windowPointTopLeft[1]-1),
+                      cv::Scalar(0),
+                      -1);
+    }
+    /*! - Bottom edge removal */
+    if (this->windowPointBottomRight[1] < image.size().height) {
+        cv::rectangle(image,
+                      cv::Point(this->windowPointTopLeft[0]-1, this->windowPointBottomRight[1]+1),
+                      cv::Point(this->windowPointBottomRight[0]+1, image.size().height),
+                      cv::Scalar(0),
+                      -1);
+    }
+}
+
 /*! This method computes the points of the window used for windowing
  @return void
  @param image openCV matrix of the input image

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -45,7 +45,10 @@ void CenterOfBrightness::Reset(uint64_t CurrentSimNanos)
 void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
 {
     CameraImageMsgPayload imageBuffer = this->imageInMsg.zeroMsgPayload;
-    OpNavCOBMsgPayload cobBuffer = this->opnavCOBOutMsg.zeroMsgPayload;
+
+    OpNavCOBMsgPayload cobBuffer;
+    cobBuffer = this->opnavCOBOutMsg.zeroMsgPayload;
+
     cv::Mat imageCV;
 
     /*! - Read in the image*/
@@ -87,8 +90,7 @@ void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
 
     /*!- If no lit pixels are found do not validate the image as a measurement */
     if (!locations.empty()){
-        Eigen::Vector2d cobCoordinates;
-        cobCoordinates = this->weightedCenterOfBrightness(locations);
+        Eigen::Vector2d cobCoordinates = this->weightedCenterOfBrightness(locations);
 
         cobBuffer.valid = true;
         cobBuffer.timeTag = this->sensorTimeTag;
@@ -128,10 +130,10 @@ std::vector<cv::Vec2i> CenterOfBrightness::extractBrightPixels(cv::Mat image)
  */
 Eigen::Vector2d CenterOfBrightness::weightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels)
 {
-    uint32_t weight, weightSum;
+    uint32_t weight;
+    uint32_t weightSum = 0;
     Eigen::Vector2d coordinates;
     coordinates.setZero();
-    weightSum = 0;
     for(auto & pixel : nonZeroPixels) {
         /*! Individual pixel intensity used as the weight for the contribution to the solution*/
         weight = (uint32_t) this->imageGray.at<unsigned char>(pixel[1], pixel[0]);

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
@@ -24,17 +24,12 @@
 #include <Eigen/Dense>
 #include "architecture/messaging/messaging.h"
 #include "opencv2/opencv.hpp"
-#include "opencv2/highgui.hpp"
 #include "opencv2/core/mat.hpp"
-#include "opencv2/imgcodecs.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/dnn.hpp"
 
 #include "architecture/msgPayloadDefC/CameraImageMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/OpNavCOBMsgPayload.h"
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
 
 /*! @brief visual object tracking using center of brightness detection */

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
@@ -55,6 +55,7 @@ private:
     std::vector<cv::Vec2i> extractBrightPixels(cv::Mat image);
     Eigen::Vector2d weightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels);
     void computeWindow(cv::Mat const &image);
+    void applyWindow (cv::Mat const &image) const;
 
 public:
     Message<OpNavCOBMsgPayload> opnavCOBOutMsg;  //!< The name of the OpNav center of brightness output message

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
@@ -37,15 +37,19 @@
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
 
-
 /*! @brief visual object tracking using center of brightness detection */
 class CenterOfBrightness: public SysModel {
 public:
     CenterOfBrightness();
     ~CenterOfBrightness();
-    
+
     void UpdateState(uint64_t CurrentSimNanos);
     void Reset(uint64_t CurrentSimNanos);
+
+    void setWindowCenter(const Eigen::VectorXi& center);
+    Eigen::VectorXi getWindowCenter() const;
+    void setWindowSize(int32_t width, int32_t height);
+    Eigen::VectorXi getWindowSize() const;
 
 private:
     std::vector<cv::Vec2i> extractBrightPixels(cv::Mat image);
@@ -65,10 +69,11 @@ public:
 
 private:
     uint64_t sensorTimeTag;              //!< [ns] Current time tag for sensor out
+    Eigen::VectorXi windowCenter{};            //!< [px] center of mask to be used for windowing
+    int32_t windowWidth{};                     //!< [px] width of mask to be used for windowing
+    int32_t windowHeight{};                    //!< [px] height of mask to be used for windowing
     /* OpenCV specific arguments needed for finding all non-zero pixels*/
     cv::Mat imageGray;                   //!< [cv mat] Gray scale image for weighting
 };
 
-
 #endif
-

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
@@ -54,6 +54,7 @@ public:
 private:
     std::vector<cv::Vec2i> extractBrightPixels(cv::Mat image);
     Eigen::Vector2d weightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels);
+    void computeWindow(cv::Mat const &image);
 
 public:
     Message<OpNavCOBMsgPayload> opnavCOBOutMsg;  //!< The name of the OpNav center of brightness output message
@@ -72,6 +73,9 @@ private:
     Eigen::VectorXi windowCenter{};            //!< [px] center of mask to be used for windowing
     int32_t windowWidth{};                     //!< [px] width of mask to be used for windowing
     int32_t windowHeight{};                    //!< [px] height of mask to be used for windowing
+    Eigen::Vector2i windowPointTopLeft{};      //!< [px] top left point of window
+    Eigen::Vector2i windowPointBottomRight{};  //!< [px] bottom right point of window
+    bool validWindow = false;            //!< [px] true if window is set, false if center, height, or width equal 0
     /* OpenCV specific arguments needed for finding all non-zero pixels*/
     cv::Mat imageGray;                   //!< [cv mat] Gray scale image for weighting
 };

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.i
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.i
@@ -16,6 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
+
 %module centerOfBrightness
 %{
    #include "centerOfBrightness.h"
@@ -30,6 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "sys_model.h"
 %include "swig_conly_data.i"
 %include "std_array.i"
+%include "swig_eigen.i"
 
 %include "centerOfBrightness.h"
 
@@ -42,4 +44,3 @@ struct CameraImageMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.rst
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.rst
@@ -2,7 +2,8 @@ Executive Summary
 -----------------
 
 Module reads in a message containing a pointer to an image and writes out the weighted center of brightness of the
-image for any pixel above a parametrized threshold.
+image for any pixel above a parametrized threshold. A window mask can be specified such that only the pixels within the
+specified window are considered.
 
 
 Message Connection Descriptions
@@ -21,7 +22,8 @@ provides information on what this message is used for.
       - Description
     * - opnavCirclesOutMsg
       - :ref:`OpNavCOBMsgPayload`
-      - output center of brightness message containing number of detected pixels, and center-of-brightness in pixel space
+      - output center of brightness message containing number of detected pixels, and center-of-brightness in pixel
+        space
     * - imageInMsg
       - :ref:`CameraImageMsgPayload`
       - camera image input message containing the pointer to the image
@@ -42,11 +44,12 @@ Both of these are implemented using OpenCV methods.
 Afterwards the weighted center-of-brightness is implemented by finding all the non-zero pixels (all pixels that were
 not thresholded down), and finding their intensity (which will be their weight).
 Assuming the image is made up of pixels :math:`p` with and x and y component, that :math:`I` is the intensity, and
-:math:`I_{\mathrm{min}` is the threshold value, the center of brightness is then defined as:
+:math:`I_{\mathrm{min}` is the threshold value, the center of brightness within the window of the image
+(:math:`\mathrm{window} \in \mathrm{image}`) is then defined as:
 
 .. math::
 
-    \mathcal{P} &= \{p \in \mathrm{image} \hspace{5cm} |  \hspace{5cm} I(p) > I_{\mathrm{min}\} \\
+    \mathcal{P} &= \{p \in \mathrm{window} \hspace{5cm} |  \hspace{5cm} I(p) > I_{\mathrm{min}\} \\
     I_\mathrm{tot} &= \sum_{p \in \mathcal{P}} I(p) \\
     p_{\mathrm{cob}} &= \frac{1}{I_\mathrm{tot}}\sum_{p \in \mathcal{P}} I(p) * p }
 
@@ -63,14 +66,19 @@ This section is to outline the steps needed to setup a Center of Brightness in P
 
     from Basilisk.fswAlgorithms import centerOfBrightness
 
-#. Create an instantiation of a Spinning body::
+#. Create an instantiation of centerOfBrightness::
 
     cobAlgorithm = centerOfBrightness.CenterOfBrightness()
 
-#. Define all physical parameters for a Spinning Body. For example::
+#. Define the image processing parameters. For example::
 
     cobAlgorithm.blurSize = 7
     cobAlgorithm.threshold = 10
+
+#. Define the window mask (optional)::
+
+    cobAlgorithm.setWindowCenter(windowCenter)
+    cobAlgorithm.setWindowSize(windowWidth, windowHeight)
 
 #. Subscribe to the image message output by the camera model or visualization interface::
 


### PR DESCRIPTION
* **Tickets addressed:** MAXGNC-833
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The centerOfBrightness module was updated to accept the input parameters for a masking window, and the module then applies that window to only consider pixels within the window for the computation of the center of brightness.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
The unit test was updated to check the windowing approach.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
The documentation was updated accordingly.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
At the moment, swig_eigen.i doesn't include the Eigen::Vector2i type, so Eigen::VectorXi was used instead for the corresponding windowing input parameters. This should be changed once the swig_eigen.i file has been updated.
