### PR TITLE
Cielim remove unused dependencies

### DIFF
--- a/src/simulation/vizard/cielimInterface/Custom.cmake
+++ b/src/simulation/vizard/cielimInterface/Custom.cmake
@@ -1,4 +1,3 @@
 find_package(cppzmq CONFIG REQUIRED)
 target_link_libraries(${TARGET_NAME} PRIVATE cppzmq::cppzmq)
 target_link_libraries(${TARGET_NAME} PRIVATE vizMessage)
-include(usingOpenCV)

--- a/src/simulation/vizard/cielimInterface/cielimInterface.cpp
+++ b/src/simulation/vizard/cielimInterface/cielimInterface.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2023, University of Colorado at Boulder
+ Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/vizard/cielimInterface/cielimInterface.h
+++ b/src/simulation/vizard/cielimInterface/cielimInterface.h
@@ -32,8 +32,6 @@
 #include "simulation/vizard/_GeneralModuleFiles/vizStructures.h"
 
 #include <fstream>
-#include <map>
-#include <memory>
 #include <vector>
 #include <zmq.h>
 

--- a/src/simulation/vizard/cielimInterface/cielimInterface.h
+++ b/src/simulation/vizard/cielimInterface/cielimInterface.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2023, University of Colorado at Boulder
+ Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/vizard/cielimInterface/zmqConnector.cpp
+++ b/src/simulation/vizard/cielimInterface/zmqConnector.cpp
@@ -24,17 +24,17 @@ ZmqConnector::ZmqConnector() = default;
 void ZmqConnector::connect() {
     if (!this->isConnected()) {
         this->context = std::make_shared<zmq::context_t>();
-        this->requester_socket = std::make_unique<zmq::socket_t>(*this->context, ZMQ_REQ);
+        this->requesterSocket = std::make_unique<zmq::socket_t>(*this->context, ZMQ_REQ);
         std::cout << this->comAddress << ":" << this->comPortNumber << std::endl;
-        this->requester_socket->connect(this->comProtocol + "://" + this->comAddress + ":" + this->comPortNumber);
+        this->requesterSocket->connect(this->comProtocol + "://" + this->comAddress + ":" + this->comPortNumber);
     }
     this->ping();
     this->ping();
 }
 
 bool ZmqConnector::isConnected() const {
-    if (this->requester_socket) {
-        return this->requester_socket->connected();
+    if (this->requesterSocket) {
+        return this->requesterSocket->connected();
     }
     return false;
 }
@@ -54,14 +54,14 @@ void ZmqConnector::send(const vizProtobufferMessage::VizMessage& message) {
 
     auto emptyMsg = zmq::message_t(0);
 
-    this->requester_socket->send(zmq::message_t("SIM_UPDATE", 10), ZMQ_SNDMORE);
-    this->requester_socket->send(emptyMsg, ZMQ_SNDMORE);
-    this->requester_socket->send(emptyMsg, ZMQ_SNDMORE);
-    this->requester_socket->send(payload, ZMQ_NULL);
+    this->requesterSocket->send(zmq::message_t("SIM_UPDATE", 10), ZMQ_SNDMORE);
+    this->requesterSocket->send(emptyMsg, ZMQ_SNDMORE);
+    this->requesterSocket->send(emptyMsg, ZMQ_SNDMORE);
+    this->requesterSocket->send(payload, ZMQ_NULL);
 
     // Receive pong
     auto pong = zmq::message_t();
-    auto res = this->requester_socket->recv(&pong, ZMQ_NULL);
+    auto res = this->requesterSocket->recv(&pong, ZMQ_NULL);
 }
 
 void ZmqConnector::message_buffer_deallocate(void *data, void *hint)
@@ -80,11 +80,11 @@ ImageData ZmqConnector::requestImage(size_t cameraId) {
                                               ZmqConnector::message_buffer_deallocate,
                                               nullptr);
 
-    auto res = this->requester_socket->send(imageRequestMessage, zmq::send_flags::none);
+    auto res = this->requesterSocket->send(imageRequestMessage, zmq::send_flags::none);
     auto imageLengthMessage = zmq::message_t();
     auto imageMessage = zmq::message_t();
-    res = this->requester_socket->recv(imageLengthMessage, zmq::recv_flags::none);
-    res = this->requester_socket->recv(imageMessage, zmq::recv_flags::none);
+    res = this->requesterSocket->recv(imageLengthMessage, zmq::recv_flags::none);
+    res = this->requesterSocket->recv(imageMessage, zmq::recv_flags::none);
 
     const int32_t *lengthPoint = imageLengthMessage.data<int32_t>();
     const void *imagePoint = imageMessage.data();
@@ -97,8 +97,8 @@ ImageData ZmqConnector::requestImage(size_t cameraId) {
 
 
 void ZmqConnector::ping() {
-    this->requester_socket->send(zmq::message_t("PING", 4), ZMQ_NULL);
+    this->requesterSocket->send(zmq::message_t("PING", 4), ZMQ_NULL);
     auto message = zmq::message_t();
-    auto res = this->requester_socket->recv(message, zmq::recv_flags::none);
+    auto res = this->requesterSocket->recv(message, zmq::recv_flags::none);
     std::cout << message.str() << std::endl;
 }

--- a/src/simulation/vizard/cielimInterface/zmqConnector.cpp
+++ b/src/simulation/vizard/cielimInterface/zmqConnector.cpp
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2023 University of Colorado at Boulder
+ Copyright (c) 2023 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/vizard/cielimInterface/zmqConnector.h
+++ b/src/simulation/vizard/cielimInterface/zmqConnector.h
@@ -23,10 +23,6 @@
 #include "vizMessage.pb.h"
 #include <zmq.hpp>
 #include <string>
-#include "opencv2/opencv.hpp"
-#include "opencv2/highgui.hpp"
-#include "opencv2/core/mat.hpp"
-#include "opencv2/imgcodecs.hpp"
 
 struct ImageData{
     int32_t imageBufferLength;

--- a/src/simulation/vizard/cielimInterface/zmqConnector.h
+++ b/src/simulation/vizard/cielimInterface/zmqConnector.h
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2023 University of Colorado at Boulder
+ Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/vizard/cielimInterface/zmqConnector.h
+++ b/src/simulation/vizard/cielimInterface/zmqConnector.h
@@ -42,7 +42,7 @@ public:
 
 private:
     std::shared_ptr<zmq::context_t> context;
-    std::unique_ptr<zmq::socket_t> requester_socket;
+    std::unique_ptr<zmq::socket_t> requesterSocket;
     int firstPass{}; //!< Flag to initialize the viz at first timestep
     std::string comProtocol = "tcp";
     std::string comAddress = "127.0.0.1";


### PR DESCRIPTION
* **Tickets addressed:** gnc-939
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
An unused opencv dependency is removed from the cielim interface. This dependency caused the module to not build when the opNav build flag was selected.

## Verification
Build, test, run, and CI is successful.

## Documentation
NA

## Future work
None
