### PR TITLE
Resolve numpy warning in sunline srukf test

### DIFF
--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/sunlineSRuKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/sunlineSRuKF_test_utilities.py
@@ -37,7 +37,7 @@ color_z = 'lightgreen'
 m2km = 1.0 / 1000.0
 
 
-def states(x, testName, show_plots):
+def states(x, testName):
     numStates = len(x[0, :]) - 1
 
     t = np.zeros(len(x[:, 0]))
@@ -79,12 +79,10 @@ def states(x, testName, show_plots):
     plt.title('Third rate component (rad/s)')
     plt.grid()
 
-    if show_plots:
-        plt.show()
-    plt.close()
+    return plt
 
 
-def energy(t, energy, testName, show_plots):
+def energy(t, energy, testName):
     conserved = np.zeros(len(t))
     for i in range(len(t)):
         conserved[i] = (energy[i] - energy[0]) / energy[0]
@@ -95,12 +93,10 @@ def energy(t, energy, testName, show_plots):
     plt.title('Energy ' + testName)
     plt.grid()
 
-    if show_plots:
-        plt.show()
-    plt.close()
+    return plt
 
 
-def state_covar(x, Pflat, testName, show_plots):
+def state_covar(x, Pflat, testName):
     numStates = len(x[0, :]) - 1
 
     P = np.zeros([len(Pflat[:, 0]), numStates, numStates])
@@ -156,12 +152,10 @@ def state_covar(x, Pflat, testName, show_plots):
     plt.title('Third rate component (m/s)')
     plt.grid()
 
-    if show_plots:
-        plt.show()
-    plt.close()
+    return plt
 
 
-def post_fit_residuals(Res, noise, testName, show_plots):
+def post_fit_residuals(Res, noise, testName):
     MeasNoise = np.zeros(len(Res[:, 0]))
     t = np.zeros(len(Res[:, 0]))
     for i in range(len(Res[:, 0])):
@@ -198,12 +192,10 @@ def post_fit_residuals(Res, noise, testName, show_plots):
     plt.title('Third Meas Comp (m)')
     plt.grid()
 
-    if show_plots:
-        plt.show()
-    plt.close()
+    return plt
 
 
-def two_orbits(r_BN, r_BN2, show_plots):
+def two_orbits(r_BN, r_BN2):
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     ax.set_xlabel('$R_x$, km')
@@ -215,7 +207,5 @@ def two_orbits(r_BN, r_BN2, show_plots):
             ax.scatter(r_BN2[i, 1] * m2km, r_BN2[i, 2] * m2km, r_BN2[i, 3] * m2km, color=color_y, label="Meas orbit")
     ax.scatter(0, 0, color='r')
     ax.set_title('Spacecraft Orbits')
-    if show_plots:
-        plt.show()
-    plt.close()
-    return
+
+    return plt

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -109,14 +109,12 @@ def setup_css_config_msg(CSSOrientationList, cssConfigDataInMsg):
 
 @pytest.mark.parametrize("show_plots", [False])
 def test_propagation_kf(show_plots):
-    """Module Unit Test"""
     state_propagation_flyby(show_plots)
 
 
 @pytest.mark.parametrize("initial_error", [False, True])
 @pytest.mark.parametrize("show_plots", [False])
 def test_measurements_kf(show_plots, initial_error):
-    """Module Unit Test"""
     state_update_flyby(show_plots, initial_error)
 
 

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -105,7 +105,6 @@ def setup_css_config_msg(CSSOrientationList, cssConfigDataInMsg):
     cssConfigData.cssVals = totalCSSList
     cssConfigDataInMsg.write(cssConfigData)
 
-    return
 
 
 @pytest.mark.parametrize("show_plots", [False])
@@ -194,7 +193,6 @@ def state_propagation_flyby(show_plots):
                                rtol=1E-10,
                                err_msg='state propagation error',
                                verbose=True)
-    return
 
 
 def state_update_flyby(show_plots, initial_error):
@@ -355,7 +353,6 @@ def state_update_flyby(show_plots, initial_error):
     filter_plots.post_fit_residuals(gyro_post_fit_log, gyroSigma, 'Update Gyro PreFit', show_plots)
     filter_plots.post_fit_residuals(gyro_pre_fit_log, gyroSigma, 'Update Gyro PostFit', show_plots)
 
