### PR TITLE
Feature/830 892 912 filter architecture refactor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,6 +296,7 @@ function(generate_package_targets TARGET_LIST LIB_DEP_LIST MODULE_DIR)
     target_include_directories(
       ${TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/${PARENT_DIR}) # Exposes module .h files to the PYTHON_wrap.c(xx) file
                                                                 # (not located in src)
+    target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/fswAlgorithms/_GeneralModuleFiles")
 
     target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/architecture/_GeneralModuleFiles"
     )# Exposes framework files for easy includes
@@ -543,6 +544,7 @@ generate_package_targets("${VIZ_INTERFACE_TARGETS}" "${ARCHITECTURE_LIBS};" "sim
 generate_package_targets("${THERMAL_TARGETS}" "${ARCHITECTURE_LIBS};" "simulation")
 
 # FSW ALGORITHMS
+find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/_GeneralModuleFiles" GENERAL_TARGETS)
 find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/attControl" ATT_CONTROL_TARGETS)
 find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/attDetermination" ATT_DET_TARGETS)
 find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/attGuidance" ATT_GUID_TARGETS)
@@ -561,6 +563,7 @@ find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/orbitControl" ORBIT_CONT
 find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/transDetermination" TRANS_DET_TARGETS)
 find_package_targets("${CMAKE_SOURCE_DIR}/fswAlgorithms/vehicleConfigData" VEH_CONFIG_TARGETS)
 
+generate_package_targets("${GENERAL_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${ATT_CONTROL_TARGETS}" "${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${ATT_DET_TARGETS}" "fswAlgorithmsLib;${ARCHITECTURE_LIBS};" "fswAlgorithms")
 generate_package_targets("${ATT_GUID_TARGETS}" "attGuidanceLib;${ARCHITECTURE_LIBS};" "fswAlgorithms")

--- a/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -29,20 +30,21 @@ private:
     std::function<const StateVector(const double, const StateVector&)> propagator; //!< [-] state propagator using dynamics
     std::function<const Eigen::MatrixXd(const double, const StateVector&)> dynamicsMatrix; //!< [-] partial of dynamics wrt state
 
-    StateVector rk4(const std::function<const StateVector(const double, const StateVector&)>& ODEfunction,
+    static StateVector rk4(std::function<const StateVector(const double, const StateVector&)> ODEfunction,
             const StateVector& X0,
             double t0,
-            double dt) const;
+            double dt) ;
 
 public:
-    DynamicsModel();
-    ~DynamicsModel();
+    DynamicsModel() = default;
+    ~DynamicsModel() = default;
 
-    StateVector propagate(const std::array<double, 2>, const StateVector& state, const double dt) const;
-    void setPropagator(const std::function<const StateVector(const double, const StateVector&)>& dynamicsPropagator);
+    StateVector propagate(std::array<double, 2>, const StateVector& state, double dt) const;
+    void setDynamics(const std::function<const StateVector(const double, const StateVector&)>& dynamicsPropagator);
 
-    Eigen::MatrixXd computeDynamicsMatrix(const double time, const StateVector& state) const;
-    void setDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>& dynamicsMatrixCalculator);
+    Eigen::MatrixXd computeDynamicsMatrix(double time, const StateVector& state) const;
+    void setDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+            dynamicsMatrixCalculator);
 };
 
 #endif

--- a/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.rst
@@ -1,0 +1,55 @@
+Executive Summary
+-----------------
+
+This class provides an container for all the dynamics models and components to a kalman filter.
+This class is a necessary component to any Kalman Filter implementation
+
+Virtual and Private method descriptors
+-------------------------------
+The following table lists all the class methods and their function
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25 50
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+      - Protected or Private
+      - Virtual or not
+    * - rk4
+      - RK4 integrator
+      - private
+      - non-virtual
+    * - propagate
+      - integrate the equations of motion provided in setter
+      - public
+      - non-virtual
+    * - computeDynamicsMatrix
+      - compute the dynamics matrix given the partials provided in setter
+      - public
+      - non-virtual
+
+
+Module assumptions and limitations
+-------------------------------
+
+Only an RK4 is provided currently as an integrator
+
+User Guide
+----------
+
+This section lists all the setters and getters that are defined by the interface
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+      - Necessity
+    * - setDynamics
+      - set the equations of motion function
+      - necessary
+    * - setDynamicsMatrix
+      - set the dynamics matrix given a state
+      - necessary for extended kalman filters

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -2,7 +2,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -21,10 +22,8 @@
 #include "ekfInterface.h"
 
 EkfInterface::EkfInterface(FilterType type){
-    this->ckfOnlyMode = type;
+    this->filterType = type;
 }
