### PR TITLE
Feature/515 new camera parameters

### DIFF
--- a/src/architecture/_GeneralModuleFiles/swig_eigen.i
+++ b/src/architecture/_GeneralModuleFiles/swig_eigen.i
@@ -41,14 +41,14 @@ inline constexpr bool always_false_v = false;
 %fragment("castPyToC", "header", fragment="static_fail") %{
 /*
 The following method takes a Python object and tries to convert it to the type T
-If this is succesful, the value is returned. If it is unsucessful, an appropriate 
+If this is succesful, the value is returned. If it is unsucessful, an appropriate
 error message is returned.
 */
 template<class T>
 std::variant<T, std::string> castPyToC(PyObject *input)
-{        
+{
     if (PyErr_Occurred()) return "castPyToC was pre-errored!";
-    
+
     if constexpr (std::is_same_v<T, bool>)
     {
         if (!PyBool_Check(input))
@@ -60,7 +60,7 @@ std::variant<T, std::string> castPyToC(PyObject *input)
     }
     else if constexpr (std::is_integral_v<T>)
     {
-        // Before 3.10, PyLong_AsLong could call __int__, which silently casts float 
+        // Before 3.10, PyLong_AsLong could call __int__, which silently casts float
         // objects to int (with loss of data). We want to prevent that, so instead we
         // call PyNumber_Index beforehand, which will call __index__, which does not
         // allow implicit casts to int (and appropriately raises a warning)
@@ -96,14 +96,14 @@ std::variant<T, std::string> castPyToC(PyObject *input)
     else if constexpr (std::is_floating_point_v<T>)
     {
         double val = PyFloat_AsDouble(input);
-        
+
         if (PyErr_Occurred())
         {
             PyErr_Clear();
             return "Cannot parse value as a floating point.";
         }
 
-        return (T) val;    
+        return (T) val;
     }
     else
     {
@@ -157,7 +157,7 @@ struct RotationCoversion<Eigen::Vector3d, To>
 
 template<class To>
 struct RotationCoversion<Eigen::Vector4d, To>
-{ 
+{
     inline static To convert(const Eigen::Vector4d& input) {return To{ (Eigen::Quaterniond{ input[0], input[1], input[2], input[3] }).toRotationMatrix() };};
 };
 
@@ -219,18 +219,18 @@ std::optional<std::string> checkPyObjectIsMatrixLike(PyObject *input)
         return "Input is not a sequence";
     }
 
-    auto [numberRows, numberColumns] = maybeSize.value(); 
+    auto [numberRows, numberColumns] = maybeSize.value();
 
     if (T::RowsAtCompileTime != -1 && T::RowsAtCompileTime != numberRows)
     {
-        std::string errorMsg = "Input does not have the correct number of rows. Expected " 
+        std::string errorMsg = "Input does not have the correct number of rows. Expected "
             + std::to_string(T::RowsAtCompileTime) + " but found " + std::to_string(numberRows);
         return errorMsg;
     }
 
     if (T::ColsAtCompileTime != -1 && T::ColsAtCompileTime != numberColumns)
     {
-        std::string errorMsg = "Input does not have the correct number of columns. Expected " 
+        std::string errorMsg = "Input does not have the correct number of columns. Expected "
             + std::to_string(T::ColsAtCompileTime) + " but found " + std::to_string(numberColumns);
         return errorMsg;
     }
@@ -244,7 +244,7 @@ std::optional<std::string> checkPyObjectIsMatrixLike(PyObject *input)
             return "All rows must be the same length! Row " + std::to_string(row) + " is not.";
         }
     }
-    
+
     return {};
 }
 }
@@ -273,9 +273,9 @@ T pyObjToEigenMatrix(PyObject *input)
     T result;
 
     auto [numberRows, numberColumns] = getInputSize(input).value();
-    
+
     // Resize can be called even for non-dynamic matrices as long as the
-    // fixed-sizes do not change. 
+    // fixed-sizes do not change.
     result.resize(numberRows, numberColumns);
 
     for(Py_ssize_t row=0; row<numberRows; row++)
@@ -296,7 +296,7 @@ T pyObjToEigenMatrix(PyObject *input)
             else
             {
                 valueOrErrorMsg = castPyToC<ScalarType>(rowPyObj);
-            } 
+            }
 
             if (std::holds_alternative<std::string>(valueOrErrorMsg))
             {
@@ -304,7 +304,7 @@ T pyObjToEigenMatrix(PyObject *input)
                     "Row " + std::to_string(row) + ", Column " + std::to_string(col) +": "
                     + std::get<std::string>(valueOrErrorMsg)
                 ).c_str());
