### PR TITLE
Exclude SPICE file types from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '.*\.(tls|bsp|tpc|bc)$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0


### PR DESCRIPTION
* **Tickets addressed:** #334
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The primary SPICE file types were added as pre-commit excludes.

## Verification
CI should run. Exclusion was tested manually.

## Documentation
NA

## Future work
NA