-
-EkfInterface::~EkfInterface() = default;
 
 /*! Reset all of the filter states, including the custom reset
  @return void
@@ -32,69 +31,19 @@ EkfInterface::~EkfInterface() = default;
  */
 void EkfInterface::Reset(uint64_t currentSimNanos)
 {
-    this->customReset();
-
-    assert(this->stateInitial.size() == this->covarInitial.rows() &&
-    this->stateInitial.size() == this->covarInitial.cols());
-    assert(this->stateInitial.size() - this->constantRateStates.size() == this->processNoise.rows() &&
-    this->stateInitial.size() - this->constantRateStates.size() == this->processNoise.cols());
-
-    this->state = this->unitConversion * this->stateInitial;
-    this->stateError.resize(this->state.size());
-    this->stateError.setZero();
+    KalmanFilter::Reset(currentSimNanos);
+    this->stateError = Eigen::VectorXd ::Zero(this->state.size());
     this->stateTransitionMatrix = Eigen::MatrixXd::Identity(this->state.size(), this->state.size());
-    this->covar = this->unitConversion*this->unitConversion * this->covarInitial;
-    this->covar.resize(this->state.size(), this->state.size());
-    this->previousFilterTimeTag = (double) currentSimNanos*NANO2SEC;
-    if (this->constantRateStates.size() > 0){
-        this->constantRateStates = this->unitConversion * this->constantRateStates;
-        this->processNoise.resize(this->constantRateStates.size(), this->constantRateStates.size());
+    if (this->stateInitial.hasVelocity()) {
+        this->processNoise.resize(this->state.getVelocityStates().size(), this->state.getVelocityStates().size());
     }
-    else{
-        this->processNoise.resize(this->state.size()/2, this->state.size()/2);
+    else {
+        this->processNoise.resize(this->state.getPositionStates().size(), this->state.getPositionStates().size());
     }
 
+    this->customReset();
 }
 
-/*! Filter update
- @return void
- @param currentSimNanos The clock time at which the function was called (nanoseconds)
- */
-void EkfInterface::UpdateState(uint64_t currentSimNanos)
-{
-    this->customInitializeUpdate();
-    /*! Read all available measurements, add their information to the Measurement container class, then sort the
-     * vector in chronological order */
-    this->readFilterMeasurements();
-    this->orderMeasurementsChronologically();
-    /*! Loop through all of the measurements assuming they are in chronological order by first testing if a value
-     * has been populated in the measurements array*/
-     for (int index =0 ; index < MAX_MEASUREMENT_NUMBER; ++index) {
-         auto measurement = Measurement();
-         if (!this->measurements[index].has_value()){
-             continue;}
-         else{
-             measurement = this->measurements[index].value();}
-         /*! - If the time tag from a valid measurement is new compared to previous step,
-         propagate and update the filter*/
-         if (measurement.timeTag >= this->previousFilterTimeTag && measurement.validity) {
-             /*! - time update to the measurement time and compute pre-fit residuals*/
-             this->timeUpdate(measurement.timeTag);
-             measurement.preFitResiduals = EkfInterface::computeResiduals(measurement);
-             /*! - measurement update and compute post-fit residuals  */
-             this->measurementUpdate(measurement);
-             measurement.postFitResiduals = EkfInterface::computeResiduals(measurement);
-             this->measurements[index] = measurement;
-         }
-     }
-    /*! - If current clock time is further ahead than the last measurement time, then
-    propagate to this current time-step*/
-    if ((double) currentSimNanos * NANO2SEC > this->previousFilterTimeTag) {
-        this->timeUpdate((double) currentSimNanos * NANO2SEC);
-    }
-    this->customFinalizeUpdate();
-    this->writeOutputMessages(currentSimNanos);
-}
 
 /*! Perform the time update for kalman filter.
  @return void
@@ -106,38 +55,37 @@ void EkfInterface::timeUpdate(const double updateTime)
     this->stateTransitionMatrix = Eigen::MatrixXd::Identity(this->state.size(), this->state.size());
     std::array<double, 2> time = {0, dt};
 
-    /*! - Prepare full state and STM vector which is the state and flattened STM concatenated */
-    Eigen::MatrixXd reshapedStm = this->stateTransitionMatrix.reshaped<Eigen::RowMajor>().transpose();
-    Eigen::VectorXd flatStm(Eigen::Map<Eigen::VectorXd>(reshapedStm.data(), reshapedStm.cols()*reshapedStm.rows()));
-    Eigen::VectorXd stateStm(this->state.size() + flatStm.size());
-    stateStm << this->state, flatStm;
-
     /*! - Propagate full state and STM vector using dynamics specified in child class */
-    Eigen::VectorXd propagatedStateStm;
-    propagatedStateStm = propagate(time, stateStm, dt);
+    StateVector stateStm = this->state;
+    stateStm.attachStm(this->stateTransitionMatrix);
+    StateVector propagatedStateStm = this->dynamics.propagate(time, stateStm, dt);
 
-    Eigen::VectorXd propagatedStm;
-    propagatedStm = propagatedStateStm.tail(this->state.size()*this->state.size());
-    Eigen::MatrixXd stmTranspose(Eigen::Map<Eigen::MatrixXd>(propagatedStm.data(), this->state.size(), this->state.size()));
-    this->stateTransitionMatrix = stmTranspose.transpose();
+    this->stateTransitionMatrix = propagatedStateStm.detachStm();
 
     /*! - Unpack propagated states and update state, and state error */
-    this->state = propagatedStateStm.head(this->state.size());
+    this->state = propagatedStateStm;
     this->stateError = this->stateTransitionMatrix * this->stateError;
+    this->stateLogged = this->state.addVector(this->stateError);
 
     /*! - Update the covariance Pbar = Phi*P*Phi^T + Gamma*Q*Gamma^T
      * The process noise mapping will depend on the number of "rate" states */
     Eigen::MatrixXd processNoiseMapping;
-    if (this->constantRateStates.size() > 0) {
-        processNoiseMapping = Eigen::MatrixXd::Identity(this->state.size(), this->state.size());
+    if (!this->state.hasVelocity()) {
+        processNoiseMapping = Eigen::MatrixXd::Identity(this->state.getPositionStates().size(),
+                                                        this->state.getPositionStates().size());
         processNoiseMapping *= pow(dt, 2) / 2;
     }
     else{
-        processNoiseMapping.setZero(this->state.size(), this->state.size()/2);
-        processNoiseMapping.block(0, 0, this->state.size()/2, this->state.size()/2) =
-            pow(dt, 2) / 2 * Eigen::MatrixXd::Identity(this->state.size()/2, this->state.size()/2);
-        processNoiseMapping.block(this->state.size()/2, 0, this->state.size()/2, this->state.size()/2) =
-            dt * Eigen::MatrixXd::Identity(this->state.size()/2, this->state.size()/2);
+        processNoiseMapping.setZero(this->state.getPositionStates().size() + this->state.getVelocityStates().size(),
+                                    this->state.getVelocityStates().size());
+        processNoiseMapping.block(0, 0, this->state.getPositionStates().size(),
+                                  this->state.getPositionStates().size()) =
+            pow(dt, 2) / 2 * Eigen::MatrixXd::Identity(this->state.getPositionStates().size(),
+                                  this->state.getPositionStates().size());
+        processNoiseMapping.block(this->state.getPositionStates().size(), 0, this->state.getVelocityStates().size(),
+                                                        this->state.getVelocityStates().size()) =
+            dt * Eigen::MatrixXd::Identity(this->state.getVelocityStates().size(),
+                                                        this->state.getVelocityStates().size());
     }
     this->covar = this->stateTransitionMatrix*this->covar*this->stateTransitionMatrix.transpose() +
             processNoiseMapping*this->processNoise*processNoiseMapping.transpose();
@@ -150,19 +98,19 @@ void EkfInterface::timeUpdate(const double updateTime)
  @param Measurement
  @return void
  */
-void EkfInterface::measurementUpdate(const Measurement &measurement)
+void EkfInterface::measurementUpdate(const MeasurementModel &measurement)
 {
     /*! - Compute the valid observations delta */
-    Eigen::VectorXd measurementDelta = measurement.observation - measurement.model(this->state);
+    Eigen::VectorXd measurementDelta = measurement.getObservation() - measurement.model(this->state);
     /*! - Compute the measurement matrix at this state */
-    Eigen::MatrixXd measurementMatrix = computeMeasurementMatrix(this->state);
+    Eigen::MatrixXd measurementMatrix = measurement.computeMeasurementMatrix(this->state);
 
     /*! - Compute the Kalman Gain */
-    Eigen::MatrixXd kalmanGain = EkfInterface::computeKalmanGain(this->covar, measurementMatrix, measurement.noise);
+    Eigen::MatrixXd kalmanGain = EkfInterface::computeKalmanGain(this->covar, measurementMatrix, measurement.getMeasurementNoise());
 
     /*! - Update the covariance */
-    EkfInterface::updateCovariance(measurementMatrix, measurement.noise, kalmanGain);
-    if (this->covar.maxCoeff() > this->minCovarNorm || this->ckfOnlyMode == FilterType::Classical){
+    EkfInterface::updateCovariance(measurementMatrix, measurement.getMeasurementNoise(), kalmanGain);
+    if (this->covar.maxCoeff() > this->minCovarNorm || this->filterType == FilterType::Classical){
         /*! - Compute the update with a CKF if the covariance is high at the time of the update to avoid divergence*/
         EkfInterface::ckfUpdate(kalmanGain, measurementDelta, measurementMatrix);
     }
@@ -214,7 +162,7 @@ void EkfInterface::ckfUpdate(const Eigen::MatrixXd &kalmanGain,
                              const Eigen::MatrixXd &measurementMatrix){
 
     this->stateError = this->stateError + kalmanGain*(measurementDelta - measurementMatrix*this->stateError);
-    this->updatedWithCkf = true;
+    this->stateLogged = this->state.addVector(this->stateError);
 }
 
 /*! Extended Kalman Filter Update (the reference state is updated given the state error)
@@ -225,56 +173,29 @@ void EkfInterface::ckfUpdate(const Eigen::MatrixXd &kalmanGain,
 void EkfInterface::ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &measurementDelta){
 
     this->stateError = kalmanGain*measurementDelta;
-    this->state += this->stateError;
-    this->updatedWithCkf = false;
+
+    this->state = this->state.addVector(this->stateError);
+    this->stateLogged = this->state;
 }
 
 /*! Compute the measurement residuals at a given time.
 @param Measurement
 @return Eigen::VectorXd
  */
-Eigen::VectorXd EkfInterface::computeResiduals(const Measurement &measurement)
+Eigen::VectorXd EkfInterface::computeResiduals(const MeasurementModel &measurement)
 {
-    Eigen::VectorXd measurementDelta(measurement.observation - measurement.model(this->state));
-    Eigen::MatrixXd measurementMatrix = computeMeasurementMatrix(this->state);
+    Eigen::VectorXd measurementDelta(measurement.getObservation() - measurement.model(this->state));
+    Eigen::MatrixXd measurementMatrix = measurement.computeMeasurementMatrix(this->state);
 
     return measurementDelta - measurementMatrix*this->stateError;
 }
 
-/*!- Order the measurements chronologically (standard sort)
- @return void
- */
-void EkfInterface::orderMeasurementsChronologically(){
-    std::sort(this->measurements.begin(), this->measurements.end(),
-              [](std::optional<Measurement> meas1, std::optional<Measurement> meas2){
-                    if (!meas1.has_value()){return false;}
-                    else if (!meas2.has_value()){return true;}
-                    else {return meas1.value().timeTag < meas2.value().timeTag;}
-                                  });
-}
-
-/*! Runge-Kutta 4 (RK4) function for state propagation
-    @param ODEfunction function handle that includes the equations of motion
-    @param X0 initial state
-    @param t0 initial time
-    @param dt time step
-    @return Eigen::VectorXd
-*/
-Eigen::VectorXd EkfInterface::rk4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                                const Eigen::VectorXd& X0,
-                                double t0,
-                                double dt) const
-{
-    double h = dt;
-
-    Eigen::VectorXd k1 = ODEfunction(t0, X0);
-    Eigen::VectorXd k2 = ODEfunction(t0 + h/2., X0 + h*k1/2.);
-    Eigen::VectorXd k3 = ODEfunction(t0 + h/2., X0 + h*k2/2.);
-    Eigen::VectorXd k4 = ODEfunction(t0 + h, X0 + h*k3);
-
-    Eigen::VectorXd X = X0 + 1./6.*h*(k1 + 2.*k2 + 2.*k3 + k4);
-
-    return X;
+/*! Get the filter dynamics matrix (A = df/dX evaluated at the reference)
+    @return Eigen::VectorXd stateInitial
+    */
+void EkfInterface::setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+            dynamicsMatrixCalculator){
+    this->dynamics.setDynamicsMatrix(dynamicsMatrixCalculator);
 }
 
 /*! Set a minimum value (infinite norm, meaning maximal term) of the covariance before switching to Extended KF updates.
@@ -283,7 +204,7 @@ Eigen::VectorXd EkfInterface::rk4(const std::function<Eigen::VectorXd(double, Ei
     @return void
     */
 void EkfInterface::setMinimumCovarianceNormForEkf(const double infiniteNorm){
-    assert(this->ckfOnlyMode == FilterType::Extended && "EKF minimum norm set in a Classical implementation: this is "
+    assert(this->filterType == FilterType::Extended && "EKF minimum norm set in a Classical implementation: this is "
                                                         "only used in an extended kalman filter to temporarily use "
                                                         "linear updates when the covariance is high");
     this->minCovarNorm = infiniteNorm;
@@ -293,87 +214,8 @@ void EkfInterface::setMinimumCovarianceNormForEkf(const double infiniteNorm){
     @return double infiniteNorm
     */
 double EkfInterface::getMinimumCovarianceNormForEkf() const {
-    assert(this->ckfOnlyMode == FilterType::Extended && "EKF minimum norm requested in a Classical implementation: "
+    assert(this->filterType == FilterType::Extended && "EKF minimum norm requested in a Classical implementation: "
                                                         "this is only used in an extended kalman filter to temporarily "
                                                         "use linear updates when the covariance is high");
     return this->minCovarNorm;
-}
-
-/*! Set the filter initial state vector
-    @param Eigen::VectorXd initialStateInput
-    @return void
-    */
-void EkfInterface::setInitialState(const Eigen::VectorXd &initialStateInput){
-    this->stateInitial.resize(initialStateInput.size());
-    this->stateInitial << initialStateInput;
-}
-
-/*! Get the filter initial state vector
-    @return Eigen::VectorXd stateInitial
-    */
-Eigen::VectorXd EkfInterface::getInitialState() const {
-    return this->stateInitial;
-}
-
-/*! Set the filter initial state covariance
-    @param Eigen::MatrixXd initialCovarianceInput
-    @return void
-    */
-void EkfInterface::setInitialCovariance(const Eigen::MatrixXd &initialCovarianceInput){
-    this->covarInitial.resize(initialCovarianceInput.rows(), initialCovarianceInput.cols());
-    this->covarInitial << initialCovarianceInput;
-}
-
-/*! Get the filter initial state covariance
-    @return Eigen::MatrixXd covarInitial
-    */
-Eigen::MatrixXd EkfInterface::getInitialCovariance() const {
-    return this->covarInitial;
-}
-
-/*! Set the filter process noise
-    @param Eigen::MatrixXd processNoiseInput
-    @return void
-    */
-void EkfInterface::setProcessNoise(const Eigen::MatrixXd &processNoiseInput){
-    this->processNoise.resize(processNoiseInput.rows(), processNoiseInput.cols());
-    this->processNoise << processNoiseInput;
-}
-
-/*! Get the filter process noise
-    @return Eigen::MatrixXd processNoise
-    */
-Eigen::MatrixXd EkfInterface::getProcessNoise() const {
-    return this->processNoise;
-}
-
-/*! Set a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
- * outside facing interface is in SI
-    @param double conversion
-    */
-void EkfInterface::setUnitConversionFromSItoState(const double conversion){
-    this->unitConversion = conversion;
-}
-
-/*! Get a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
- * outside facing interface is in SI
-    @return double unitConversion
-    */
-double EkfInterface::getUnitConversionFromSItoState() const{
-    return this->unitConversion;
-}
-
-/*! Set a constant rate with which the rates will evolve: states(k+1) = states(k) + rateStates*dt
-    @param Eigen::VectorXd rateStates
-    @return void
-    */
-void EkfInterface::setConstantRateStates(const Eigen::VectorXd &rateStates){
-    this->constantRateStates = rateStates;
-}
-
-/*! Get the constant rate
-    @return Eigen::VectorXd rateStates
-    */
-Eigen::VectorXd EkfInterface::getConstantRateStates() const{
-    return this->constantRateStates;
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -29,6 +30,9 @@
 #include "architecture/messaging/messaging.h"
 #include "fswAlgorithms/_GeneralModuleFiles/filterInterfaceDefinitions.h"
 #include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h"
+#include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/dynamicModels.h"
 
 /*! Enumerator class to set if the filter is meant to be used purely as a linear/classical KF,
  * no reference state updates will be performed in the classical filter, while the EKF updates the reference
@@ -36,59 +40,23 @@
 enum class FilterType {Classical, Extended};
 
 /*! @brief Extended or Classical/Linear Kalman Filter base class. */
-class EkfInterface: public SysModel  {
+class EkfInterface: public KalmanFilter {
 public:
     EkfInterface(FilterType type);
-    ~EkfInterface() override;
+    ~EkfInterface() = default;
     void Reset(uint64_t CurrentSimNanos) override;
-    void UpdateState(uint64_t CurrentSimNanos) override;
 
+    void setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+        dynamicsMatrixCalculator);
     void setMinimumCovarianceNormForEkf(double infiniteNorm);
     double getMinimumCovarianceNormForEkf() const;
-    void setInitialState(const Eigen::VectorXd &initialState);
-    Eigen::VectorXd getInitialState() const;
-    void setInitialCovariance(const Eigen::MatrixXd &initialCovariance);
-    Eigen::MatrixXd getInitialCovariance() const;
-    void setProcessNoise(const Eigen::MatrixXd &processNoise);
-    Eigen::MatrixXd getProcessNoise() const;
-    void setUnitConversionFromSItoState(double conversion);
-    double getUnitConversionFromSItoState() const ;
-    void setConstantRateStates(const Eigen::VectorXd &rateStates);
-    Eigen::VectorXd getConstantRateStates() const;
 
-protected:
-    virtual void customReset(){/* virtual */};
-    virtual void customInitializeUpdate(){/* virtual */};
-    virtual void customFinalizeUpdate(){/* virtual */};
-    virtual Eigen::VectorXd propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt)=0;
-    virtual Eigen::MatrixXd computeDynamicsMatrix(const Eigen::VectorXd& state)=0;
-    virtual Eigen::MatrixXd computeMeasurementMatrix(const Eigen::VectorXd& state)=0;
-    /*! Read method neads to read incoming messages containing the measurements for the filter.
-     * Their information must be added to the Measurement container class, and added to the measurements vector.
-     * Each measurement must be paired with a measurement model provided in the measurementModels.h */
-    virtual void readFilterMeasurements()=0;
-    virtual void writeOutputMessages(uint64_t CurrentSimNanos)=0;
-
-    Eigen::VectorXd rk4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                const Eigen::VectorXd& X0,
-                double t0,
-                double dt) const;
-
-    std::array<std::optional<Measurement>, MAX_MEASUREMENT_NUMBER> measurements;  //!< [Measurements] All measurement containers in chronological order
-    double previousFilterTimeTag = 0; //!< [s]  Last filter time-tag
-    double unitConversion = 1; //!< [-] Scale that converts input units (SI) to a desired unit for the inner maths
-    bool updatedWithCkf = true; //!< [-] Flag to signal that filter was last updated with a Linear measurement update
-
-    Eigen::VectorXd state; //!< [-] State estimate for time TimeTag
-    Eigen::VectorXd stateError; //!< [-] State error for time TimeTag
-    Eigen::VectorXd constantRateStates; //!< [-] Constant rate states if the filter doesn not estimate them
-    Eigen::MatrixXd stateTransitionMatrix; //!< [-] State Transition Matrix
-    Eigen::MatrixXd covar; //!< [-] covariance
 
 private:
-    void timeUpdate(const double updateTime);
-    void measurementUpdate(const Measurement &measurement);
-    Eigen::VectorXd computeResiduals(const Measurement &measurement);
+    void timeUpdate(double updateTime) final;
+    void measurementUpdate(const MeasurementModel &measurement) final;
+
+    Eigen::VectorXd computeResiduals(const MeasurementModel &measurement) final;
     Eigen::MatrixXd computeKalmanGain(const Eigen::MatrixXd &covar,
                                     const Eigen::MatrixXd &measurementMatrix,
                                     const Eigen::MatrixXd &measurementNoise) const;
@@ -96,14 +64,10 @@ private:
     void ckfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &yMeas, const Eigen::MatrixXd &measurementMatrix);
     void ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &yMeas);
 
-    void orderMeasurementsChronologically();
-
-    Eigen::MatrixXd processNoise; //!< [-] process noise matrix
-    Eigen::VectorXd stateInitial; //!< [-] State estimate for time TimeTag at previous time
-    Eigen::MatrixXd covarInitial; //!< [-] covariance at previous time
+    Eigen::MatrixXd stateTransitionMatrix; //!< [-] State Transition Matrix
     double minCovarNorm = 1E-5; /*!< [-] Infinite norm after which the filter will begin processing measurements as
     an extended kalman filter */
-    FilterType ckfOnlyMode = FilterType::Extended; //!< [-] flag to know whether the filter is being run as a linear KF or extended KF
+    FilterType filterType = FilterType::Extended; //!< [-] flag to know whether the filter is being run as a linear KF or extended KF
 };
 
 #endif /* EKF_INTERFACE_HPP */

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.i
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.i
@@ -1,0 +1,36 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module ekfInterface
+%{
+   #include "ekfInterface.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "kalmanFilter.i"
+
+%include "ekfInterface.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.rst
@@ -2,7 +2,7 @@ Executive Summary
 -----------------
 
 This class provides an interface for Extended (and Classical) Kalman Filters. Modules which inherit from it will
-benefit from having the core functionality of these basic filters.
+benefit from having the core functionality of these basic filters. This class inherits from the Kalman Filter interface.
 
 The math is derived primarily using the equations in Tapley, Schutz, and Born's Statistical Orbit Determination textbook
 Chapter 4. This contains further information on this module's mathematical framework, and the flow diagrams describing
@@ -50,30 +50,6 @@ provides information on what this message is used for.
       - update using the extended kalman filter
       - private
       - non-virtual
-    * - orderMeasurementsChronologically
-      - order the messages chronologically
-      - private
-      - non-virtual
-    * - customReset
-      - perform addition reset duties in child class
-      - protected
-      - virtual, optional
-    * - propagate
-      - add a dynamics model for the inputs in child class
-      - protected
-      - virtual, needs to be populated
-    * - readFilterMeasurements
-      - read the specific measurements in a child class
-      - protected
-      - virtual, needs to be populated
-    * - writeOutputMessages
-      - write the specific measurements in a child class
-      - protected
-      - virtual, needs to be populated
-    * - rk4
-      - Runge-Kutta 4 integrator if needed for propagation
-      - protected
-      - non-virtual
 
 
 Module assumptions and limitations
@@ -110,18 +86,3 @@ This section also lists all the setters and getters that are defined by the inte
     * - set/getConstantRateStates
       - if using constant rates (not estimated by the filter) that integrate the state linearly, set this rate component
       - necessary
-    * - set/getInitialState
-      - filter initial state
-      - necessary
-    * - set/getInitialCovariance
-      - filter initial covariance (square matrix size of state)
-      - necessary
-    * - set/getProcessNoise
-      - filter process noise value (square matrix size of state)
-      - necessary
-    * - set/getConstantMeasurementNoise
-      - filter measurement noise (square matrix size of observations)
-      - optional
-    * - set/getUnitConversionFromSItoState
-      - conversion from SI to internal filter units
-      - optional

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
@@ -1,0 +1,264 @@
+
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "kalmanFilter.h"
+
+void KalmanFilter::Reset(uint64_t currentSimNanos) {
+    assert(this->stateInitial.size() == this->covarInitial.rows() &&
+    this->stateInitial.size() == this->covarInitial.cols());
+
+    this->state = this->stateInitial.scale(this->unitConversion);
+    this->stateLogged = this->state;
+    this->covar = this->unitConversion*this->unitConversion * this->covarInitial;
+    this->covar.resize(this->state.size(), this->state.size());
+
+    this->previousFilterTimeTag = (double) currentSimNanos*NANO2SEC;
+}
+
+/*! Take the relative position measurements and output an estimate of the
+ spacecraft states in the inertial frame.
+ @return void
+ @param currentSimNanos The clock time at which the function was called (nanoseconds)
+ */
+void KalmanFilter::UpdateState(uint64_t currentSimNanos)
+{
+    this->customInitializeUpdate();
+    /*! Read all available measurements, add their information to the Measurement container class, then sort the
+     * vector in chronological order */
+    this->readFilterMeasurements();
+    this->orderMeasurementsChronologically();
+    /*! Loop through all of the measurements assuming they are in chronological order by first testing if a value
+     * has been populated in the measurements array*/
+     for (int index =0 ; index < MAX_MEASUREMENT_NUMBER; ++index) {
+         auto measurement = MeasurementModel();
+         if (!this->measurements[index].has_value()){
+             continue;}
+         else{
+             measurement = this->measurements[index].value();}
+         /*! - If the time tag from a valid measurement is new compared to previous step,
+         propagate and update the filter*/
+         if (measurement.getTimeTag() >= this->previousFilterTimeTag && measurement.getValidity()) {
+             /*! - time update to the measurement time and compute pre-fit residuals*/
+             this->timeUpdate(measurement.getTimeTag());
+             measurement.setPreFitResiduals(this->computeResiduals(measurement));
+             /*! - measurement update and compute post-fit residuals  */
+             this->measurementUpdate(measurement);
+             measurement.setPostFitResiduals(measurement.getObservation() - measurement.model(this->state));
+             this->measurements[index] = measurement;
+         }
+     }
+    /*! - If current clock time is further ahead than the last measurement time, then
+    propagate to this current time-step*/
+    if ((double) currentSimNanos * NANO2SEC > this->previousFilterTimeTag) {
+        this->timeUpdate((double) currentSimNanos * NANO2SEC);
+    }
+    this->customFinalizeUpdate();
+    this->writeOutputMessages(currentSimNanos);
+}
+
+/*!- Order the measurements chronologically (standard sort)
+ @return void
+ */
+void KalmanFilter::orderMeasurementsChronologically(){
+    std::sort(this->measurements.begin(), this->measurements.end(),
+              [](std::optional<MeasurementModel> meas1, std::optional<MeasurementModel> meas2){
+                    if (!meas1.has_value()){return false;}
+                    else if (!meas2.has_value()){return true;}
+                    else {return meas1.value().getTimeTag() < meas2.value().getTimeTag();}
+                                  });
+}
+
+/*! Set the filter initial state position vector
+    @param Eigen::VectorXd initial position vector
+    @return void
+    */
+void KalmanFilter::setInitialPosition(const Eigen::VectorXd &initialPositionInput){
+    PositionState positionState;
+    positionState.setValues(initialPositionInput);
+    this->stateInitial.setPosition(positionState);
+}
+
+/*! Get the filter initial state position vector
+    @return std::optional<Eigen::VectorXd> initial position vector
+    */
+std::optional<Eigen::VectorXd> KalmanFilter::getInitialPosition() const {
+    std::optional<Eigen::VectorXd> position;
+    if (this->stateInitial.hasPosition()){
+        position = this->stateInitial.getPositionStates();
+    }
+    return position;
+}
+
+/*! Set the filter initial state velocity vector
+    @param Eigen::VectorXd  initial velocity vector
+    @return void
+    */
+void KalmanFilter::setInitialVelocity(const Eigen::VectorXd &initialVelocityInput){
+    VelocityState velocityState;
+    velocityState.setValues(initialVelocityInput);
+    this->stateInitial.setVelocity(velocityState);
+}
+
+/*! Get the filter initial state velocity vector
+    @return  std::optional<Eigen::VectorXd> initial velocity vector
+    */
+std::optional<Eigen::VectorXd> KalmanFilter::getInitialVelocity() const {
+    std::optional<Eigen::VectorXd> velocity;
+    if (this->stateInitial.hasVelocity()){
+        velocity = this->stateInitial.getVelocityStates();
+    }
+    return velocity;
+}
+
+/*! Set the filter initial state acceleration vector
+    @param  Eigen::VectorXd initial acceleration vector
+    @return void
+    */
+void KalmanFilter::setInitialAcceleration(const Eigen::VectorXd &initialAccelerationInput){
+    AccelerationState accelerationState;
+    accelerationState.setValues(initialAccelerationInput);
+    this->stateInitial.setAcceleration(accelerationState);
+}
+
+/*! Get the filter initial state acceleration vector
+    @return  std::optional<Eigen::VectorXd> initial acceleration vector
+    */
+std::optional<Eigen::VectorXd> KalmanFilter::getInitialAcceleration() const {
+    std::optional<Eigen::VectorXd> acceleration;
+    if (this->stateInitial.hasAcceleration()){
+        acceleration = this->stateInitial.getAccelerationStates();
+    }
+    return acceleration;
+}
+
+/*! Set the filter initial state bias vector
+    @param Eigen::VectorXd  initial bias vector
+    @return void
+    */
+void KalmanFilter::setInitialBias(const Eigen::VectorXd &initialBiasInput){
+    BiasState biasState;
+    biasState.setValues(initialBiasInput);
+    this->stateInitial.setBias(biasState);
+}
+
+/*! Get the filter initial state bias vector
+    @return std::optional<Eigen::VectorXd> initial bias vector
+    */
+std::optional<Eigen::VectorXd> KalmanFilter::getInitialBias() const {
+    std::optional<Eigen::VectorXd> bias;
+    if (this->stateInitial.hasBias()){
+        bias = this->stateInitial.getBiasStates();
+    }
+    return bias;
+}
+
+/*! Set the filter initial state consider parameter vector
+    @param Eigen::VectorXd initial consider parameter vector
+    @return void
+    */
+void KalmanFilter::setInitialConsiderParameters(const Eigen::VectorXd &initialConsiderInput){
+    ConsiderState considerState;
+    considerState.setValues(initialConsiderInput);
+    this->stateInitial.setConsider(considerState);
+}
+
+/*! Get the filter initial state consider parameter vector
+    @return std::optional<Eigen::VectorXd>  initial consider parameter vector
+    */
+std::optional<Eigen::VectorXd> KalmanFilter::getInitialConsiderParameters() const {
+    std::optional<Eigen::VectorXd> consider;
+    if (this->stateInitial.hasConsider()){
+        consider = this->stateInitial.getConsiderStates();
+    }
+    return consider;
+}
+
+/*! Set the filter equations of motion of the state (X_dot = f(t, X))
+    @param Eigen::VectorXd initialStateInput
+    @return void
+    */
+void KalmanFilter::setFilterDynamics(const std::function<const StateVector(const double, const StateVector&)>&
+        dynamicsPropagator){
+    this->dynamics.setDynamics(dynamicsPropagator);
+}
+
+/*! Set the filter initial state covariance
+    @param Eigen::MatrixXd initialCovarianceInput
+    @return void
+    */
+void KalmanFilter::setInitialCovariance(const Eigen::MatrixXd &initialCovarianceInput){
+    this->covarInitial.resize(initialCovarianceInput.rows(), initialCovarianceInput.cols());
+    this->covarInitial << initialCovarianceInput;
+}
+
+/*! Get the filter initial state covariance
+    @return Eigen::MatrixXd covarInitial
+    */
+Eigen::MatrixXd KalmanFilter::getInitialCovariance() const {
+    return this->covarInitial;
+}
+
+/*! Set the filter process noise
+    @param Eigen::MatrixXd processNoiseInput
+    @return void
+    */
+void KalmanFilter::setProcessNoise(const Eigen::MatrixXd &processNoiseInput){
+    this->processNoise.resize(processNoiseInput.rows(), processNoiseInput.cols());
+    this->processNoise << processNoiseInput;
+}
+
+/*! Get the filter process noise
+    @return Eigen::MatrixXd processNoise
+    */
+Eigen::MatrixXd KalmanFilter::getProcessNoise() const {
+    return this->processNoise;
+}
+
+/*! Set the filter measurement noise scale factor if desirable
+    @param double measurementNoiseScale
+    @return void
+    */
+void KalmanFilter::setMeasurementNoiseScale(const double measurementNoiseScale) {
+    this->measNoiseScaling = measurementNoiseScale;
+}
+
+/*! Get the filter measurement noise scale factor
+    @return double measurementNoiseScale
+    */
+double KalmanFilter::getMeasurementNoiseScale() const {
+    return this->measNoiseScaling;
+}
+
+/*! Set a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
+ * outside facing interface is in SI
+    @param double conversion
+    */
+void KalmanFilter::setUnitConversionFromSItoState(const double conversion){
+    this->unitConversion = conversion;
+}
+
+/*! Get a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
+ * outside facing interface is in SI
+    @return double unitConversion
+    */
+double KalmanFilter::getUnitConversionFromSItoState() const{
+    return this->unitConversion;
+}

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h
@@ -1,0 +1,98 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+#ifndef KALMAN_FILTER_INTERFACE_HPP
+#define KALMAN_FILTER_INTERFACE_HPP
+
+#include <Eigen/Dense>
+#include <functional>
+#include <optional>
+#include <array>
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "fswAlgorithms/_GeneralModuleFiles/filterInterfaceDefinitions.h"
+#include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/dynamicModels.h"
+
+/*! @brief Kalman Filter interface */
+class KalmanFilter: public SysModel  {
+public:
+    KalmanFilter() = default;
+    ~KalmanFilter() = default;
+    void Reset(uint64_t currentSimNanos) override;
+    void UpdateState(uint64_t currentSimNanos) final;
+
+    void setInitialPosition(const Eigen::VectorXd &initialPositionInput);
+    std::optional<Eigen::VectorXd> getInitialPosition() const;
+    void setInitialVelocity(const Eigen::VectorXd &initialVelocityInput);
+    std::optional<Eigen::VectorXd> getInitialVelocity() const;
+    void setInitialAcceleration(const Eigen::VectorXd &initialAccelerationInput);
+    std::optional<Eigen::VectorXd> getInitialAcceleration() const;
+    void setInitialBias(const Eigen::VectorXd &initialBiasInput);
+    std::optional<Eigen::VectorXd> getInitialBias() const;
+    void setInitialConsiderParameters(const Eigen::VectorXd &initialConsiderInput);
+    std::optional<Eigen::VectorXd> getInitialConsiderParameters() const;
+
+    void setInitialCovariance(const Eigen::MatrixXd &initialCovariance);
+    Eigen::MatrixXd getInitialCovariance() const;
+    void setProcessNoise(const Eigen::MatrixXd &processNoise);
+    Eigen::MatrixXd getProcessNoise() const;
+    void setUnitConversionFromSItoState(double conversion);
+    double getUnitConversionFromSItoState() const;
+    void setMeasurementNoiseScale(double measurementNoiseScale);
+    double getMeasurementNoiseScale() const;
+    void setFilterDynamics(const std::function<const StateVector(double, const StateVector&)> &dynamicsPropagator);
+
+protected:
+    virtual void customReset(){/* virtual */};
+    virtual void customInitializeUpdate(){/* virtual */};
+    virtual void customFinalizeUpdate(){/* virtual */};
+    /*! Read method neads to read incoming messages containing the measurements for the filter.
+     * Their information must be added to the Measurement container class, and added to the measurements vector.
+     * Each measurement must be paired with a measurement model provided in the measurementModels.h */
+    virtual void readFilterMeasurements(){/* virtual */};
+    virtual void writeOutputMessages(uint64_t CurrentSimNanos){/* virtual */};
+
+    virtual void timeUpdate(double updateTime)=0;
+    virtual void measurementUpdate(const MeasurementModel &measurement)=0;
+    virtual Eigen::VectorXd computeResiduals(const MeasurementModel &measurement)=0;
+    void orderMeasurementsChronologically();
+
+    std::array<std::optional<MeasurementModel>, MAX_MEASUREMENT_NUMBER> measurements;  //!< [Measurements] All
+    //!< measurement containers in chronological order
+    DynamicsModel dynamics;
+    double previousFilterTimeTag = 0; //!< [s]  Time tag for state covar/etc
+    double unitConversion = 1; //!< [-] Scale that converts input units (SI) to a desired unit for the inner maths
+    double measNoiseScaling = 1; //!< [-] Scale factor for the measurement noise
+
+    StateVector state; //!< [-] State estimate for time TimeTag
+    StateVector stateInitial; //!< [-] State estimate for time TimeTag at previous time
+    StateVector stateLogged; //!< [-] State variable for logging
+    StateVector xBar; //!< [-] Current mean state estimate
+    Eigen::VectorXd stateError; //!< [-] Current mean state error
+
+    Eigen::MatrixXd processNoise; //!< [-] process noise matrix
+    Eigen::MatrixXd covarInitial; //!< [-] covariance at previous time
+    Eigen::MatrixXd covar; //!< [-] covariance
+};
+
+#endif /* KALMAN_FILTER_INTERFACE_HPP */

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.i
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.i
@@ -1,0 +1,53 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module kalmanFilter
+%{
+   #include "kalmanFilter.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "swig_conly_data.i"
+%include "std_vector.i"
+%include "std_string.i"
+%include "swig_eigen.i"
+%include "sys_model.i"
+
+%typemap(out) std::optional<Eigen::VectorXd> %{
+    if ($1.has_value()) {
+        std::optional<Eigen::VectorXd> &tmp_ov = $1;
+        {
+            Eigen::VectorXd result = tmp_ov.value();
+            $typemap(out, Eigen::VectorXd)
+        }
+    } else {
+        $result = Py_None;
+        Py_INCREF($result);
+    }
+%}
+
+%include "kalmanFilter.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.rst
@@ -1,0 +1,106 @@
+Executive Summary
+-----------------
+
+This virtual class provides an interface for all Kalman Filters. Modules which inherit from it will
+benefit from having the core logic of a sequential filter
+
+Virtual and Private method descriptors
+-------------------------------
+The following table lists all the class methods and their function
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25 50
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+      - Protected or Private
+      - Virtual or not
+    * - UpdateState
+      - Loop through measurements and update filter states according to time
+      - public
+      - final
+    * - timeUpdate
+      - filter time update
+      - protected
+      - virtual
+    * - measurementUpdate
+      - filter measurement update in the presence of measurements
+      - protected
+      - virtual
+    * - computeResiduals
+      - compute filter post fit residuals
+      - protected
+      - virtual
+    * - customReset
+      - perform addition reset duties in child class
+      - protected
+      - virtual, optional
+    * - readFilterMeasurements
+      - read the specific measurements in a child class
+      - protected
+      - virtual, needs to be populated
+    * - writeOutputMessages
+      - write the specific measurements in a child class
+      - protected
+      - virtual, needs to be populated
+    * - orderMeasurementsChronologically
+      - Runge-Kutta 4 integrator if needed for propagation
+      - private
+      - non-virtual
+
+
+Module assumptions and limitations
+-------------------------------
+
+The module inherits all assumptions made while implementing a Kalman filter:
+    • Observability considerations
+    • Gaussian covariances
+    • Linearity limits
+    • and more
+
+Otherwise, the limitations are governed by the measurement model and dynamics models relative
+to the required performance.
+
+User Guide
+----------
+
+This section lists all the setters and getters that are defined by the interface
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+      - Necessity
+    * - set/getInitialPosition
+      - filter initial position component of the states
+      - optional
+    * - set/getInitialVelocity
+      - filter initial velocity component of the states
+      - optional
+    * - set/getInitialAcceleration
+      - filter initial acceleration component of the states
+      - optional
+    * - set/getInitialBias
+      - filter initial bias component of the states
+      - optional
+    * - set/getInitialConsider
+      - filter initial consider component of the states
+      - optional
+    * - set/getInitialCovariance
+      - filter initial covariance (square matrix size of state)
+      - necessary
+    * - set/getProcessNoise
+      - filter process noise value (square matrix size of state)
+      - necessary
+    * - set/getUnitConversionFromSItoState
+      - conversion from SI to internal filter units
+      - optional
+    * - set/getMeasurementNoiseScale
+      - filter measurement noise scale factor
+      - optional
+    * - setFilterDynamics
+      - provide the dynamics class to the filter
+      - necessary

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -19,34 +20,176 @@
 
 #include "measurementModels.h"
 
-/*! Measurement model that takes three components of the state vector and normalizes them
- * @param Eigen::VectorXd state
- * @return Eigen::VectorXd
+/*! Function to represent measurement model which inputs a stateModel and outputs a matrix
+ * @param StateVector
+ * @return Eigen::MatrixXd
  */
-Eigen::VectorXd normalizedFirstThreeStates(Eigen::VectorXd state)
-{
-    assert(state.size() > 2);
-    return state.head(3).normalized();
+Eigen::MatrixXd MeasurementModel::model(const StateVector& state) const {
+    return this->measurementModel(state);
 }
 
-/*! Measurement model that takes components of the state vector
- * @param Eigen::VectorXd state
- * @return Eigen::VectorXd
+/*! Set function to represent measurement model which inputs a stateModel and outputs a matrix
+ * @param std::function<const Eigen::MatrixXd(const StateVector&)>
  */
-Eigen::VectorXd firstThreeStates(Eigen::VectorXd state)
-{
-    assert(state.size() > 2);
-    return state.head(3);
+void MeasurementModel::setMeasurementModel(const std::function<const Eigen::MatrixXd(const StateVector&)> &modelCalculator) {
+    this->measurementModel = modelCalculator;
 }
 
-/*! Measurement model that takes last 3 components of the state vector
- * @param Eigen::VectorXd state
+/*! Function to represent measurement matrix which inputs a stateModel and outputs a matrix (partial of measurement
+ * @param StateVector
+ * @return Eigen::MatrixXd
+ */
+Eigen::MatrixXd MeasurementModel::computeMeasurementMatrix(const StateVector& state) const {
+    return this->measurementPartials(state);
+}
+
+/*! Set function to represent measurement matrix which inputs a stateModel and outputs a matrix (partial of measurement
+ * model with respect to state)
+ * @param std::function<const Eigen::MatrixXd(const StateVector&)>
+ */
+void MeasurementModel::setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const StateVector&)> &hMatrixCalculator){
+    this->measurementPartials = hMatrixCalculator;
+}
+
+/*! Return the size of the observation
+   @return size_t
+*/
+size_t MeasurementModel::size() const {
+    return this->getObservation().size();
+}
+
+/*! Get measurement name
+ * @return std::string
+ */
+std::string MeasurementModel::getMeasurementName() const {
+    return this->name;
+}
+
+/*! Set measurement name
+ * @param std::string
+ */
+void MeasurementModel::setMeasurementName(std::string_view measurementName){
+    this->name = measurementName;
+}
+
+/*! Get measurement time tag
+ * @return double
+ */
+double MeasurementModel::getTimeTag() const {
+    return this->timeTag;
+}
+
+/*! Set measurement time tag
+ * @param double
+ */
+void MeasurementModel::setTimeTag(const double measurementTimeTag){
+    this->timeTag = measurementTimeTag;
+}
+
+/*! Get measurement validity
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd lastThreeStates(Eigen::VectorXd state)
+bool MeasurementModel::getValidity() const {
+    return this->validity;
+}
+
+/*! Set measurement validity
+ * @param bool
+ */
+void MeasurementModel::setValidity(const bool measurementValidity){
+    this->validity = measurementValidity;
+}
+
+/*! Get measurement observation
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::getObservation() const {
+    return this->observation;
+}
+
+/*! Set measurement observation
+ * @param Eigen::VectorXd
+ */
+void MeasurementModel::setObservation(const Eigen::VectorXd& measurementObserved){
+    this->observation = measurementObserved;
+}
+
+/*! Get measurement noise
+ * @return Eigen::MatrixXd
+ */
+Eigen::MatrixXd MeasurementModel::getMeasurementNoise() const {
+    return this->noise;
+}
+
+/*! Set measurement noise
+ * @param Eigen::MatrixXd
+ */
+void MeasurementModel::setMeasurementNoise(const Eigen::MatrixXd& measurementNoise){
+    this->noise = measurementNoise;
+}
+
+/*! Get post fit residuals of observation
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::getPostFitResiduals() const {
+    return this->postFitResiduals;
+}
+
+/*! Set post fit residuals of observation
+ * @param Eigen::VectorXd
+ */
+void MeasurementModel::setPostFitResiduals(const Eigen::VectorXd& measurementPostFit){
+    this->postFitResiduals = measurementPostFit;
+}
+
+/*! Get pre fit residuals of observation
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::getPreFitResiduals() const {
+    return this->preFitResiduals;
+}
+
+/*! Set pre fit residuals of observation
+ * @param Eigen::VectorXd
+ */
+void MeasurementModel::setPreFitResiduals(const Eigen::VectorXd& measurementPreFit){
+    this->preFitResiduals = measurementPreFit;
+}
+
+/*! Measurement model that returns the position component of the state
+ * @param StateVector state
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::positionStates(const StateVector &state)
 {
-    assert(state.size() > 2);
-    return state.tail(3);
+    return state.getPositionStates();
+}
+
+/*! Measurement model that returns the unit vector of the position state
+ * @param StateVector state
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::normalizedPositionStates(const StateVector &state)
+{
+    return state.getPositionStates()/state.getPositionStates().norm();
+}
+
+/*! Measurement model that returns the position component of the state, and performs a MRP shadow set check
+ * @param StateVector state
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::mrpStates(const StateVector &state)
+{
+    return mrpSwitch(state.getPositionStates(), 1);
+}
+
+/*! Measurement model that returns the velocity component of the state
+ * @param StateVector state
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::velocityStates(const StateVector &state)
+{
+    return state.getVelocityStates();
 }
 
 /*! Measurement model that takes first 3 components of the state vector and interprets them as MRPs

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -18,36 +19,59 @@
  */
 
 #include <Eigen/Core>
+#include <string_view>
 #include "architecture/utilities/rigidBodyKinematics.hpp"
+#include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
 
 #ifndef FILTER_MEAS_MODELS_H
 #define FILTER_MEAS_MODELS_H
 
 /*! @brief Container class for measurement data and models */
-class Measurement{
+class MeasurementModel{
 public:
-    Measurement() = default;
+    MeasurementModel() = default;
+    ~MeasurementModel() = default;
 
-    std::string name = ""; //!< [-] name of measurement  type
-    size_t size = 0; //!< [-] size of observation vector
-    double timeTag = 0; //!< [-] Observation time tag
+    static Eigen::VectorXd positionStates(const StateVector &state);
+    static Eigen::VectorXd normalizedPositionStates(const StateVector &state);
+    static Eigen::VectorXd mrpStates(const StateVector &state);
+    static Eigen::VectorXd velocityStates(const StateVector &state);
+
+    Eigen::MatrixXd model(const StateVector& state) const;
+    void setMeasurementModel(const std::function<const Eigen::MatrixXd(const StateVector&)>& modelCalculator);
+    Eigen::MatrixXd computeMeasurementMatrix(const StateVector& state) const;
+    void setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const StateVector&)>& hMatrixCalculator);
+
+    size_t size() const;
+    std::string getMeasurementName() const;
+    void setMeasurementName(std::string_view measurementName);
+    double getTimeTag() const;
+    void setTimeTag(double measurementTimeTag);
+    bool getValidity() const;
+    void setValidity(bool measurementValidity);
+    Eigen::VectorXd getObservation() const;
+    void setObservation(const Eigen::VectorXd& measurementObserved);
+    Eigen::MatrixXd getMeasurementNoise() const;
+    void setMeasurementNoise(const Eigen::MatrixXd& measurementNoise);
+    Eigen::VectorXd getPreFitResiduals() const;
+    void setPreFitResiduals(const Eigen::VectorXd& measurementPreFit);
+    Eigen::VectorXd getPostFitResiduals() const;
+    void setPostFitResiduals(const Eigen::VectorXd& measurementPostFit);
+
+
+private:
+    std::string name{}; //!< [-] Name of measurement  type
+    double timeTag{}; //!< [-] Observation time tag
     bool validity = false; //!< [-] Observation validity
     Eigen::VectorXd observation; //!< [-] Observation data vector
-    Eigen::MatrixXd noise; //!< [-] Constant measurement Noise
-    Eigen::MatrixXd choleskyNoise; //!< [-] cholesky of Qnoise
+    Eigen::MatrixXd noise; //!< [-] Measurement Noise
+    Eigen::MatrixXd choleskyNoise; //!< [-] Cholesky decomposition of measurement noise
     Eigen::VectorXd postFitResiduals; //!< [-] Observation post fit residuals
     Eigen::VectorXd preFitResiduals; //!< [-] Observation pre fit residuals
-     /*! Each measurement must be paired with a measurement model as a function which inputs the
-     * sigma point matrix and outputs the modeled measurement for each sigma point */
-    std::function<const Eigen::MatrixXd(const Eigen::MatrixXd)> model; //!< [-] observation measurement model
+
+    std::function<const Eigen::MatrixXd(const StateVector&)> measurementModel; //!< [-] observation measurement model
+    std::function<const Eigen::MatrixXd(const StateVector&)> measurementPartials; //!< [-] partial of measurement model wrt state
+
 };
-
-
-
-/*! @brief Measurement models used to map a state vector to a measurement */
-Eigen::VectorXd normalizedFirstThreeStates(Eigen::VectorXd state);
-Eigen::VectorXd firstThreeStates(Eigen::VectorXd state, size_t beginSlice, size_t endSlice);
-Eigen::VectorXd lastThreeStates(Eigen::VectorXd state);
-Eigen::VectorXd mrpFirstThreeStates(Eigen::VectorXd state);
 
 #endif

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.rst
@@ -1,0 +1,80 @@
+Executive Summary
+-----------------
+
+This class provides an container for all the measurement models and components to a kalman filter.
+This class is a necessary component to any Kalman Filter implementation
+
+Virtual and Private method descriptors
+-------------------------------
+The following table lists all the class methods and their function
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25 50
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+      - Protected or Private
+      - Virtual or not
+    * - model
+      - compute measurement model give a state
+      - public
+      - necessary
+    * - computeMeasurementMatrix
+      - compute measurement matrix give a state
+      - public
+      - necessary
+
+Module assumptions and limitations
+-------------------------------
+
+None
+
+User Guide
+----------
+
+This section lists all the setters and getters that are defined by the interface
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+      - Necessity
+    * - get/setMeasurementName
+      - set the name of the measurement to distinguish it from others
+      - necessary
+    * - get/setTimeTag
+      - set the measurement time tag
+      - necessary
+    * - get/setValidity
+      - set the measurement validity
+      - necessary
+    * - get/setObservation
+      - set the measurement observation value
+      - necessary
+    * - get/setMeasurementNoise
+      - set the measurement noise matrix
+      - necessary
+    * - get/setPreFitResiduals
+      - set the measurement pre fit residuals
+      - necessary
+    * - get/setPostFitResiduals
+      - set the measurement pre fit residuals
+      - necessary
+
+.. list-table:: Static methods for common measurement models
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+    * - positionStates
+      - measurement of position state
+    * - normalizedPositionStates
+      - measurement of heading direction
+    * - mrpStates
+      - measurement of position state with a shadow set check
+    * - velocityStates
+      - measurement of velocity states

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.cpp
@@ -2,7 +2,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -20,38 +21,23 @@
 
 #include "srukfInterface.h"
 
-SRukfInterface::SRukfInterface() = default;
-
-SRukfInterface::~SRukfInterface() = default;
-
 /*! Reset all of the filter states, including the custom reset
  @return void
  @param currentSimNanos The clock time at which the function was called (nanoseconds)
  */
 void SRukfInterface::Reset(uint64_t currentSimNanos)
 {
-    this->customReset();
+    KalmanFilter::Reset(currentSimNanos);
 
-    assert(this->stateInitial.size() == this->covarInitial.rows() &&
-    this->stateInitial.size() == this->covarInitial.cols());
-    assert(this->stateInitial.size() == this->processNoise.rows() &&
-    this->stateInitial.size() == this->processNoise.cols());
-
-    this->state = this->unitConversion * this->stateInitial;
     this->sBar = this->unitConversion*this->unitConversion * this->covarInitial;
-    this->covar = this->unitConversion*this->unitConversion * this->covarInitial;
-    this->covar.resize(this->state.size(), this->state.size());
     this->sBar.resize(this->state.size(), this->state.size());
-    this->processNoise.resize(this->state.size(), this->state.size());
 
-    this->previousFilterTimeTag = (double) currentSimNanos*NANO2SEC;
     this->numberSigmaPoints = this->state.size()*2+1;
 
     /*! - Ensure that all internal filter matrices are zeroed*/
     this->wM.setZero(this->numberSigmaPoints);
     this->wC.setZero(this->numberSigmaPoints);
     this->sBar.setZero(this->state.size(), this->state.size());
-    this->sigmaPoints.setZero(this->state.size(), this->numberSigmaPoints);
     this->cholProcessNoise.setZero(this->state.size(), this->state.size());
 
     /*! - Set lambda/gamma to standard value for unscented kalman filters */
@@ -62,7 +48,7 @@ void SRukfInterface::Reset(uint64_t currentSimNanos)
     this->wM(0) = this->lambda / ((double) this->state.size() + this->lambda);
     this->wC(0) = this->lambda / ((double) this->state.size() + this->lambda) +
             (1 - this->alpha*this->alpha + this->beta);
-    for (size_t i = 1; i < this->numberSigmaPoints; ++i)
+    for (auto i = 1; i < this->numberSigmaPoints; ++i)
     {
         this->wM(i) = 1.0 / (2.0 * ((double) this->state.size() + this->lambda));
         this->wC(i) = this->wM(i);
@@ -70,52 +56,11 @@ void SRukfInterface::Reset(uint64_t currentSimNanos)
 
     /*! - Perform cholesky decompositions of covariance and noise */
     this->sBar = SRukfInterface::choleskyDecomposition(this->covar);
+    this->processNoise.resize(this->state.size(), this->state.size());
     this->cholProcessNoise = SRukfInterface::choleskyDecomposition(this->unitConversion*this->unitConversion*
             this->processNoise);
-}
 
-/*! Take the relative position measurements and outputs an estimate of the
- spacecraft states in the inertial frame.
- @return void
- @param currentSimNanos The clock time at which the function was called (nanoseconds)
- */
-void SRukfInterface::UpdateState(uint64_t currentSimNanos)
-{
-    this->customInitializeUpdate();
-    /*! Read all available measurements, add their information to the Measurement container class, then sort the
-     * vector in chronological order */
-    this->readFilterMeasurements();
-    this->orderMeasurementsChronologically();
-    /*! Loop through all of the measurements assuming they are in chronological order by first testing if a value
-     * has been populated in the measurements array*/
-     for (int index =0 ; index < MAX_MEASUREMENT_NUMBER; ++index) {
-         auto measurement = Measurement();
-         if (!this->measurements[index].has_value()){
-             continue;}
-         else{
-             measurement = this->measurements[index].value();}
-         /*! - If the time tag from a valid measurement is new compared to previous step,
-         propagate and update the filter*/
-         if (measurement.timeTag >= this->previousFilterTimeTag && measurement.validity) {
-              /*! - prepare measurement data */
-             measurement.choleskyNoise = SRukfInterface::choleskyDecomposition(measurement.noise);
-
-             /*! - time update to the measurement time and compute pre-fit residuals*/
-             this->timeUpdate(measurement.timeTag);
-             measurement.preFitResiduals = this->computeResiduals(measurement);
-             /*! - measurement update and compute post-fit residuals  */
-             this->measurementUpdate(measurement);
-             measurement.postFitResiduals = measurement.observation - measurement.model(this->state);
-             this->measurements[index] = measurement;
-         }
-     }
-    /*! - If current clock time is further ahead than the last measurement time, then
-    propagate to this current time-step*/
-    if ((double) currentSimNanos * NANO2SEC > this->previousFilterTimeTag) {
-        this->timeUpdate((double) currentSimNanos * NANO2SEC);
-    }
-    this->customFinalizeUpdate();
-    this->writeOutputMessages(currentSimNanos);
+    this->customReset();
 }
 
 /*! Perform the time update for kalman filter.
@@ -133,31 +78,31 @@ void SRukfInterface::timeUpdate(double updateTime)
     std::array<double, 2> time = {0, dt};
 
     /*! - Copy over the current state estimate into the 0th Sigma point and propagate by dt*/
-    this->sigmaPoints.col(0) = propagate(time, this->state, dt);
-    /*! - Scale that Sigma point by the appopriate scaling factor (Wm[0])*/
-    this->xBar = this->wM(0)*this->sigmaPoints.col(0);
+    this->sigmaPoints[0] = this->dynamics.propagate(time, this->state, dt);
+    /*! - Scale that Sigma point by the appropriate scaling factor (Wm[0])*/
+    this->xBar = this->sigmaPoints[0].scale(this->wM(0));
 
     /*! - For each Sigma point, apply sBar-based error, propagate forward, and scale by Wm just like 0th.
      Note that we perform +/- sigma points simultaneously in loop to save loop values.*/
     for (size_t i = 1; i<this->state.size() + 1; ++i)
     {
         /*! - Adding covariance columns from sigma points*/
-        this->sigmaPoints.col(i) = propagate(time, this->state + this->eta * this->sBar.col(i-1), dt);
+        this->sigmaPoints[i] = dynamics.propagate(time, this->state.addVector(this->eta * this->sBar.col(i-1)), dt);
         /*! - Subtracting covariance columns from sigma points*/
-        this->sigmaPoints.col(i + this->state.size()) =
-                propagate(time, this->state - this->eta * this->sBar.col(i-1), dt);
+        this->sigmaPoints[i + this->state.size()] =
+                this->dynamics.propagate(time, this->state.addVector(-this->eta * this->sBar.col(i-1)), dt);
     }
 
     /*! - Compute xbar according to Eq (19)*/
     for (size_t i = 1; i<this->numberSigmaPoints; ++i)
     {
-        this->xBar += this->wM(i)*this->sigmaPoints.col(i);
+        this->xBar = this->xBar.add(this->sigmaPoints[i].scale(this->wM(i)));
     }
 
     /*! - Assemble the A matrix for QR decomposition as seen in equation 20 in the reference document*/
     for (size_t i = 1; i < this->numberSigmaPoints; ++i)
     {
-        A.col(i-1) = sqrt(this->wC(i))*(this->sigmaPoints.col(i) - this->xBar);
+        A.col(i-1) = this->sigmaPoints[i].add(this->xBar.scale(-1)).scale( sqrt(this->wC(i))).returnValues();
     }
 
     A.block(0, this->numberSigmaPoints-1, this->state.size(), this->state.size()) =
@@ -168,13 +113,13 @@ void SRukfInterface::timeUpdate(double updateTime)
 
     /*! - Shift the sBar matrix over by the xBar vector using the appropriate weight
      like in equation 21 in design document.*/
-    Eigen::VectorXd xError = this->sigmaPoints.col(0) - this->xBar;
+    Eigen::VectorXd xError = this->sigmaPoints[0].add(this->xBar.scale(-1)).returnValues();
 
     /*! - Cholesky update block for vectors.*/
     this->sBar = SRukfInterface::choleskyUpDownDate(this->sBar, xError, this->wC(0));
 
     this->covar = this->sBar*this->sBar.transpose();
-    this->state = this->sigmaPoints.col(0);
+    this->state = this->sigmaPoints[0];
     this->previousFilterTimeTag = updateTime;
 }
 
@@ -185,20 +130,22 @@ void SRukfInterface::timeUpdate(double updateTime)
  @param Measurement
  @return void
  */
-void SRukfInterface::measurementUpdate(const Measurement &measurement)
+void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
 {
+    this->cholMeasNoise.setZero(measurement.size(), measurement.size());
+    this->cholMeasNoise = this->choleskyDecomposition(measurement.getMeasurementNoise());
     /*! - Compute the valid observations and the measurement model for all observations*/
-    Eigen::MatrixXd yMeas(measurement.size, this->numberSigmaPoints);
+    Eigen::MatrixXd yMeas(measurement.size(), this->numberSigmaPoints);
     for(size_t j=0; j < this->numberSigmaPoints; ++j)
     {
         /*! Sigma points positions need to be normalized for the measurement model.*/
-        yMeas.col(j) = measurement.model(this->sigmaPoints.col(j));
+        yMeas.col(j) = measurement.model(this->sigmaPoints[j]);
     }
 
     /*! - Compute the value for the yBar parameter (note that this is equation 23 in the
      time update section of the reference document*/
     Eigen::VectorXd yBar;
-    yBar.setZero(measurement.size);
+    yBar.setZero(measurement.size());
     for(size_t i=0; i<this->numberSigmaPoints; ++i)
     {
         yBar += this->wM(i) * yMeas.col(i);
@@ -207,18 +154,18 @@ void SRukfInterface::measurementUpdate(const Measurement &measurement)
     /*! - Populate the matrix that we perform the QR decomposition on in the measurement
      update section of the code.  This is based on the difference between the yBar
      parameter and the calculated measurement models.  Equation 24. */
-    Eigen::MatrixXd A(measurement.size, 2*this->state.size() + measurement.size);
+    Eigen::MatrixXd A(measurement.size(), 2*this->state.size() + measurement.size());
     for(size_t i=1; i<this->numberSigmaPoints; ++i)
     {
         A.col(i-1) = sqrt(this->wC(1))*(yMeas.col(i) - yBar);
     }
-    A.block(0, this->numberSigmaPoints-1, measurement.size, measurement.size) =
-            measurement.choleskyNoise;
+    A.block(0, this->numberSigmaPoints-1, measurement.size(), measurement.size()) =
+            this->cholMeasNoise;
 
     /*! - Perform QR decomposition (only R again) of the above matrix to obtain the
      current Sy matrix*/
     Eigen::MatrixXd sy;
-    sy.setZero(measurement.size, measurement.size);
+    sy.setZero(measurement.size(), measurement.size());
     sy = SRukfInterface::qrDecompositionJustR(A);
 
     /*! - Cholesky update block for vectors.*/
@@ -230,17 +177,17 @@ void SRukfInterface::measurementUpdate(const Measurement &measurement)
     Eigen::VectorXd xError;
     xError.setZero(this->state.size());
     Eigen::MatrixXd kMat;
-    kMat.setZero(this->state.size(), measurement.size);
+    kMat.setZero(this->state.size(), measurement.size());
     Eigen::MatrixXd STkMatT;
-    STkMatT.setZero(measurement.size, this->state.size());
+    STkMatT.setZero(measurement.size(), this->state.size());
     Eigen::MatrixXd pXY;
-    pXY.setZero(this->state.size(), measurement.size);
+    pXY.setZero(this->state.size(), measurement.size());
 
     for(size_t i=0; i<this->numberSigmaPoints; ++i)
     {
-        xError = this->sigmaPoints.col(i) - this->xBar;
+        xError = this->sigmaPoints[i].add(this->xBar.scale(-1)).returnValues();
         yError = yMeas.col(i) - yBar;
-        kMat =  this->wC(i) * xError * yError.transpose();
+        kMat = this->wC(i) * xError * yError.transpose();
         pXY += kMat;
     }
 
@@ -253,11 +200,11 @@ void SRukfInterface::measurementUpdate(const Measurement &measurement)
     /*! - Difference the yBar and the observations to get the observed error and
      multiply by the Kalman Gain to get the state update.  Add the state update
      to the state to get the updated state value (equation 27).*/
-    this->state = this->xBar + kMat*(measurement.observation - yBar);
+    this->state = this->xBar.addVector(kMat*(measurement.getObservation() - yBar));
 
     /*! - Compute the updated matrix U from equation 28 */
     Eigen::MatrixXd Umat;
-    Umat.setZero(this->state.size(), measurement.size);
+    Umat.setZero(this->state.size(), measurement.size());
     Umat = kMat * sy;
 
     /*! - For each column in the update matrix, perform a cholesky down-date on it to
@@ -277,34 +224,22 @@ void SRukfInterface::measurementUpdate(const Measurement &measurement)
 @param Measurement
 @return Eigen::VectorXd
  */
-Eigen::VectorXd SRukfInterface::computeResiduals(const Measurement &measurement)
+Eigen::VectorXd SRukfInterface::computeResiduals(const MeasurementModel &measurement)
 {
     /*! - Compute Post Fit Residuals, first get Y (eq 22) using the states post fit*/
-    Eigen::MatrixXd yMeas(measurement.size, this->numberSigmaPoints);
+    Eigen::MatrixXd yMeas(measurement.size(), this->numberSigmaPoints);
     for(size_t j=0; j < this->numberSigmaPoints; ++j)
     {
         /*! Sigma points positions need to be normalized for the measurement model.*/
-        yMeas.col(j) = measurement.model(this->sigmaPoints.col(j));
+        yMeas.col(j) = measurement.model(this->sigmaPoints[j]);
     }
     /*! - Compute the value for the yBar parameter (equation 23)*/
     Eigen::VectorXd yBar;
-    yBar.setZero(measurement.observation.size());
+    yBar.setZero(measurement.size());
     for(size_t i=0; i<this->numberSigmaPoints; ++i){
         yBar += this->wM(i)*yMeas.col(i);
     }
-    return measurement.observation - yBar;
-}
-
-/*!- Order the measurements chronologically (standard sort)
- @return void
- */
-void SRukfInterface::orderMeasurementsChronologically(){
-    std::sort(this->measurements.begin(), this->measurements.end(),
-              [](std::optional<Measurement> meas1, std::optional<Measurement> meas2){
-                    if (!meas1.has_value()){return false;}
-                    else if (!meas2.has_value()){return true;}
-                    else {return meas1.value().timeTag < meas2.value().timeTag;}
-                                  });
+    return measurement.getObservation() - yBar;
 }
 
 /*! Perform a QR decomposition using HouseholderQR from Eigen, but only returns the transpose of the
@@ -312,7 +247,7 @@ void SRukfInterface::orderMeasurementsChronologically(){
  @return Eigen::MatrixXd
  @param Eigen::MatrixXd input : The input matrix. If not square, provide it with more cols then rows
  */
-Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd input) const
+Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd &input) const
 {
     Eigen::HouseholderQR<Eigen::MatrixXd> qrDecomposition(input.transpose());
     Eigen::MatrixXd R_tilde;
@@ -345,8 +280,8 @@ Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd input
  @param Eigen::VectorXd inputVector : Take it's outer product V.V^T to add into the recomposed P matrix
  @param Eigen::VectorXd coefficient : Factor that is square rooted and scales the outer product P +/- sqrt(v)V.V^T
  */
-Eigen::MatrixXd SRukfInterface::choleskyUpDownDate(const Eigen::MatrixXd input,
-                                               const Eigen::VectorXd inputVector,
+Eigen::MatrixXd SRukfInterface::choleskyUpDownDate(const Eigen::MatrixXd &input,
+                                               const Eigen::VectorXd &inputVector,
                                                const double coefficient) const
 {
     Eigen::MatrixXd P;
@@ -367,7 +302,7 @@ Eigen::MatrixXd SRukfInterface::choleskyUpDownDate(const Eigen::MatrixXd input,
  @return Eigen::MatrixXd
  @param Eigen::MatrixXd input : The input matrix
  */
-Eigen::MatrixXd SRukfInterface::choleskyDecomposition(const Eigen::MatrixXd input) const
+Eigen::MatrixXd SRukfInterface::choleskyDecomposition(const Eigen::MatrixXd &input) const
 {
     Eigen::LLT<Eigen::MatrixXd> choleskyDecomp(input);
     return choleskyDecomp.matrixL();
@@ -378,7 +313,7 @@ Eigen::MatrixXd SRukfInterface::choleskyDecomposition(const Eigen::MatrixXd inpu
  @param Eigen::MatrixXd U, an upper triangular matrix
  @param Eigen::MatrixXd b, the right hand side of the Ux = b
  */
-Eigen::MatrixXd SRukfInterface::backSubstitution(const Eigen::MatrixXd U, const Eigen::MatrixXd b) const
+Eigen::MatrixXd SRukfInterface::backSubstitution(const Eigen::MatrixXd &U, const Eigen::MatrixXd &b) const
 {
     assert(U.rows() == b.rows());
 
@@ -406,7 +341,7 @@ Eigen::MatrixXd SRukfInterface::backSubstitution(const Eigen::MatrixXd U, const 
  @param Eigen::MatrixXd L, an lower triangular matrix
  @param Eigen::MatrixXd b, the right hand side of the Ux = b
  */
-Eigen::MatrixXd SRukfInterface::forwardSubstitution(const Eigen::MatrixXd L, const Eigen::MatrixXd b) const
+Eigen::MatrixXd SRukfInterface::forwardSubstitution(const Eigen::MatrixXd &L, const Eigen::MatrixXd &b) const
 {
     assert(L.rows() == b.rows());
 
@@ -426,31 +361,6 @@ Eigen::MatrixXd SRukfInterface::forwardSubstitution(const Eigen::MatrixXd L, con
         x.col(col) = xCol;
     }
     return x;
-}
-
-
-/*! Runge-Kutta 4 (RK4) function for state propagation
-    @param ODEfunction function handle that includes the equations of motion
-    @param X0 initial state
-    @param t0 initial time
-    @param dt time step
-    @return Eigen::VectorXd
-*/
-Eigen::VectorXd SRukfInterface::rk4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                                const Eigen::VectorXd& X0,
-                                double t0,
-                                double dt) const
-{
-    double h = dt;
-
-    Eigen::VectorXd k1 = ODEfunction(t0, X0);
-    Eigen::VectorXd k2 = ODEfunction(t0 + h/2., X0 + h*k1/2.);
-    Eigen::VectorXd k3 = ODEfunction(t0 + h/2., X0 + h*k2/2.);
-    Eigen::VectorXd k4 = ODEfunction(t0 + h, X0 + h*k3);
-
-    Eigen::VectorXd X = X0 + 1./6.*h*(k1 + 2.*k2 + 2.*k3 + k4);
-
-    return X;
 }
 
 /*! Set the filter alpha parameter
@@ -481,68 +391,4 @@ void SRukfInterface::setBeta(const double betaInput){
     */
 double SRukfInterface::getBeta() const {
     return this->beta;
-}
-
-/*! Set the filter initial state vector
-    @param Eigen::VectorXd initialStateInput
-    @return void
-    */
-void SRukfInterface::setInitialState(const Eigen::VectorXd initialStateInput){
-    this->stateInitial.resize(initialStateInput.size());
-    this->stateInitial << initialStateInput;
-}
-
-/*! Get the filter initial state vector
-    @return Eigen::VectorXd stateInitial
-    */
-Eigen::VectorXd SRukfInterface::getInitialState() const {
-    return this->stateInitial;
-}
-
-/*! Set the filter initial state covariance
-    @param Eigen::MatrixXd initialCovarianceInput
-    @return void
-    */
-void SRukfInterface::setInitialCovariance(const Eigen::MatrixXd initialCovarianceInput){
-    this->covarInitial.resize(initialCovarianceInput.rows(), initialCovarianceInput.cols());
-    this->covarInitial << initialCovarianceInput;
-}
-
-/*! Get the filter initial state covariance
-    @return Eigen::MatrixXd covarInitial
-    */
-Eigen::MatrixXd SRukfInterface::getInitialCovariance() const {
-    return this->covarInitial;
-}
-
-/*! Set the filter process noise
-    @param Eigen::MatrixXd processNoiseInput
-    @return void
-    */
-void SRukfInterface::setProcessNoise(const Eigen::MatrixXd processNoiseInput){
-    this->processNoise.resize(processNoiseInput.rows(), processNoiseInput.cols());
-    this->processNoise << processNoiseInput;
-}
-
-/*! Get the filter process noise
-    @return Eigen::MatrixXd processNoise
-    */
-Eigen::MatrixXd SRukfInterface::getProcessNoise() const {
-    return this->processNoise;
-}
-
-/*! Set a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
- * outside facing interface is in SI
-    @param double conversion
-    */
-void SRukfInterface::setUnitConversionFromSItoState(const double conversion){
-    this->unitConversion = conversion;
-}
-
-/*! Get a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
- * outside facing interface is in SI
-    @return double unitConversion
-    */
-double SRukfInterface::getUnitConversionFromSItoState() const{
-    return this->unitConversion;
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -28,72 +29,40 @@
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "fswAlgorithms/_GeneralModuleFiles/filterInterfaceDefinitions.h"
+#include "fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h"
 #include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
 
 /*! @brief Square Root unscented Kalman Filter base class */
-class SRukfInterface: public SysModel  {
+class SRukfInterface: public KalmanFilter {
 public:
-    SRukfInterface();
-    ~SRukfInterface() override;
-    void Reset(uint64_t CurrentSimNanos) override;
-    void UpdateState(uint64_t CurrentSimNanos) override;
+    SRukfInterface() = default;
+    ~SRukfInterface() = default;
+    void Reset(uint64_t CurrentSimNanos) final;
 
-    void setAlpha(const double alpha);
+    void setAlpha(double alpha);
     double getAlpha() const;
-    void setBeta(const double beta);
+    void setBeta(double beta);
     double getBeta() const;
-    void setInitialState(const Eigen::VectorXd initialState);
-    Eigen::VectorXd getInitialState() const;
-    void setInitialCovariance(const Eigen::MatrixXd initialCovariance);
-    Eigen::MatrixXd getInitialCovariance() const;
-    void setProcessNoise(const Eigen::MatrixXd processNoise);
-    Eigen::MatrixXd getProcessNoise() const;
-    void setUnitConversionFromSItoState(const double conversion);
-    double getUnitConversionFromSItoState() const ;
-
-protected:
-    virtual void customReset(){/* virtual */};
-    virtual void customInitializeUpdate(){/* virtual */};
-    virtual void customFinalizeUpdate(){/* virtual */};
-    virtual Eigen::VectorXd propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt)=0;
-    /*! Read method neads to read incoming messages containing the measurements for the filter.
-     * Their information must be added to the Measurement container class, and added to the measurements vector.
-     * Each measurement must be paired with a measurement model provided in the measurementModels.h */
-    virtual void readFilterMeasurements()=0;
-    virtual void writeOutputMessages(uint64_t CurrentSimNanos)=0;
-
-    Eigen::VectorXd rk4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                const Eigen::VectorXd& X0,
-                double t0,
-                double dt) const;
-
-    std::array<std::optional<Measurement>, MAX_MEASUREMENT_NUMBER> measurements;  //!< [Measurements] All measurement containers in chronological order
-    double previousFilterTimeTag = 0; //!< [s]  Time tag for statecovar/etc
-    double unitConversion = 1; //!< [-] Scale that converts input units (SI) to a desired unit for the inner maths
-
-    size_t numberSigmaPoints=0; //!< [s]  2n+1 sigma points for convenience
-    Eigen::VectorXd state; //!< [-] State estimate for time TimeTag
-    Eigen::MatrixXd sBar; //!< [-] Time updated covariance
-    Eigen::MatrixXd covar; //!< [-] covariance
-    Eigen::VectorXd xBar; //!< [-] Current mean state estimate
-    Eigen::MatrixXd sigmaPoints; //!< [-]    sigma point matrix
-
-    Eigen::MatrixXd yMeas; //!< [-] Measurement model data
-    Eigen::VectorXd postFits; //!< [-] PostFit residuals
-    Eigen::MatrixXd cholProcessNoise; //!< [-] cholesky of Qnoise
 
 private:
-    void timeUpdate(const double updateTime);
-    void measurementUpdate(const Measurement &measurement);
-    Eigen::VectorXd computeResiduals(const Measurement &measurement);
-    Eigen::MatrixXd qrDecompositionJustR(const Eigen::MatrixXd input) const;
-    Eigen::MatrixXd choleskyUpDownDate(const Eigen::MatrixXd input,
-                                       const Eigen::VectorXd inputVector,
-                                       const double coefficient) const;
-    Eigen::MatrixXd backSubstitution(const Eigen::MatrixXd U, const Eigen::MatrixXd b) const;
-    Eigen::MatrixXd forwardSubstitution(const Eigen::MatrixXd L, const Eigen::MatrixXd b) const;
-    Eigen::MatrixXd choleskyDecomposition(const Eigen::MatrixXd input) const;
-    void orderMeasurementsChronologically();
+    void timeUpdate(double updateTime) final;
+    void measurementUpdate(const MeasurementModel &measurement) final;
+
+    Eigen::VectorXd computeResiduals(const MeasurementModel &measurement) final;
+    Eigen::MatrixXd qrDecompositionJustR(const Eigen::MatrixXd &input) const;
+    Eigen::MatrixXd choleskyUpDownDate(const Eigen::MatrixXd &input,
+                                       const Eigen::VectorXd &inputVector,
+                                       double coefficient) const;
+    Eigen::MatrixXd backSubstitution(const Eigen::MatrixXd &U, const Eigen::MatrixXd &b) const;
+    Eigen::MatrixXd forwardSubstitution(const Eigen::MatrixXd &L, const Eigen::MatrixXd &b) const;
+    Eigen::MatrixXd choleskyDecomposition(const Eigen::MatrixXd &input) const;
+
+    Eigen::MatrixXd sBar; //!< [-] Time updated covariance
+    std::array<StateVector, 2*MAX_STATES_VECTOR+1> sigmaPoints; //!< [-]    sigma point vector
+    int numberSigmaPoints=0;//!< [-] number of sigma points
+    Eigen::MatrixXd cholProcessNoise; //!< [-] cholesky of Qnoise
+    Eigen::MatrixXd cholMeasNoise; //!< [-] cholesky of Measurement noise
 
     double beta=0;
     double alpha=0;
@@ -102,11 +71,7 @@ private:
 
     Eigen::VectorXd wM;
     Eigen::VectorXd wC;
-
-    Eigen::MatrixXd processNoise; //!< [-] process noise matrix
-    Eigen::VectorXd stateInitial; //!< [-] State estimate for time TimeTag at previous time
     Eigen::MatrixXd sBarInitial; //!< [-] Time updated covariance at previous time
-    Eigen::MatrixXd covarInitial; //!< [-] covariance at previous time
 };
 
 #endif /* SRUKF_INTERFACE_HPP */

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.i
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.i
@@ -1,0 +1,36 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module srukfInterface
+%{
+   #include "srukfInterface.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "kalmanFilter.i"
+
+%include "srukfInterface.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.rst
@@ -2,7 +2,7 @@ Executive Summary
 -----------------
 
 This class provides an interface for square root unscented Kalman Filters. Modules which inherit from it will
-benefit from having the core functionality of the SRuKF
+benefit from having the core functionality of the SRuKF. This class inherits from the Kalman Filter interface
 
 The math is derived primarily using the following equations:
 :download:`PDF Description </../../src/fswAlgorithms/opticalNavigation/relativeODuKF/_Documentation/inertialUKF_DesignBasis.pdf>`
@@ -54,30 +54,6 @@ provides information on what this message is used for.
       - perform a cholesky decomposition
       - private
       - non-virtual
-    * - customReset
-      - perform addition reset duties in child class
-      - protected
-      - virtual, optional
-    * - measurementModel
-      - add a measurement model for the inputs in child class
-      - protected
-      - virtual, needs to be populated
-    * - propagate
-      - add a dynamics model for the inputs in child class
-      - protected
-      - virtual, needs to be populated
-    * - readFilterMeasurements
-      - read the specific measurements in a child class
-      - protected
-      - virtual, needs to be populated
-    * - writeOutputMessages
-      - write the specific measurements in a child class
-      - protected
-      - virtual, needs to be populated
-    * - rk4
-      - Runge-Kutta 4 integrator if needed for propagation
-      - protected
-      - non-virtual
 
 
 Module assumptions and limitations
@@ -110,20 +86,3 @@ This section lists all the setters and getters that are defined by the interface
     * - set/getBeta
       - filter beta parameter
       - necessary
-    * - set/getInitialState
-      - filter initial state
-      - necessary
-    * - set/getInitialCovariance
-      - filter initial covariance (square matrix size of state)
-      - necessary
-    * - set/getProcessNoise
-      - filter process noise value (square matrix size of state)
-      - necessary
-    * - set/getConstantMeasurementNoise
-      - filter measurement noise (square matrix size of observations)
-      - optional
-    * - set/getUnitConversionFromSItoState
-      - conversion from SI to internal filter units
-      - optional
-
-    

--- a/src/fswAlgorithms/_GeneralModuleFiles/stateModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/stateModels.cpp
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -19,10 +20,6 @@
 
 #include "stateModels.h"
 
-State::State() = default;
-
-State::~State() = default;
-
 /*! Set the values of a given state
    @param Eigen::VectorXd
 */
@@ -37,21 +34,68 @@ Eigen::VectorXd State::getValues() const {
     return this->values;
 }
 
-StateVector::StateVector() = default;
-
-StateVector::~StateVector() = default;
-
 /*! Set the positional components of your state (cartesian position, attitude, etc)
    @param Eigen::VectorXd positionComponents
 */
-size_t StateVector::size() const{
-    size_t totalSize = 0;
-    totalSize += this->position.getValues().size();
-    totalSize += this->velocity.getValues().size();
-    totalSize += this->acceleration.getValues().size();
-    totalSize += this->bias.getValues().size();
-    totalSize += this->considerParameters.getValues().size();
+long StateVector::size() const{
+    long totalSize = 0;
+    if (this->hasPosition()){
+        totalSize += this->getPositionStates().size();
+    }
+    if (this->hasVelocity()){
+        totalSize += this->getVelocityStates().size();
+    }
+    if (this->hasAcceleration()){
+        totalSize += this->getAccelerationStates().size();
+    }
+    if (this->hasBias()){
+        totalSize += this->getBiasStates().size();
+    }
+    if (this->hasConsider()){
+        totalSize += this->getConsiderStates().size();
+    }
     return totalSize;
+}
+
+/*! Add a eigen vector to a state, assuming the order of position, velocity, acceleration, bias, consider
+   @param Eigen::VectorXd vector
+   @return StateVector sumVector
+*/
+StateVector StateVector::addVector(const Eigen::VectorXd &vector) const {
+    assert(vector.size() == this->size());
+    long lastIndex = 0;
+    StateVector sum;
+    if (this->hasPosition()){
+        PositionState positionState;
+        positionState.setValues(this->getPositionStates() + vector.segment(0, this->getPositionStates().size()));
+        sum.setPosition(positionState);
+        lastIndex += this->getPositionStates().size();
+    }
+    if (this->hasVelocity()){
+        VelocityState velocityState;
+        velocityState.setValues(this->getVelocityStates() + vector.segment(lastIndex, this->getVelocityStates().size()));
+        sum.setVelocity(velocityState);
+        lastIndex += this->getVelocityStates().size();
+    }
+    if (this->hasAcceleration()){
+        AccelerationState accelerationState;
+        accelerationState.setValues(this->getAccelerationStates() + vector.segment(
+                lastIndex,this->getAccelerationStates().size()));
+        sum.setAcceleration(accelerationState);
+        lastIndex += this->getAccelerationStates().size();
+    }
+    if (this->hasBias()){
+        BiasState biasState;
+        biasState.setValues(this->getBiasStates() + vector.segment(lastIndex, this->getBiasStates().size()));
+        sum.setBias(biasState);
+        lastIndex += this->getBiasStates().size();
+    }
+    if (this->hasConsider()){
+        ConsiderState considerState;
+        considerState.setValues(this->getConsiderStates() + vector.segment(lastIndex, this->getConsiderStates().size()));
+        sum.setConsider(considerState);
+    }
+    return sum;
 }
 
 /*! Add two states together
@@ -60,12 +104,32 @@ size_t StateVector::size() const{
 */
 StateVector StateVector::add(const StateVector &vector) const {
     StateVector sum;
-    sum.setPositionStates(this->position.getValues() + vector.getPositionStates());
-    sum.setVelocityStates(this->velocity.getValues() + vector.getVelocityStates());
-    sum.setAccelerationStates(this->acceleration.getValues() + vector.getAccelerationStates());
-    sum.setBiasStates(this->bias.getValues() + vector.getBiasStates());
-    sum.setConsiderStates(this->considerParameters.getValues() + vector.getConsiderStates());
-    sum.attachSTM(this->stm + vector.detatchSTM());
+    if (this->hasPosition() && vector.hasPosition()){
+        PositionState sumPosition;
+        sumPosition.setValues(this->getPositionStates() + vector.getPositionStates());
+        sum.setPosition(sumPosition);
+    }
+    if (this->hasVelocity() && vector.hasVelocity()){
+        VelocityState sumVelocity;
+        sumVelocity.setValues(this->getVelocityStates() + vector.getVelocityStates());
+        sum.setVelocity(sumVelocity);
+    }
+    if (this->hasAcceleration() && vector.hasAcceleration()){
+        AccelerationState sumAcceleration;
+        sumAcceleration.setValues(this->getAccelerationStates() + vector.getAccelerationStates());
+        sum.setAcceleration(sumAcceleration);
+    }
+    if (this->hasBias() && vector.hasBias()){
+        BiasState sumBias;
+        sumBias.setValues(this->getBiasStates() + vector.getBiasStates());
+        sum.setBias(sumBias);
+    }
+    if (this->hasConsider() && vector.hasConsider()){
+        ConsiderState sumConsider;
+        sumConsider.setValues(this->getConsiderStates() + vector.getConsiderStates());
+        sum.setConsider(sumConsider);
+    }
+    sum.attachStm(this->detachStm() + vector.detachStm());
     return sum;
 }
 
@@ -75,95 +139,216 @@ StateVector StateVector::add(const StateVector &vector) const {
 */
 StateVector StateVector::scale(const double scalar) const {
     StateVector scaledVector;
-    scaledVector.setPositionStates(this->position.getValues()*scalar);
-    scaledVector.setVelocityStates(this->velocity.getValues()*scalar);
-    scaledVector.setAccelerationStates(this->acceleration.getValues()*scalar);
-    scaledVector.setBiasStates(this->bias.getValues()*scalar);
-    scaledVector.setConsiderStates(this->considerParameters.getValues()*scalar);
-    scaledVector.attachSTM(this->stm*scalar);
+    if (this->hasPosition()){
+        PositionState scaledPosition;
+        scaledPosition.setValues(this->getPositionStates()*scalar);
+        scaledVector.setPosition(scaledPosition);
+    }
+    if (this->hasVelocity()){
+        VelocityState scaledVelocity;
+        scaledVelocity.setValues(this->getVelocityStates()*scalar);
+        scaledVector.setVelocity(scaledVelocity);
+    }
+    if (this->hasAcceleration()){
+        AccelerationState scaledAcceleration;
+        scaledAcceleration.setValues(this->getAccelerationStates()*scalar);
+        scaledVector.setAcceleration(scaledAcceleration);
+    }
+    if (this->hasBias()){
+        BiasState scaledBias;
+        scaledBias.setValues(this->getBiasStates()*scalar);
+        scaledVector.setBias(scaledBias);
+    }
+    if (this->hasConsider()){
+        ConsiderState scaledConsider;
+        scaledConsider.setValues(this->getConsiderStates()*scalar);
+        scaledVector.setConsider(scaledConsider);
+    }
+    scaledVector.attachStm(this->stm*scalar);
     return scaledVector;
+}
+
+/*! Return the full state vector
+   @return Eigen::VectorXd fullStateVector
+*/
+Eigen::VectorXd StateVector::returnValues() const {
+    long numerOfStates = this->size();
+    Eigen::VectorXd stateVectorValues;
+    stateVectorValues.setZero(numerOfStates);
+    long lastIndex = 0;
+    if (this->hasPosition()){
+        stateVectorValues.segment(0, this->getPositionStates().size()) = this->getPositionStates();
+        lastIndex += this->getPositionStates().size();
+    }
+    if (this->hasVelocity()){
+        stateVectorValues.segment(lastIndex, this->getVelocityStates().size()) = this->getVelocityStates();
+        lastIndex += this->getVelocityStates().size();
+    }
+    if (this->hasAcceleration()){
+        stateVectorValues.segment(lastIndex, this->getAccelerationStates().size()) = this->getAccelerationStates();
+        lastIndex += this->getAccelerationStates().size();
+    }
+    if (this->hasBias()){
+        stateVectorValues.segment(lastIndex, this->getBiasStates().size()) = this->getBiasStates();
+        lastIndex += this->getBiasStates().size();
+    }
+    if (this->hasConsider()){
+        stateVectorValues.segment(lastIndex, this->getConsiderStates().size()) = this->getConsiderStates();
+    }
+    return stateVectorValues;
+}
+
+/*! Check if the state vector has a position state
+   @return bool
+*/
+bool StateVector::hasPosition() const {
+    return this->position.has_value();
 }
 
 /*! Set the positional components of your state (cartesian position, attitude, etc)
    @param Eigen::VectorXd positionComponents
 */
-void StateVector::setPositionStates(const Eigen::VectorXd &positionComponents){
-    this->position.setValues(positionComponents);
+void StateVector::setPosition(const PositionState &positionState){
+    this->position = positionState;
 }
 
 /*! Get the positional components of your state (cartesian position, attitude, etc)
    @return Eigen::VectorXd
 */
 Eigen::VectorXd StateVector::getPositionStates() const {
-    return this->position.getValues();
+    return this->getPosition().getValues();
+}
+
+
+/*! Get the positional state class of your state vector(cartesian position, attitude, etc)
+   @return PositionState
+*/
+PositionState StateVector::getPosition() const {
+    return this->position.value();
+}
+
+/*! Check if the state vector has a velocity state
+   @return bool
+*/
+bool StateVector::hasVelocity() const {
+    return this->velocity.has_value();
 }
 
 /*! Set the velocity components of your state (cartesian velocity, angular rate, etc)
-   @param Eigen::VectorXd setVelocityStates
+   @param Eigen::VectorXd velocityComponents
 */
-void StateVector::setVelocityStates(const Eigen::VectorXd &velocityComponents){
-    this->velocity.setValues(velocityComponents);
+void StateVector::setVelocity(const VelocityState &velocityState){
+    this->velocity = velocityState;
+}
+
+/*! Get the velocity class of your state (cartesian velocity, angular rate, etc)
+   @return Eigen::VectorXd
+*/
+VelocityState StateVector::getVelocity() const {
+    return this->velocity.value();
 }
 
 /*! Get the velocity components of your state (cartesian velocity, angular rate, etc)
    @return Eigen::VectorXd
 */
 Eigen::VectorXd StateVector::getVelocityStates() const {
-    return this->velocity.getValues();
+    return this->getVelocity().getValues();
 }
 
-/*! Set the acceleration components of your state (cartesian acceleration, angular acceleration, etc)
-   @param Eigen::VectorXd accelerationComponents
+/*! Check if the state vector has a acceleration state
+   @return bool
 */
-void StateVector::setAccelerationStates(const Eigen::VectorXd &accelerationComponents){
-    this->acceleration.setValues(accelerationComponents);
+bool StateVector::hasAcceleration() const {
+    return this->acceleration.has_value();
+}
+
+/*! Set the acceleration class of your state (cartesian acceleration, angular acceleration, etc)
+   @param Eigen::VectorXd velocityComponents
+*/
+void StateVector::setAcceleration(const AccelerationState &accelerationState){
+    this->acceleration = accelerationState;
+}
+
+/*! Get the velocity class of your state (cartesian acceleration, angular acceleration, etc)
+   @return Eigen::VectorXd
+*/
+AccelerationState StateVector::getAcceleration() const {
+    return this->acceleration.value();
 }
 
 /*! Get the acceleration components of your state (cartesian acceleration, angular acceleration, etc)
    @return Eigen::VectorXd
 */
 Eigen::VectorXd StateVector::getAccelerationStates() const {
-    return this->acceleration.getValues();
+    return this->getAcceleration().getValues();
 }
 
-/*! Set the bias parameters of your state (gyro bias, scale factors, etc)
-   @param Eigen::VectorXd biasComponents
+/*! Check if the state vector has a bias state
+   @return bool
 */
-void StateVector::setBiasStates(const Eigen::VectorXd &biasComponents){
-    this->bias.setValues(biasComponents);
+bool StateVector::hasBias() const {
+    return this->bias.has_value();
 }
 
-/*! Get the bias parameters of your state (gyro bias, scale factors, etc)
+/*! Set the bias class of your state (cartesian bias, angular bias, etc)
+   @param Eigen::VectorXd velocityComponents
+*/
+void StateVector::setBias(const BiasState &biasState){
+    this->bias = biasState;
+}
+
+/*! Get the velocity class of your state (cartesian bias, angular bias, etc)
+   @return Eigen::VectorXd
+*/
+BiasState StateVector::getBias() const {
+    return this->bias.value();
+}
+
+/*! Get the bias components of your state (cartesian bias, angular bias, etc)
    @return Eigen::VectorXd
 */
 Eigen::VectorXd StateVector::getBiasStates() const {
-    return this->bias.getValues();
+    return this->getBias().getValues();
 }
 
-/*! Set the consider parameters of your state (gravitational parameter, etc)
-   @param Eigen::VectorXd considerParameters
+/*! Check if the state vector has a considerParameters state
+   @return bool
 */
-void StateVector::setConsiderStates(const Eigen::VectorXd &considerComponents){
-    this->considerParameters.setValues(considerComponents);
+bool StateVector::hasConsider() const {
+    return this->considerParameters.has_value();
 }
 
-/*! Get the consider parameters of your state (gravitational parameter, etc)
+/*! Set the considerParameters class of your state (cartesian considerParameters, angular considerParameters, etc)
+   @param Eigen::VectorXd velocityComponents
+*/
+void StateVector::setConsider(const ConsiderState &considerParametersState){
+    this->considerParameters = considerParametersState;
+}
+
+/*! Get the velocity class of your state (cartesian considerParameters, angular considerParameters, etc)
+   @return Eigen::VectorXd
+*/
+ConsiderState StateVector::getConsider() const {
+    return this->considerParameters.value();
+}
+
+/*! Get the considerParameters components of your state (cartesian considerParameters, angular considerParameters, etc)
    @return Eigen::VectorXd
 */
 Eigen::VectorXd StateVector::getConsiderStates() const {
-    return this->considerParameters.getValues();
+    return this->getConsider().getValues();
 }
 
 /*! Attach the state transition matrix of your state for simultaneous propagation
    @param Eigen::MatrixXd stm
 */
-void StateVector::attachSTM(const Eigen::MatrixXd& stm){
+void StateVector::attachStm(const Eigen::MatrixXd& stm){
     this->stm = stm;
 }
 
-/*! Detatch the state transition matrix of your state for simultaneous propagation
+/*! Detach the state transition matrix of your state for simultaneous propagation
    @return Eigen::MatrixXd stm
 */
-Eigen::MatrixXd StateVector::detatchSTM() const{
+Eigen::MatrixXd StateVector::detachStm() const{
     return this->stm;
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/stateModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/stateModels.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -22,14 +23,15 @@
 #define FILTER_STATE_MODELS_H
 
 #include <Eigen/Core>
+#include <optional>
 
 /*! @brief State class */
 class State{
 private:
     Eigen::VectorXd values;
 public:
-    State();
-    ~State();
+    State() = default;
+    ~State() = default;
     void setValues(const Eigen::VectorXd& componentValues);
     Eigen::VectorXd getValues() const;
 };
@@ -44,34 +46,49 @@ class ConsiderState : public State{};
 /*! @brief State models used to map a state vector to a measurement */
 class StateVector{
 private:
-    PositionState position;
-    VelocityState velocity;
-    AccelerationState acceleration;
-    BiasState bias;
-    ConsiderState considerParameters;
+    std::optional<PositionState> position;
+    std::optional<VelocityState> velocity;
+    std::optional<AccelerationState> acceleration;
+    std::optional<BiasState> bias;
+    std::optional<ConsiderState> considerParameters;
     Eigen::MatrixXd stm;
 
 public:
-    StateVector();
-    ~StateVector();
+    StateVector() = default;
+    ~StateVector() = default;
 
-    size_t size() const;
+    long size() const;
     StateVector add(const StateVector &vector) const;
+    StateVector addVector(const Eigen::VectorXd &vector) const;
     StateVector scale(const double scalar) const;
+    Eigen::VectorXd returnValues() const;
 
-    void setPositionStates(const Eigen::VectorXd& positionComponents);
+    void setPosition(const PositionState &position);
+    PositionState getPosition() const;
     Eigen::VectorXd getPositionStates() const;
-    void setVelocityStates(const Eigen::VectorXd& velocityComponents);
+    bool hasPosition() const;
+    void setVelocity(const VelocityState &velocity);
+    VelocityState getVelocity() const;
     Eigen::VectorXd getVelocityStates() const;
-    void setAccelerationStates(const Eigen::VectorXd& accelerationComponents);
+    bool hasVelocity() const;
+    void setAcceleration(const AccelerationState &acceleration);
+    AccelerationState getAcceleration() const;
     Eigen::VectorXd getAccelerationStates() const;
-    void setBiasStates(const Eigen::VectorXd& biasComponents);
+    bool hasAcceleration() const;
+    void setBias(const BiasState &bias);
+    BiasState getBias() const;
     Eigen::VectorXd getBiasStates() const;
-    void setConsiderStates(const Eigen::VectorXd& considerComponents);
+    bool hasBias() const;
+    void setConsider(const ConsiderState &consider);
+    ConsiderState getConsider() const;
     Eigen::VectorXd getConsiderStates() const;
+    bool hasConsider() const;
 
-    void attachSTM(const Eigen::MatrixXd& stm);
-    Eigen::MatrixXd detatchSTM() const;
+    void attachStm(const Eigen::MatrixXd& stm);
+    Eigen::MatrixXd detachStm() const;
+
+
+
 };
 
 #endif

--- a/src/fswAlgorithms/_GeneralModuleFiles/stateModels.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/stateModels.rst
@@ -1,0 +1,87 @@
+Executive Summary
+-----------------
+
+This class provides an container for all the state models to a kalman filter.
+This class is a necessary component to any Kalman Filter implementation
+
+Virtual and Private method descriptors
+-------------------------------
+The following table lists all the state class
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+    * - get/setValues
+      - return the values of a given state
+
+Position, Velocity, Acceleration, Bias, and ConsiderParameters all inherit the state type.
+The following table lists all the stateVector class, which contains all the different state types and a stm matrix
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+    * - size
+      - return the total size of all the states
+    * - add
+      - add state vectors
+    * - addVector
+      - add Eigen::Vector values to the state vector in order Position, Velocity, Accel, Bias, Consider
+    * - scale
+      - scale a stateVector by a scalar
+    * - returnValues
+      - return all fo the values in an Eigen::Vector following the previous order
+
+
+Module assumptions and limitations
+-------------------------------
+
+The states are strongly typed, but the covariance is not (yet).
+When returning values, the order of the states is Position, Velocity, Accel, Bias, Consider
+
+User Guide
+----------
+
+This section lists all the setters and getters that are defined by the interface
+
+.. list-table:: Interface methods which remain private
+    :widths: 25 75 25
+    :header-rows: 1
+
+    * - Method Name
+      - Method Function
+    * - get/setPosition
+      - the position state class
+    * - get/setPositionVector
+      - the values of the position state class
+    * - hasPosition
+      - does the state vector contain a position
+    * - get/setVelocity
+      - the velocity state class
+    * - get/setVelocityVector
+      - the values of the velocity state class
+    * - hasVelocity
+      - does the state vector contain a velocity
+    * - get/setAcceleration
+      - the acceleration state class
+    * - get/setAccelerationVector
+      - the values of the acceleration state class
+    * - hasAcceleration
+      - does the state vector contain a acceleration
+    * - get/setBias
+      - the bias state class
+    * - get/setBiasVector
+      - the values of the bias state class
+    * - hasBias
+      - does the state vector contain a bias
+    * - get/setConsider
+      - the consider parameter state class
+    * - get/setConsiderVector
+      - the values of the consider parameter state class
+    * - hasConsider
+      - does the state vector contain a consider parameter

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -23,25 +24,49 @@ InertialAttitudeUkf::InertialAttitudeUkf(AttitudeFilterMethod method){
     this->measurementAcceptanceMethod = method;
 }
 
-InertialAttitudeUkf::~InertialAttitudeUkf() = default;
-
-
 void InertialAttitudeUkf::customReset(){
     /*! No custom reset for this module */
+    std::function<StateVector(double, const StateVector)> attitudeDynamics = [this](double t, const StateVector &state){
+        Eigen::Vector3d mrp(state.getPositionStates());
+        Eigen::Vector3d omega(state.getVelocityStates());
+        Eigen::MatrixXd bMat = bmatMrp(mrp);
+
+        StateVector stateDerivative;
+        PositionState mrpDot;
+        mrpDot.setValues(0.25*bMat*omega);
+        stateDerivative.setPosition(mrpDot);
+
+        Eigen::Vector3d wheelTorque = Eigen::Vector3d::Zero();
+        for(int i=0; i<this->rwArrayConfigPayload.numRW; i++){
+            Eigen::Vector3d gsMatrix = Eigen::Map<Eigen::Vector3d>(&this->rwArrayConfigPayload.GsMatrix_B[i*3]);
+            wheelTorque -= this->wheelAccelerations[i]*this->rwArrayConfigPayload.JsList[i]*gsMatrix;
+        }
+
+        VelocityState omegaDot;
+        omegaDot.setValues(-this->spacecraftInertiaInverse*(tildeMatrix(omega)*this->spacecraftInertia*omega + wheelTorque));
+        stateDerivative.setVelocity(omegaDot);
+
+        return stateDerivative;
+    };
+    this->dynamics.setDynamics(attitudeDynamics);
 }
 
 /*! Before every update, check the MRP norm for a shadow set switch
  @return void
  */
 void InertialAttitudeUkf::customInitializeUpdate(){
-    this->state.head(3) << mrpSwitch(this->state.head(3), this->mrpSwitchThreshold);
+    PositionState mrp;
+    mrp.setValues(mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
+    this->state.setPosition(mrp);
 }
 
 /*! After every update, check the MRP norm for a shadow set switch
  @return void
  */
 void InertialAttitudeUkf::customFinalizeUpdate(){
-    this->state.head(3) << mrpSwitch(this->state.head(3), this->mrpSwitchThreshold);
+    PositionState mrp;
+    mrp.setValues( mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
+    this->state.setPosition(mrp);
 }
 
 /*! Read the message containing the measurement data.
@@ -56,33 +81,33 @@ void InertialAttitudeUkf::writeOutputMessages(uint64_t CurrentSimNanos) {
 
     /*! - Write the flyby OD estimate into the copy of the navigation message structure*/
     navAttPayload.timeTag = this->previousFilterTimeTag;
-    eigenMatrixXd2CArray(this->state.head(3), navAttPayload.sigma_BN);
-    eigenMatrixXd2CArray(this->state.tail(3), navAttPayload.omega_BN_B);
+    eigenMatrixXd2CArray(this->state.getPositionStates(), navAttPayload.sigma_BN);
+    eigenMatrixXd2CArray(this->state.getVelocityStates(), navAttPayload.omega_BN_B);
 
     /*! - Populate the filter states output buffer and write the output message*/
     filterPayload.timeTag = this->previousFilterTimeTag;
-    eigenMatrixXd2CArray(this->state, filterPayload.state);
-    eigenMatrixXd2CArray(this->xBar, filterPayload.stateError);
+    eigenMatrixXd2CArray(this->state.returnValues(), filterPayload.state);
+    eigenMatrixXd2CArray(this->xBar.returnValues(), filterPayload.stateError);
     eigenMatrixXd2CArray(this->covar, filterPayload.covar);
 
     for (size_t index = 0; index < MAX_MEASUREMENT_NUMBER; index ++){
         if (this->measurements[index].has_value()) {
             auto measurement = this->measurements[index].value();
-            if (measurement.name == "starTracker"){
+            if (measurement.getMeasurementName() == "starTracker"){
                 starTrackerPayload.valid = true;
                 starTrackerPayload.numberOfObservations = 1;
-                starTrackerPayload.sizeOfObservations = measurement.observation.size();
-                eigenMatrixXd2CArray(measurement.observation, &starTrackerPayload.observation[0]);
-                eigenMatrixXd2CArray(measurement.postFitResiduals, &starTrackerPayload.postFits[0]);
-                eigenMatrixXd2CArray(measurement.preFitResiduals, &starTrackerPayload.preFits[0]);
+                starTrackerPayload.sizeOfObservations = measurement.size();
+                eigenMatrixXd2CArray(measurement.getObservation(), &starTrackerPayload.observation[0]);
+                eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &starTrackerPayload.postFits[0]);
+                eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &starTrackerPayload.preFits[0]);
                 }
-            if (measurement.name == "gyro"){
+            if (measurement.getMeasurementName() == "gyro"){
                 gyroPayload.valid = true;
                 gyroPayload.numberOfObservations = 1;
-                gyroPayload.sizeOfObservations = measurement.observation.size();
-                eigenMatrixXd2CArray(measurement.observation, &gyroPayload.observation[0]);
-                eigenMatrixXd2CArray(measurement.postFitResiduals, &gyroPayload.postFits[0]);
-                eigenMatrixXd2CArray(measurement.preFitResiduals, &gyroPayload.preFits[0]);
+                gyroPayload.sizeOfObservations = measurement.size();
+                eigenMatrixXd2CArray(measurement.getObservation(), &gyroPayload.observation[0]);
+                eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &gyroPayload.postFits[0]);
+                eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &gyroPayload.preFits[0]);
                 }
             this->measurements[index].reset();
         }
@@ -119,16 +144,16 @@ void InertialAttitudeUkf::readStarTrackerData(){
     for (int index = 0; index < this->numberOfStarTackers; index ++){
         auto starTracker = this->starTrackerMessages[index].starTrackerMsg();
         if (starTracker.timeTag*NANO2SEC > this->previousFilterTimeTag){
-            auto starTrackerMeasurement = Measurement();
-            starTrackerMeasurement.name = "starTracker";
-            starTrackerMeasurement.timeTag = starTracker.timeTag*NANO2SEC;
-            starTrackerMeasurement.validity = true;
-            starTrackerMeasurement.size = 3;
+            auto starTrackerMeasurement = MeasurementModel();
+            starTrackerMeasurement.setMeasurementName("starTracker");
+            starTrackerMeasurement.setTimeTag(starTracker.timeTag*NANO2SEC);
+            starTrackerMeasurement.setValidity(true);
 
-            starTrackerMeasurement.noise = this->starTrackerMessages[index].measurementNoise;
-            starTrackerMeasurement.observation = mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl),
-                    this->mrpSwitchThreshold);
-            starTrackerMeasurement.model = mrpFirstThreeStates;
+            starTrackerMeasurement.setMeasurementNoise(
+                    this->measNoiseScaling * this->starTrackerMessages[index].measurementNoise);
+            starTrackerMeasurement.setObservation(mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl),
+                    this->mrpSwitchThreshold));
+            starTrackerMeasurement.setMeasurementModel(MeasurementModel::mrpStates);
             this->measurements[this->measurementIndex] = starTrackerMeasurement;
             this->measurementIndex += 1;
             this->validStarTracker = true;
@@ -174,15 +199,15 @@ void InertialAttitudeUkf::readGyroData(){
             lowPass.processMeasurement(omega_BN_B);
         }
 
-        auto gyroMeasurement = Measurement();
-        gyroMeasurement.name = "gyro";
-        gyroMeasurement.timeTag = meanMeasurementTime;
-        gyroMeasurement.validity = true;
-        gyroMeasurement.size = 3;
+        auto gyroMeasurement = MeasurementModel();
+        gyroMeasurement.setMeasurementName("gyro");
+        gyroMeasurement.setTimeTag(meanMeasurementTime);
+        gyroMeasurement.setValidity(true);
 
-        gyroMeasurement.noise = this->gyroNoise/std::sqrt(numberOfValidGyroMeasurements);
-        gyroMeasurement.observation = lowPass.getCurrentState();
-        gyroMeasurement.model = lastThreeStates;
+        gyroMeasurement.setMeasurementNoise(
+                this->measNoiseScaling * this->gyroNoise/std::sqrt(numberOfValidGyroMeasurements));
+        gyroMeasurement.setObservation(lowPass.getCurrentState());
+        gyroMeasurement.setMeasurementModel(MeasurementModel::velocityStates);
         this->measurements[this->measurementIndex] = gyroMeasurement;
         this->measurementIndex += 1;
     }
@@ -214,49 +239,6 @@ void InertialAttitudeUkf::readFilterMeasurements() {
     if (measurementAcceptanceMethod == AttitudeFilterMethod::GyroWhenDazzled && !this->validStarTracker) {
         readGyroData();
     }
-}
-
-/*! Integrate the equations of motion of two body point mass gravity using Runge-Kutta 4 (RK4)
-    @param interval integration interval
-    @param X0 initial state
-    @param dt time step
-    @return Eigen::VectorXd
-*/
-Eigen::VectorXd InertialAttitudeUkf::propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt){
-    double t_0 = interval[0];
-    double t_f = interval[1];
-    double t = t_0;
-    Eigen::VectorXd X = X0;
-
-    std::function<Eigen::VectorXd(double, Eigen::VectorXd)> attitudeDynamics = [this](double t, Eigen::VectorXd state)
-    {
-        Eigen::Vector3d mrp(state.head(3));
-        Eigen::Vector3d omega(state.tail(3));
-        Eigen::MatrixXd Bmat = bmatMrp(mrp);
-
-        Eigen::VectorXd stateDerivative(state.size());
-        stateDerivative.head(3) << 0.25*Bmat*omega;
-
-        Eigen::Vector3d wheelTorque = Eigen::Vector3d::Zero();
-        for(int i=0; i<this->rwArrayConfigPayload.numRW; i++){
-            Eigen::Vector3d GsMatrix = Eigen::Map<Eigen::Vector3d>(&this->rwArrayConfigPayload.GsMatrix_B[i*3]);
-            wheelTorque -= this->wheelAccelerations[i]*this->rwArrayConfigPayload.JsList[i]*GsMatrix;
-        }
-
-        stateDerivative.tail(3) << -this->spacecraftInertiaInverse*(tildeMatrix(omega)*this->spacecraftInertia*omega + wheelTorque);
-
-        return stateDerivative;
-    };
-
-    /*! Propagate to t_final with an RK4 integrator */
-    double N = ceil((t_f-t_0)/dt);
-    for (int c=0; c < N; c++) {
-        double step = std::min(dt,t_f-t);
-        X = this->rk4(attitudeDynamics, X, t, step);
-        t = t + step;
-    }
-
-    return X;
 }
 
 /*! Set the gyro measurement noise matrix

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -56,15 +57,14 @@ enum class AttitudeFilterMethod {StarOnly, GyroWhenDazzled, AllMeasurements};
 class InertialAttitudeUkf: public SRukfInterface {
 public:
     InertialAttitudeUkf(AttitudeFilterMethod method);
-    ~InertialAttitudeUkf() override;
+    ~InertialAttitudeUkf() = default;
 
 private:
-    void customReset() override;
-    void readFilterMeasurements() override;
-    void writeOutputMessages(uint64_t CurrentSimNanos) override;
-    Eigen::VectorXd propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt) override;
-    void customInitializeUpdate() override;
-    void customFinalizeUpdate() override;
+    void customReset() final;
+    void readFilterMeasurements() final;
+    void writeOutputMessages(uint64_t CurrentSimNanos) final;
+    void customInitializeUpdate() final;
+    void customFinalizeUpdate() final;
 
     /*! Specific read messages */
     void readRWSpeedData();

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.i
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.i
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -25,13 +26,8 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 
-%include "swig_conly_data.i"
-%include "std_vector.i"
-%include "std_string.i"
-%include "swig_eigen.i"
+%include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.i"
 
-%include "sys_model.i"
-%include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 %include "inertialAttitudeUkf.h"
 
 %include "architecture/msgPayloadDefCpp/FilterMsgPayload.h"

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
@@ -1,6 +1,7 @@
 # ISC License
 #
-# Copyright (c) 2024, University of Colorado at Boulder
+# Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+# University of Colorado at Boulder
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -19,7 +20,7 @@ import numpy as np
 import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import inertialAttitudeUkf
-from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion
+from Basilisk.utilities import SimulationBaseClass, macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
 
 starOnly = inertialAttitudeUkf.AttitudeFilterMethod_StarOnly
@@ -70,9 +71,8 @@ def setup_filter_data(filter_object):
     filter_object.setAlpha(0.02)
     filter_object.setBeta(2.0)
 
-    states = [0.05, 0.5, 0.1, 0.2, -0.05, 0.1]
-
-    filter_object.setInitialState([[s] for s in states])
+    filter_object.setInitialPosition([0.05, 0.5, 0.1])
+    filter_object.setInitialVelocity([0.2, -0.05, 0.1])
     filter_object.setInitialCovariance([[1, 0.0, 0.0, 0.0, 0.0, 0.0],
                                         [0.0, 1, 0.0, 0.0, 0.0, 0.0],
                                         [0.0, 0.0, 1, 0.0, 0.0, 0.0],
@@ -147,12 +147,12 @@ def test_propagation_kf(show_plots):
     rw_speeds = messaging.RWSpeedMsg().write(rw_speeds_data)
     intertialAttitudeFilter.rwSpeedMsg.subscribeTo(rw_speeds)
 
-    states = [0.05, 0.5, 0.1, -0.02, 0.005, -0.01]
-    intertialAttitudeFilter.setInitialState([[s] for s in states])
-    initState = intertialAttitudeFilter.getInitialState()
+    intertialAttitudeFilter.setInitialPosition([0.05, 0.5, 0.1])
+    intertialAttitudeFilter.setInitialVelocity([-0.02, 0.005, -0.01])
+    initState = [0.05, 0.5, 0.1, -0.02, 0.005, -0.01]
 
     st_1_data = messaging.STAttMsgPayload()
-    st_1_data.MRP_BdyInrtl = [initState[0][0], initState[1][0], initState[2][0]]
+    st_1_data.MRP_BdyInrtl = initState[:3]
     st_1_data.timeTag = 0
 
     star_tracker1 = inertialAttitudeUkf.StarTrackerMessage()
@@ -162,7 +162,7 @@ def test_propagation_kf(show_plots):
     intertialAttitudeFilter.addStarTrackerInput(star_tracker1)
 
     st_2_data = messaging.STAttMsgPayload()
-    st_2_data.MRP_BdyInrtl = [initState[0][0], initState[1][0], initState[2][0]]
+    st_2_data.MRP_BdyInrtl = initState[:3]
     st_2_data.timeTag = 0
 
     star_tracker2 = inertialAttitudeUkf.StarTrackerMessage()
@@ -180,7 +180,9 @@ def test_propagation_kf(show_plots):
 
     sim_time = 100
     time = np.linspace(0, sim_time, sim_time+1)
-    initial_condition = np.array(intertialAttitudeFilter.getInitialState()).reshape([6, ])
+    initial_condition = np.zeros(6)
+    initial_condition[:3] = np.array(intertialAttitudeFilter.getInitialPosition()).reshape(3)
+    initial_condition[3:] = np.array(intertialAttitudeFilter.getInitialVelocity()).reshape(3)
     expected = rk4(attitude_dynamics, time, initial_condition, np.array(I).reshape([3,3]))
 
     unit_test_sim.InitializeSimulation()
@@ -262,14 +264,16 @@ def test_measurements_kf(show_plots, initial_error, method):
     rw_speeds = messaging.RWSpeedMsg().write(rw_speeds_data)
     intertialAttitudeFilter.rwSpeedMsg.subscribeTo(rw_speeds)
 
-    initState = intertialAttitudeFilter.getInitialState()
+    initial_condition = np.zeros(6)
+    initial_condition[:3] = np.array(intertialAttitudeFilter.getInitialPosition()).reshape(3)
+    initial_condition[3:] = np.array(intertialAttitudeFilter.getInitialVelocity()).reshape(3)
 
     if initial_error:
-        states = [0, 0, 0, 0, 0, 0]
-        intertialAttitudeFilter.setInitialState([[s] for s in states])
+        intertialAttitudeFilter.setInitialPosition([0, 0, 0])
+        intertialAttitudeFilter.setInitialVelocity([0, 0, 0])
 
     st_1_data = messaging.STAttMsgPayload()
-    st_1_data.MRP_BdyInrtl = [initState[0][0], initState[1][0], initState[2][0]]
+    st_1_data.MRP_BdyInrtl = initial_condition[:3]
     st_1_data.timeTag = 0
 
     star_tracker1 = inertialAttitudeUkf.StarTrackerMessage()
@@ -279,7 +283,7 @@ def test_measurements_kf(show_plots, initial_error, method):
     intertialAttitudeFilter.addStarTrackerInput(star_tracker1)
 
     st_2_data = messaging.STAttMsgPayload()
-    st_2_data.MRP_BdyInrtl = [initState[0][0], initState[1][0], initState[2][0]]
+    st_2_data.MRP_BdyInrtl = initial_condition[:3]
     st_2_data.timeTag = 0
 
     star_tracker2 = inertialAttitudeUkf.StarTrackerMessage()
@@ -308,7 +312,6 @@ def test_measurements_kf(show_plots, initial_error, method):
     max_buffer_len = 120
     substeps = 50
     time = np.linspace(0, sim_time, substeps*sim_time+1)
-    initial_condition = np.array(initState).reshape([6, ])
     expected = np.zeros([len(time), 7])
     expected[:int(len(time)/2), :] = rk4(attitude_dynamics, time[:int(len(time)/2)], initial_condition,
                                          np.array(I).reshape([3,3]))

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/uKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/uKF_test_utilities.py
@@ -1,7 +1,8 @@
 #
 #  ISC License
 #
-# Copyright (c) 2024, University of Colorado at Boulder
+#  Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+#  University of Colorado at Boulder
 #
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
@@ -16,20 +17,14 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 import inspect
-import math
 import os
-import sys
-
 import numpy as np
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('fswAlgorithms')
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib.patches import Ellipse
 
 color_x = 'dodgerblue'
 color_y = 'salmon'

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/sunlineSRuKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/sunlineSRuKF_test_utilities.py
@@ -1,7 +1,8 @@
 #
 #  ISC License
 #
-# Copyright (c) 2024, University of Colorado at Boulder
+#  Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+#  University of Colorado at Boulder
 #
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
@@ -16,10 +17,7 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 import inspect
-import math
 import os
-import sys
-
 import numpy as np
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -1,6 +1,7 @@
 # ISC License
 #
-# Copyright (c) 2024, University of Colorado at Boulder
+# Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+# University of Colorado at Boulder
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -20,7 +21,7 @@ import numpy as np
 import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import sunlineSRuKF
-from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion
+from Basilisk.utilities import SimulationBaseClass, macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
 
 
@@ -70,9 +71,8 @@ def setup_filter_data(filter_object):
     filter_object.setAlpha(0.02)
     filter_object.setBeta(2.0)
 
-    states = [0.0, 0.0, 1.0, 0.02, -0.005, 0.01]
-
-    filter_object.setInitialState([[s] for s in states])
+    filter_object.setInitialPosition([0.0, 0.0, 1.0])
+    filter_object.setInitialVelocity([0.02, -0.005, 0.01])
     filter_object.setInitialCovariance([[0.0001, 0.0, 0.0, 0.0, 0.0, 0.0],
                                         [0.0, 0.0001, 0.0, 0.0, 0.0, 0.0],
                                         [0.0, 0.0, 0.0001, 0.0, 0.0, 0.0],
@@ -109,7 +109,6 @@ def setup_css_config_msg(CSSOrientationList, cssConfigDataInMsg):
 def test_propagation_kf(show_plots):
     state_propagation_flyby(show_plots)
 
-
 @pytest.mark.parametrize("initial_error", [False, True])
 def test_measurements_kf(show_plots, initial_error):
     state_update_flyby(initial_error, show_plots)
@@ -138,9 +137,11 @@ def state_propagation_flyby(show_plots=False):
     unit_test_sim.AddModelToTask(unit_task_name, sun_heading_data_log)
 
     simpleNavMsgData = messaging.NavAttMsgPayload()
-    initState = sunHeadingFilter.getInitialState()
+    initState = np.zeros(6)
+    initState[:3] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
+    initState[3:] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
     simpleNavMsgData.timeTag = 0
-    simpleNavMsgData.omega_BN_B = [initState[3][0], initState[4][0], initState[5][0]]
+    simpleNavMsgData.omega_BN_B = initState[3:]
     simpleNavMsg = messaging.NavAttMsg().write(simpleNavMsgData)
     sunHeadingFilter.navAttInMsg.subscribeTo(simpleNavMsg)
 
@@ -165,10 +166,11 @@ def state_propagation_flyby(show_plots=False):
     cssMsg = messaging.CSSArraySensorMsg().write(cssDataMsg)
     sunHeadingFilter.cssDataInMsg.subscribeTo(cssMsg)
 
-    sim_time = 5
-    time = np.linspace(0, 5, 6)
+    sim_time = 50
+    time = np.linspace(0, sim_time, sim_time+1)
     expected = np.zeros([len(time), 7])
-    expected[0, 1:] = np.array(sunHeadingFilter.getInitialState()).reshape([6, ])
+    expected[0, 1:4] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
+    expected[0, 4:7] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
     expected = rk4(sunline_dynamics, time, expected[0, 1:], normalizeState=True)
 
     unit_test_sim.InitializeSimulation()
@@ -188,7 +190,11 @@ def state_propagation_flyby(show_plots=False):
                                rtol=1E-10,
                                err_msg='state propagation error',
                                verbose=True)
-
+    diff = np.copy(state_data_log)
+    diff[:, 1:] -= expected[:, 1:]
+    if show_plots:
+        filter_plots.state_covar(state_data_log, covariance_data_log, 'Update').show()
+        filter_plots.states(diff, 'Update').show()
 
 def state_update_flyby(initial_error, show_plots=False):
     unit_task_name = "unitTask"  # arbitrary name (don't change)
@@ -207,9 +213,6 @@ def state_update_flyby(initial_error, show_plots=False):
 
     # Add test module to runtime call list
     setup_filter_data(sunHeadingFilter)
-    if initial_error:
-        states = [1.0, 0.0, 0.0, -0.02, 0.005, -0.01]
-        sunHeadingFilter.setInitialState([[s] for s in states])
     unit_test_sim.AddModelToTask(unit_task_name, sunHeadingFilter)
 
     sun_heading_data_log = sunHeadingFilter.filterOutMsg.recorder()
@@ -225,10 +228,12 @@ def state_update_flyby(initial_error, show_plots=False):
     unit_test_sim.AddModelToTask(unit_task_name, nav_att_data_log)
 
     simpleNavMsgData = messaging.NavAttMsgPayload()
-    initState = sunHeadingFilter.getInitialState()
-    simpleNavMsgData.timeTag = 0
-    simpleNavMsgData.omega_BN_B = [initState[3][0], initState[4][0], initState[5][0]]
-    simpleNavMsg = messaging.NavAttMsg()
+    initState = np.zeros(6)
+    initState[:3] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
+    initState[3:] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    simpleNavMsgData.timeTag = -1
+    simpleNavMsgData.omega_BN_B = initState[3:]
+    simpleNavMsg = messaging.NavAttMsg().write(simpleNavMsgData)
     sunHeadingFilter.navAttInMsg.subscribeTo(simpleNavMsg)
 
     CSSOrientationList = [
@@ -249,12 +254,17 @@ def state_update_flyby(initial_error, show_plots=False):
     sim_time = 1000
     time = np.linspace(0, sim_time, sim_time+1)
     expected = np.zeros([len(time), 7])
-    expected[0, 1:] = np.array([0.0, 0.0, 1.0, 0.02, -0.005, 0.01])
+    expected[0, 1:4] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
+    expected[0, 4:7] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
     expected = rk4(sunline_dynamics, time, expected[0, 1:], normalizeState=True)
 
     bodyFrame = np.zeros([len(time), 7])
     bodyFrame[0, 1:] = np.array([0.0, 0.0, 0.0, expected[0, 4], expected[0, 5], expected[0, 6]])
     bodyFrame = rk4(mrp_integration, time, bodyFrame[0, 1:], mrpShadow=True)
+
+    if initial_error:
+        sunHeadingFilter.setInitialPosition([1.0, 0.0, 0.0])
+        sunHeadingFilter.setInitialVelocity([-0.02, 0.005, -0.01])
 
     cssDataMsg = messaging.CSSArraySensorMsgPayload()
     cssMsg = messaging.CSSArraySensorMsg()
@@ -262,7 +272,6 @@ def state_update_flyby(initial_error, show_plots=False):
 
     cssSigma = sunHeadingFilter.getCssMeasurementNoiseStd()
     gyroSigma = sunHeadingFilter.getGyroMeasurementNoiseStd()
-
     unit_test_sim.InitializeSimulation()
     for i in range(0, len(time)-1):
         BN = rbk.MRP2C(bodyFrame[i, 1:4])
@@ -325,14 +334,14 @@ def state_update_flyby(initial_error, show_plots=False):
                                expected[half_time:, 1:4],
                                 rtol=1E-9,
                                 atol=5*cssSigma,
-                                err_msg='state propagation error',
+                                err_msg='heading estimation error',
                                 verbose=True)
     # testing that rate estimate is correct within 5 sigma
     np.testing.assert_allclose(state_data_log[half_time:, 4:],
                                 expected[half_time:, 4:],
                                rtol=1E-9,
                                atol=5*gyroSigma,
-                               err_msg='state propagation error',
+                               err_msg='rate estimation error',
                                verbose=True)
     # testing that covariance is shrinking
     np.testing.assert_array_less(np.diag(covariance_data_log[half_time, 1:].reshape([6, 6])),
@@ -343,13 +352,13 @@ def state_update_flyby(initial_error, show_plots=False):
     diff = np.copy(state_data_log)
     diff[:, 1:] -= expected[:, 1:]
     if show_plots:
-        plt_1 = filter_plots.state_covar(state_data_log, covariance_data_log, 'Update').show()
-        plt_2 = filter_plots.states(diff, 'Update').show()
-        plt_3 = filter_plots.post_fit_residuals(css_post_fit_log, cssSigma, 'Update CSS PreFit').show()
-        plt_4 = filter_plots.post_fit_residuals(css_pre_fit_log, cssSigma, 'Update CSS PostFit').show()
-        plt_5 = filter_plots.post_fit_residuals(gyro_post_fit_log, gyroSigma, 'Update Gyro PreFit').show()
-        plt_6 = filter_plots.post_fit_residuals(gyro_pre_fit_log, gyroSigma, 'Update Gyro PostFit').show()
+        filter_plots.state_covar(state_data_log, covariance_data_log, 'Update').show()
+        filter_plots.states(diff, 'Update').show()
+        filter_plots.post_fit_residuals(css_post_fit_log, cssSigma, 'Update CSS PreFit').show()
+        filter_plots.post_fit_residuals(css_pre_fit_log, cssSigma, 'Update CSS PostFit').show()
+        filter_plots.post_fit_residuals(gyro_post_fit_log, gyroSigma, 'Update Gyro PreFit').show()
+        filter_plots.post_fit_residuals(gyro_pre_fit_log, gyroSigma, 'Update Gyro PostFit').show()
 
 
 if __name__ == "__main__":
-    state_update_flyby(False, False)
+    state_update_flyby(True, True)

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -19,10 +20,6 @@
 
 #include "sunlineSRuKF.h"
 
-SunlineSRuKF::SunlineSRuKF() = default;
-
-SunlineSRuKF::~SunlineSRuKF() = default;
-
 /*! Initialize C-wrapped output messages */
 void SunlineSRuKF::SelfInit(){
     NavAttMsg_C_init(&this->navAttOutMsgC);
@@ -34,6 +31,7 @@ void SunlineSRuKF::SelfInit(){
  @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
  */
 void SunlineSRuKF::customReset() {
+    this->setFilterDynamics(SunlineSRuKF::stateDerivative);
     /*! - Check if the required messages have been connected */
     assert(this->cssDataInMsg.isLinked());
     assert(this->cssConfigInMsg.isLinked());
@@ -48,7 +46,9 @@ void SunlineSRuKF::customReset() {
  @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
  */
 void SunlineSRuKF::customFinalizeUpdate() {
-    this->state.head(3).normalize();
+    PositionState heading;
+    heading.setValues(this->state.getPositionStates().normalized());
+    this->state.setPosition(heading);
 }
 
 /*! Read the message containing the measurement data.
@@ -62,39 +62,41 @@ void SunlineSRuKF::writeOutputMessages(uint64_t CurrentSimNanos) {
     FilterResidualsMsgPayload filterCssResMsgBuffer = this->filterCssResOutMsg.zeroMsgPayload;
 
     /*! - Write the sunline estimate into the copy of the navigation message structure*/
-    eigenMatrixXd2CArray(this->state.head(3), navAttOutMsgBuffer.vehSunPntBdy);
+    eigenMatrixXd2CArray(this->state.getPositionStates(), navAttOutMsgBuffer.vehSunPntBdy);
 
     /*! - Populate the filter states output buffer and write the output message*/
     filterMsgBuffer.timeTag = this->previousFilterTimeTag;
-    eigenMatrixXd2CArray(1/this->unitConversion*this->state, filterMsgBuffer.state);
-    eigenMatrixXd2CArray(1/this->unitConversion*this->xBar, filterMsgBuffer.stateError);
-    eigenMatrixXd2CArray(1/this->unitConversion/this->unitConversion*this->covar, filterMsgBuffer.covar);
+    eigenMatrixXd2CArray(this->state.returnValues(), filterMsgBuffer.state);
+    eigenMatrixXd2CArray(this->xBar.returnValues(), filterMsgBuffer.stateError);
+    eigenMatrixXd2CArray(this->covar, filterMsgBuffer.covar);
     filterMsgBuffer.numberOfStates = this->state.size();
 
-    auto optionalMeasurement = this->measurements[0];
-    if (optionalMeasurement.has_value() && optionalMeasurement->name == "gyro") {
-        auto measurement = Measurement();
-        measurement = optionalMeasurement.value();
-        filterGyroResMsgBuffer.valid = true;
-        filterGyroResMsgBuffer.numberOfObservations = 1;
-        filterGyroResMsgBuffer.sizeOfObservations = measurement.observation.size();
-        eigenMatrixXd2CArray(measurement.observation, &filterGyroResMsgBuffer.observation[0]);
-        eigenMatrixXd2CArray(measurement.postFitResiduals, &filterGyroResMsgBuffer.postFits[0]);
-        eigenMatrixXd2CArray(measurement.preFitResiduals, &filterGyroResMsgBuffer.preFits[0]);
-        this->measurements[0].reset();
+    int i = 0;
+    for(auto optionalMeasurement : this->measurements){
+        if (optionalMeasurement.has_value() && optionalMeasurement->getMeasurementName() == "gyro") {
+            auto measurement = MeasurementModel();
+            measurement = optionalMeasurement.value();
+            filterGyroResMsgBuffer.valid = true;
+            filterGyroResMsgBuffer.numberOfObservations = 1;
+            filterGyroResMsgBuffer.sizeOfObservations = measurement.size();
+            eigenMatrixXd2CArray(measurement.getObservation(), &filterGyroResMsgBuffer.observation[0]);
+            eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &filterGyroResMsgBuffer.postFits[0]);
+            eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &filterGyroResMsgBuffer.preFits[0]);
+        }
+        else if (optionalMeasurement.has_value() && optionalMeasurement->getMeasurementName() == "css") {
+            auto measurement = MeasurementModel();
+            measurement = optionalMeasurement.value();
+            filterCssResMsgBuffer.valid = true;
+            filterCssResMsgBuffer.numberOfObservations = 1;
+            filterCssResMsgBuffer.sizeOfObservations = measurement.size();
+            eigenMatrixXd2CArray(measurement.getObservation(), &filterCssResMsgBuffer.observation[0]);
+            eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &filterCssResMsgBuffer.postFits[0]);
+            eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &filterCssResMsgBuffer.preFits[0]);
+        }
+        this->measurements[i].reset();
+        i += 1;
     }
-    optionalMeasurement = this->measurements[1];
-    if (optionalMeasurement.has_value() && optionalMeasurement->name == "css") {
-        auto measurement = Measurement();
-        measurement = optionalMeasurement.value();
-        filterCssResMsgBuffer.valid = true;
-        filterCssResMsgBuffer.numberOfObservations = 1;
-        filterCssResMsgBuffer.sizeOfObservations = measurement.observation.size();
-        eigenMatrixXd2CArray(measurement.observation, &filterCssResMsgBuffer.observation[0]);
-        eigenMatrixXd2CArray(measurement.postFitResiduals, &filterCssResMsgBuffer.postFits[0]);
-        eigenMatrixXd2CArray(measurement.preFitResiduals, &filterCssResMsgBuffer.preFits[0]);
-        this->measurements[1].reset();
-    }
+
 
     this->navAttOutMsg.write(&navAttOutMsgBuffer, this->moduleID, CurrentSimNanos);
     NavAttMsg_C_write(&navAttOutMsgBuffer, &this->navAttOutMsgC, this->moduleID, CurrentSimNanos);
@@ -110,18 +112,16 @@ void SunlineSRuKF::readGyroMeasurements() {
     /*! Read rate gyro measurements */
     NavAttMsgPayload navAttInputBuffer = this->navAttInMsg();
 
-    auto gyroMeasurements = Measurement();
-    gyroMeasurements.validity = true;
-    gyroMeasurements.name = "gyro";
-    gyroMeasurements.size = 3;
-    gyroMeasurements.timeTag = navAttInputBuffer.timeTag;
-    gyroMeasurements.observation = cArray2EigenVector3d(navAttInputBuffer.omega_BN_B);
-    gyroMeasurements.model = lastThreeStates;
-    gyroMeasurements.noise.resize(3, 3);
-    Eigen::MatrixXd I = Eigen::Matrix3d::Identity();
-    gyroMeasurements.noise = pow(this->measNoiseScaling * this->gyroMeasNoiseStd, 2) * I;
+    if (navAttInputBuffer.timeTag >= this->previousFilterTimeTag){
+        auto gyroMeasurements = MeasurementModel();
+        gyroMeasurements.setValidity(true);
+        gyroMeasurements.setMeasurementName("gyro");
+        gyroMeasurements.setTimeTag(navAttInputBuffer.timeTag);
+        gyroMeasurements.setObservation(cArray2EigenVector3d(navAttInputBuffer.omega_BN_B));
+        gyroMeasurements.setMeasurementModel(MeasurementModel::velocityStates);
+        Eigen::MatrixXd I = Eigen::Matrix3d::Identity();
+        gyroMeasurements.setMeasurementNoise(this->measNoiseScaling * pow(this->gyroMeasNoiseStd, 2) * I);
 
-    if (gyroMeasurements.validity && gyroMeasurements.timeTag >= this->previousFilterTimeTag){
         /*! - Read measurement and cholesky decomposition its noise*/
         this->measurements[this->filterMeasurement] = gyroMeasurements;
         this->filterMeasurement += 1;
@@ -134,14 +134,15 @@ void SunlineSRuKF::readGyroMeasurements() {
 void SunlineSRuKF::readCssMeasurements() {
     /*! Read css data msg */
     CSSArraySensorMsgPayload cssInputBuffer = this->cssDataInMsg();
-
-    auto cssMeasurements = Measurement();
+    auto cssMeasurements = MeasurementModel();
+    cssMeasurements.setValidity(false);
 
     /*! - Zero the observed active CSS count */
     this->numActiveCss = 0;
 
     /*! - Define the linear model matrix H */
-    Eigen::MatrixXd H;
+    Eigen::MatrixXd hMatrix;
+    Eigen::VectorXd cssObservation;
 
     /*! - Loop over the maximum number of sensors to check for good measurements */
     /*! -# Isolate if measurement is good */
@@ -154,31 +155,32 @@ void SunlineSRuKF::readCssMeasurements() {
     {
         if (cssInputBuffer.CosValue[i] > this->sensorUseThresh)
         {
-            cssMeasurements.validity = true;
-            cssMeasurements.timeTag = cssInputBuffer.timeTag;
-            cssMeasurements.observation.conservativeResize(this->numActiveCss+1);
-            cssMeasurements.observation(this->numActiveCss) = cssInputBuffer.CosValue[i];
-            H.conservativeResize(this->numActiveCss+1, 3);
+            cssMeasurements.setValidity(true);
+            cssObservation.conservativeResize(this->numActiveCss+1);
+            cssObservation(this->numActiveCss) = cssInputBuffer.CosValue[i];
+            hMatrix.conservativeResize(this->numActiveCss+1, 3);
             for (int j=0; j<3; ++j) {
-                H(this->numActiveCss,j) = this->cssConfigInputBuffer.cssVals[i].CBias * this->cssConfigInputBuffer.cssVals[i].nHat_B[j];
+                hMatrix(this->numActiveCss,j) = this->cssConfigInputBuffer.cssVals[i].CBias *
+                        this->cssConfigInputBuffer.cssVals[i].nHat_B[j];
             }
-            cssMeasurements.noise.resize(this->numActiveCss+1, this->numActiveCss+1);
-            Eigen::MatrixXd I(this->numActiveCss+1, this->numActiveCss+1);
-            I.setIdentity();
-            cssMeasurements.noise = pow(this->measNoiseScaling * this->cssMeasNoiseStd, 2) * I;
+            cssMeasurements.setTimeTag(cssInputBuffer.timeTag);
             this->numActiveCss += 1;
         }
     }
-    cssMeasurements.size = this->numActiveCss;
 
-    std::function<const Eigen::VectorXd(const Eigen::VectorXd)> linearModel = [H](const Eigen::VectorXd &state) {
-        return H * state.head(3);
+    std::function<const Eigen::VectorXd(const StateVector)> linearModel = [hMatrix](const StateVector &state) {
+        Eigen::VectorXd observed = hMatrix * state.getPositionStates();
+        return observed;
     };
 
-    if (cssMeasurements.validity && cssMeasurements.timeTag >= this->previousFilterTimeTag){
+    if (cssMeasurements.getValidity() && cssMeasurements.getTimeTag() >= this->previousFilterTimeTag){
         /*! - Read measurement and cholesky decomposition its noise*/
-        cssMeasurements.model = linearModel;
-        cssMeasurements.name = "css";
+        Eigen::MatrixXd I(this->numActiveCss, this->numActiveCss);
+        I.setIdentity();
+        cssMeasurements.setMeasurementNoise(this->measNoiseScaling * pow(this->cssMeasNoiseStd, 2) * I);
+        cssMeasurements.setObservation(cssObservation);
+        cssMeasurements.setMeasurementModel(linearModel);
+        cssMeasurements.setMeasurementName("css");
         this->measurements[this->filterMeasurement] = cssMeasurements;
         this->filterMeasurement += 1;
     }
@@ -196,40 +198,28 @@ void SunlineSRuKF::readFilterMeasurements() {
     this->readCssMeasurements();
 }
 
-/*! Integrate the equations of motion of two body point mass gravity using Runge-Kutta 4 (RK4)
-    @param interval integration interval
-    @param X0 initial state
-    @param dt time step
-    @return Eigen::VectorXd
-*/
-Eigen::VectorXd SunlineSRuKF::propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt){
-    double t_0 = interval[0];
-    double t_f = interval[1];
-    double t = t_0;
-    Eigen::VectorXd X = X0;
+/*! Define the equations of motion for the filter dynamics
+    @param double time
+    @return StateVector inputState
+    @return StateVector outputState
+    */
+StateVector SunlineSRuKF::stateDerivative(const double t, const StateVector &state){
+    StateVector XDot;
+    /*! Implement propagation with rate derivatives set to zero */
+    Eigen::Vector3d sHat  = state.getPositionStates();
+    Eigen::Vector3d omega = state.getVelocityStates();
 
-    std::function<Eigen::VectorXd(double, Eigen::VectorXd)> stateDerivative = [](double t, Eigen::VectorXd state)
-    {
-        Eigen::VectorXd XDot(state.size());
-        /*! Implement propagation with rate derivatives set to zero */
-        Eigen::Vector3d sHat  = state.segment(0, 3);
-        Eigen::Vector3d omega = state.segment(3, 3);
-        XDot.segment(0,3) = sHat.cross(omega);
-        XDot.segment(3,3).setZero();
+    PositionState xDotPosition;
+    VelocityState xDotVelocity;
 
-        return XDot;
-    };
+    xDotPosition.setValues(sHat.cross(omega));
+    xDotVelocity.setValues(Eigen::VectorXd::Zero(3));
 
-    /*! Propagate to t_final with an RK4 integrator */
-    double N = ceil((t_f-t_0)/dt);
-    for (int c=0; c < N; c++) {
-        double step = std::min(dt,t_f-t);
-        X = this->rk4(stateDerivative, X, t, step);
-        t = t + step;
-    }
+    XDot.setPosition(xDotPosition);
+    XDot.setVelocity(xDotVelocity);
 
-    return X;
-}
+    return XDot;
+};
 
 /*! Set the CSS measurement noise
     @param double cssMeasurementNoise
@@ -245,14 +235,6 @@ void SunlineSRuKF::setCssMeasurementNoiseStd(const double cssMeasurementNoiseStd
     */
 void SunlineSRuKF::setGyroMeasurementNoiseStd(const double gyroMeasurementNoiseStd) {
     this->gyroMeasNoiseStd = gyroMeasurementNoiseStd;
-}
-
-/*! Set the filter measurement noise scale factor if desirable
-    @param double measurementNoiseScale
-    @return void
-    */
-void SunlineSRuKF::setMeasurementNoiseScale(const double measurementNoiseScale) {
-    this->measNoiseScaling = measurementNoiseScale;
 }
 
 /*! Get the CSS measurement noise
@@ -271,9 +253,17 @@ double SunlineSRuKF::getGyroMeasurementNoiseStd() const {
     return this->gyroMeasNoiseStd;
 }
 
-/*! Get the filter measurement noise scale factor
-    @return double measNoiseScaling
+/*! Set the threshold value to accept a css measurement
+    @param double threshold
+    @return void
     */
-double SunlineSRuKF::getMeasurementNoiseScale() const {
-    return this->measNoiseScaling;
+void SunlineSRuKF::setSensorThreshold(double threshold){
+    this->sensorUseThresh = threshold;
+}
+
+/*! Get the threshold value to accept a css measurement
+    @return double threshold
+    */
+double SunlineSRuKF::getSensorThreshold() const{
+    return this->sensorUseThresh;
 }

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -37,23 +38,22 @@
 
 class SunlineSRuKF: public SRukfInterface {
 public:
-    SunlineSRuKF();
-    ~SunlineSRuKF() override;
-    void SelfInit() override;                 //!< Self initialization for C-wrapped messages
+    SunlineSRuKF() = default;
+    ~SunlineSRuKF() = default;
 
 private:
-    void customReset() override;
+    void SelfInit() final;
+    void customReset() final;
     void readCssMeasurements();
     void readGyroMeasurements();
-    void readFilterMeasurements() override;
-    void customFinalizeUpdate() override;
-    void writeOutputMessages(uint64_t CurrentSimNanos) override;
-    Eigen::VectorXd propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt) override;
+    void readFilterMeasurements() final;
+    void customFinalizeUpdate() final;
+    void writeOutputMessages(uint64_t CurrentSimNanos) final;
+    static StateVector stateDerivative(double t, const StateVector &state);
 
     int filterMeasurement = 0;   //!< [-] Number of measurements of different types being read
     int numActiveCss = 0;        //!< [-] Number of currently active CSS sensors
     double sensorUseThresh = 0;  //!< Threshold below which we discount sensors
-    double measNoiseScaling = 1; //!< [s] Scale factor that can be applied on the measurement noise to over/under weight
     double cssMeasNoiseStd = 0;  //!< [-] CSS measurement noise std
     double gyroMeasNoiseStd = 0; //!< [rad/s] rate gyro measurement noise std
     CSSConfigMsgPayload cssConfigInputBuffer;
@@ -68,12 +68,12 @@ public:
     Message<FilterResidualsMsgPayload>    filterGyroResOutMsg;
     Message<FilterResidualsMsgPayload>    filterCssResOutMsg;
 
-    void setCssMeasurementNoiseStd(const double cssMeasurementNoiseStd);
-    void setGyroMeasurementNoiseStd(const double gyroMeasurementNoiseStd);
-    void setMeasurementNoiseScale(const double measurementNoiseScale);
+    void setCssMeasurementNoiseStd(double cssMeasurementNoiseStd);
+    void setGyroMeasurementNoiseStd(double gyroMeasurementNoiseStd);
     double getCssMeasurementNoiseStd() const;
     double getGyroMeasurementNoiseStd() const;
-    double getMeasurementNoiseScale() const;
+    void setSensorThreshold(double threshold);
+    double getSensorThreshold() const;
 
 };
 

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.i
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.i
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -25,13 +26,8 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 
-%include "swig_conly_data.i"
-%include "std_vector.i"
-%include "std_string.i"
-%include "swig_eigen.i"
+%include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.i"
 
-%include "sys_model.i"
-%include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 %include "sunlineSRuKF.h"
 
 %include "architecture/msgPayloadDefC/NavAttMsgPayload.h"

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/_UnitTest/flybyODuKF_test_utilities.py
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/_UnitTest/flybyODuKF_test_utilities.py
@@ -1,7 +1,8 @@
 #
 #  ISC License
 #
-# Copyright (c) 2024, University of Colorado at Boulder
+#  Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+#  University of Colorado at Boulder
 #
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
@@ -16,10 +17,7 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 import inspect
-import math
 import os
-import sys
-
 import numpy as np
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/_UnitTest/test_flybyODuKF.py
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/_UnitTest/test_flybyODuKF.py
@@ -1,6 +1,7 @@
 # ISC License
 #
-# Copyright (c) 2024, University of Colorado at Boulder
+# Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+# University of Colorado at Boulder
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -64,9 +65,9 @@ def setup_filter_data(filter_object):
     orbital_elements.omega = 0.01
     orbital_elements.f = 0.1
     r, v = orbitalMotion.elem2rv(filter_object.getCentralBodyGravitationParameter(), orbital_elements)
-    states = r.tolist() + v.tolist()
 
-    filter_object.setInitialState([[s] for s in states])
+    filter_object.setInitialPosition(r)
+    filter_object.setInitialVelocity(v)
     filter_object.setInitialCovariance([[1000. * 1E6, 0.0, 0.0, 0.0, 0.0, 0.0],
                                         [0.0, 1000. * 1E6, 0.0, 0.0, 0.0, 0.0],
                                         [0.0, 0.0, 1000. * 1E6, 0.0, 0.0, 0.0],
@@ -126,7 +127,8 @@ def state_update_flyby(show_plots):
     time = np.linspace(0, int(multT1 * t1), int(multT1 * t1 // dt) + 1)
     energy = np.zeros(len(time))
     expected = np.zeros([len(time), 7])
-    expected[0, 1:] = np.array(flyby_module.getInitialState()).reshape([6, ])
+    expected[0, 1:4] = np.array(flyby_module.getInitialPosition()).reshape(3)
+    expected[0, 4:7] = np.array(flyby_module.getInitialVelocity()).reshape(3)
     energy[0] = -flyby_module.getCentralBodyGravitationParameter() / (2 * orbitalMotion.rv2elem(
         flyby_module.getCentralBodyGravitationParameter(), expected[0, 1:4], expected[0, 4:]).a)
 
@@ -246,7 +248,8 @@ def state_propagation_flyby(show_plots, dt):
     dydt = np.zeros(6)
     energy = np.zeros(len(time))
     expected = np.zeros([len(time), 7])
-    expected[0, 1:] = np.array(flyby_module.getInitialState()).reshape([6, ])
+    expected[0, 1:4] = np.array(flyby_module.getInitialPosition()).reshape(3)
+    expected[0, 4:7] = np.array(flyby_module.getInitialVelocity()).reshape(3)
     energy[0] = -flyby_module.getCentralBodyGravitationParameter() / (2 * orbitalMotion.rv2elem(
         flyby_module.getCentralBodyGravitationParameter(), expected[0, 1:4], expected[0, 4:]).a)
     expected = rk4(two_body_gravity, time, expected[0, 1:])

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.cpp
@@ -1,12 +1,13 @@
 /*
  ISC License
- 
- Copyright (c) 2024, University of Colorado at Boulder
- 
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,14 +15,10 @@
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
+
  */
 
 #include "flybyODuKF.h"
-
-FlybyODuKF::FlybyODuKF() = default;
-
-FlybyODuKF::~FlybyODuKF() = default;
 
 /*! Reset the flyby OD filter to an initial state and
  initializes the internal estimation matrices.
@@ -31,9 +28,26 @@ FlybyODuKF::~FlybyODuKF() = default;
 void FlybyODuKF::customReset() {
     /*! - Check if the required message has not been connected */
     assert(this->opNavHeadingMsg.isLinked());
-
     /*! - Initialize filter parameters and change units to km and s */
     this->muCentral *= pow(this->unitConversion, 3); // mu is input in meters
+    double centralBody = this->muCentral;
+    std::function<StateVector(double, const StateVector)> twoBodyDynamics = [centralBody](double t, const StateVector &state){
+        StateVector XDot;
+        /*! Implement propagation with rate derivatives set to zero */
+        /*! Implement point mass gravity for the propagation */
+        PositionState flybyPosition;
+        VelocityState flybyVelocity;
+        flybyPosition.setValues(state.getVelocityStates());
+        flybyVelocity.setValues(-centralBody/(pow(state.getPositionStates().norm(),3)) * state.getPositionStates());
+
+        XDot.setPosition(flybyPosition);
+        XDot.setVelocity(flybyVelocity);
+
+        return XDot;
+    };
+
+    /*! - Set the filter dynamics */
+    this->dynamics.setDynamics(twoBodyDynamics);
 }
 
 /*! Read the message containing the measurement data.
@@ -46,26 +60,26 @@ void FlybyODuKF::writeOutputMessages(uint64_t CurrentSimNanos) {
     FilterResidualsMsgPayload residualsBuffer = this->opNavResidualMsg.zeroMsgPayload;
 
     /*! - Write the flyby OD estimate into the copy of the navigation message structure*/
-    eigenMatrixXd2CArray(1/this->unitConversion*this->state.head(3), navTransOutMsgBuffer.r_BN_N);
-    eigenMatrixXd2CArray(1/this->unitConversion*this->state.tail(3), navTransOutMsgBuffer.v_BN_N);
+    eigenMatrixXd2CArray(this->state.scale(1/this->unitConversion).getPositionStates(), navTransOutMsgBuffer.r_BN_N);
+    eigenMatrixXd2CArray(this->state.scale(1/this->unitConversion).getVelocityStates(), navTransOutMsgBuffer.v_BN_N);
 
     /*! - Populate the filter states output buffer and write the output message*/
     opNavFilterMsgBuffer.timeTag = this->previousFilterTimeTag;
-    eigenMatrixXd2CArray(1/this->unitConversion*this->state, opNavFilterMsgBuffer.state);
-    eigenMatrixXd2CArray(1/this->unitConversion*this->xBar, opNavFilterMsgBuffer.stateError);
+    eigenMatrixXd2CArray(this->state.scale(1/this->unitConversion).returnValues(), opNavFilterMsgBuffer.state);
+    eigenMatrixXd2CArray(this->xBar.scale(1/this->unitConversion).returnValues(), opNavFilterMsgBuffer.stateError);
     eigenMatrixXd2CArray(1/this->unitConversion/this->unitConversion*this->covar, opNavFilterMsgBuffer.covar);
     opNavFilterMsgBuffer.numberOfStates = this->state.size();
 
     auto optionalMeasurement = this->measurements[0];
     if (optionalMeasurement.has_value()) {
-        auto measurement = Measurement();
+        auto measurement = MeasurementModel();
         measurement = optionalMeasurement.value();
         residualsBuffer.valid = true;
         residualsBuffer.numberOfObservations = 1;
-        residualsBuffer.sizeOfObservations = measurement.observation.size();
-        eigenMatrixXd2CArray(measurement.observation, &residualsBuffer.observation[0]);
-        eigenMatrixXd2CArray(measurement.postFitResiduals, &residualsBuffer.postFits[0]);
-        eigenMatrixXd2CArray(measurement.preFitResiduals, &residualsBuffer.preFits[0]);
+        residualsBuffer.sizeOfObservations = measurement.getObservation().size();
+        eigenMatrixXd2CArray(measurement.getObservation(), &residualsBuffer.observation[0]);
+        eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &residualsBuffer.postFits[0]);
+        eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &residualsBuffer.preFits[0]);
         this->measurements[0].reset();
     }
     this->opNavResidualMsg.write(&residualsBuffer, this->moduleID, CurrentSimNanos);
@@ -79,70 +93,21 @@ void FlybyODuKF::writeOutputMessages(uint64_t CurrentSimNanos) {
  */
 void FlybyODuKF::readFilterMeasurements() {
     this->opNavHeadingBuffer = this->opNavHeadingMsg();
-    auto headingMeasurement = Measurement();
+    auto headingMeasurement = MeasurementModel();
 
-    headingMeasurement.timeTag = this->opNavHeadingBuffer.timeTag;
-    headingMeasurement.validity = this->opNavHeadingBuffer.valid;
+    headingMeasurement.setTimeTag(this->opNavHeadingBuffer.timeTag);
+    headingMeasurement.setValidity(this->opNavHeadingBuffer.valid);
 
-    if (headingMeasurement.validity && headingMeasurement.timeTag >= this->previousFilterTimeTag){
+    if (headingMeasurement.getValidity() && headingMeasurement.getTimeTag() >= this->previousFilterTimeTag){
         /*! - Read measurement and cholesky decomposition its noise*/
-        headingMeasurement.observation = cArray2EigenVector3d(this->opNavHeadingBuffer.rhat_BN_N);
-        headingMeasurement.observation.normalize();
-        headingMeasurement.size = 3;
-        headingMeasurement.noise = this->measNoiseScaling * cArray2EigenMatrixXd(this->opNavHeadingBuffer.covar_N,
-                                                                               (int) headingMeasurement.size,
-                                                                               (int) headingMeasurement.size);
-        headingMeasurement.model = normalizedFirstThreeStates;
+        headingMeasurement.setObservation(cArray2EigenVector3d(this->opNavHeadingBuffer.rhat_BN_N));
+        headingMeasurement.getObservation().normalize();
+        headingMeasurement.setMeasurementNoise(this->measNoiseScaling * cArray2EigenMatrixXd(this->opNavHeadingBuffer.covar_N,
+                                                                               (int) headingMeasurement.size(),
+                                                                               (int) headingMeasurement.size()));
+        headingMeasurement.setMeasurementModel(MeasurementModel::normalizedPositionStates);
         this->measurements[0] = headingMeasurement;
     }
-}
-
-/*! Integrate the equations of motion of two body point mass gravity using Runge-Kutta 4 (RK4)
-    @param interval integration interval
-    @param X0 initial state
-    @param dt time step
-    @return Eigen::VectorXd
-*/
-Eigen::VectorXd FlybyODuKF::propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt){
-    double t_0 = interval[0];
-    double t_f = interval[1];
-    double t = t_0;
-    Eigen::VectorXd X = X0;
-
-    std::function<Eigen::VectorXd(double, Eigen::VectorXd)> twoBodyDynamics = [this](double t, Eigen::VectorXd state)
-    {
-        Eigen::VectorXd stateDerivative(state.size());
-        /*! Implement point mass gravity for the propagation */
-        stateDerivative.segment(0,3) = state.segment(3, 3);
-        stateDerivative.segment(3,3) = - this->muCentral/(pow(state.head(3).norm(),3)) * state.head(3);
-
-        return stateDerivative;
-    };
-
-    /*! Propagate to t_final with an RK4 integrator */
-    double N = ceil((t_f-t_0)/dt);
-    for (int c=0; c < N; c++) {
-        double step = std::min(dt,t_f-t);
-        X = this->rk4(twoBodyDynamics, X, t, step);
-        t = t + step;
-    }
-
-    return X;
-}
-
-/*! Set the filter measurement noise scale factor if desirable
-    @param double measurementNoiseScale
-    @return void
-    */
-void FlybyODuKF::setMeasurementNoiseScale(const double measurementNoiseScale) {
-    this->measNoiseScaling = measurementNoiseScale;
-}
-
-/*! Get the filter measurement noise scale factor
-    @return double measNoiseScaling
-    */
-double FlybyODuKF::getMeasurementNoiseScale() const {
-    return this->measNoiseScaling;
 }
 
 /*! Set the gravitational parameter used for orbit propagation

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.h
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.h
@@ -1,12 +1,13 @@
 /*
  ISC License
- 
- Copyright (c) 2024, University of Colorado at Boulder
- 
+
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
  copyright notice and this permission notice appear in all copies.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,9 +15,8 @@
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- 
- */
 
+ */
 
 /*! @brief Top level structure for the flyby OD unscented kalman filter.
  Used to estimate the spacecraft's inertial position relative to a body.
@@ -34,19 +34,19 @@
 #include "architecture/msgPayloadDefCpp/FilterMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/FilterResidualsMsgPayload.h"
 
+#include "fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h"
 #include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 #include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
 
 class FlybyODuKF: public SRukfInterface {
 public:
-    FlybyODuKF();
-    ~FlybyODuKF() override;
+    FlybyODuKF() = default;
+    ~FlybyODuKF() = default;
 
 private:
-    void customReset() override;
-    void readFilterMeasurements() override;
-    void writeOutputMessages(uint64_t CurrentSimNanos) override;
-    Eigen::VectorXd propagate(std::array<double, 2> interval, const Eigen::VectorXd& X0, double dt) override;
+    void customReset() final;
+    void readFilterMeasurements() final;
+    void writeOutputMessages(uint64_t CurrentSimNanos) final;
 
 public:
     ReadFunctor<OpNavUnitVecMsgPayload> opNavHeadingMsg;
@@ -55,15 +55,11 @@ public:
     Message<FilterMsgPayload> opNavFilterMsg;
     Message<FilterResidualsMsgPayload> opNavResidualMsg;
 
-    void setMeasurementNoiseScale(const double measurementNoiseScale);
-    double getMeasurementNoiseScale() const ;
-    void setCentralBodyGravitationParameter(const double mu);
+    void setCentralBodyGravitationParameter(double mu);
     double getCentralBodyGravitationParameter() const ;
-
 
 private:
 
-    double measNoiseScaling = 1; //!< [s] Scale factor that can be applied on the measurement noise to over/under weight
     double muCentral = 1; //!< [GM] gravitation parameter of central body
 };
 

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.i
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.i
@@ -1,7 +1,8 @@
 /*
  ISC License
 
- Copyright (c) 2024, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -25,13 +26,8 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 
-%include "swig_conly_data.i"
-%include "std_vector.i"
-%include "std_string.i"
-%include "swig_eigen.i"
+%include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.i"
 
-%include "sys_model.i"
-%include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 %include "flybyODuKF.h"
 
 %include "architecture/msgPayloadDefC/NavTransMsgPayload.h"


### PR DESCRIPTION
* **Tickets addressed:** bsk-830-892-912
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Refactor the current filter architecture classes. The primary goal is to strongly type the states in order to be able to identify different components to the state vector, all the while gathering main functionalities in interfaces to minimize code duplication and facilitate testing.

The first commit creates a kalman filter interface
The second commits create or refactor the state, measurement, and dynamics classes which are implemented in set in filter implementations
The rest of the commits refactor existing filter under this interface, removing a lot of fields from the modules
Verification

## Verification
All unit tests were nearly unchanged and still pass

## Documentation
Documentation was updated and new files were added

## Future work

This approach could extend to the covariance, which is a bit more involved to type according to the state given the cross correlations


