### PR TITLE
Fix state vector class name

### DIFF
--- a/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.cpp
@@ -22,15 +22,15 @@
 
 /*! Call the propagation function for the dynamics
    @param std::array<double, 2> interval : time interval
-   @param StateVector state : initial state
+   @param FilterStateVector state : initial state
    @param double dt: time step
-   @return StateVector propagatedState
+   @return FilterStateVector propagatedState
 */
-StateVector DynamicsModel::propagate(const std::array<double, 2> interval, const StateVector& state, const double dt) const {
+FilterStateVector DynamicsModel::propagate(const std::array<double, 2> interval, const FilterStateVector& state, const double dt) const {
     double t_0 = interval[0];
     double t_f = interval[1];
     double t = t_0;
-    StateVector X(state);
+    FilterStateVector X(state);
 
     /*! Propagate to t_final with an RK4 integrator */
     double N = ceil((t_f-t_0)/dt);
@@ -44,23 +44,23 @@ StateVector DynamicsModel::propagate(const std::array<double, 2> interval, const
 }
 
 /*! Set the propagation function for the dynamics
-   @param std::function<const StateVector(const StateVector&)>& dynamicsPropagator
+   @param std::function<const FilterStateVector(const FilterStateVector&)>& dynamicsPropagator
 */
-void DynamicsModel::setDynamics(const std::function<const StateVector(const double, const StateVector&)>& dynamicsPropagator){
+void DynamicsModel::setDynamics(const std::function<const FilterStateVector(const double, const FilterStateVector&)>& dynamicsPropagator){
     this->propagator = dynamicsPropagator;
 }
 
 /*! Call the dynamics matrix containing the partials of the dynamics with respect to the state
-   @param std::function<const Eigen::MatrixXd(const StateVector&)>& dynamicsMatrixCalculator
+   @param std::function<const Eigen::MatrixXd(const FilterStateVector&)>& dynamicsMatrixCalculator
 */
-Eigen::MatrixXd DynamicsModel::computeDynamicsMatrix(const double time, const StateVector& state) const {
+Eigen::MatrixXd DynamicsModel::computeDynamicsMatrix(const double time, const FilterStateVector& state) const {
     return this->dynamicsMatrix(time, state);
 }
 
 /*! Set the dynamics matrix containing the partials of the dynamics with respect to the state
-   @param std::function<const Eigen::MatrixXd(const StateVector&)>& dynamicsMatrixCalculator
+   @param std::function<const Eigen::MatrixXd(const FilterStateVector&)>& dynamicsMatrixCalculator
 */
-void DynamicsModel::setDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+void DynamicsModel::setDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)>&
         dynamicsMatrixCalculator){
     this->dynamicsMatrix = dynamicsMatrixCalculator;
 }
@@ -72,16 +72,16 @@ void DynamicsModel::setDynamicsMatrix(const std::function<const Eigen::MatrixXd(
     @param dt time step
     @return Eigen::VectorXd
 */
-    StateVector DynamicsModel::rk4(std::function<const StateVector(const double, const StateVector&)> ODEfunction,
-            const StateVector& X0,
+    FilterStateVector DynamicsModel::rk4(std::function<const FilterStateVector(const double, const FilterStateVector&)> ODEfunction,
+            const FilterStateVector& X0,
             double t0,
             double dt) {
     double h = dt;
 
-    StateVector k1 = ODEfunction(t0, X0);
-    StateVector k2 = ODEfunction(t0 + h/2., X0.add(k1.scale(h/2.)));
-    StateVector k3 = ODEfunction(t0 + h/2., X0.add(k2.scale(h/2.)));
-    StateVector k4 = ODEfunction(t0 + h, X0.add(k3.scale(h)));
+    FilterStateVector k1 = ODEfunction(t0, X0);
+    FilterStateVector k2 = ODEfunction(t0 + h/2., X0.add(k1.scale(h/2.)));
+    FilterStateVector k3 = ODEfunction(t0 + h/2., X0.add(k2.scale(h/2.)));
+    FilterStateVector k4 = ODEfunction(t0 + h, X0.add(k3.scale(h)));
 
     return X0.add(k1.scale(h/6.).add(k2.scale(h/3.)).add(k3.scale(h/3.)).add(k4.scale(h/6.)));
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/dynamicModels.h
@@ -27,11 +27,11 @@
 /*! @brief Measurement models used to map a state vector to a measurement */
 class DynamicsModel{
 private:
-    std::function<const StateVector(const double, const StateVector&)> propagator; //!< [-] state propagator using dynamics
-    std::function<const Eigen::MatrixXd(const double, const StateVector&)> dynamicsMatrix; //!< [-] partial of dynamics wrt state
+    std::function<const FilterStateVector(const double, const FilterStateVector&)> propagator; //!< [-] state propagator using dynamics
+    std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)> dynamicsMatrix; //!< [-] partial of dynamics wrt state
 
-    static StateVector rk4(std::function<const StateVector(const double, const StateVector&)> ODEfunction,
-            const StateVector& X0,
+    static FilterStateVector rk4(std::function<const FilterStateVector(const double, const FilterStateVector&)> ODEfunction,
+            const FilterStateVector& X0,
             double t0,
             double dt) ;
 
@@ -39,11 +39,11 @@ public:
     DynamicsModel() = default;
     ~DynamicsModel() = default;
 
-    StateVector propagate(std::array<double, 2>, const StateVector& state, double dt) const;
-    void setDynamics(const std::function<const StateVector(const double, const StateVector&)>& dynamicsPropagator);
+    FilterStateVector propagate(std::array<double, 2>, const FilterStateVector& state, double dt) const;
+    void setDynamics(const std::function<const FilterStateVector(const double, const FilterStateVector&)>& dynamicsPropagator);
 
-    Eigen::MatrixXd computeDynamicsMatrix(double time, const StateVector& state) const;
-    void setDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+    Eigen::MatrixXd computeDynamicsMatrix(double time, const FilterStateVector& state) const;
+    void setDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)>&
             dynamicsMatrixCalculator);
 };
 

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -56,9 +56,9 @@ void EkfInterface::timeUpdate(const double updateTime)
     std::array<double, 2> time = {0, dt};
 
     /*! - Propagate full state and STM vector using dynamics specified in child class */
-    StateVector stateStm = this->state;
+    FilterStateVector stateStm = this->state;
     stateStm.attachStm(this->stateTransitionMatrix);
-    StateVector propagatedStateStm = this->dynamics.propagate(time, stateStm, dt);
+    FilterStateVector propagatedStateStm = this->dynamics.propagate(time, stateStm, dt);
 
     this->stateTransitionMatrix = propagatedStateStm.detachStm();
 
@@ -193,7 +193,7 @@ Eigen::VectorXd EkfInterface::computeResiduals(const MeasurementModel &measureme
 /*! Get the filter dynamics matrix (A = df/dX evaluated at the reference)
     @return Eigen::VectorXd stateInitial
     */
-void EkfInterface::setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+void EkfInterface::setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)>&
             dynamicsMatrixCalculator){
     this->dynamics.setDynamicsMatrix(dynamicsMatrixCalculator);
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
@@ -46,7 +46,7 @@ public:
     ~EkfInterface() = default;
     void Reset(uint64_t CurrentSimNanos) override;
 
-    void setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const StateVector&)>&
+    void setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)>&
         dynamicsMatrixCalculator);
     void setMinimumCovarianceNormForEkf(double infiniteNorm);
     double getMinimumCovarianceNormForEkf() const;

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
@@ -23,7 +23,7 @@
 
 void KalmanFilter::Reset(uint64_t currentSimNanos) {
     assert(this->stateInitial.size() == this->covarInitial.rows() &&
-    this->stateInitial.size() == this->covarInitial.cols());
+           this->stateInitial.size() == this->covarInitial.cols());
 
     this->state = this->stateInitial.scale(this->unitConversion);
     this->stateLogged = this->state;
@@ -195,7 +195,7 @@ std::optional<Eigen::VectorXd> KalmanFilter::getInitialConsiderParameters() cons
     @param Eigen::VectorXd initialStateInput
     @return void
     */
-void KalmanFilter::setFilterDynamics(const std::function<const StateVector(const double, const StateVector&)>&
+void KalmanFilter::setFilterDynamics(const std::function<const FilterStateVector(const double, const FilterStateVector&)>&
         dynamicsPropagator){
     this->dynamics.setDynamics(dynamicsPropagator);
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h
@@ -60,7 +60,7 @@ public:
     double getUnitConversionFromSItoState() const;
     void setMeasurementNoiseScale(double measurementNoiseScale);
     double getMeasurementNoiseScale() const;
-    void setFilterDynamics(const std::function<const StateVector(double, const StateVector&)> &dynamicsPropagator);
+    void setFilterDynamics(const std::function<const FilterStateVector(double, const FilterStateVector&)> &dynamicsPropagator);
 
 protected:
     virtual void customReset(){/* virtual */};
@@ -84,10 +84,10 @@ protected:
     double unitConversion = 1; //!< [-] Scale that converts input units (SI) to a desired unit for the inner maths
     double measNoiseScaling = 1; //!< [-] Scale factor for the measurement noise
 
-    StateVector state; //!< [-] State estimate for time TimeTag
-    StateVector stateInitial; //!< [-] State estimate for time TimeTag at previous time
-    StateVector stateLogged; //!< [-] State variable for logging
-    StateVector xBar; //!< [-] Current mean state estimate
+    FilterStateVector state; //!< [-] State estimate for time TimeTag
+    FilterStateVector stateInitial; //!< [-] State estimate for time TimeTag at previous time
+    FilterStateVector stateLogged; //!< [-] State variable for logging
+    FilterStateVector xBar; //!< [-] Current mean state estimate
     Eigen::VectorXd stateError; //!< [-] Current mean state error
 
     Eigen::MatrixXd processNoise; //!< [-] process noise matrix

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
@@ -21,33 +21,33 @@
 #include "measurementModels.h"
 
 /*! Function to represent measurement model which inputs a stateModel and outputs a matrix
- * @param StateVector
+ * @param FilterStateVector
  * @return Eigen::MatrixXd
  */
-Eigen::MatrixXd MeasurementModel::model(const StateVector& state) const {
+Eigen::MatrixXd MeasurementModel::model(const FilterStateVector& state) const {
     return this->measurementModel(state);
 }
 
 /*! Set function to represent measurement model which inputs a stateModel and outputs a matrix
- * @param std::function<const Eigen::MatrixXd(const StateVector&)>
+ * @param std::function<const Eigen::MatrixXd(const FilterStateVector&)>
  */
-void MeasurementModel::setMeasurementModel(const std::function<const Eigen::MatrixXd(const StateVector&)> &modelCalculator) {
+void MeasurementModel::setMeasurementModel(const std::function<const Eigen::MatrixXd(const FilterStateVector&)> &modelCalculator) {
     this->measurementModel = modelCalculator;
 }
 
 /*! Function to represent measurement matrix which inputs a stateModel and outputs a matrix (partial of measurement
- * @param StateVector
+ * @param FilterStateVector
  * @return Eigen::MatrixXd
  */
-Eigen::MatrixXd MeasurementModel::computeMeasurementMatrix(const StateVector& state) const {
+Eigen::MatrixXd MeasurementModel::computeMeasurementMatrix(const FilterStateVector& state) const {
     return this->measurementPartials(state);
 }
 
 /*! Set function to represent measurement matrix which inputs a stateModel and outputs a matrix (partial of measurement
  * model with respect to state)
- * @param std::function<const Eigen::MatrixXd(const StateVector&)>
+ * @param std::function<const Eigen::MatrixXd(const FilterStateVector&)>
  */
-void MeasurementModel::setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const StateVector&)> &hMatrixCalculator){
+void MeasurementModel::setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const FilterStateVector&)> &hMatrixCalculator){
     this->measurementPartials = hMatrixCalculator;
 }
 
@@ -157,37 +157,37 @@ void MeasurementModel::setPreFitResiduals(const Eigen::VectorXd& measurementPreF
 }
 
 /*! Measurement model that returns the position component of the state
- * @param StateVector state
+ * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::positionStates(const StateVector &state)
+Eigen::VectorXd MeasurementModel::positionStates(const FilterStateVector &state)
 {
     return state.getPositionStates();
 }
 
 /*! Measurement model that returns the unit vector of the position state
- * @param StateVector state
+ * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::normalizedPositionStates(const StateVector &state)
+Eigen::VectorXd MeasurementModel::normalizedPositionStates(const FilterStateVector &state)
 {
     return state.getPositionStates()/state.getPositionStates().norm();
 }
 
 /*! Measurement model that returns the position component of the state, and performs a MRP shadow set check
- * @param StateVector state
+ * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::mrpStates(const StateVector &state)
+Eigen::VectorXd MeasurementModel::mrpStates(const FilterStateVector &state)
 {
     return mrpSwitch(state.getPositionStates(), 1);
 }
 
 /*! Measurement model that returns the velocity component of the state
- * @param StateVector state
+ * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::velocityStates(const StateVector &state)
+Eigen::VectorXd MeasurementModel::velocityStates(const FilterStateVector &state)
 {
     return state.getVelocityStates();
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
@@ -32,15 +32,15 @@ public:
     MeasurementModel() = default;
     ~MeasurementModel() = default;
 
-    static Eigen::VectorXd positionStates(const StateVector &state);
-    static Eigen::VectorXd normalizedPositionStates(const StateVector &state);
-    static Eigen::VectorXd mrpStates(const StateVector &state);
-    static Eigen::VectorXd velocityStates(const StateVector &state);
+    static Eigen::VectorXd positionStates(const FilterStateVector &state);
+    static Eigen::VectorXd normalizedPositionStates(const FilterStateVector &state);
+    static Eigen::VectorXd mrpStates(const FilterStateVector &state);
+    static Eigen::VectorXd velocityStates(const FilterStateVector &state);
 
-    Eigen::MatrixXd model(const StateVector& state) const;
-    void setMeasurementModel(const std::function<const Eigen::MatrixXd(const StateVector&)>& modelCalculator);
-    Eigen::MatrixXd computeMeasurementMatrix(const StateVector& state) const;
-    void setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const StateVector&)>& hMatrixCalculator);
+    Eigen::MatrixXd model(const FilterStateVector& state) const;
+    void setMeasurementModel(const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& modelCalculator);
+    Eigen::MatrixXd computeMeasurementMatrix(const FilterStateVector& state) const;
+    void setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& hMatrixCalculator);
 
     size_t size() const;
     std::string getMeasurementName() const;
@@ -69,8 +69,8 @@ private:
     Eigen::VectorXd postFitResiduals; //!< [-] Observation post fit residuals
     Eigen::VectorXd preFitResiduals; //!< [-] Observation pre fit residuals
 
-    std::function<const Eigen::MatrixXd(const StateVector&)> measurementModel; //!< [-] observation measurement model
-    std::function<const Eigen::MatrixXd(const StateVector&)> measurementPartials; //!< [-] partial of measurement model wrt state
+    std::function<const Eigen::MatrixXd(const FilterStateVector&)> measurementModel; //!< [-] observation measurement model
+    std::function<const Eigen::MatrixXd(const FilterStateVector&)> measurementPartials; //!< [-] partial of measurement model wrt state
 
 };
 

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.h
@@ -59,7 +59,7 @@ private:
     Eigen::MatrixXd choleskyDecomposition(const Eigen::MatrixXd &input) const;
 
     Eigen::MatrixXd sBar; //!< [-] Time updated covariance
-    std::array<StateVector, 2*MAX_STATES_VECTOR+1> sigmaPoints; //!< [-]    sigma point vector
+    std::array<FilterStateVector, 2*MAX_STATES_VECTOR+1> sigmaPoints; //!< [-]    sigma point vector
     int numberSigmaPoints=0;//!< [-] number of sigma points
     Eigen::MatrixXd cholProcessNoise; //!< [-] cholesky of Qnoise
     Eigen::MatrixXd cholMeasNoise; //!< [-] cholesky of Measurement noise

--- a/src/fswAlgorithms/_GeneralModuleFiles/stateModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/stateModels.cpp
@@ -37,7 +37,7 @@ Eigen::VectorXd State::getValues() const {
 /*! Set the positional components of your state (cartesian position, attitude, etc)
    @param Eigen::VectorXd positionComponents
 */
-long StateVector::size() const{
+long FilterStateVector::size() const{
     long totalSize = 0;
     if (this->hasPosition()){
         totalSize += this->getPositionStates().size();
@@ -59,12 +59,12 @@ long StateVector::size() const{
 
 /*! Add a eigen vector to a state, assuming the order of position, velocity, acceleration, bias, consider
    @param Eigen::VectorXd vector
-   @return StateVector sumVector
+   @return FilterStateVector sumVector
 */
-StateVector StateVector::addVector(const Eigen::VectorXd &vector) const {
+FilterStateVector FilterStateVector::addVector(const Eigen::VectorXd &vector) const {
     assert(vector.size() == this->size());
     long lastIndex = 0;
-    StateVector sum;
+    FilterStateVector sum;
     if (this->hasPosition()){
         PositionState positionState;
         positionState.setValues(this->getPositionStates() + vector.segment(0, this->getPositionStates().size()));
@@ -99,11 +99,11 @@ StateVector StateVector::addVector(const Eigen::VectorXd &vector) const {
 }
 
 /*! Add two states together
-   @param StateVector vector
-   @return StateVector sumVector
+   @param FilterStateVector vector
+   @return FilterStateVector sumVector
 */
-StateVector StateVector::add(const StateVector &vector) const {
-    StateVector sum;
+FilterStateVector FilterStateVector::add(const FilterStateVector &vector) const {
+    FilterStateVector sum;
     if (this->hasPosition() && vector.hasPosition()){
         PositionState sumPosition;
         sumPosition.setValues(this->getPositionStates() + vector.getPositionStates());
@@ -135,10 +135,10 @@ StateVector StateVector::add(const StateVector &vector) const {
 
 /*! Scale a state vector by a constant
    @param double scalar
-   @return StateVector scaledVector
+   @return FilterStateVector scaledVector
 */
-StateVector StateVector::scale(const double scalar) const {
-    StateVector scaledVector;
+FilterStateVector FilterStateVector::scale(const double scalar) const {
+    FilterStateVector scaledVector;
     if (this->hasPosition()){
         PositionState scaledPosition;
         scaledPosition.setValues(this->getPositionStates()*scalar);
@@ -169,9 +169,9 @@ StateVector StateVector::scale(const double scalar) const {
 }
 
 /*! Return the full state vector
-   @return Eigen::VectorXd fullStateVector
+   @return Eigen::VectorXd fullFilterStateVector
 */
-Eigen::VectorXd StateVector::returnValues() const {
+Eigen::VectorXd FilterStateVector::returnValues() const {
     long numerOfStates = this->size();
     Eigen::VectorXd stateVectorValues;
     stateVectorValues.setZero(numerOfStates);
@@ -201,21 +201,21 @@ Eigen::VectorXd StateVector::returnValues() const {
 /*! Check if the state vector has a position state
    @return bool
 */
-bool StateVector::hasPosition() const {
+bool FilterStateVector::hasPosition() const {
     return this->position.has_value();
 }
 
 /*! Set the positional components of your state (cartesian position, attitude, etc)
    @param Eigen::VectorXd positionComponents
 */
-void StateVector::setPosition(const PositionState &positionState){
+void FilterStateVector::setPosition(const PositionState &positionState){
     this->position = positionState;
 }
 
 /*! Get the positional components of your state (cartesian position, attitude, etc)
    @return Eigen::VectorXd
 */
-Eigen::VectorXd StateVector::getPositionStates() const {
+Eigen::VectorXd FilterStateVector::getPositionStates() const {
     return this->getPosition().getValues();
 }
 
@@ -223,132 +223,132 @@ Eigen::VectorXd StateVector::getPositionStates() const {
 /*! Get the positional state class of your state vector(cartesian position, attitude, etc)
    @return PositionState
 */
-PositionState StateVector::getPosition() const {
+PositionState FilterStateVector::getPosition() const {
     return this->position.value();
 }
 
 /*! Check if the state vector has a velocity state
    @return bool
 */
-bool StateVector::hasVelocity() const {
+bool FilterStateVector::hasVelocity() const {
     return this->velocity.has_value();
 }
 
 /*! Set the velocity components of your state (cartesian velocity, angular rate, etc)
    @param Eigen::VectorXd velocityComponents
 */
-void StateVector::setVelocity(const VelocityState &velocityState){
+void FilterStateVector::setVelocity(const VelocityState &velocityState){
     this->velocity = velocityState;
 }
 
 /*! Get the velocity class of your state (cartesian velocity, angular rate, etc)
    @return Eigen::VectorXd
 */
-VelocityState StateVector::getVelocity() const {
+VelocityState FilterStateVector::getVelocity() const {
     return this->velocity.value();
 }
 
 /*! Get the velocity components of your state (cartesian velocity, angular rate, etc)
    @return Eigen::VectorXd
 */
-Eigen::VectorXd StateVector::getVelocityStates() const {
+Eigen::VectorXd FilterStateVector::getVelocityStates() const {
     return this->getVelocity().getValues();
 }
 
 /*! Check if the state vector has a acceleration state
    @return bool
 */
-bool StateVector::hasAcceleration() const {
+bool FilterStateVector::hasAcceleration() const {
     return this->acceleration.has_value();
 }
 
 /*! Set the acceleration class of your state (cartesian acceleration, angular acceleration, etc)
    @param Eigen::VectorXd velocityComponents
 */
-void StateVector::setAcceleration(const AccelerationState &accelerationState){
+void FilterStateVector::setAcceleration(const AccelerationState &accelerationState){
     this->acceleration = accelerationState;
 }
 
 /*! Get the velocity class of your state (cartesian acceleration, angular acceleration, etc)
    @return Eigen::VectorXd
 */
-AccelerationState StateVector::getAcceleration() const {
+AccelerationState FilterStateVector::getAcceleration() const {
     return this->acceleration.value();
 }
 
 /*! Get the acceleration components of your state (cartesian acceleration, angular acceleration, etc)
    @return Eigen::VectorXd
 */
-Eigen::VectorXd StateVector::getAccelerationStates() const {
+Eigen::VectorXd FilterStateVector::getAccelerationStates() const {
     return this->getAcceleration().getValues();
 }
 
 /*! Check if the state vector has a bias state
    @return bool
 */
-bool StateVector::hasBias() const {
+bool FilterStateVector::hasBias() const {
     return this->bias.has_value();
 }
 
 /*! Set the bias class of your state (cartesian bias, angular bias, etc)
    @param Eigen::VectorXd velocityComponents
 */
-void StateVector::setBias(const BiasState &biasState){
+void FilterStateVector::setBias(const BiasState &biasState){
     this->bias = biasState;
 }
 
 /*! Get the velocity class of your state (cartesian bias, angular bias, etc)
    @return Eigen::VectorXd
 */
-BiasState StateVector::getBias() const {
+BiasState FilterStateVector::getBias() const {
     return this->bias.value();
 }
 
 /*! Get the bias components of your state (cartesian bias, angular bias, etc)
    @return Eigen::VectorXd
 */
-Eigen::VectorXd StateVector::getBiasStates() const {
+Eigen::VectorXd FilterStateVector::getBiasStates() const {
     return this->getBias().getValues();
 }
 
 /*! Check if the state vector has a considerParameters state
    @return bool
 */
-bool StateVector::hasConsider() const {
+bool FilterStateVector::hasConsider() const {
     return this->considerParameters.has_value();
 }
 
 /*! Set the considerParameters class of your state (cartesian considerParameters, angular considerParameters, etc)
    @param Eigen::VectorXd velocityComponents
 */
-void StateVector::setConsider(const ConsiderState &considerParametersState){
+void FilterStateVector::setConsider(const ConsiderState &considerParametersState){
     this->considerParameters = considerParametersState;
 }
 
 /*! Get the velocity class of your state (cartesian considerParameters, angular considerParameters, etc)
    @return Eigen::VectorXd
 */
-ConsiderState StateVector::getConsider() const {
+ConsiderState FilterStateVector::getConsider() const {
     return this->considerParameters.value();
 }
 
 /*! Get the considerParameters components of your state (cartesian considerParameters, angular considerParameters, etc)
    @return Eigen::VectorXd
 */
-Eigen::VectorXd StateVector::getConsiderStates() const {
+Eigen::VectorXd FilterStateVector::getConsiderStates() const {
     return this->getConsider().getValues();
 }
 
 /*! Attach the state transition matrix of your state for simultaneous propagation
    @param Eigen::MatrixXd stm
 */
-void StateVector::attachStm(const Eigen::MatrixXd& stm){
+void FilterStateVector::attachStm(const Eigen::MatrixXd& stm){
     this->stm = stm;
 }
 
 /*! Detach the state transition matrix of your state for simultaneous propagation
    @return Eigen::MatrixXd stm
 */
-Eigen::MatrixXd StateVector::detachStm() const{
+Eigen::MatrixXd FilterStateVector::detachStm() const{
     return this->stm;
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/stateModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/stateModels.h
@@ -30,8 +30,6 @@ class State{
 private:
     Eigen::VectorXd values;
 public:
-    State() = default;
-    ~State() = default;
     void setValues(const Eigen::VectorXd& componentValues);
     Eigen::VectorXd getValues() const;
 };
@@ -44,7 +42,7 @@ class ConsiderState : public State{};
 
 
 /*! @brief State models used to map a state vector to a measurement */
-class StateVector{
+class FilterStateVector{
 private:
     std::optional<PositionState> position;
     std::optional<VelocityState> velocity;
@@ -54,13 +52,10 @@ private:
     Eigen::MatrixXd stm;
 
 public:
-    StateVector() = default;
-    ~StateVector() = default;
-
     long size() const;
-    StateVector add(const StateVector &vector) const;
-    StateVector addVector(const Eigen::VectorXd &vector) const;
-    StateVector scale(const double scalar) const;
+    FilterStateVector add(const FilterStateVector &vector) const;
+    FilterStateVector addVector(const Eigen::VectorXd &vector) const;
+    FilterStateVector scale(const double scalar) const;
     Eigen::VectorXd returnValues() const;
 
     void setPosition(const PositionState &position);

--- a/src/fswAlgorithms/_GeneralModuleFiles/stateModels.rst
+++ b/src/fswAlgorithms/_GeneralModuleFiles/stateModels.rst
@@ -18,7 +18,7 @@ The following table lists all the state class
       - return the values of a given state
 
 Position, Velocity, Acceleration, Bias, and ConsiderParameters all inherit the state type.
-The following table lists all the stateVector class, which contains all the different state types and a stm matrix
+The following table lists all the FilterStateVector class, which contains all the different state types and a stm matrix
 
 .. list-table:: Interface methods which remain private
     :widths: 25 75
@@ -33,7 +33,7 @@ The following table lists all the stateVector class, which contains all the diff
     * - addVector
       - add Eigen::Vector values to the state vector in order Position, Velocity, Accel, Bias, Consider
     * - scale
-      - scale a stateVector by a scalar
+      - scale a FilterStateVector by a scalar
     * - returnValues
       - return all fo the values in an Eigen::Vector following the previous order
 

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -26,12 +26,12 @@ InertialAttitudeUkf::InertialAttitudeUkf(AttitudeFilterMethod method){
 
 void InertialAttitudeUkf::customReset(){
     /*! No custom reset for this module */
-    std::function<StateVector(double, const StateVector)> attitudeDynamics = [this](double t, const StateVector &state){
+    std::function<FilterStateVector(double, const FilterStateVector)> attitudeDynamics = [this](double t, const FilterStateVector &state){
         Eigen::Vector3d mrp(state.getPositionStates());
         Eigen::Vector3d omega(state.getVelocityStates());
         Eigen::MatrixXd bMat = bmatMrp(mrp);
 
-        StateVector stateDerivative;
+        FilterStateVector stateDerivative;
         PositionState mrpDot;
         mrpDot.setValues(0.25*bMat*omega);
         stateDerivative.setPosition(mrpDot);

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
@@ -168,7 +168,7 @@ void SunlineSRuKF::readCssMeasurements() {
         }
     }
 
-    std::function<const Eigen::VectorXd(const StateVector)> linearModel = [hMatrix](const StateVector &state) {
+    std::function<const Eigen::VectorXd(const FilterStateVector)> linearModel = [hMatrix](const FilterStateVector &state) {
         Eigen::VectorXd observed = hMatrix * state.getPositionStates();
         return observed;
     };
@@ -200,11 +200,11 @@ void SunlineSRuKF::readFilterMeasurements() {
 
 /*! Define the equations of motion for the filter dynamics
     @param double time
-    @return StateVector inputState
-    @return StateVector outputState
+    @return FilterStateVector inputState
+    @return FilterStateVector outputState
     */
-StateVector SunlineSRuKF::stateDerivative(const double t, const StateVector &state){
-    StateVector XDot;
+FilterStateVector SunlineSRuKF::stateDerivative(const double t, const FilterStateVector &state){
+    FilterStateVector XDot;
     /*! Implement propagation with rate derivatives set to zero */
     Eigen::Vector3d sHat  = state.getPositionStates();
     Eigen::Vector3d omega = state.getVelocityStates();

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
@@ -49,7 +49,7 @@ private:
     void readFilterMeasurements() final;
     void customFinalizeUpdate() final;
     void writeOutputMessages(uint64_t CurrentSimNanos) final;
-    static StateVector stateDerivative(double t, const StateVector &state);
+    static FilterStateVector stateDerivative(double t, const FilterStateVector &state);
 
     int filterMeasurement = 0;   //!< [-] Number of measurements of different types being read
     int numActiveCss = 0;        //!< [-] Number of currently active CSS sensors

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.cpp
@@ -31,8 +31,8 @@ void FlybyODuKF::customReset() {
     /*! - Initialize filter parameters and change units to km and s */
     this->muCentral *= pow(this->unitConversion, 3); // mu is input in meters
     double centralBody = this->muCentral;
-    std::function<StateVector(double, const StateVector)> twoBodyDynamics = [centralBody](double t, const StateVector &state){
-        StateVector XDot;
+    std::function<FilterStateVector(double, const FilterStateVector)> twoBodyDynamics = [centralBody](double t, const FilterStateVector &state){
+        FilterStateVector XDot;
         /*! Implement propagation with rate derivatives set to zero */
         /*! Implement point mass gravity for the propagation */
         PositionState flybyPosition;

--- a/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
@@ -31,8 +31,8 @@ void LinearODeKF::customReset() {
         this->constantVelocity = this->constantVelocityInitial.value()*this->unitConversion;
     }
     /*! - Set the dynamics matrix calculator*/
-    std::function<Eigen::MatrixXd(double, const StateVector)> dynamicsMatrixCalculator= [this]
-            (double time, const StateVector &state){
+    std::function<Eigen::MatrixXd(double, const FilterStateVector)> dynamicsMatrixCalculator= [this]
+            (double time, const FilterStateVector &state){
         Eigen::VectorXd position = state.getPositionStates();
         Eigen::MatrixXd dynamicsMatrix = Eigen::MatrixXd::Zero(state.size(), state.size());
         if (!this->constantVelocity) {
@@ -45,8 +45,8 @@ void LinearODeKF::customReset() {
     this->dynamics.setDynamicsMatrix(dynamicsMatrixCalculator);
 
     /*! - Set the filter dynamics (linear) */
-    std::function<StateVector(double, const StateVector)> twoBodyDynamics = [this](double t, const StateVector &state){
-        StateVector XDot;
+    std::function<FilterStateVector(double, const FilterStateVector)> twoBodyDynamics = [this](double t, const FilterStateVector &state){
+        FilterStateVector XDot;
         PositionState stateDerivative;
 
         if (this->constantVelocity) {
@@ -137,10 +137,10 @@ void LinearODeKF::readFilterMeasurements() {
 }
 
 /*! Compute the measurement matrix to linearize the measurement model
-    @param StateVector state
+    @param FilterStateVector state
     @return Eigen::MatrixXd
 */
-Eigen::MatrixXd LinearODeKF::measurementMatrix(const StateVector &state){
+Eigen::MatrixXd LinearODeKF::measurementMatrix(const FilterStateVector &state){
 
     Eigen::Vector3d position = state.getPositionStates();
     Eigen::MatrixXd measurementMatrix = Eigen::MatrixXd::Zero(position.size(), state.size());

--- a/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.h
+++ b/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.h
@@ -48,7 +48,7 @@ private:
     void customReset() final;
     void readFilterMeasurements() final;
     void writeOutputMessages(uint64_t CurrentSimNanos) final;
-    static Eigen::MatrixXd measurementMatrix(const StateVector &state);
+    static Eigen::MatrixXd measurementMatrix(const FilterStateVector &state);
 
 public:
     ReadFunctor<OpNavUnitVecMsgPayload> opNavHeadingMsg;


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
`StateVector` class name in the filters was clashing with the `StateVector`. This of course doesn't work due to C++ one definition rule (ODR). Unfortunately, the code base doesn't make appropriate use of namespaces (yet!).

## Verification
CI runs.

## Documentation
Updated

## Future work
As we make significant changes, namespaces within the code base will start appearing which will facilitate using class names that are relevant but separated by namespaces.
