### PR TITLE
Add back variable logging for retention policies

### DIFF
--- a/src/utilities/MonteCarlo/RetentionPolicy.py
+++ b/src/utilities/MonteCarlo/RetentionPolicy.py
@@ -1,11 +1,17 @@
-import pandas as pd
+import numpy as np
+from dataclasses import dataclass
 from Basilisk.utilities import unitTestSupport
 
-
+@dataclass
 class VariableRetentionParameters:
     """
     Represents a variable's logging parameters.
     """
+    varName:str
+    varRate:int
+    startIndex:int
+    stopIndex:int
+    varType:str
 
     def __init__(self, varName, varRate, startIndex=0, stopIndex=0, varType='double'):
         self.varName = varName
@@ -14,7 +20,7 @@ class VariableRetentionParameters:
         self.stopIndex = stopIndex
         self.varType = varType
 
-
+@dataclass
 class MessageRetentionParameters:
     """
     Represents a message's logging parameters.
@@ -22,11 +28,12 @@ class MessageRetentionParameters:
         name: name of the message recorder
         retainedVars: the message variable to record
     """
+    msgRecName:str
+    retainedVars:str
 
     def __init__(self, name, retainedVars):
         self.msgRecName = name
         self.retainedVars = retainedVars
-
 
 class RetentionPolicy:
     """
@@ -54,6 +61,8 @@ class RetentionPolicy:
         for variable in self.varLogList:
             simInstance.AddVariableForMultiProcessLogging(variable.varName, variable.varRate,
                                               variable.startIndex, variable.stopIndex, variable.varType)
+
+
 
     def addRetentionFunction(self, function):
         self.retentionFunctions.append(function)
@@ -98,9 +107,8 @@ class RetentionPolicy:
                     }
                 }
         """
-        data = {"messages": {}, "variables": {}, "custom": {}}
-        df = pd.DataFrame()
-        dataFrames = []
+        data = {"messages": {}, "variables": {}, "custom": {} }
+
         for retentionPolicy in retentionPolicies:
             for msgParam in retentionPolicy.messageLogList:
 

--- a/src/utilities/MonteCarlo/RetentionPolicy.py
+++ b/src/utilities/MonteCarlo/RetentionPolicy.py
@@ -52,7 +52,7 @@ class RetentionPolicy:
 
     def addLogsToSim(self, simInstance):
         for variable in self.varLogList:
-            simInstance.AddVariableForLogging(variable.varName, variable.varRate,
+            simInstance.AddVariableForMultiProcessLogging(variable.varName, variable.varRate,
                                               variable.startIndex, variable.stopIndex, variable.varType)
 
     def addRetentionFunction(self, function):
@@ -117,7 +117,7 @@ class RetentionPolicy:
                     data["messages"][msgParam.msgRecName + "." + varName] = msgData
 
             for variable in retentionPolicy.varLogList:
-                data["variables"][variable.varName] = simInstance.GetLogVariableData(variable.varName)
+                data["variables"][variable.varName] = simInstance.GetMultiProcessLoggerVariableData(variable.varName)
 
             for func in retentionPolicy.retentionFunctions:
                 tmpModuleData = func(simInstance)

--- a/src/utilities/MonteCarlo/_UnitTests/SimpleTestModule.py
+++ b/src/utilities/MonteCarlo/_UnitTests/SimpleTestModule.py
@@ -1,0 +1,18 @@
+
+from Basilisk.architecture import sysModel
+class SimpleTestModule(sysModel.SysModel):
+
+    def __init__(self):
+        super(SimpleTestModule, self).__init__()
+
+        self._ticker = 0
+        self.moduleTag = "testModule"
+
+    def UpdateState(self, current_sim_nanos):
+        self._ticker += 1
+
+    def GetTicker(self):
+        return self._ticker
+
+    def Reset(self, current_sim_nanos):
+        pass

--- a/src/utilities/pythonVariableLogger.py
+++ b/src/utilities/pythonVariableLogger.py
@@ -27,9 +27,10 @@ class PythonVariableLogger(sysModel.SysModel):
         timesCubed   = log.b
     """
 
+
     def __init__(
-        self, 
-        logging_functions: Dict[str, LoggingFunction], 
+        self,
+        logging_functions: Dict[str, LoggingFunction],
         min_log_period: int = 0
     ) -> None:
         """Initializer.
@@ -38,7 +39,7 @@ class PythonVariableLogger(sysModel.SysModel):
             logging_functions (Dict[str, LoggingFunction]): A dictionary where the
                 keys are the names of variables to store, and the values are functions
                 called to retrieve these variables. These functions must accept a single
-                input, an integer with the time in nanoseconds when the function is 
+                input, an integer with the time in nanoseconds when the function is
                 called.
             min_log_period (int, optional): The minimum interval between data recordings
                 Defaults to 0.
@@ -59,11 +60,11 @@ class PythonVariableLogger(sysModel.SysModel):
     def times(self):
         """Retrieve the times when the data was logged"""
         return np.array(self._times)
-    
+
     def Reset(self, CurrentSimNanos):
         self.clear()
         return super().Reset(CurrentSimNanos)
-    
+
     def UpdateState(self, CurrentSimNanos):
         if CurrentSimNanos >= self._next_update_time:
             self._times.append(CurrentSimNanos)
@@ -71,7 +72,7 @@ class PythonVariableLogger(sysModel.SysModel):
                 try:
                     val = logging_function(CurrentSimNanos)
                 except Exception as ex:
-                    self.bskLogger.bskLog(sysModel.BSK_ERROR, 
+                    self.bskLogger.bskLog(sysModel.BSK_ERROR,
                                         f"Error while logging '{variable_name}'"
                                         f" in logger '{self.ModelTag}': {ex}")
                     val = None
@@ -80,7 +81,15 @@ class PythonVariableLogger(sysModel.SysModel):
 
             self._next_update_time += self.min_log_period
         return super().UpdateState(CurrentSimNanos)
-    
+
+    def GetData(self, name:str):
+        """
+        :param name: The variable to be fetched
+        :return: Returns a 2D numpy array where the first column is variable recording time in nanoseconds
+        and the additional column(s) are the message data columns.
+        """
+        return np.column_stack([self.times(), self.__getattr__(name)])
+
     def __getattr__(self, __name: str) -> Any:
         if __name in self._variables:
             return np.array(self._variables[__name])


### PR DESCRIPTION
* **Tickets addressed:** MAXGNC-722
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
By creating new methods with similar functionality to the deprecated functions needed to log functions in parallelized simulations, we can better clarify where these should be used and properly phase out the old functions and variables.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
Added these functions to the MonteCarlo tests

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
bskPrinciples-11 still says the old functions are deprecated but we may want to add these functions to the MonteCarlo documentation

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Add tests that verify the contents of the logs instead of just verifying that they run.