### PR TITLE
Feature/835 brightness increase tracking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 conan>=1.40.1, <2.00.0
+opencv-contrib-python
+opencv-python
 pandas
 parse>=1.18.0
 Pillow

--- a/src/architecture/msgPayloadDefCpp/OpNavCOBMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/OpNavCOBMsgPayload.h
@@ -37,6 +37,7 @@ OpNavCOBMsgPayload
     int64_t cameraID; //!< -- [-]   ID of the camera that took the image
     double centerOfBrightness[2]; //!< -- [-]   Center x, y of bright pixels
     int32_t pixelsFound; //!< -- [-] Number of bright pixels found in the image
+    double rollingAverageBrightness; //!< [-] brightness computed over rolling average
 }OpNavCOBMsgPayload;
 
 #endif /* COBOPNAVMSG_H */

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -130,13 +130,12 @@ std::vector<cv::Vec2i> CenterOfBrightness::extractBrightPixels(cv::Mat image)
  */
 Eigen::Vector2d CenterOfBrightness::weightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels)
 {
-    uint32_t weight;
     uint32_t weightSum = 0;
     Eigen::Vector2d coordinates;
     coordinates.setZero();
     for(auto & pixel : nonZeroPixels) {
         /*! Individual pixel intensity used as the weight for the contribution to the solution*/
-        weight = (uint32_t) this->imageGray.at<unsigned char>(pixel[1], pixel[0]);
+        auto weight = this->imageGray.at<unsigned char>(pixel[1], pixel[0]);
         coordinates[0] += weight * pixel[0];
         coordinates[1] += weight * pixel[1];
         weightSum += weight; // weighted sum of all the pixels

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -100,6 +100,7 @@ void CenterOfBrightness::UpdateState(uint64_t CurrentSimNanos)
         cobBuffer.centerOfBrightness[0] = cobData.first[0];
         cobBuffer.centerOfBrightness[1] = cobData.first[1];
         cobBuffer.pixelsFound = static_cast<int32_t> (locations.size());
+        cobBuffer.rollingAverageBrightness = this->brightnessHistory.mean();
     }
 
     this->opnavCOBOutMsg.write(&cobBuffer, this->moduleID, CurrentSimNanos);

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
@@ -48,7 +48,7 @@ public:
 
 private:
     std::vector<cv::Vec2i> extractBrightPixels(cv::Mat image);
-    Eigen::Vector2d weightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels);
+    std::pair<Eigen::Vector2d, double> computeWeightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels);
     void computeWindow(cv::Mat const &image);
     void applyWindow (cv::Mat const &image) const;
 

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.h
@@ -51,6 +51,7 @@ private:
     std::pair<Eigen::Vector2d, double> computeWeightedCenterOfBrightness(std::vector<cv::Vec2i> nonZeroPixels);
     void computeWindow(cv::Mat const &image);
     void applyWindow (cv::Mat const &image) const;
+    void updateBrightnessHistory(double brightness);
 
 public:
     Message<OpNavCOBMsgPayload> opnavCOBOutMsg;  //!< The name of the OpNav center of brightness output message
@@ -63,6 +64,7 @@ public:
     int32_t threshold = 50;                 //!< [px] Threshold value on whether or not to include the solution
     bool saveImages = false;                  //!< [-] 1 to save images to file for debugging
     std::string saveDir = "./";                //!< The name of the directory to save images
+    int32_t numberOfPointsBrightnessAverage = 5;  //!< [-] number of points to be used for rolling average of brightness
 
 private:
     uint64_t sensorTimeTag;              //!< [ns] Current time tag for sensor out
@@ -72,6 +74,7 @@ private:
     Eigen::Vector2i windowPointTopLeft{};      //!< [px] top left point of window
     Eigen::Vector2i windowPointBottomRight{};  //!< [px] bottom right point of window
     bool validWindow = false;            //!< [px] true if window is set, false if center, height, or width equal 0
+    Eigen::VectorXd brightnessHistory{};    //!< [-] brightness history to be used for rolling average
     /* OpenCV specific arguments needed for finding all non-zero pixels*/
     cv::Mat imageGray;                   //!< [cv mat] Gray scale image for weighting
 };

--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.rst
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.rst
@@ -3,7 +3,10 @@ Executive Summary
 
 Module reads in a message containing a pointer to an image and writes out the weighted center of brightness of the
 image for any pixel above a parametrized threshold. A window mask can be specified such that only the pixels within the
-specified window are considered.
+specified window are considered. The module also computes the normalized total brightness of all bright pixels
+(brightness between 0 and 1, summed up over all bright pixels) and determines the rolling average of the brightness
+over the last few time steps. If there are no bright pixels, the brightness history (and rolling average) will not be
+updated.
 
 
 Message Connection Descriptions
@@ -23,7 +26,7 @@ provides information on what this message is used for.
     * - opnavCirclesOutMsg
       - :ref:`OpNavCOBMsgPayload`
       - output center of brightness message containing number of detected pixels, and center-of-brightness in pixel
-        space
+        space, as well as the rolling average of the total brightness.
     * - imageInMsg
       - :ref:`CameraImageMsgPayload`
       - camera image input message containing the pointer to the image
@@ -54,6 +57,12 @@ Assuming the image is made up of pixels :math:`p` with and x and y component, th
     p_{\mathrm{cob}} &= \frac{1}{I_\mathrm{tot}}\sum_{p \in \mathcal{P}} I(p) * p }
 
 where the center of brightess :math:`p_{\mathrm{cob}}` has an x and y component which are then written to the message.
+The normalized total brightness is equal to
+
+.. math::
+    I_\mathrm{tot, normalized} = \frac{I_\mathrm{tot}}{255}
+
+and the rolling average is computed over the last :math:`N` time steps, as specified by numberOfPointsBrightnessAverage.
 
 If the incomping image is not valid, or there were no pixels above the threshold, the image is tagged as invalid.
 Downstream algorithms can therefore know when to skip a measurement.
@@ -79,6 +88,10 @@ This section is to outline the steps needed to setup a Center of Brightness in P
 
     cobAlgorithm.setWindowCenter(windowCenter)
     cobAlgorithm.setWindowSize(windowWidth, windowHeight)
+
+#. Specify the number of data points to be used for the rolling average of total brightness (optional)::
+
+    cobAlgorithm.numberOfPointsBrightnessAverage = 5
 
 #. Subscribe to the image message output by the camera model or visualization interface::
 


### PR DESCRIPTION
* **Tickets addressed:** MAXGNC-835
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The centerOfBrightness module was updated to compute the total normalized brightness and determine the rolling average of the total brightness. This can be used to track the brightness of the asteroid and make sure it is increasing over time.

The reviewers should be aware that this branch is based off the 833-cob-windowing branch which is currently under review and needs to be merged first (commits 1-10).

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
The unit test was updated and passes.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
The documentation was updated accordingly.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A