### PR TITLE
Adjust conan dependencies workflow to use pull_request_target

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -1,6 +1,6 @@
 name: "Rebuild default Conan cache"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR patches #341 so that the workflow is run in the context of `develop` rather than the original feature branch. Otherwise, the cache created as a result of this workflow is not made available to future feature branches.

## Verification
We merge it and find out. If it fails, nothing is harmed except an extra cache entry that can be cleaned up manually.

## Documentation
No documentation changes.

## Future work
Same as #341, except this time hopefully it works.