### PR TITLE
Refactor/193 coarse sun sensor refactor

### DIFF
--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_customFovCss.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_customFovCss.py
@@ -1,0 +1,129 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+import inspect
+import os
+
+import numpy as np
+import pytest
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+from Basilisk.simulation import coarseSunSensor
+from Basilisk.utilities import astroFunctions
+from Basilisk.utilities import macros
+from Basilisk.utilities import SimulationBaseClass
+
+
+@pytest.mark.parametrize("xi", [np.pi/6, np.pi/3, np.pi/2])
+@pytest.mark.parametrize("eta", [np.pi/6, np.pi/3, np.pi/2])
+@pytest.mark.parametrize("zeta", [np.pi/6, np.pi/3, np.pi/2])
+@pytest.mark.parametrize("sunLocation", [0, 1, 2, 3])
+@pytest.mark.parametrize("accuracy", [1e-10])
+def test_customFovCss(show_plots, xi, eta, zeta, sunLocation, accuracy):
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    lHat_B = [1, 0, 0]
+    mHat_B = [0, 1, 0]
+    nHat_B = [0, 0, 1]
+
+    # Construct algorithm and associated C++ container
+    CSS = coarseSunSensor.CoarseSunSensor()
+    CSS.ModelTag = "coarseSunSensor"
+    CSS.scaleFactor = 1
+    CSS.lHat_B = lHat_B
+    CSS.mHat_B = mHat_B
+    CSS.nHat_B = nHat_B
+    CSS.customFov = True
+    CSS.fovXi = xi
+    CSS.fovEta = eta
+    CSS.fovZeta = zeta
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, CSS)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+
+    omega_BN_B = np.array([0.1, -0.2, 0.3])
+
+    # Create input navigation message
+    SCStatesMsgData = messaging.SCStatesMsgPayload()
+    SCStatesMsgData.r_BN_N = [0, 0, 0]
+    SCStatesMsgData.sigma_BN = [0, 0, 0]
+    SCStatesMsg = messaging.SCStatesMsg().write(SCStatesMsgData)
+    CSS.stateInMsg.subscribeTo(SCStatesMsg)
+
+    x = 0
+    y = 0
+    match sunLocation:
+        case 0:
+            y = np.sin(xi - accuracy)
+        case 1:
+            x = np.sin(zeta - accuracy)
+        case 2:
+            y = -np.sin(eta - accuracy)
+        case 3:
+            x = -np.sin(zeta - accuracy)
+    z = (1 - x*x - y*y)**0.5
+
+    # Create input Sun spice msg
+    SpicePlanetStateMsgData = messaging.SpicePlanetStateMsgPayload()
+    SpicePlanetStateMsgData.PositionVector = astroFunctions.AU * 1000 * np.array([x, y, z])
+    SpicePlanetStateMsg = messaging.SpicePlanetStateMsg().write(SpicePlanetStateMsgData)
+    CSS.sunInMsg.subscribeTo(SpicePlanetStateMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = CSS.cssDataOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    moduleOutput = dataLog.OutputData[0]
+
+    truth = np.dot(nHat_B, [x, y, z])
+
+    # set the filtered output truth states
+    np.testing.assert_allclose(moduleOutput, truth, rtol=0, atol=accuracy, verbose=True)
+
+    return
+
+
+if __name__ == "__main__":
+    test_customFovCss(False, np.pi/6, np.pi/3, np.pi/2, 0, 1e-10)

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.rst
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.rst
@@ -15,9 +15,27 @@ The corruption types are outlined in this
 .. warning::
   Be careful when generating CSS objects in a loop or using a function! It is often convenient to initialize many CSS' with the same attributes using a loop with a function like ``setupCSS(CSS)`` where ``setupCSS`` initializes the field of view, sensor noise, min / max outputs, etc. If you do this, be sure to disown the memory in Python so the object doesn't get accidentally garbage collected or freed for use. You can disown the memory though ``cssObject.this.disown()``.
 
-The coarse sun sensor module also supports user-enabled faulty behavior by assigning a values to the ``.faultState`` member of a given sensor. An example of such call would is ``cssSensor.faultState = coarse_sun_sensor.CSSFAULT_OFF`` where ``cssSensor`` is an instantiated sensor, and ``coarse_sun_sensor`` is the imported module. 
+It is possible to define an asymmetrical field of view for the CSS. This is useful when trying to simulate baffles that partially limit the field of view of the sensor in a certain direction, usually to avoid reflected sunlight fo enter the view of the CSS. This requires not only the definition of the CSS boresight vector :math:`\boldsymbol{\hat{n}}`, but also two additional unit vectors :math:`\boldsymbol{\hat{l}}` and :math:`\boldsymbol{\hat{m}}` that define a full CSS frame. This custom field of view is modeled as the combination of two pseudo-ellipses in the :math:`(l,m)` plane. The resulting planar, closed curve is projected onto the unit sphere surface in the positive :math:`\boldsymbol{\hat{n}}` direction. The custom field of view can be set up as follows::
 
-The module currently supports the following faults: 
+    CSS = coarseSunSensor.CoarseSunSensor()
+    CSS.ModelTag = "coarseSunSensor"
+    CSS.scaleFactor = 1
+    CSS.lHat_B = lHat_B
+    CSS.mHat_B = mHat_B
+    CSS.nHat_B = nHat_B
+    CSS.customFov = True
+    CSS.fovXi = xi
+    CSS.fovEta = eta
+    CSS.fovZeta = zeta
+    CSS.n1 = n1
+    CSS.n2 = n2
+
+
+where :math:`\xi` indicates the half-angle field of view in the :math:`+\boldsymbol{\hat{m}}` direction, :math:`\eta` indicates the half-angle field of view in the :math:`-\boldsymbol{\hat{m}}` direction, and :math:`\zeta` indicates the half-angle field of view in the positive :math:`\pm \boldsymbol{\hat{l}}` direction. By design, the field of view is symmetric with respect to the :math:`(l,n)` plane. The coefficients :math:`n_1` and :math:`n_2` are warping coefficients that allow to obtain more rectangular shapes for the two half ellipsoids as :math:`n_1, n_2 >> 2`. Setting :math:`n_1 = n_2 = 2` ensures that the half ellipsoids are, in fact, half ellipses; setting :math:`\xi = \eta = \zeta` returns a regular conical field of view.
+
+The coarse sun sensor module also supports user-enabled faulty behavior by assigning a values to the ``.faultState`` member of a given sensor. An example of such call would is ``cssSensor.faultState = coarse_sun_sensor.CSSFAULT_OFF`` where ``cssSensor`` is an instantiated sensor, and ``coarse_sun_sensor`` is the imported module.
+
+The module currently supports the following faults:
 
 .. list-table:: ``CoarseSunSensor`` Fault Types
     :widths: 35 50
@@ -32,9 +50,9 @@ The module currently supports the following faults:
     * - ``CSSFAULT_STUCK_MAX``
       - CSS signal is stuck on the maximum value
     * - ``CSSFAULT_STUCK_RAND``
-      - CSS signal is stuck on a random value 
+      - CSS signal is stuck on a random value
     * - ``CSSFAULT_RAND``
-      - CSS produces random values 
+      - CSS produces random values
 
 
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-193
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This modification features the ability to define a custom field of view (FOV) for the CSS. Such field of view is defined as the union of two half ellipses on the XY plane of the CSS's frame. The CSS's Z axis is aligned with the boresight of the sensor. 
The resulting figure in the XY plane is symmetric with respect to X = 0 plane. Along the ±Y axis, the user can specify different FOV amplitudes, effectively mimicking the presence of baffles. Baffles along the ±X axis can also be defined, but they have the same amplitude by design.

## Verification
A UnitTest is added to test that, using the custom FOV, the Sun's angle with respect to the CSS's boresight is computed correctly.

## Documentation
Documentation is updated to reflect the changes.

## Future work
n/a
