### PR TITLE
Add cmake policy 148

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,10 @@ if(POLICY CMP0046)
   cmake_policy(SET CMP0046 NEW)
 endif()
 
+if(POLICY CMP0148)
+  cmake_policy(SET CMP0148 OLD)
+endif ()
+
 project("basilisk")
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Projects using the FindPythonInterp and/or FindPythonLibs modules should be updated to use one of their replacements

* **Tickets addressed:** 979
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Projects using the [FindPythonInterp](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html#module:FindPythonInterp) and/or [FindPythonLibs](https://cmake.org/cmake/help/latest/module/FindPythonLibs.html#module:FindPythonLibs) modules should be updated to use one of their replacements. But this will take time and so for now we will use the cmaek policy 148 as old.

## Verification
CI runs successfully.

## Documentation
None

## Future work
Update findpython
