### PR TITLE
Remove --gtest_output flag

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,6 @@ jobs:
           extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}
   build-linux:
     name: Build Linux
-    needs: pre-commit
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -93,7 +92,6 @@ jobs:
 
   build-windows:
     name: Build Windows
-    needs: pre-commit
     runs-on: windows-2019
     strategy:
       matrix:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -82,12 +82,7 @@ jobs:
         if: ${{ always() }}
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
-        run: ctest --gtest_output "json:../ctest/ctest-results-linux-${{ matrix.python-version }}.json"
-      - name: "Upload Google Test CTest results"
-        uses: actions/upload-artifact@v4
-        with:
-          name: ctest-results-${{ matrix.python-version }}
-          path: ctest/ctest-results-${{ matrix.python-version }}.json
+        run: ctest
         if: ${{ always() }}
 
   build-windows:
@@ -172,4 +167,5 @@ jobs:
         shell: pwsh
         run: |
           cd dist3
-          ctest --gtest_output "json:../ctest/ctest-results-windows-${{ matrix.python-version }}.json"; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}
+          ctest
+          if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}


### PR DESCRIPTION
* **Tickets addressed:** EMAGNC-1025
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
This commit removes the need for pre-commit to run before the other tests and stops storing the output of ctest which was breaking tests earlier.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
All changes are verified by current tests.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
In the future we may want to move to XML output storing.
