### PR TITLE
Increment python version 3.10

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     permissions:
       actions: read
       contents: read
@@ -97,7 +97,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We've uncovered some SWIG issues in basilisk when using Python 3.9. To keep things moving I'm incrementing our CI to python 3.10 until we have fixed the swig issues.

## Verification
CI runs successfully. 

## Documentation
NA

## Future work
Fix he SWIG issue for python 3.9.
