### PR TITLE
Add two-axis gimbal state message

### DIFF
--- a/src/architecture/msgPayloadDefC/TwoAxisGimbalMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/TwoAxisGimbalMsgPayload.h
@@ -1,0 +1,31 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef twoAxisGimbalSimMsg_h
+#define twoAxisGimbalSimMsg_h
+
+
+/*! @brief Structure used to define the two-axis gimbal state information */
+typedef struct {
+    double theta1;                   //!< [rad] Sequential rotation angle about first rotation axis
+    double theta2;                   //!< [rad] Sequential rotation angle about second rotation axis
+}TwoAxisGimbalMsgPayload;
+
+
+#endif /* twoAxisGimbalSimMsg_h */


### PR DESCRIPTION
* **Tickets addressed:** bsk-270
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
A new `twoAxisGimbalMsgPayload` message is added to support the gimbal simulation module. The message contains the gimbal sequential tip and tilt angles.

## Verification
N/A

## Documentation
N/A

## Future work
N/A
