### PR TITLE
Hotfix/ekf units asserts

### DIFF
--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -110,7 +110,8 @@ void EkfInterface::measurementUpdate(const MeasurementModel &measurement)
 
     /*! - Update the covariance */
     EkfInterface::updateCovariance(measurementMatrix, measurement.getMeasurementNoise(), kalmanGain);
-    if (this->covar.maxCoeff() > this->minCovarNorm || this->filterType == FilterType::Classical){
+    if ((this->covar.maxCoeff() > this->minCovarNorm && this->filterType == FilterType::Extended) ||
+    this->filterType == FilterType::Classical){
         /*! - Compute the update with a CKF if the covariance is high at the time of the update to avoid divergence*/
         EkfInterface::ckfUpdate(kalmanGain, measurementDelta, measurementMatrix);
     }

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -205,9 +205,6 @@ void EkfInterface::setFilterDynamicsMatrix(const std::function<const Eigen::Matr
     @return void
     */
 void EkfInterface::setMinimumCovarianceNormForEkf(const double infiniteNorm){
-    assert(this->filterType == FilterType::Extended && "EKF minimum norm set in a Classical implementation: this is "
-                                                        "only used in an extended kalman filter to temporarily use "
-                                                        "linear updates when the covariance is high");
     this->minCovarNorm = infiniteNorm;
 }
 
@@ -215,8 +212,5 @@ void EkfInterface::setMinimumCovarianceNormForEkf(const double infiniteNorm){
     @return double infiniteNorm
     */
 double EkfInterface::getMinimumCovarianceNormForEkf() const {
-    assert(this->filterType == FilterType::Extended && "EKF minimum norm requested in a Classical implementation: "
-                                                        "this is only used in an extended kalman filter to temporarily "
-                                                        "use linear updates when the covariance is high");
     return this->minCovarNorm/this->unitConversion/this->unitConversion;
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -40,7 +40,7 @@ void EkfInterface::Reset(uint64_t currentSimNanos)
     else {
         this->processNoise.resize(this->state.getPositionStates().size(), this->state.getPositionStates().size());
     }
-
+    this->minCovarNorm = this->minCovarNorm*this->unitConversion*this->unitConversion;
     this->customReset();
 }
 
@@ -217,5 +217,5 @@ double EkfInterface::getMinimumCovarianceNormForEkf() const {
     assert(this->filterType == FilterType::Extended && "EKF minimum norm requested in a Classical implementation: "
                                                         "this is only used in an extended kalman filter to temporarily "
                                                         "use linear updates when the covariance is high");
-    return this->minCovarNorm;
+    return this->minCovarNorm/this->unitConversion/this->unitConversion;
 }


### PR DESCRIPTION
* **Tickets addressed:** bsk-1122
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description
Some small bugs were fond in the EKF interface. 
The first commit fixes the units of the ckf/ekf update threshold for the covariance
The second commit adds a check in the measurement update for the filter type
The third commit removes assert no longer protecting against anything given the last commit (this also allows for easier implementation of the module)

## Verification
Tests pass

## Documentation
None

## Future work
None
