### PR TITLE
Flip the thrust direction vector output message

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -104,7 +104,7 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
     double T_F[3];
     v3Copy(thrusterConfigFIn.tHatThrust_B, T_F);
     v3Scale(thrusterConfigFIn.maxThrust, T_F, T_F);
-    
+
     double FM[3][3];
     tprComputeFinalRotation(r_CM_M, r_TM_F, T_F, FM);
 
@@ -189,6 +189,7 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
 
     /*! compute thruster direction in body frame coordinates */
     m33tMultV3(FB, T_F, bodyHeadingOut.rHat_XB_B);
+    v3Scale(-1.0, bodyHeadingOut.rHat_XB_B, bodyHeadingOut.rHat_XB_B);
     v3Normalize(bodyHeadingOut.rHat_XB_B, bodyHeadingOut.rHat_XB_B);
 
     /*! write output body heading message */
@@ -268,7 +269,7 @@ void tprComputeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[
     double bVec[3];
     v3Copy(r_CM_F, bVec);
     double b = v3Norm(bVec);
-    
+
     double c1 = v3Norm(r_CT_F);
 
     double psi;
@@ -287,7 +288,7 @@ void tprComputeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[
 
         psi = asin( fmin( fmax( (c1*sin(nu)*cosGamma2 - c2*sin(beta)*cosGamma1)/b, -1 ), 1 ) );
     }
-    
+
     double e_psi[3];
     v3Cross(THat_F, r_CT_F, e_psi);
     v3Normalize(e_psi, e_psi);
@@ -300,8 +301,8 @@ void tprComputeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[
 
 void tprComputeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3])
 {
-    double e1 = e_theta[0];  
-    double e2 = e_theta[1];  
+    double e1 = e_theta[0];
+    double e2 = e_theta[1];
     double e3 = e_theta[2];
 
     double A = 2 * (F2M[1][0]*e2*e2 + F2M[0][0]*e1*e2 + F2M[2][0]*e2*e3) - F2M[1][0];
@@ -313,7 +314,7 @@ void tprComputeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3]
     double t, t1, t2, y, y1, y2, theta;
     if (fabs(A) < epsilon) {
         if (fabs(B) < epsilon) {
-            // zero-th order equation has no solution 
+            // zero-th order equation has no solution
             // the solution of the minimum problem is theta = MPI
             theta = MPI;
         }
@@ -325,7 +326,7 @@ void tprComputeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3]
     }
     else {
         if (Delta < 0) {
-            // second order equation has no solution 
+            // second order equation has no solution
             // the solution of the minimum problem is found
             if (fabs(B) < epsilon) {
                 t = 0.0;


### PR DESCRIPTION
* **Tickets addressed:** bsk-294
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description
The `thrusterPlatformReference` module currently outputs the thruster platform force direction rather than the thrust direction vector. The module should be changed to output the thrust direction vector, that is, the direction of the particles ejected from the thruster.

The commit also includes pre-commit changes

## Verification
N/A

## Documentation
N/A

## Future work
N/A