-                
+
                 Py_DECREF(rowPyObj);
 
                 return {};
@@ -324,7 +324,7 @@ T pyObjToEigenMatrix(PyObject *input)
 {
 /*
 Creates a new rotation of the templated type T with the given 'input'.
-Translation might fail, in which case the error flag will be set (disambiguate 
+Translation might fail, in which case the error flag will be set (disambiguate
 using PyErr_Occurred()). If this happens, the returned value is undefined.
 */
 template<class T>
@@ -339,7 +339,7 @@ T pyObjToRotation(PyObject *input)
         return {};
     }
 
-    auto [numberRows, numberColumns] = maybeSize.value(); 
+    auto [numberRows, numberColumns] = maybeSize.value();
 
     if (numberRows == 3 && numberColumns == 1)
     {
@@ -355,7 +355,7 @@ T pyObjToRotation(PyObject *input)
     }
     else
     {
-        std::string errorMsg = "Unknown rotation dimensions: " 
+        std::string errorMsg = "Unknown rotation dimensions: "
             + std::to_string(numberRows) + "x" + std::to_string(numberColumns)
             + ". Expected dimensions 3x1, 4x1, or 3x3.";
         PyErr_SetString(PyExc_ValueError, errorMsg.c_str());
@@ -376,7 +376,7 @@ void fillPyObjList(PyObject *input, const T& value)
     {
         PyObject *locRow = PyList_New(0);
         for(auto j=0; j<value.outerSize(); j++)
-        {            
+        {
             auto toAppend = castCToPy<typename T::Scalar>(value(i,j));
             PyList_Append(locRow, toAppend);
             Py_DECREF(toAppend);
@@ -532,7 +532,7 @@ void fillPyObjList<Eigen::Quaterniond>(PyObject *input, const Eigen::Quaterniond
 // Types partially fixed-size should have precedence 160 < precedence < 165
 // Fully dynamically sized should have precedence 165 < precendence < 170
 //
-// Boolean matrices should have lower precendence than integer matrices, 
+// Boolean matrices should have lower precendence than integer matrices,
 // which should have lower precendence than double matrices.
 //
 // For reference, std::array has precendence 155, and std::vector has precendence 160
@@ -563,9 +563,9 @@ EIGEN_MAT_WRAP(Eigen::MatrixXd, 169)
 // Rotation wrappers work so that they can be set from Python on any
 // of the three ways we have of representing rotations: MRPs (3x1 vector),
 // quaternions (4x1 vector), or rotation matrix (3x3 vector).
-// 
+//
 // Their return type, however, is always an MRPd.
 //
-// The precedence should be that of fixed-size double eigen matrices (159). 
+// The precedence should be that of fixed-size double eigen matrices (159).
 EIGEN_ROT_WRAP(Eigen::MRPd       , 159)
 EIGEN_ROT_WRAP(Eigen::Quaterniond, 159)

--- a/src/architecture/_GeneralModuleFiles/swig_eigen.i
+++ b/src/architecture/_GeneralModuleFiles/swig_eigen.i
@@ -548,6 +548,8 @@ void fillPyObjList<Eigen::Quaterniond>(PyObject *input, const Eigen::Quaterniond
 //      foo(MatrixXi)
 //      foo(MatrixXd)
 
+EIGEN_MAT_WRAP(Eigen::Vector2i, 157)
+EIGEN_MAT_WRAP(Eigen::Vector2d, 157)
 EIGEN_MAT_WRAP(Eigen::Vector3i, 158)
 EIGEN_MAT_WRAP(Eigen::Vector3d, 159)
 EIGEN_MAT_WRAP(Eigen::Matrix3d, 159)

--- a/src/architecture/msgPayloadDefCpp/CameraModelMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/CameraModelMsgPayload.h
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2016-2018, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef CAMERA_MODEL_MSG_H
+#define CAMERA_MODEL_MSG_H
+
+#define MAX_STRING_LENGTH 256
+/*! @brief Structure used to define the camera model*/
+
+typedef struct {
+    int cameraId;          //!< [-]   ID of the camera that took the snapshot*/
+    bool isOn; //!<  The camera is taking images at rendering rate if 1, 0 if not*/
+    char parentName[MAX_STRING_LENGTH];  //!< [-] Name of the parent body to which the camera should be attached
+    double fieldOfView[2];        //!< [rad]   Camera Field of View, edge-to-edge along camera y-axis */
+    int resolution[2];         //!< [-] Camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels*/
+    uint64_t renderRate;       //!< [ns] Frame time interval at which to capture images in units of nanosecond */
+    double cameraBodyFramePosition[3];     //!< [m] Camera position in body frame */
+    double bodyToCameraMrp[3];        //!< [-] MRP defining the orientation of the camera frame relative to the body frame */
+    double focalLength;
+    int gaussianPointSpreadFunction;  //!< Size of square Gaussian kernel to model point spread function, must be odd
+    double cosmicRayFrequency;  //!< Frequency at which cosmic rays can strike the camera
+    double readNoise;  //!< Read noise standard deviation
+    double systemGain;  //!< Mapping from current to pixel intensity
+    bool enableStrayLight;  //!< Add basic stray light modelling to images
+}CameraModelMsgPayload;
+
+#endif

--- a/src/simulation/sensors/camera/_UnitTest/test_camera.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_camera.py
@@ -1,6 +1,6 @@
 # ISC License
 #
-# Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+# Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -644,5 +644,3 @@ void Camera::setEnableStrayLight(const bool cameraEnableStrayLight) {
 bool Camera::getEnableStrayLight() const {
     return this->enableStrayLight;
 }
-
-

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -316,7 +316,7 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraMsg = this->cameraConfigOutMsg.zeroMsgPayload;
     cameraModelMsg = this->cameraModelOutMsg.zeroMsgPayload;
 
-    /*! - Populate the camera message */
+    /*! - Populate the camera config message */
     cameraMsg.cameraID = this->cameraID;
     strcpy(cameraMsg.parentName, this->parentName);
     cameraMsg.resolution[0] = this->resolution[0];

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -27,11 +27,12 @@
  */
 
 /* modify the path to reflect the new module names */
-#include <string.h>
 #include "camera.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include <string.h>
 
 /*! The constructor for the Camera module. It also sets some default values at its creation.  */
 Camera::Camera()

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -394,3 +394,232 @@ void Camera::UpdateState(uint64_t currentSimNanos)
         this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
     }
 }
+
+/*! Set the name of the parent body to which the camera should be attached
+    @param cameraParentName
+    @return void
+    */
+void Camera::setParentName(const std::string& cameraParentName) {
+    this->parentSpacecraftName = cameraParentName;
+}
+
+/*! Get the name of the parent body to which the camera should be attached
+    @return std::string parentSpacecraftName
+    */
+std::string Camera::getParentName() const {
+    return this->parentSpacecraftName;
+}
+
+/*! Set the camera to on, allowing it to take images
+    @return void
+    */
+void Camera::setCameraOn() {
+    this->cameraIsImaging = true;
+}
+
+/*! Set the camera to off, not allowing it to take images
+    @return void
+    */
+void Camera::setCameraOff() {
+    this->cameraIsImaging = false;
+}
+
+/*! Get if the camera is currently taking images
+    @return int cameraIsImaging
+    */
+bool Camera::isCameraOn() const {
+    return this->cameraIsImaging;
+}
+
+/*! Set the camera Id
+    @param cameraId int
+    @return void
+    */
+void Camera::setCameraId(const int cameraId) {
+    this->cameraIdentification = cameraId;
+}
+
+/*! Get the camera Id
+    @return int cameraIdentification
+    */
+int Camera::getCameraId() const {
+    return this->cameraIdentification;
+}
+
+/*! Set camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
+    @param cameraResolution Eigen::Vector2i
+    @return void
+    */
+void Camera::setResolution(const Eigen::Vector2i& cameraResolution) {
+    this->resolution = cameraResolution;
+}
+
+/*! Get camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
+    @return Eigen::Vector2i resolution
+    */
+Eigen::Vector2i Camera::getResolution() const {
+    return this->resolution;
+}
+
+/*! Set the frame time interval at which to capture images in units of nanosecond
+    @param cameraImageCadence uint64_t
+    @return void
+    */
+void Camera::setImageCadence(const uint64_t& cameraImageCadence) {
+    this->renderRate = cameraImageCadence;
+}
+
+/*! Get the frame time interval at which to capture images in units of nanosecond
+    @return uint64_t imageCadence
+    */
+uint64_t Camera::getImageCadence() const {
+    return this->imageCadence;
+}
+
+/*! Set the camera y-axis field of view edge-to-edge
+    @param fov Eigen::Vector2d
+    @return void
+    */
+void Camera::setFieldOfView(const Eigen::Vector2d& fov) {
+    this->cameraFieldOfView = fov;
+}
+
+/*! Get the camera y-axis field of view edge-to-edge
+    @return Eigen::Vector2d fieldOfView
+    */
+Eigen::Vector2d Camera::getFieldOfView() const {
+    return this->cameraFieldOfView;
+}
+
+/*! Set the camera position in body frame
+    @param cameraPosition_B Eigen::Vector3d
+    @return void
+    */
+void Camera::setCameraBodyFramePosition(const Eigen::Vector3d& cameraPosition_B) {
+    this->cameraBodyFramePosition = cameraPosition_B;
+}
+
+/*! Get the camera position in body frame
+    @return Eigen::Vector3d cameraPos_B
+    */
+Eigen::Vector3d Camera::getCameraBodyFramePosition() const {
+    return this->cameraBodyFramePosition;
+}
+
+/*! Set the orientation of the camera frame relative to the body frame
+    @param cameraMrp_CB Eigen::Vector3d
+    @return void
+    */
+void Camera::setBodyToCameraMrp(const Eigen::Vector3d& cameraMrp_CB) {
+    this->bodyToCameraMrp = cameraMrp_CB;
+}
+
+/*! Get the orientation of the camera frame relative to the body frame
+    @return Eigen::Vector3d sigma_CB
+    */
+Eigen::Vector3d Camera::getBodyToCameraMrp() const {
+    return this->bodyToCameraMrp;
+}
+
+/*! Set the camera focal length
+    @param cameraFocalLength double
+    @return void
+    */
+void Camera::setFocalLength(const double cameraFocalLength) {
+    this->focalLength = cameraFocalLength;
+}
+
+/*! Get the camera focal length
+    @return double focalLength
+    */
+double Camera::getFocalLength() const {
+    return this->focalLength;
+}
+
+
+/*! Set the size of square Gaussian kernel to model point spread function
+    @param cameraGaussianPointSpreadFunction int
+    @return void
+    */
+void Camera::setGaussianPointSpreadFunction(const int cameraGaussianPointSpreadFunction){
+    // asserts the value of cameraGaussianPointSpreadFunction must be odd
+    assert(cameraGaussianPointSpreadFunction % 2 == 1 && "Gaussian point spread function should be odd");
+    this->gaussianPointSpreadFunction = cameraGaussianPointSpreadFunction;
+}
+
+/*! Get the size of square Gaussian kernel to model point spread function
+    @return int gaussianPointSpreadFunction
+    */
+int Camera::getGaussianPointSpreadFunction() const {
+    return this->gaussianPointSpreadFunction;
+}
+
+/*! Set the frequency at which cosmic rays can strike the camera
+    @param cameraCosmicRayFrequency double
+    @return void
+    */
+
+void Camera::setCosmicRayFrequency(const double cameraCosmicRayFrequency) {
+    this->cosmicRayFrequency = cameraCosmicRayFrequency;
+}
+
+/*! Get the frequency at which cosmic rays can strike the camera
+    @return double cosmicRayFrequency
+    */
+
+double Camera::getCosmicRayFrequency() const{
+    return this->cosmicRayFrequency;
+}
+
+/*! Set the read noise standard deviation
+    @param cameraReadNoise double
+    @return void
+    */
+
+void Camera::setReadNoise(const double cameraReadNoise) {
+    this->readNoise = cameraReadNoise;
+}
+
+/*! Get the read noise standard deviation
+    @return double readNoise
+    */
+
+double Camera::getReadNoise() const {
+    return this->readNoise;
+}
+
+/*! Set the mapping from current to pixel intensity
+    @param cameraGain double
+    @return void
+    */
+
+void Camera::setSystemGain(const double cameraGain) {
+    this->systemGain = cameraGain;
+}
+
+/*! Get the mapping from current to pixel intensity
+    @return double systemGain
+    */
+
+double Camera::getSystemGain() const {
+    return this->systemGain;
+}
+
+/*! Set the mapping from current to pixel intensity
+    @param cameraEnableStrayLight bool
+    @return void
+    */
+
+void Camera::setEnableStrayLight(const bool cameraEnableStrayLight) {
+    this->enableStrayLight = cameraEnableStrayLight;
+}
+
+/*! Set the mapping from current to pixel intensity
+    @return bool enableStrayLight
+    */
+
+bool Camera::getEnableStrayLight() const {
+    return this->enableStrayLight;
+}
+
+

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -317,7 +317,7 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraModelMsg = this->cameraModelOutMsg.zeroMsgPayload;
 
     /*! - Populate the camera config message */
-    cameraMsg.cameraID = this->cameraID;
+    cameraMsg.cameraID = this->cameraId;
     strcpy(cameraMsg.parentName, this->parentName);
     cameraMsg.resolution[0] = this->resolution[0];
     cameraMsg.resolution[1] = this->resolution[1];
@@ -334,7 +334,7 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraMsg.ppMaxBlurSize = this->ppMaxBlurSize;
 
     /*! - Populate the camera model message */
-    cameraModelMsg.cameraID = this->cameraIdentification;
+    cameraModelMsg.cameraId = this->cameraIdentification;
     strcpy(cameraModelMsg.parentName, this->parentSpacecraftName.c_str());
     cameraModelMsg.resolution[0] = this->resolution[0];
     cameraModelMsg.resolution[1] = this->resolution[1];

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -309,10 +309,12 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     CameraImageMsgPayload imageBuffer = {};
     CameraImageMsgPayload imageOut;
     CameraConfigMsgPayload cameraMsg;
+    CameraModelMsgPayload cameraModelMsg;
 
     /* zero output messages */
     imageOut = this->imageOutMsg.zeroMsgPayload;
     cameraMsg = this->cameraConfigOutMsg.zeroMsgPayload;
+    cameraModelMsg = this->cameraModelOutMsg.zeroMsgPayload;
 
     /*! - Populate the camera message */
     cameraMsg.cameraID = this->cameraID;
@@ -331,8 +333,29 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraMsg.ppFocusDistance = this->ppFocusDistance;
     cameraMsg.ppMaxBlurSize = this->ppMaxBlurSize;
 
+    /*! - Populate the camera model message */
+    cameraModelMsg.cameraID = this->cameraIdentification;
+    strcpy(cameraModelMsg.parentName, this->parentSpacecraftName.c_str());
+    cameraModelMsg.resolution[0] = this->resolution[0];
+    cameraModelMsg.resolution[1] = this->resolution[1];
+    cameraModelMsg.renderRate = this->imageCadence;
+    cameraModelMsg.fieldOfView[0] = this->cameraFieldOfView[0];
+    cameraModelMsg.fieldOfView[1] = this->cameraFieldOfView[1];
+    cameraModelMsg.isOn = this->cameraIsImaging;
+    eigenVector3d2CArray(this->cameraBodyFramePosition, cameraModelMsg.cameraBodyFramePosition);
+    eigenVector3d2CArray(this->bodyToCameraMrp, cameraModelMsg.bodyToCameraMrp);
+    cameraModelMsg.focalLength = this->focalLength;
+    cameraModelMsg.gaussianPointSpreadFunction = this->gaussianPointSpreadFunction;
+    cameraModelMsg.cosmicRayFrequency = this->cosmicRayFrequency;
+    cameraModelMsg.readNoise = this->readNoise;
+    cameraModelMsg.systemGain = this->systemGain;
+    cameraModelMsg.enableStrayLight = this->enableStrayLight;
+
     /*! - Update the camera config data no matter if an image is present*/
     this->cameraConfigOutMsg.write(&cameraMsg, this->moduleID, currentSimNanos);
+
+    /*! - Update the camera model data no matter if an image is present*/
+    this->cameraModelOutMsg.write(&cameraModelMsg, this->moduleID, currentSimNanos);
 
     cv::Mat imageCV;
     cv::Mat blurred;

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -36,7 +36,6 @@
 /*! The constructor for the Camera module. It also sets some default values at its creation.  */
 Camera::Camera()
 {
-    this->renderRate = (uint64_t) (60*1E9);
     v3SetZero(this->cameraPos_B);
     v3SetZero(this->sigma_CB);
 }

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -23,6 +23,8 @@
 #include <stdint.h>
 #include <math.h>
 #include <Eigen/Dense>
+#include <Eigen/Core>
+#include <string_view>
 #include "opencv2/opencv.hpp"
 #include "opencv2/highgui.hpp"
 #include "opencv2/core/mat.hpp"
@@ -30,6 +32,7 @@
 
 #include "architecture/msgPayloadDefC/CameraImageMsgPayload.h"
 #include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/CameraModelMsgPayload.h"
 #include "architecture/messaging/messaging.h"
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
@@ -52,11 +55,58 @@ public:
     void addCosmicRayBurst(const cv::Mat&, cv::Mat &mDst, double);
     void applyFilters(cv::Mat &mSource, cv::Mat &mDst);
 
+    void setParentName(const std::string& cameraParentName);
+    std::string getParentName() const;
+    void setCameraOn();
+    void setCameraOff();
+    bool isCameraOn() const;
+    void setCameraId(int cameraId);
+    int getCameraId() const;
+    void setResolution(const Eigen::Vector2i& cameraResolution);
+    Eigen::Vector2i getResolution() const;
+    void setImageCadence(const uint64_t& cameraRenderRate);
+    uint64_t getImageCadence() const;
+    void setFieldOfView(const Eigen::Vector2d& fov);
+    Eigen::Vector2d getFieldOfView() const;
+    void setCameraBodyFramePosition(const Eigen::Vector3d& cameraPosition_B);
+    Eigen::Vector3d getCameraBodyFramePosition() const;
+    void setBodyToCameraMrp(const Eigen::Vector3d& cameraMrp_CB);
+    Eigen::Vector3d getBodyToCameraMrp() const;
+    void setFocalLength (double cameraFocalLength);
+    double getFocalLength() const;
+    void setGaussianPointSpreadFunction(int cameraGaussianPointSpreadFunction);
+    int getGaussianPointSpreadFunction() const;
+    void setCosmicRayFrequency(double cameraCosmicRayFrequency);
+    double getCosmicRayFrequency() const;
+    void setReadNoise(double cameraReadNoise);
+    double getReadNoise() const;
+    void setSystemGain(double cameraGain);
+    double getSystemGain() const;
+    void setEnableStrayLight(bool cameraEnablesStrayLight);
+    bool getEnableStrayLight() const;
+
+private:
+    std::string parentSpacecraftName{};  //!< [-] Name of the parent body to which the camera should be attached
+    bool cameraIsImaging{}; //!< [-] Is the camera currently taking images
+    int cameraIdentification{1}; //!< [-] Camera identification
+    Eigen::Vector2i resolution{512, 512}; //!< [-] Camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
+    uint64_t imageCadence{static_cast<uint64_t>(60*1E9)};       //!< [ns] Frame time interval at which to capture images in units of nanosecond
+    Eigen::Vector2d cameraFieldOfView{0.7, 0.7};       //!< [r] camera y-axis field of view edge-to-edge
+    Eigen::Vector3d cameraBodyFramePosition{};     //!< [m] Camera position in body frame
+    Eigen::Vector3d bodyToCameraMrp{};        //!< [-] MRP defining the orientation of the camera frame relative to the body frame
+    double focalLength{};   //!< Camera focal length
+    int gaussianPointSpreadFunction{};  //!< Size of square Gaussian kernel to model point spread function, must be odd
+    double cosmicRayFrequency{};  //!< Frequency at which cosmic rays can strike the camera
+    double readNoise{};  //!< Read noise standard deviation
+    double systemGain{};  //!< Mapping from current to pixel intensity
+    bool enableStrayLight{};  //!< Add basic stray light modelling to images
+
 public:
     std::string filename{};                //!< Filename for module to read an image directly
     ReadFunctor<CameraImageMsgPayload> imageInMsg;      //!< camera image input message
     Message<CameraImageMsgPayload> imageOutMsg;         //!< camera image output message
     Message<CameraConfigMsgPayload> cameraConfigOutMsg; //!< The name of the CameraConfigMsg output message
+    Message<CameraModelMsgPayload> cameraModelOutMsg; //!< The name of the CameraModelMsg output message
     std::string saveDir{};                 //!< The name of the directory to save images
     uint64_t sensorTimeTag{};              //!< [ns] Current time tag for sensor out
     int32_t saveImages{};                  //!< [-] 1 to save images to file for debugging

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -114,7 +114,7 @@ public:
     /*! Camera parameters */
     char parentName[MAX_STRING_LENGTH]{};  //!< [-] Name of the parent body to which the camera should be attached
     int cameraIsOn{}; //!< [-] Is the camera currently taking images
-    int cameraID{1}; //!< [-] Is the camera currently taking images
+    int cameraId{1}; //!< [-] Is the camera currently taking images
     uint64_t renderRate{static_cast<uint64_t>(60*1E9)};       //!< [ns] Frame time interval at which to capture images in units of nanosecond
     double fieldOfView{0.7};       //!< [r] camera y-axis field of view edge-to-edge
     double cameraPos_B[3]{};     //!< [m] Camera position in body frame

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -44,7 +44,7 @@ class Camera: public SysModel {
 public:
     Camera();
     ~Camera();
-    
+
     void UpdateState(uint64_t currentSimNanos) override;
     void Reset(uint64_t currentSimNanos) override;
     void hsvAdjust(const cv::Mat&, cv::Mat &mDst);
@@ -110,7 +110,7 @@ public:
     std::string saveDir{};                 //!< The name of the directory to save images
     uint64_t sensorTimeTag{};              //!< [ns] Current time tag for sensor out
     int32_t saveImages{};                  //!< [-] 1 to save images to file for debugging
-    
+
     /*! Camera parameters */
     char parentName[MAX_STRING_LENGTH]{};  //!< [-] Name of the parent body to which the camera should be attached
     int cameraIsOn{}; //!< [-] Is the camera currently taking images

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -115,8 +115,7 @@ public:
     char parentName[MAX_STRING_LENGTH]{};  //!< [-] Name of the parent body to which the camera should be attached
     int cameraIsOn{}; //!< [-] Is the camera currently taking images
     int cameraID{1}; //!< [-] Is the camera currently taking images
-    int resolution[2]{512, 512};         //!< [-] Camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
-    uint64_t renderRate{};       //!< [ns] Frame time interval at which to capture images in units of nanosecond
+    uint64_t renderRate{static_cast<uint64_t>(60*1E9)};       //!< [ns] Frame time interval at which to capture images in units of nanosecond
     double fieldOfView{0.7};       //!< [r] camera y-axis field of view edge-to-edge
     double cameraPos_B[3]{};     //!< [m] Camera position in body frame
     double sigma_CB[3]{};        //!< [-] MRP defining the orientation of the camera frame relative to the body frame

--- a/src/simulation/sensors/camera/camera.i
+++ b/src/simulation/sensors/camera/camera.i
@@ -32,6 +32,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "sys_model.i"
 %include "camera.h"
 
+%include "architecture/msgPayloadDefCpp/CameraModelMsgPayload.h"
 %include "architecture/msgPayloadDefC/CameraImageMsgPayload.h"
 
 %include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"

--- a/src/simulation/sensors/camera/camera.i
+++ b/src/simulation/sensors/camera/camera.i
@@ -1,7 +1,7 @@
  /*
  ISC License
 
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above

--- a/src/simulation/sensors/camera/camera.rst
+++ b/src/simulation/sensors/camera/camera.rst
@@ -34,6 +34,9 @@ provides information on what this message is used for.
     * - cameraConfigOutMsg
       - :ref:`CameraConfigMsgPayload`
       - camera parameters output message
+    * - cameraConfigOutMsg
+      - :ref:`CameraModelMsgPayload`
+      - updated camera parameters output message
     * - imageOutMsg
       - :ref:`CameraImageMsgPayload`
       - camera output message

--- a/src/simulation/sensors/camera/camera.rst
+++ b/src/simulation/sensors/camera/camera.rst
@@ -5,7 +5,7 @@ codebase. Although images are provided by the visualization, they are
 renders of the Unity engine and are not necessarily representative of
 a camera. The module reads in an image from a file, or in the
 simulation as a pointer to image data, then corrupts it according to
-input parameters. 
+input parameters.
 
 Module Assumptions and Limitations
 ----------------------------------

--- a/src/simulation/vizard/cielimInterface/cielimInterface.h
+++ b/src/simulation/vizard/cielimInterface/cielimInterface.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2023, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
* **Tickets addressed:** bsk-515
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
A new camera model message was added. The difference to the old one is a new private field, some of the parameters are a duplicate from the old public field, some have different variable types,  and new ones were also added. The simulation was modified to create and populate the new message.

## Verification
Unit test was updated to test the reading and writing of the camera message 

## Documentation
Documentation was updated with the new camera model message 

## Future work
No future work