### PR TITLE
Clean up spurious warnings during build

### DIFF
--- a/src/architecture/system_model/sim_model.cpp
+++ b/src/architecture/system_model/sim_model.cpp
@@ -52,7 +52,7 @@ void activateNewThread(void *threadData)
 }
 
 SimThreadExecution::SimThreadExecution(uint64_t threadIdent, uint64_t currentSimNanos) :
-    currentThreadNanos(currentSimNanos), threadID(threadIdent)
+    threadID(threadIdent), currentThreadNanos(currentSimNanos)
 {
 
 }
@@ -152,6 +152,7 @@ void SimThreadExecution::StepUntilStop()
  */
 void SimThreadExecution::moveProcessMessages() const {
     for(auto const* process : this->processList) {
+        static_cast<void>(process);  // "use" the unused variable
         //process->routeInterfaces(this->CurrentNanos);
     }
 }
@@ -197,6 +198,7 @@ void SimThreadExecution::selfInitProcesses() const {
  */
 void SimThreadExecution::crossInitProcesses() const {
     for(auto const* process : this->processList) {
+        static_cast<void>(process);  // "use" the unused variable
         //process->crossInitProcess();
     }
 }

--- a/src/fswAlgorithms/attGuidance/sunSafePointCpp/sunSafePointCpp.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePointCpp/sunSafePointCpp.cpp
@@ -40,7 +40,7 @@ void SunSafePointCpp::Reset(uint64_t callTime) {
     // Compute an Eigen axis orthogonal to sHatBdyCmd
     if (this->sHatBdyCmd.norm()  < 0.1) {
       char info[MAX_LOGGING_LENGTH];
-      sprintf(info, "The module vector sHatBdyCmd is not setup as a unit vector [%f, %f %f]",
+      snprintf(info, sizeof(info), "The module vector sHatBdyCmd is not setup as a unit vector [%f, %f %f]",
                 this->sHatBdyCmd[0], this->sHatBdyCmd[1], this->sHatBdyCmd[2]);
       _bskLog(this->bskLogger, BSK_ERROR, info);
     } else {

--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.cpp
@@ -102,13 +102,10 @@ void PointCloudTriangulation::readMessages()
     CameraConfigMsgPayload cameraConfigInMsgBuffer = this->cameraConfigInMsg();
 
     /* velocity information either from ephemeris message or nav message */
-    uint64_t timeTagVelocityInfo{};
     if (this->initialPhase) {
         this->vScaleFactor = cArray2EigenVector3d(ephemerisInMsgBuffer.v_BdyZero_N).norm();
-        timeTagVelocityInfo = ephemerisInMsgBuffer.timeTag * SEC2NANO;
     } else {
         this->vScaleFactor = cArray2EigenVector3d(navTransInMsgBuffer.v_BN_N).norm();
-        timeTagVelocityInfo = navTransInMsgBuffer.timeTag * SEC2NANO;
     }
 
     /* direction of motion message */


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
There are a lot of spurious warnings produced by the build. These can prevent developers from identifying warnings or errors produced by their own ongoing changes, which makes it much easier to miss important bugs caused by gaffes that the compiler was trying to warn about.

## Verification
The build is now entirely warning-free, at least under its current configuration of warning flags -- and with Swig 4.2.1 installed. I know some developers have an earlier version of Swig installed (e.g. 4.1.1); upgrading `swig` will automatically clear out a whole host of `sprintf` warnings -- so you should do that in your local environment!

## Documentation
No documentation changes.

## Future work
No future work, just making it easier to *do* that future work well :)