-    return
 
 
 if __name__ == "__main__":

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -268,7 +268,8 @@ def state_update_flyby(initial_error, show_plots=False):
         BN = rbk.MRP2C(bodyFrame[i, 1:4])
         cosList = []
         for j in range(len(CSSOrientationList)):
-            cosList.append(np.dot(CSSOrientationList[j], np.matmul(BN, [0, 0, 1])) + np.random.normal(0, cssSigma, 1))
+            cosList.append((np.dot(CSSOrientationList[j], np.matmul(BN, [0, 0, 1]))
+                            + np.random.normal(0, cssSigma, 1))[0])
         cssDataMsg.CosValue = np.array(cosList)
         cssDataMsg.timeTag = time[i]
         omega = expected[0, 4:] + np.random.normal(0, gyroSigma, 3)

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -106,19 +106,16 @@ def setup_css_config_msg(CSSOrientationList, cssConfigDataInMsg):
     cssConfigDataInMsg.write(cssConfigData)
 
 
-
-@pytest.mark.parametrize("show_plots", [False])
 def test_propagation_kf(show_plots):
     state_propagation_flyby(show_plots)
 
 
 @pytest.mark.parametrize("initial_error", [False, True])
-@pytest.mark.parametrize("show_plots", [False])
 def test_measurements_kf(show_plots, initial_error):
-    state_update_flyby(show_plots, initial_error)
+    state_update_flyby(initial_error, show_plots)
 
 
-def state_propagation_flyby(show_plots):
+def state_propagation_flyby(show_plots=False):
     unit_task_name = "unitTask"  # arbitrary name (don't change)
     unit_process_name = "TestProcess"  # arbitrary name (don't change)
 
@@ -193,7 +190,7 @@ def state_propagation_flyby(show_plots):
                                verbose=True)
 
 
-def state_update_flyby(show_plots, initial_error):
+def state_update_flyby(initial_error, show_plots=False):
     unit_task_name = "unitTask"  # arbitrary name (don't change)
     unit_process_name = "TestProcess"  # arbitrary name (don't change)
 

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -344,13 +344,13 @@ def state_update_flyby(show_plots, initial_error):
 
     diff = np.copy(state_data_log)
     diff[:, 1:] -= expected[:, 1:]
-    filter_plots.state_covar(state_data_log, covariance_data_log, 'Update', show_plots)
-    filter_plots.states(diff, 'Update', show_plots)
-    filter_plots.post_fit_residuals(css_post_fit_log, cssSigma, 'Update CSS PreFit', show_plots)
-    filter_plots.post_fit_residuals(css_pre_fit_log, cssSigma, 'Update CSS PostFit', show_plots)
-    filter_plots.post_fit_residuals(gyro_post_fit_log, gyroSigma, 'Update Gyro PreFit', show_plots)
-    filter_plots.post_fit_residuals(gyro_pre_fit_log, gyroSigma, 'Update Gyro PostFit', show_plots)
-
+    if show_plots:
+        plt_1 = filter_plots.state_covar(state_data_log, covariance_data_log, 'Update').show()
+        plt_2 = filter_plots.states(diff, 'Update').show()
+        plt_3 = filter_plots.post_fit_residuals(css_post_fit_log, cssSigma, 'Update CSS PreFit').show()
+        plt_4 = filter_plots.post_fit_residuals(css_pre_fit_log, cssSigma, 'Update CSS PostFit').show()
+        plt_5 = filter_plots.post_fit_residuals(gyro_post_fit_log, gyroSigma, 'Update Gyro PreFit').show()
+        plt_6 = filter_plots.post_fit_residuals(gyro_pre_fit_log, gyroSigma, 'Update Gyro PostFit').show()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* **Tickets addressed:** 983
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR resolves a numpy deprecation warning in the `test_sunlineSRuKF` test. Specifically: Only ndim-0 arrays are treated as scalars. NumPy used to treat all arrays of size 1 (e.g., np.array([3.14])) as scalars. In the future, this will be limited to arrays of ndim 0 (e.g., np.array(3.14)). 

The PR performs a few clean up operations in the first four commits. The warning is resolved in the final commit. 

## Verification
CI to run successfully.

## Documentation
NA

## Future work
NA
