### PR TITLE
Default intialize class variables in LowPassFilter

### DIFF
--- a/src/architecture/utilities/signalProcessing.cpp
+++ b/src/architecture/utilities/signalProcessing.cpp
@@ -19,10 +19,6 @@
 
 #include "architecture/utilities/signalProcessing.h"
 
-LowPassFilter::LowPassFilter()=default;
-
-LowPassFilter::~LowPassFilter()=default;
-
 /**
  * Process a measurement into the low pass filter
  * @param measurement Eigen::Vector3d

--- a/src/architecture/utilities/signalProcessing.cpp
+++ b/src/architecture/utilities/signalProcessing.cpp
@@ -24,7 +24,7 @@
  * @param measurement Eigen::Vector3d
  * @return void
  */
-void LowPassFilter::processMeasurement(const Eigen::Vector3d measurement){
+void LowPassFilter::processMeasurement(const Eigen::Vector3d& measurement){
 
     double omegaStep = this->filterStep*this->filterCutOff;
     this->currentState = 1/(2+omegaStep)*(this->currentState*(2-omegaStep) + omegaStep*(measurement+this->currentMeasurement));

--- a/src/architecture/utilities/signalProcessing.h
+++ b/src/architecture/utilities/signalProcessing.h
@@ -38,8 +38,8 @@ public:
 private:
     double filterStep=0.5;         /*!< [s]      filter time step (assumed to be fixed) */
     double filterCutOff=0.1*22/7*2;    /*!< [rad/s]  Cutoff frequency for the filter        */
-    Eigen::Vector3d currentState;  /*!< [-] Current state of the filter                 */
-    Eigen::Vector3d currentMeasurement;   /*!< [-] Current measurement that we read            */
+    Eigen::Vector3d currentState=Eigen::Vector3d::Zero();  /*!< [-] Current state of the filter                 */
+    Eigen::Vector3d currentMeasurement=Eigen::Vector3d::Zero();   /*!< [-] Current measurement that we read            */
 };
 
 #endif

--- a/src/architecture/utilities/signalProcessing.h
+++ b/src/architecture/utilities/signalProcessing.h
@@ -33,10 +33,10 @@ public:
     Eigen::Vector3d getCurrentState() const;
 
 private:
-    double filterStep=0.5;         /*!< [s]      filter time step (assumed to be fixed) */
-    double filterCutOff=0.1*22/7*2;    /*!< [rad/s]  Cutoff frequency for the filter        */
-    Eigen::Vector3d currentState=Eigen::Vector3d::Zero();  /*!< [-] Current state of the filter                 */
-    Eigen::Vector3d currentMeasurement=Eigen::Vector3d::Zero();   /*!< [-] Current measurement that we read            */
+    double filterStep=0.5; /*!< [s] filter time step (assumed to be fixed) */
+    double filterCutOff=0.1*22/7*2; /*!< [rad/s]  Cutoff frequency for the filter */
+    Eigen::Vector3d currentState=Eigen::Vector3d::Zero(); /*!< [-] Current state of the filter */
+    Eigen::Vector3d currentMeasurement=Eigen::Vector3d::Zero(); /*!< [-] Current measurement that we read */
 };
 
 #endif

--- a/src/architecture/utilities/signalProcessing.h
+++ b/src/architecture/utilities/signalProcessing.h
@@ -24,15 +24,12 @@
 
 class LowPassFilter{
 public:
-    LowPassFilter();
-    ~LowPassFilter();
-
-    void setFilterStep(const double filterStepSeconds);
+    void setFilterStep(double filterStepSeconds);
     double getFilterStep() const;
-    void setFilterCutoff(const double cutOffValue);
+    void setFilterCutoff(double cutOffValue);
     double getFilterCutoff() const;
 
-    void processMeasurement(const Eigen::Vector3d measurement);
+    void processMeasurement(Eigen::Vector3d measurement);
     Eigen::Vector3d getCurrentState() const;
 
 private:

--- a/src/architecture/utilities/signalProcessing.h
+++ b/src/architecture/utilities/signalProcessing.h
@@ -29,7 +29,7 @@ public:
     void setFilterCutoff(double cutOffValue);
     double getFilterCutoff() const;
 
-    void processMeasurement(Eigen::Vector3d measurement);
+    void processMeasurement(const Eigen::Vector3d& measurement);
     Eigen::Vector3d getCurrentState() const;
 
 private:


### PR DESCRIPTION
* **Tickets addressed:** #324 324
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The class variables of `LowPassFilter` in signalProcessing.h are not default initialized and therefore may contain garbage data. This is what is causing the sporadic failures in the `LowPassFilter/GeneralPerformance.lowPassFilterProperties` test set (I was previously mistaken for assigning blame to the method for obtaining pi).

## Verification
Tests do in fact pass routinely on multiple platforms.

## Documentation
NA

## Future work
NA
