### PR TITLE
Update inertial attitude ukf to accept IMUSensorMsgPayload

### DIFF
--- a/src/architecture/msgPayloadDefC/IMUSensorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/IMUSensorMsgPayload.h
@@ -27,6 +27,8 @@ typedef struct{
     double AccelPlatform[3];        //!< m/s2 Apparent acceleration of the platform
     double DRFramePlatform[3];      //!< r  Accumulated DRs in platform
     double AngVelPlatform[3];       //!< r/s Angular velocity in platform frame
+    double timeTag;                 //!< [-] Observation time tag
+    double numberOfValidGyroMeasurements;   //!< Number of valid gyro measurements
 }IMUSensorMsgPayload;
 
 

--- a/src/architecture/msgPayloadDefC/IMUSensorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/IMUSensorMsgPayload.h
@@ -20,16 +20,14 @@
 #ifndef _IMU_SENSOR_MESSAG_H
 #define _IMU_SENSOR_MESSAG_H
 
-
 //! @brief Simulated IMU Sensor output message definition.
-typedef struct{
-    double DVFramePlatform[3];      //!< m/s Accumulated DVs in platform
-    double AccelPlatform[3];        //!< m/s2 Apparent acceleration of the platform
-    double DRFramePlatform[3];      //!< r  Accumulated DRs in platform
-    double AngVelPlatform[3];       //!< r/s Angular velocity in platform frame
-    double timeTag;                 //!< [-] Observation time tag
-    double numberOfValidGyroMeasurements;   //!< Number of valid gyro measurements
-}IMUSensorMsgPayload;
-
+typedef struct {
+    double DVFramePlatform[3];             //!< m/s Accumulated DVs in platform
+    double AccelPlatform[3];               //!< m/s2 Apparent acceleration of the platform
+    double DRFramePlatform[3];             //!< r  Accumulated DRs in platform
+    double AngVelPlatform[3];              //!< r/s Angular velocity in platform frame
+    double timeTag;                        //!< [-] Observation time tag
+    double numberOfValidGyroMeasurements;  //!< Number of valid gyro measurements
+} IMUSensorMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDefC/STAttMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/STAttMsgPayload.h
@@ -22,9 +22,10 @@
 
 /*! @brief Output structure for ST attitude measurement in vehicle body frame*/
 typedef struct {
-    uint64_t timeTag;        //!< [ns] Vehicle time code associated with measurement
+    double timeTag;        //!< [s] Vehicle time code associated with measurement
     double MRP_BdyInrtl[3];  //!< [-] MRP estimate of inertial to body transformation
     double omega_BN_B[3];    //!< [rad/s] Platform inertial angular velocity
+    double dcm_CB[9];    //!< Star Tracker mount frame in the body frame
 } STAttMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDefC/STAttMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/STAttMsgPayload.h
@@ -22,10 +22,10 @@
 
 /*! @brief Output structure for ST attitude measurement in vehicle body frame*/
 typedef struct {
-    double timeTag;        //!< [s] Vehicle time code associated with measurement
+    double timeTag;          //!< [s] Vehicle time code associated with measurement
     double MRP_BdyInrtl[3];  //!< [-] MRP estimate of inertial to body transformation
     double omega_BN_B[3];    //!< [rad/s] Platform inertial angular velocity
-    double dcm_CB[9];    //!< Star Tracker mount frame in the body frame
+    double dcm_CB[9];        //!< Star Tracker mount frame in the body frame
 } STAttMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDefC/STSensorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/STSensorMsgPayload.h
@@ -23,7 +23,7 @@
 
 /*! @brief Star tracker sensor message */
 typedef struct {
-    double timeTag;       //!< [s] Time tag placed on the output state
+    double timeTag;         //!< [s] Time tag placed on the output state
     double qInrtl2Case[4];  //!< [-] Quaternion to go from the inertial to case
     double omega_CN_C[3];   //!< [rad/s] Inertial angular velocity in case frame
 } STSensorMsgPayload;

--- a/src/architecture/msgPayloadDefC/STSensorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/STSensorMsgPayload.h
@@ -23,7 +23,7 @@
 
 /*! @brief Star tracker sensor message */
 typedef struct {
-    uint64_t timeTag;       //!< [ns] Time tag placed on the output state
+    double timeTag;       //!< [s] Time tag placed on the output state
     double qInrtl2Case[4];  //!< [-] Quaternion to go from the inertial to case
     double omega_CN_C[3];   //!< [rad/s] Inertial angular velocity in case frame
 } STSensorMsgPayload;

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -101,7 +101,7 @@ void EkfInterface::timeUpdate(const double updateTime)
 void EkfInterface::measurementUpdate(const MeasurementModel &measurement)
 {
     /*! - Compute the valid observations delta */
-    Eigen::VectorXd measurementDelta = measurement.getObservation() - measurement.model(this->state);
+    Eigen::VectorXd measurementDelta = measurement.subMeasurements(measurement.getObservation(), measurement.model(this->state));
     /*! - Compute the measurement matrix at this state */
     Eigen::MatrixXd measurementMatrix = measurement.computeMeasurementMatrix(this->state);
 
@@ -113,7 +113,7 @@ void EkfInterface::measurementUpdate(const MeasurementModel &measurement)
     if ((this->covar.maxCoeff() > this->minCovarNorm && this->filterType == FilterType::Extended) ||
     this->filterType == FilterType::Classical){
         /*! - Compute the update with a CKF if the covariance is high at the time of the update to avoid divergence*/
-        EkfInterface::ckfUpdate(kalmanGain, measurementDelta, measurementMatrix);
+        EkfInterface::ckfUpdate(kalmanGain, EkfInterface::computeResiduals(measurement));
     }
     else{
         /*! - Compute the update with a EKF, the reference state is changed by the filter update */
@@ -154,15 +154,13 @@ void EkfInterface::updateCovariance(const Eigen::MatrixXd &measMat, const Eigen:
 
 /*! Classical Kalman Filter Update (the reference state is unchanged)
 @param Eigen::MatrixXd kalmanGain
-@param Eigen::VectorXd measurementDelta
-@param Eigen::MatrixXd measurementMatrix
+@param Eigen::VectorXd residual
 @return void
  */
 void EkfInterface::ckfUpdate(const Eigen::MatrixXd &kalmanGain,
-                             const Eigen::VectorXd &measurementDelta,
-                             const Eigen::MatrixXd &measurementMatrix){
+                             const Eigen::VectorXd &residual){
 
-    this->stateError = this->stateError + kalmanGain*(measurementDelta - measurementMatrix*this->stateError);
+    this->stateError = this->stateError + kalmanGain*residual;
     this->stateLogged = this->state.addVector(this->stateError);
 }
 
@@ -185,10 +183,10 @@ void EkfInterface::ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::Vec
  */
 Eigen::VectorXd EkfInterface::computeResiduals(const MeasurementModel &measurement)
 {
-    Eigen::VectorXd measurementDelta(measurement.getObservation() - measurement.model(this->state));
+    Eigen::VectorXd measurementDelta(measurement.subMeasurements(measurement.getObservation(), measurement.model(this->state)));
     Eigen::MatrixXd measurementMatrix = measurement.computeMeasurementMatrix(this->state);
 
-    return measurementDelta - measurementMatrix*this->stateError;
+    return measurement.subMeasurements(measurementDelta, measurementMatrix*this->stateError);
 }
 
 /*! Get the filter dynamics matrix (A = df/dX evaluated at the reference)

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.cpp
@@ -21,36 +21,30 @@
 
 #include "ekfInterface.h"
 
-EkfInterface::EkfInterface(FilterType type){
-    this->filterType = type;
-}
+EkfInterface::EkfInterface(FilterType type) { this->filterType = type; }
 
 /*! Reset all of the filter states, including the custom reset
  @return void
  @param currentSimNanos The clock time at which the function was called (nanoseconds)
  */
-void EkfInterface::reset(uint64_t currentSimNanos)
-{
+void EkfInterface::reset(uint64_t currentSimNanos) {
     KalmanFilter::reset(currentSimNanos);
     this->stateError = Eigen::VectorXd ::Zero(this->state.size());
     this->stateTransitionMatrix = Eigen::MatrixXd::Identity(this->state.size(), this->state.size());
     if (this->stateInitial.hasVelocity()) {
         this->processNoise.resize(this->state.getVelocityStates().size(), this->state.getVelocityStates().size());
-    }
-    else {
+    } else {
         this->processNoise.resize(this->state.getPositionStates().size(), this->state.getPositionStates().size());
     }
-    this->minCovarNorm = this->minCovarNorm*this->unitConversion*this->unitConversion;
+    this->minCovarNorm = this->minCovarNorm * this->unitConversion * this->unitConversion;
     this->customreset();
 }
-
 
 /*! Perform the time update for kalman filter.
  @return void
  @param updateTime The time that we need to fix the filter to (seconds)
  */
-void EkfInterface::timeUpdate(const double updateTime)
-{
+void EkfInterface::timeUpdate(const double updateTime) {
     double dt = updateTime - this->previousFilterTimeTag;
     this->stateTransitionMatrix = Eigen::MatrixXd::Identity(this->state.size(), this->state.size());
     std::array<double, 2> time = {0, dt};
@@ -71,56 +65,55 @@ void EkfInterface::timeUpdate(const double updateTime)
      * The process noise mapping will depend on the number of "rate" states */
     Eigen::MatrixXd processNoiseMapping;
     if (!this->state.hasVelocity()) {
-        processNoiseMapping = Eigen::MatrixXd::Identity(this->state.getPositionStates().size(),
-                                                        this->state.getPositionStates().size());
+        processNoiseMapping =
+            Eigen::MatrixXd::Identity(this->state.getPositionStates().size(), this->state.getPositionStates().size());
         processNoiseMapping *= pow(dt, 2) / 2;
-    }
-    else{
+    } else {
         processNoiseMapping.setZero(this->state.getPositionStates().size() + this->state.getVelocityStates().size(),
                                     this->state.getVelocityStates().size());
-        processNoiseMapping.block(0, 0, this->state.getPositionStates().size(),
-                                  this->state.getPositionStates().size()) =
-            pow(dt, 2) / 2 * Eigen::MatrixXd::Identity(this->state.getPositionStates().size(),
-                                  this->state.getPositionStates().size());
-        processNoiseMapping.block(this->state.getPositionStates().size(), 0, this->state.getVelocityStates().size(),
-                                                        this->state.getVelocityStates().size()) =
-            dt * Eigen::MatrixXd::Identity(this->state.getVelocityStates().size(),
-                                                        this->state.getVelocityStates().size());
+        processNoiseMapping.block(
+            0, 0, this->state.getPositionStates().size(), this->state.getPositionStates().size()) =
+            pow(dt, 2) / 2 *
+            Eigen::MatrixXd::Identity(this->state.getPositionStates().size(), this->state.getPositionStates().size());
+        processNoiseMapping.block(this->state.getPositionStates().size(),
+                                  0,
+                                  this->state.getVelocityStates().size(),
+                                  this->state.getVelocityStates().size()) =
+            dt *
+            Eigen::MatrixXd::Identity(this->state.getVelocityStates().size(), this->state.getVelocityStates().size());
     }
-    this->covar = this->stateTransitionMatrix*this->covar*this->stateTransitionMatrix.transpose() +
-            processNoiseMapping*this->processNoise*processNoiseMapping.transpose();
+    this->covar = this->stateTransitionMatrix * this->covar * this->stateTransitionMatrix.transpose() +
+                  processNoiseMapping * this->processNoise * processNoiseMapping.transpose();
 
     this->previousFilterTimeTag = updateTime;
 }
-
 
 /*! Perform the measurement update for the kalman filter.
  @param Measurement
  @return void
  */
-void EkfInterface::measurementUpdate(const MeasurementModel &measurement)
-{
+void EkfInterface::measurementUpdate(const MeasurementModel &measurement) {
     /*! - Compute the valid observations delta */
-    Eigen::VectorXd measurementDelta = measurement.subMeasurements(measurement.getObservation(), measurement.model(this->state));
+    Eigen::VectorXd measurementDelta =
+        measurement.subMeasurements(measurement.getObservation(), measurement.model(this->state));
     /*! - Compute the measurement matrix at this state */
     Eigen::MatrixXd measurementMatrix = measurement.computeMeasurementMatrix(this->state);
 
     /*! - Compute the Kalman Gain */
-    Eigen::MatrixXd kalmanGain = EkfInterface::computeKalmanGain(this->covar, measurementMatrix, measurement.getMeasurementNoise());
+    Eigen::MatrixXd kalmanGain =
+        EkfInterface::computeKalmanGain(this->covar, measurementMatrix, measurement.getMeasurementNoise());
 
     /*! - Update the covariance */
     EkfInterface::updateCovariance(measurementMatrix, measurement.getMeasurementNoise(), kalmanGain);
     if ((this->covar.maxCoeff() > this->minCovarNorm && this->filterType == FilterType::Extended) ||
-    this->filterType == FilterType::Classical){
+        this->filterType == FilterType::Classical) {
         /*! - Compute the update with a CKF if the covariance is high at the time of the update to avoid divergence*/
         EkfInterface::ckfUpdate(kalmanGain, EkfInterface::computeResiduals(measurement));
-    }
-    else{
+    } else {
         /*! - Compute the update with a EKF, the reference state is changed by the filter update */
         EkfInterface::ekfUpdate(kalmanGain, measurementDelta);
     }
 }
-
 
 /*! Compute the Kalman Gain
 @param Eigen::MatrixXd covar
@@ -132,11 +125,10 @@ Eigen::MatrixXd EkfInterface::computeKalmanGain(const Eigen::MatrixXd &covarianc
                                                 const Eigen::MatrixXd &measurementMatrix,
                                                 const Eigen::MatrixXd &measurementNoise) const {
     Eigen::MatrixXd kalmanGain(covariance.cols(), measurementNoise.cols());
-    kalmanGain = covariance*measurementMatrix.transpose();
-    kalmanGain *= (measurementMatrix*covariance*measurementMatrix.transpose() + measurementNoise).inverse();
+    kalmanGain = covariance * measurementMatrix.transpose();
+    kalmanGain *= (measurementMatrix * covariance * measurementMatrix.transpose() + measurementNoise).inverse();
     return kalmanGain;
 }
-
 
 /*! Update the covariance using the Joseph form of the update
 @param Eigen::MatrixXd measMat
@@ -144,23 +136,22 @@ Eigen::MatrixXd EkfInterface::computeKalmanGain(const Eigen::MatrixXd &covarianc
 @param Eigen::MatrixXd kalmanGain
 @return void
  */
-void EkfInterface::updateCovariance(const Eigen::MatrixXd &measMat, const Eigen::MatrixXd &noise, const Eigen::MatrixXd &kalmanGain){
+void EkfInterface::updateCovariance(const Eigen::MatrixXd &measMat,
+                                    const Eigen::MatrixXd &noise,
+                                    const Eigen::MatrixXd &kalmanGain) {
     Eigen::MatrixXd josephTransform(this->state.size(), this->state.size());
-    josephTransform = Eigen::MatrixXd::Identity(this->state.size(), this->state.size()) - kalmanGain*measMat;
-    this->covar = josephTransform*this->covar*josephTransform.transpose();
-    this->covar += kalmanGain*noise*kalmanGain.transpose();
+    josephTransform = Eigen::MatrixXd::Identity(this->state.size(), this->state.size()) - kalmanGain * measMat;
+    this->covar = josephTransform * this->covar * josephTransform.transpose();
+    this->covar += kalmanGain * noise * kalmanGain.transpose();
 }
-
 
 /*! Classical Kalman Filter Update (the reference state is unchanged)
 @param Eigen::MatrixXd kalmanGain
 @param Eigen::VectorXd residual
 @return void
  */
-void EkfInterface::ckfUpdate(const Eigen::MatrixXd &kalmanGain,
-                             const Eigen::VectorXd &residual){
-
-    this->stateError = this->stateError + kalmanGain*residual;
+void EkfInterface::ckfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &residual) {
+    this->stateError = this->stateError + kalmanGain * residual;
     this->stateLogged = this->state.addVector(this->stateError);
 }
 
@@ -169,9 +160,8 @@ void EkfInterface::ckfUpdate(const Eigen::MatrixXd &kalmanGain,
 @param Eigen::VectorXd measurementDelta
 @return void
  */
-void EkfInterface::ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &measurementDelta){
-
-    this->stateError = kalmanGain*measurementDelta;
+void EkfInterface::ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &measurementDelta) {
+    this->stateError = kalmanGain * measurementDelta;
 
     this->state = this->state.addVector(this->stateError);
     this->stateLogged = this->state;
@@ -181,19 +171,19 @@ void EkfInterface::ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::Vec
 @param Measurement
 @return Eigen::VectorXd
  */
-Eigen::VectorXd EkfInterface::computeResiduals(const MeasurementModel &measurement)
-{
-    Eigen::VectorXd measurementDelta(measurement.subMeasurements(measurement.getObservation(), measurement.model(this->state)));
+Eigen::VectorXd EkfInterface::computeResiduals(const MeasurementModel &measurement) {
+    Eigen::VectorXd measurementDelta(
+        measurement.subMeasurements(measurement.getObservation(), measurement.model(this->state)));
     Eigen::MatrixXd measurementMatrix = measurement.computeMeasurementMatrix(this->state);
 
-    return measurement.subMeasurements(measurementDelta, measurementMatrix*this->stateError);
+    return measurement.subMeasurements(measurementDelta, measurementMatrix * this->stateError);
 }
 
 /*! Get the filter dynamics matrix (A = df/dX evaluated at the reference)
     @return Eigen::VectorXd stateInitial
     */
-void EkfInterface::setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)>&
-            dynamicsMatrixCalculator){
+void EkfInterface::setFilterDynamicsMatrix(
+    const std::function<const Eigen::MatrixXd(const double, const FilterStateVector &)> &dynamicsMatrixCalculator) {
     this->dynamics.setDynamicsMatrix(dynamicsMatrixCalculator);
 }
 
@@ -202,13 +192,11 @@ void EkfInterface::setFilterDynamicsMatrix(const std::function<const Eigen::Matr
     @param double infiniteNorm
     @return void
     */
-void EkfInterface::setMinimumCovarianceNormForEkf(const double infiniteNorm){
-    this->minCovarNorm = infiniteNorm;
-}
+void EkfInterface::setMinimumCovarianceNormForEkf(const double infiniteNorm) { this->minCovarNorm = infiniteNorm; }
 
 /*! Get the minimum value of the covariance before switching to Extended KF updates.
     @return double infiniteNorm
     */
 double EkfInterface::getMinimumCovarianceNormForEkf() const {
-    return this->minCovarNorm/this->unitConversion/this->unitConversion;
+    return this->minCovarNorm / this->unitConversion / this->unitConversion;
 }

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
@@ -61,7 +61,7 @@ private:
                                     const Eigen::MatrixXd &measurementMatrix,
                                     const Eigen::MatrixXd &measurementNoise) const;
     void updateCovariance(const Eigen::MatrixXd &measMat, const Eigen::MatrixXd &noise, const Eigen::MatrixXd &kalmanGain);
-    void ckfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &yMeas, const Eigen::MatrixXd &measurementMatrix);
+    void ckfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &residual);
     void ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &yMeas);
 
     Eigen::MatrixXd stateTransitionMatrix; //!< [-] State Transition Matrix

--- a/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/ekfInterface.h
@@ -20,54 +20,56 @@
 #ifndef EKF_INTERFACE_HPP
 #define EKF_INTERFACE_HPP
 
-#include <Eigen/Dense>
-#include <functional>
-#include <optional>
-#include <array>
-#include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "fswAlgorithms/_GeneralModuleFiles/filterInterfaceDefinitions.h"
-#include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
-#include "fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h"
-#include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/macroDefinitions.h"
 #include "fswAlgorithms/_GeneralModuleFiles/dynamicModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/filterInterfaceDefinitions.h"
+#include "fswAlgorithms/_GeneralModuleFiles/kalmanFilter.h"
+#include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
+#include <Eigen/Dense>
+#include <array>
+#include <functional>
+#include <optional>
 
 /*! Enumerator class to set if the filter is meant to be used purely as a linear/classical KF,
  * no reference state updates will be performed in the classical filter, while the EKF updates the reference
  * with the computed state error at each measurement update */
-enum class FilterType {Classical, Extended};
+enum class FilterType { Classical, Extended };
 
 /*! @brief Extended or Classical/Linear Kalman Filter base class. */
-class EkfInterface: public KalmanFilter {
-public:
+class EkfInterface : public KalmanFilter {
+   public:
     EkfInterface(FilterType type);
     ~EkfInterface() = default;
     void reset(uint64_t currentSimNanos) override;
 
-    void setFilterDynamicsMatrix(const std::function<const Eigen::MatrixXd(const double, const FilterStateVector&)>&
-        dynamicsMatrixCalculator);
+    void setFilterDynamicsMatrix(
+        const std::function<const Eigen::MatrixXd(const double, const FilterStateVector &)> &dynamicsMatrixCalculator);
     void setMinimumCovarianceNormForEkf(double infiniteNorm);
     double getMinimumCovarianceNormForEkf() const;
 
-
-private:
+   private:
     void timeUpdate(double updateTime) final;
     void measurementUpdate(const MeasurementModel &measurement) final;
 
     Eigen::VectorXd computeResiduals(const MeasurementModel &measurement) final;
     Eigen::MatrixXd computeKalmanGain(const Eigen::MatrixXd &covar,
-                                    const Eigen::MatrixXd &measurementMatrix,
-                                    const Eigen::MatrixXd &measurementNoise) const;
-    void updateCovariance(const Eigen::MatrixXd &measMat, const Eigen::MatrixXd &noise, const Eigen::MatrixXd &kalmanGain);
+                                      const Eigen::MatrixXd &measurementMatrix,
+                                      const Eigen::MatrixXd &measurementNoise) const;
+    void updateCovariance(const Eigen::MatrixXd &measMat,
+                          const Eigen::MatrixXd &noise,
+                          const Eigen::MatrixXd &kalmanGain);
     void ckfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &residual);
     void ekfUpdate(const Eigen::MatrixXd &kalmanGain, const Eigen::VectorXd &yMeas);
 
-    Eigen::MatrixXd stateTransitionMatrix; //!< [-] State Transition Matrix
+    Eigen::MatrixXd stateTransitionMatrix;  //!< [-] State Transition Matrix
     double minCovarNorm = 1E-5; /*!< [-] Infinite norm after which the filter will begin processing measurements as
     an extended kalman filter */
-    FilterType filterType = FilterType::Extended; //!< [-] flag to know whether the filter is being run as a linear KF or extended KF
+    FilterType filterType =
+        FilterType::Extended;  //!< [-] flag to know whether the filter is being run as a linear KF or extended KF
 };
 
 #endif /* EKF_INTERFACE_HPP */

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
@@ -24,14 +24,13 @@
  * @param FilterStateVector
  * @return Eigen::MatrixXd
  */
-Eigen::MatrixXd MeasurementModel::model(const FilterStateVector& state) const {
-    return this->measurementModel(state);
-}
+Eigen::MatrixXd MeasurementModel::model(const FilterStateVector& state) const { return this->measurementModel(state); }
 
 /*! Set function to represent measurement model which inputs a stateModel and outputs a matrix
  * @param std::function<const Eigen::MatrixXd(const FilterStateVector&)>
  */
-void MeasurementModel::setMeasurementModel(const std::function<const Eigen::MatrixXd(const FilterStateVector&)> &modelCalculator) {
+void MeasurementModel::setMeasurementModel(
+    const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& modelCalculator) {
     this->measurementModel = modelCalculator;
 }
 
@@ -47,7 +46,8 @@ Eigen::MatrixXd MeasurementModel::computeMeasurementMatrix(const FilterStateVect
  * model with respect to state)
  * @param std::function<const Eigen::MatrixXd(const FilterStateVector&)>
  */
-void MeasurementModel::setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const FilterStateVector&)> &hMatrixCalculator){
+void MeasurementModel::setMeasurementMatrix(
+    const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& hMatrixCalculator) {
     this->measurementPartials = hMatrixCalculator;
 }
 
@@ -57,7 +57,8 @@ void MeasurementModel::setMeasurementMatrix(const std::function<const Eigen::Mat
  * @param Eigen::VectorXd measurementPredicted
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::subMeasurements(const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted) const{
+Eigen::VectorXd MeasurementModel::subMeasurements(const Eigen::VectorXd& measurementObserved,
+                                                  const Eigen::VectorXd& measurementPredicted) const {
     return this->measurementSubtraction(measurementObserved, measurementPredicted);
 }
 
@@ -65,112 +66,89 @@ Eigen::VectorXd MeasurementModel::subMeasurements(const Eigen::VectorXd& measure
  * other functions depending on the measurement type
  * @param subFunction std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)>
  */
-void MeasurementModel::setMeasurementSubtraction(const std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> &subFunction){
-    this->measurementSubtraction= subFunction;
+void MeasurementModel::setMeasurementSubtraction(
+    const std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)>& subFunction) {
+    this->measurementSubtraction = subFunction;
 }
 
 /*! Return the size of the observation
    @return size_t
 */
-size_t MeasurementModel::size() const {
-    return this->getObservation().size();
-}
+size_t MeasurementModel::size() const { return this->getObservation().size(); }
 
 /*! Get measurement name
  * @return std::string
  */
-std::string MeasurementModel::getMeasurementName() const {
-    return this->name;
-}
+std::string MeasurementModel::getMeasurementName() const { return this->name; }
 
 /*! Set measurement name
  * @param std::string
  */
-void MeasurementModel::setMeasurementName(std::string_view measurementName){
-    this->name = measurementName;
-}
+void MeasurementModel::setMeasurementName(std::string_view measurementName) { this->name = measurementName; }
 
 /*! Get measurement time tag
  * @return double
  */
-double MeasurementModel::getTimeTag() const {
-    return this->timeTag;
-}
+double MeasurementModel::getTimeTag() const { return this->timeTag; }
 
 /*! Set measurement time tag
  * @param double
  */
-void MeasurementModel::setTimeTag(const double measurementTimeTag){
-    this->timeTag = measurementTimeTag;
-}
+void MeasurementModel::setTimeTag(const double measurementTimeTag) { this->timeTag = measurementTimeTag; }
 
 /*! Get measurement validity
  * @return Eigen::VectorXd
  */
-bool MeasurementModel::getValidity() const {
-    return this->validity;
-}
+bool MeasurementModel::getValidity() const { return this->validity; }
 
 /*! Set measurement validity
  * @param bool
  */
-void MeasurementModel::setValidity(const bool measurementValidity){
-    this->validity = measurementValidity;
-}
+void MeasurementModel::setValidity(const bool measurementValidity) { this->validity = measurementValidity; }
 
 /*! Get measurement observation
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::getObservation() const {
-    return this->observation;
-}
+Eigen::VectorXd MeasurementModel::getObservation() const { return this->observation; }
 
 /*! Set measurement observation
  * @param Eigen::VectorXd
  */
-void MeasurementModel::setObservation(const Eigen::VectorXd& measurementObserved){
+void MeasurementModel::setObservation(const Eigen::VectorXd& measurementObserved) {
     this->observation = measurementObserved;
 }
 
 /*! Get measurement noise
  * @return Eigen::MatrixXd
  */
-Eigen::MatrixXd MeasurementModel::getMeasurementNoise() const {
-    return this->noise;
-}
+Eigen::MatrixXd MeasurementModel::getMeasurementNoise() const { return this->noise; }
 
 /*! Set measurement noise
  * @param Eigen::MatrixXd
  */
-void MeasurementModel::setMeasurementNoise(const Eigen::MatrixXd& measurementNoise){
-    this->noise = measurementNoise;
-}
+void MeasurementModel::setMeasurementNoise(const Eigen::MatrixXd& measurementNoise) { this->noise = measurementNoise; }
 
 /*! Get post fit residuals of observation
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::getPostFitResiduals() const {
-    return this->postFitResiduals;
-}
+Eigen::VectorXd MeasurementModel::getPostFitResiduals() const { return this->postFitResiduals; }
 
 /*! Set post fit residuals of observation
  * @param Eigen::VectorXd
  */
-void MeasurementModel::setPostFitResiduals(const Eigen::VectorXd& measurementPostFit){
+void MeasurementModel::setPostFitResiduals(const Eigen::VectorXd& measurementPostFit) {
     this->postFitResiduals = measurementPostFit;
 }
 
 /*! Get pre fit residuals of observation
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::getPreFitResiduals() const {
-    return this->preFitResiduals;
-}
+Eigen::VectorXd MeasurementModel::getPreFitResiduals() const { return this->preFitResiduals; }
 
 /*! Set pre fit residuals of observation
  * @param Eigen::VectorXd
  */
-void MeasurementModel::setPreFitResiduals(const Eigen::VectorXd& measurementPreFit){
+void MeasurementModel::setPreFitResiduals(const Eigen::VectorXd& measurementPreFit) {
     this->preFitResiduals = measurementPreFit;
 }
 
@@ -178,26 +156,21 @@ void MeasurementModel::setPreFitResiduals(const Eigen::VectorXd& measurementPreF
  * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::positionStates(const FilterStateVector &state)
-{
-    return state.getPositionStates();
-}
+Eigen::VectorXd MeasurementModel::positionStates(const FilterStateVector& state) { return state.getPositionStates(); }
 
 /*! Measurement model that returns the unit vector of the position state
  * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::normalizedPositionStates(const FilterStateVector &state)
-{
-    return state.getPositionStates()/state.getPositionStates().norm();
+Eigen::VectorXd MeasurementModel::normalizedPositionStates(const FilterStateVector& state) {
+    return state.getPositionStates() / state.getPositionStates().norm();
 }
 
 /*! Measurement model that returns the position component of the state, and performs a MRP shadow set check
  * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::mrpStates(const FilterStateVector &state)
-{
+Eigen::VectorXd MeasurementModel::mrpStates(const FilterStateVector& state) {
     return mrpSwitch(state.getPositionStates(), 1);
 }
 
@@ -205,15 +178,10 @@ Eigen::VectorXd MeasurementModel::mrpStates(const FilterStateVector &state)
  * @param FilterStateVector state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd MeasurementModel::velocityStates(const FilterStateVector &state)
-{
-    return state.getVelocityStates();
-}
+Eigen::VectorXd MeasurementModel::velocityStates(const FilterStateVector& state) { return state.getVelocityStates(); }
 
 /*! Measurement model that takes first 3 components of the state vector and interprets them as MRPs
  * @param Eigen::VectorXd state
  * @return Eigen::VectorXd
  */
-Eigen::VectorXd mrpFirstThreeStates(Eigen::VectorXd state){
-    return mrpSwitch(state.head(3), 1);
-}
+Eigen::VectorXd mrpFirstThreeStates(Eigen::VectorXd state) { return mrpSwitch(state.head(3), 1); }

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.cpp
@@ -51,6 +51,24 @@ void MeasurementModel::setMeasurementMatrix(const std::function<const Eigen::Mat
     this->measurementPartials = hMatrixCalculator;
 }
 
+/*! Subtract measurements. By default this is a linear subtraction, but could be subMrp or
+ * other functions depending on the measurement type
+ * @param Eigen::VectorXd measurementObserved
+ * @param Eigen::VectorXd measurementPredicted
+ * @return Eigen::VectorXd
+ */
+Eigen::VectorXd MeasurementModel::subMeasurements(const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted) const{
+    return this->measurementSubtraction(measurementObserved, measurementPredicted);
+}
+
+/*! Set function to add measurements. By default this add function is an R^n subtraction, but could be subMrp or
+ * other functions depending on the measurement type
+ * @param subFunction std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)>
+ */
+void MeasurementModel::setMeasurementSubtraction(const std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> &subFunction){
+    this->measurementSubtraction= subFunction;
+}
+
 /*! Return the size of the observation
    @return size_t
 */

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
@@ -18,31 +18,33 @@
 
  */
 
-#include <Eigen/Core>
-#include <string_view>
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 #include "fswAlgorithms/_GeneralModuleFiles/stateModels.h"
+#include <Eigen/Core>
+#include <string_view>
 
 #ifndef FILTER_MEAS_MODELS_H
 #define FILTER_MEAS_MODELS_H
 
 /*! @brief Container class for measurement data and models */
-class MeasurementModel{
-public:
+class MeasurementModel {
+   public:
     MeasurementModel() = default;
     ~MeasurementModel() = default;
 
-    static Eigen::VectorXd positionStates(const FilterStateVector &state);
-    static Eigen::VectorXd normalizedPositionStates(const FilterStateVector &state);
-    static Eigen::VectorXd mrpStates(const FilterStateVector &state);
-    static Eigen::VectorXd velocityStates(const FilterStateVector &state);
+    static Eigen::VectorXd positionStates(const FilterStateVector& state);
+    static Eigen::VectorXd normalizedPositionStates(const FilterStateVector& state);
+    static Eigen::VectorXd mrpStates(const FilterStateVector& state);
+    static Eigen::VectorXd velocityStates(const FilterStateVector& state);
 
     Eigen::MatrixXd model(const FilterStateVector& state) const;
     void setMeasurementModel(const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& modelCalculator);
     Eigen::MatrixXd computeMeasurementMatrix(const FilterStateVector& state) const;
     void setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& hMatrixCalculator);
-    Eigen::VectorXd subMeasurements(const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted) const;
-    void setMeasurementSubtraction(const std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)>& add);
+    Eigen::VectorXd subMeasurements(const Eigen::VectorXd& measurementObserved,
+                                    const Eigen::VectorXd& measurementPredicted) const;
+    void setMeasurementSubtraction(
+        const std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)>& add);
 
     size_t size() const;
     std::string getMeasurementName() const;
@@ -60,24 +62,24 @@ public:
     Eigen::VectorXd getPostFitResiduals() const;
     void setPostFitResiduals(const Eigen::VectorXd& measurementPostFit);
 
+   private:
+    std::string name{};                //!< [-] Name of measurement  type
+    double timeTag{};                  //!< [-] Observation time tag
+    bool validity = false;             //!< [-] Observation validity
+    Eigen::VectorXd observation;       //!< [-] Observation data vector
+    Eigen::MatrixXd noise;             //!< [-] Measurement Noise
+    Eigen::MatrixXd choleskyNoise;     //!< [-] Cholesky decomposition of measurement noise
+    Eigen::VectorXd postFitResiduals;  //!< [-] Observation post fit residuals
+    Eigen::VectorXd preFitResiduals;   //!< [-] Observation pre fit residuals
 
-private:
-    std::string name{}; //!< [-] Name of measurement  type
-    double timeTag{}; //!< [-] Observation time tag
-    bool validity = false; //!< [-] Observation validity
-    Eigen::VectorXd observation; //!< [-] Observation data vector
-    Eigen::MatrixXd noise; //!< [-] Measurement Noise
-    Eigen::MatrixXd choleskyNoise; //!< [-] Cholesky decomposition of measurement noise
-    Eigen::VectorXd postFitResiduals; //!< [-] Observation post fit residuals
-    Eigen::VectorXd preFitResiduals; //!< [-] Observation pre fit residuals
-
-    std::function<const Eigen::MatrixXd(const FilterStateVector&)> measurementModel; //!< [-] observation measurement model
-    std::function<const Eigen::MatrixXd(const FilterStateVector&)> measurementPartials; //!< [-] partial of measurement model wrt state
-    std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> measurementSubtraction
-    = [](const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted){
-        return measurementObserved - measurementPredicted;
-    };
-
+    std::function<const Eigen::MatrixXd(const FilterStateVector&)>
+        measurementModel;  //!< [-] observation measurement model
+    std::function<const Eigen::MatrixXd(const FilterStateVector&)>
+        measurementPartials;  //!< [-] partial of measurement model wrt state
+    std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> measurementSubtraction =
+        [](const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted) {
+            return measurementObserved - measurementPredicted;
+        };
 };
 
 #endif

--- a/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
+++ b/src/fswAlgorithms/_GeneralModuleFiles/measurementModels.h
@@ -41,6 +41,8 @@ public:
     void setMeasurementModel(const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& modelCalculator);
     Eigen::MatrixXd computeMeasurementMatrix(const FilterStateVector& state) const;
     void setMeasurementMatrix(const std::function<const Eigen::MatrixXd(const FilterStateVector&)>& hMatrixCalculator);
+    Eigen::VectorXd subMeasurements(const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted) const;
+    void setMeasurementSubtraction(const std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)>& add);
 
     size_t size() const;
     std::string getMeasurementName() const;
@@ -71,6 +73,10 @@ private:
 
     std::function<const Eigen::MatrixXd(const FilterStateVector&)> measurementModel; //!< [-] observation measurement model
     std::function<const Eigen::MatrixXd(const FilterStateVector&)> measurementPartials; //!< [-] partial of measurement model wrt state
+    std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> measurementSubtraction
+    = [](const Eigen::VectorXd& measurementObserved, const Eigen::VectorXd& measurementPredicted){
+        return measurementObserved - measurementPredicted;
+    };
 
 };
 

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.cpp
@@ -25,14 +25,13 @@
  @return void
  @param currentSimNanos The clock time at which the function was called (nanoseconds)
  */
-void SRukfInterface::reset(uint64_t currentSimNanos)
-{
+void SRukfInterface::reset(uint64_t currentSimNanos) {
     KalmanFilter::reset(currentSimNanos);
 
-    this->sBar = this->unitConversion*this->unitConversion * this->covarInitial;
+    this->sBar = this->unitConversion * this->unitConversion * this->covarInitial;
     this->sBar.resize(this->state.size(), this->state.size());
 
-    this->numberSigmaPoints = this->state.size()*2+1;
+    this->numberSigmaPoints = this->state.size() * 2 + 1;
 
     /*! - Ensure that all internal filter matrices are zeroed*/
     this->wM.setZero(this->numberSigmaPoints);
@@ -41,24 +40,23 @@ void SRukfInterface::reset(uint64_t currentSimNanos)
     this->cholProcessNoise.setZero(this->state.size(), this->state.size());
 
     /*! - Set lambda/gamma to standard value for unscented kalman filters */
-    this->lambda = (double) this->state.size()*(this->alpha*this->alpha - 1);
-    this->eta = sqrt((double) this->state.size() + this->lambda);
+    this->lambda = (double)this->state.size() * (this->alpha * this->alpha - 1);
+    this->eta = sqrt((double)this->state.size() + this->lambda);
 
     /*! - Set the wM/wC vectors to standard values for unscented kalman filters*/
-    this->wM(0) = this->lambda / ((double) this->state.size() + this->lambda);
-    this->wC(0) = this->lambda / ((double) this->state.size() + this->lambda) +
-            (1 - this->alpha*this->alpha + this->beta);
-    for (auto i = 1; i < this->numberSigmaPoints; ++i)
-    {
-        this->wM(i) = 1.0 / (2.0 * ((double) this->state.size() + this->lambda));
+    this->wM(0) = this->lambda / ((double)this->state.size() + this->lambda);
+    this->wC(0) =
+        this->lambda / ((double)this->state.size() + this->lambda) + (1 - this->alpha * this->alpha + this->beta);
+    for (auto i = 1; i < this->numberSigmaPoints; ++i) {
+        this->wM(i) = 1.0 / (2.0 * ((double)this->state.size() + this->lambda));
         this->wC(i) = this->wM(i);
     }
 
     /*! - Perform cholesky decompositions of covariance and noise */
     this->sBar = SRukfInterface::choleskyDecomposition(this->covar);
     this->processNoise.resize(this->state.size(), this->state.size());
-    this->cholProcessNoise = SRukfInterface::choleskyDecomposition(this->unitConversion*this->unitConversion*
-            this->processNoise);
+    this->cholProcessNoise =
+        SRukfInterface::choleskyDecomposition(this->unitConversion * this->unitConversion * this->processNoise);
 
     this->customreset();
 }
@@ -69,10 +67,9 @@ void SRukfInterface::reset(uint64_t currentSimNanos)
  @return void
  @param updateTime The time that we need to fix the filter to (seconds)
  */
-void SRukfInterface::timeUpdate(double updateTime)
-{
+void SRukfInterface::timeUpdate(double updateTime) {
     Eigen::VectorXd propagatedSigmaPoint;
-    Eigen::MatrixXd A(this->state.size(), 3*this->state.size());
+    Eigen::MatrixXd A(this->state.size(), 3 * this->state.size());
 
     double dt = updateTime - this->previousFilterTimeTag;
     std::array<double, 2> time = {0, dt};
@@ -84,29 +81,25 @@ void SRukfInterface::timeUpdate(double updateTime)
 
     /*! - For each Sigma point, apply sBar-based error, propagate forward, and scale by Wm just like 0th.
      Note that we perform +/- sigma points simultaneously in loop to save loop values.*/
-    for (size_t i = 1; i<this->state.size() + 1; ++i)
-    {
+    for (size_t i = 1; i < this->state.size() + 1; ++i) {
         /*! - Adding covariance columns from sigma points*/
-        this->sigmaPoints[i] = dynamics.propagate(time, this->state.addVector(this->eta * this->sBar.col(i-1)), dt);
+        this->sigmaPoints[i] = dynamics.propagate(time, this->state.addVector(this->eta * this->sBar.col(i - 1)), dt);
         /*! - Subtracting covariance columns from sigma points*/
         this->sigmaPoints[i + this->state.size()] =
-                this->dynamics.propagate(time, this->state.addVector(-this->eta * this->sBar.col(i-1)), dt);
+            this->dynamics.propagate(time, this->state.addVector(-this->eta * this->sBar.col(i - 1)), dt);
     }
 
     /*! - Compute xbar according to Eq (19)*/
-    for (size_t i = 1; i<this->numberSigmaPoints; ++i)
-    {
+    for (size_t i = 1; i < this->numberSigmaPoints; ++i) {
         this->xBar = this->xBar.add(this->sigmaPoints[i].scale(this->wM(i)));
     }
 
     /*! - Assemble the A matrix for QR decomposition as seen in equation 20 in the reference document*/
-    for (size_t i = 1; i < this->numberSigmaPoints; ++i)
-    {
-        A.col(i-1) = this->sigmaPoints[i].add(this->xBar.scale(-1)).scale( sqrt(this->wC(i))).returnValues();
+    for (size_t i = 1; i < this->numberSigmaPoints; ++i) {
+        A.col(i - 1) = this->sigmaPoints[i].add(this->xBar.scale(-1)).scale(sqrt(this->wC(i))).returnValues();
     }
 
-    A.block(0, this->numberSigmaPoints-1, this->state.size(), this->state.size()) =
-            this->cholProcessNoise;
+    A.block(0, this->numberSigmaPoints - 1, this->state.size(), this->state.size()) = this->cholProcessNoise;
 
     /*! - QR decomposition (only R is of interest) of the A matrix provides the new sBar matrix*/
     this->sBar = SRukfInterface::qrDecompositionJustR(A);
@@ -118,11 +111,10 @@ void SRukfInterface::timeUpdate(double updateTime)
     /*! - Cholesky update block for vectors.*/
     this->sBar = SRukfInterface::choleskyUpDownDate(this->sBar, xError, this->wC(0));
 
-    this->covar = this->sBar*this->sBar.transpose();
+    this->covar = this->sBar * this->sBar.transpose();
     this->state = this->sigmaPoints[0];
     this->previousFilterTimeTag = updateTime;
 }
-
 
 /*! Perform the measurement update for the kalman filter.
  It applies the observations in the obs vectors to the current state estimate and
@@ -130,14 +122,12 @@ void SRukfInterface::timeUpdate(double updateTime)
  @param Measurement
  @return void
  */
-void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
-{
+void SRukfInterface::measurementUpdate(const MeasurementModel &measurement) {
     this->cholMeasNoise.setZero(measurement.size(), measurement.size());
     this->cholMeasNoise = this->choleskyDecomposition(measurement.getMeasurementNoise());
     /*! - Compute the valid observations and the measurement model for all observations*/
     Eigen::MatrixXd yMeas(measurement.size(), this->numberSigmaPoints);
-    for(size_t j=0; j < this->numberSigmaPoints; ++j)
-    {
+    for (size_t j = 0; j < this->numberSigmaPoints; ++j) {
         /*! Sigma points positions need to be normalized for the measurement model.*/
         yMeas.col(j) = measurement.model(this->sigmaPoints[j]);
     }
@@ -146,21 +136,18 @@ void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
      time update section of the reference document*/
     Eigen::VectorXd yBar;
     yBar.setZero(measurement.size());
-    for(size_t i=0; i<this->numberSigmaPoints; ++i)
-    {
+    for (size_t i = 0; i < this->numberSigmaPoints; ++i) {
         yBar += this->wM(i) * yMeas.col(i);
     }
 
     /*! - Populate the matrix that we perform the QR decomposition on in the measurement
      update section of the code.  This is based on the difference between the yBar
      parameter and the calculated measurement models.  Equation 24. */
-    Eigen::MatrixXd A(measurement.size(), 2*this->state.size() + measurement.size());
-    for(size_t i=1; i<this->numberSigmaPoints; ++i)
-    {
-        A.col(i-1) = sqrt(this->wC(1))*(yMeas.col(i) - yBar);
+    Eigen::MatrixXd A(measurement.size(), 2 * this->state.size() + measurement.size());
+    for (size_t i = 1; i < this->numberSigmaPoints; ++i) {
+        A.col(i - 1) = sqrt(this->wC(1)) * (yMeas.col(i) - yBar);
     }
-    A.block(0, this->numberSigmaPoints-1, measurement.size(), measurement.size()) =
-            this->cholMeasNoise;
+    A.block(0, this->numberSigmaPoints - 1, measurement.size(), measurement.size()) = this->cholMeasNoise;
 
     /*! - Perform QR decomposition (only R again) of the above matrix to obtain the
      current Sy matrix*/
@@ -183,8 +170,7 @@ void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
     Eigen::MatrixXd pXY;
     pXY.setZero(this->state.size(), measurement.size());
 
-    for(size_t i=0; i<this->numberSigmaPoints; ++i)
-    {
+    for (size_t i = 0; i < this->numberSigmaPoints; ++i) {
         xError = this->sigmaPoints[i].add(this->xBar.scale(-1)).returnValues();
         yError = yMeas.col(i) - yBar;
         kMat = this->wC(i) * xError * yError.transpose();
@@ -200,7 +186,7 @@ void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
     /*! - Difference the yBar and the observations to get the observed error and
      multiply by the Kalman Gain to get the state update.  Add the state update
      to the state to get the updated state value (equation 27).*/
-    this->state = this->xBar.addVector(kMat*measurement.subMeasurements(measurement.getObservation(), yBar));
+    this->state = this->xBar.addVector(kMat * measurement.subMeasurements(measurement.getObservation(), yBar));
 
     /*! - Compute the updated matrix U from equation 28 */
     Eigen::MatrixXd Umat;
@@ -209,13 +195,12 @@ void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
 
     /*! - For each column in the update matrix, perform a cholesky down-date on it to
      get the total shifted S matrix (called sBar in internal parameters*/
-    for(int i=0; i < Umat.cols(); ++i)
-    {
+    for (int i = 0; i < Umat.cols(); ++i) {
         this->sBar = SRukfInterface::choleskyUpDownDate(this->sBar, Umat.col(i), -1);
     }
 
     /*! - Compute equivalent covariance based on updated sBar matrix*/
-    this->covar = this->sBar*this->sBar.transpose();
+    this->covar = this->sBar * this->sBar.transpose();
 }
 
 /*! Compute the measurement residuals if the measurement data was fresh.
@@ -224,20 +209,18 @@ void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
 @param Measurement
 @return Eigen::VectorXd
  */
-Eigen::VectorXd SRukfInterface::computeResiduals(const MeasurementModel &measurement)
-{
+Eigen::VectorXd SRukfInterface::computeResiduals(const MeasurementModel &measurement) {
     /*! - Compute Post Fit Residuals, first get Y (eq 22) using the states post fit*/
     Eigen::MatrixXd yMeas(measurement.size(), this->numberSigmaPoints);
-    for(size_t j=0; j < this->numberSigmaPoints; ++j)
-    {
+    for (size_t j = 0; j < this->numberSigmaPoints; ++j) {
         /*! Sigma points positions need to be normalized for the measurement model.*/
         yMeas.col(j) = measurement.model(this->sigmaPoints[j]);
     }
     /*! - Compute the value for the yBar parameter (equation 23)*/
     Eigen::VectorXd yBar;
     yBar.setZero(measurement.size());
-    for(size_t i=0; i<this->numberSigmaPoints; ++i){
-        yBar += this->wM(i)*yMeas.col(i);
+    for (size_t i = 0; i < this->numberSigmaPoints; ++i) {
+        yBar += this->wM(i) * yMeas.col(i);
     }
     return measurement.subMeasurements(measurement.getObservation(), yBar);
 }
@@ -247,8 +230,7 @@ Eigen::VectorXd SRukfInterface::computeResiduals(const MeasurementModel &measure
  @return Eigen::MatrixXd
  @param Eigen::MatrixXd input : The input matrix. If not square, provide it with more cols then rows
  */
-Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd &input) const
-{
+Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd &input) const {
     Eigen::HouseholderQR<Eigen::MatrixXd> qrDecomposition(input.transpose());
     Eigen::MatrixXd R_tilde;
     R_tilde.setZero(input.rows(), input.rows());
@@ -259,12 +241,12 @@ Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd &inpu
      * Math is described in the first bullet of section 3 page 3 of the reference document */
     Eigen::MatrixXd Q;
     Q = qrDecomposition.householderQ();
-    R = Q.transpose()*input.transpose();
-    R_tilde = R.block(0,0,input.rows(), input.rows());
+    R = Q.transpose() * input.transpose();
+    R_tilde = R.block(0, 0, input.rows(), input.rows());
 
     /*! Zero all terms that should be zero to avoid errors accumulating */
-    for (int i =0; i < R_tilde.rows(); ++i){
-        for (int j = 0 ; j < i; ++j){
+    for (int i = 0; i < R_tilde.rows(); ++i) {
+        for (int j = 0; j < i; ++j) {
             R_tilde(i, j) = 0;
         }
     }
@@ -281,9 +263,8 @@ Eigen::MatrixXd SRukfInterface::qrDecompositionJustR(const Eigen::MatrixXd &inpu
  @param Eigen::VectorXd coefficient : Factor that is square rooted and scales the outer product P +/- sqrt(v)V.V^T
  */
 Eigen::MatrixXd SRukfInterface::choleskyUpDownDate(const Eigen::MatrixXd &input,
-                                               const Eigen::VectorXd &inputVector,
-                                               const double coefficient) const
-{
+                                                   const Eigen::VectorXd &inputVector,
+                                                   const double coefficient) const {
     Eigen::MatrixXd P;
     P.setZero(inputVector.size(), inputVector.size());
 
@@ -291,7 +272,7 @@ Eigen::MatrixXd SRukfInterface::choleskyUpDownDate(const Eigen::MatrixXd &input,
      * Math is described in the second bullet of section 3 page 3 of the reference document */
     P = input * input.transpose();
     int sign = (coefficient > 0) ? 1 : -1;
-    P += sign*abs(coefficient)*inputVector*inputVector.transpose();
+    P += sign * abs(coefficient) * inputVector * inputVector.transpose();
 
     Eigen::MatrixXd A;
     A = SRukfInterface::choleskyDecomposition(P);
@@ -302,8 +283,7 @@ Eigen::MatrixXd SRukfInterface::choleskyUpDownDate(const Eigen::MatrixXd &input,
  @return Eigen::MatrixXd
  @param Eigen::MatrixXd input : The input matrix
  */
-Eigen::MatrixXd SRukfInterface::choleskyDecomposition(const Eigen::MatrixXd &input) const
-{
+Eigen::MatrixXd SRukfInterface::choleskyDecomposition(const Eigen::MatrixXd &input) const {
     Eigen::LLT<Eigen::MatrixXd> choleskyDecomp(input);
     return choleskyDecomp.matrixL();
 }
@@ -313,22 +293,21 @@ Eigen::MatrixXd SRukfInterface::choleskyDecomposition(const Eigen::MatrixXd &inp
  @param Eigen::MatrixXd U, an upper triangular matrix
  @param Eigen::MatrixXd b, the right hand side of the Ux = b
  */
-Eigen::MatrixXd SRukfInterface::backSubstitution(const Eigen::MatrixXd &U, const Eigen::MatrixXd &b) const
-{
+Eigen::MatrixXd SRukfInterface::backSubstitution(const Eigen::MatrixXd &U, const Eigen::MatrixXd &b) const {
     assert(U.rows() == b.rows());
 
     Eigen::MatrixXd x;
     Eigen::VectorXd xCol;
 
     x.setZero(b.rows(), b.cols());
-    for (int col =0; col < b.cols(); ++col){
+    for (int col = 0; col < b.cols(); ++col) {
         xCol.setZero(b.rows());
-        for (long i = U.rows()-1; i >= 0; --i){
+        for (long i = U.rows() - 1; i >= 0; --i) {
             xCol(i) = b(i, col);
-            for (long j = i+1 ; j < U.rows(); ++j){
-                xCol(i) = xCol(i) - U(i,j)*xCol(j);
+            for (long j = i + 1; j < U.rows(); ++j) {
+                xCol(i) = xCol(i) - U(i, j) * xCol(j);
             }
-            xCol(i) = xCol(i)/U(i,i);
+            xCol(i) = xCol(i) / U(i, i);
         }
         x.col(col) = xCol;
     }
@@ -341,22 +320,21 @@ Eigen::MatrixXd SRukfInterface::backSubstitution(const Eigen::MatrixXd &U, const
  @param Eigen::MatrixXd L, an lower triangular matrix
  @param Eigen::MatrixXd b, the right hand side of the Ux = b
  */
-Eigen::MatrixXd SRukfInterface::forwardSubstitution(const Eigen::MatrixXd &L, const Eigen::MatrixXd &b) const
-{
+Eigen::MatrixXd SRukfInterface::forwardSubstitution(const Eigen::MatrixXd &L, const Eigen::MatrixXd &b) const {
     assert(L.rows() == b.rows());
 
     Eigen::MatrixXd x;
     Eigen::VectorXd xCol;
 
     x.setZero(b.rows(), b.cols());
-    for (int col =0; col < b.cols(); ++col){
+    for (int col = 0; col < b.cols(); ++col) {
         xCol.setZero(b.rows());
-        for (int i =0; i < L.rows(); ++i){
+        for (int i = 0; i < L.rows(); ++i) {
             xCol(i) = b(i, col);
-            for (int j = 0 ; j < i; ++j){
-                xCol(i) = xCol(i) - L(i,j)*xCol(j);
+            for (int j = 0; j < i; ++j) {
+                xCol(i) = xCol(i) - L(i, j) * xCol(j);
             }
-            xCol(i) = xCol(i)/L(i,i);
+            xCol(i) = xCol(i) / L(i, i);
         }
         x.col(col) = xCol;
     }
@@ -367,28 +345,20 @@ Eigen::MatrixXd SRukfInterface::forwardSubstitution(const Eigen::MatrixXd &L, co
     @param double alphaInput
     @return void
     */
-void SRukfInterface::setAlpha(const double alphaInput){
-    this->alpha = alphaInput;
-}
+void SRukfInterface::setAlpha(const double alphaInput) { this->alpha = alphaInput; }
 
 /*! Get the filter alpha parameter
     @return double alpha
     */
-double SRukfInterface::getAlpha() const {
-    return this->alpha;
-}
+double SRukfInterface::getAlpha() const { return this->alpha; }
 
 /*! Set the filter beta parameter
     @param double betaInput
     @return void
     */
-void SRukfInterface::setBeta(const double betaInput){
-    this->beta = betaInput;
-}
+void SRukfInterface::setBeta(const double betaInput) { this->beta = betaInput; }
 
 /*! Get the filter beta parameter
     @return double beta
     */
-double SRukfInterface::getBeta() const {
-    return this->beta;
-}
+double SRukfInterface::getBeta() const { return this->beta; }

--- a/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/srukfInterface.cpp
@@ -200,7 +200,7 @@ void SRukfInterface::measurementUpdate(const MeasurementModel &measurement)
     /*! - Difference the yBar and the observations to get the observed error and
      multiply by the Kalman Gain to get the state update.  Add the state update
      to the state to get the updated state value (equation 27).*/
-    this->state = this->xBar.addVector(kMat*(measurement.getObservation() - yBar));
+    this->state = this->xBar.addVector(kMat*measurement.subMeasurements(measurement.getObservation(), yBar));
 
     /*! - Compute the updated matrix U from equation 28 */
     Eigen::MatrixXd Umat;
@@ -239,7 +239,7 @@ Eigen::VectorXd SRukfInterface::computeResiduals(const MeasurementModel &measure
     for(size_t i=0; i<this->numberSigmaPoints; ++i){
         yBar += this->wM(i)*yMeas.col(i);
     }
-    return measurement.getObservation() - yBar;
+    return measurement.subMeasurements(measurement.getObservation(), yBar);
 }
 
 /*! Perform a QR decomposition using HouseholderQR from Eigen, but only returns the transpose of the

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -20,41 +20,41 @@
 
 #include "inertialAttitudeUkf.h"
 
-InertialAttitudeUkf::InertialAttitudeUkf(AttitudeFilterMethod method){
-    this->measurementAcceptanceMethod = method;
-}
+InertialAttitudeUkf::InertialAttitudeUkf(AttitudeFilterMethod method) { this->measurementAcceptanceMethod = method; }
 
-void InertialAttitudeUkf::customreset(){
+void InertialAttitudeUkf::customreset() {
     /*! No custom reset for this module */
-    std::function<FilterStateVector(double, const FilterStateVector)> attitudeDynamics = [this](double t, const FilterStateVector &state){
-        Eigen::Vector3d mrp(state.getPositionStates());
-        Eigen::Vector3d omega(state.getVelocityStates());
-        Eigen::MatrixXd bMat = bmatMrp(mrp);
+    std::function<FilterStateVector(double, const FilterStateVector)> attitudeDynamics =
+        [this](double t, const FilterStateVector &state) {
+            Eigen::Vector3d mrp(state.getPositionStates());
+            Eigen::Vector3d omega(state.getVelocityStates());
+            Eigen::MatrixXd bMat = bmatMrp(mrp);
 
-        FilterStateVector stateDerivative;
-        PositionState mrpDot;
-        mrpDot.setValues(0.25*bMat*omega);
-        stateDerivative.setPosition(mrpDot);
+            FilterStateVector stateDerivative;
+            PositionState mrpDot;
+            mrpDot.setValues(0.25 * bMat * omega);
+            stateDerivative.setPosition(mrpDot);
 
-        Eigen::Vector3d wheelTorque = Eigen::Vector3d::Zero();
-        for(int i=0; i<this->rwArrayConfigPayload.numRW; i++){
-            Eigen::Vector3d gsMatrix = Eigen::Map<Eigen::Vector3d>(&this->rwArrayConfigPayload.GsMatrix_B[i*3]);
-            wheelTorque -= this->wheelAccelerations[i]*this->rwArrayConfigPayload.JsList[i]*gsMatrix;
-        }
+            Eigen::Vector3d wheelTorque = Eigen::Vector3d::Zero();
+            for (int i = 0; i < this->rwArrayConfigPayload.numRW; i++) {
+                Eigen::Vector3d gsMatrix = Eigen::Map<Eigen::Vector3d>(&this->rwArrayConfigPayload.GsMatrix_B[i * 3]);
+                wheelTorque -= this->wheelAccelerations[i] * this->rwArrayConfigPayload.JsList[i] * gsMatrix;
+            }
 
-        VelocityState omegaDot;
-        omegaDot.setValues(-this->spacecraftInertiaInverse*(tildeMatrix(omega)*this->spacecraftInertia*omega + wheelTorque));
-        stateDerivative.setVelocity(omegaDot);
+            VelocityState omegaDot;
+            omegaDot.setValues(-this->spacecraftInertiaInverse *
+                               (tildeMatrix(omega) * this->spacecraftInertia * omega + wheelTorque));
+            stateDerivative.setVelocity(omegaDot);
 
-        return stateDerivative;
-    };
+            return stateDerivative;
+        };
     this->dynamics.setDynamics(attitudeDynamics);
 }
 
 /*! Before every update, check the MRP norm for a shadow set switch
  @return void
  */
-void InertialAttitudeUkf::customInitializeUpdate(){
+void InertialAttitudeUkf::customInitializeUpdate() {
     PositionState mrp;
     mrp.setValues(mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
     this->state.setPosition(mrp);
@@ -63,9 +63,9 @@ void InertialAttitudeUkf::customInitializeUpdate(){
 /*! After every update, check the MRP norm for a shadow set switch
  @return void
  */
-void InertialAttitudeUkf::customFinalizeUpdate(){
+void InertialAttitudeUkf::customFinalizeUpdate() {
     PositionState mrp;
-    mrp.setValues( mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
+    mrp.setValues(mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
     this->state.setPosition(mrp);
 }
 
@@ -90,25 +90,25 @@ void InertialAttitudeUkf::writeOutputMessages(uint64_t currentSimNanos) {
     eigenMatrixXd2CArray(this->xBar.returnValues(), filterPayload.stateError);
     eigenMatrixXd2CArray(this->covar, filterPayload.covar);
 
-    for (size_t index = 0; index < MAX_MEASUREMENT_NUMBER; index ++){
+    for (size_t index = 0; index < MAX_MEASUREMENT_NUMBER; index++) {
         if (this->measurements[index].has_value()) {
             auto measurement = this->measurements[index].value();
-            if (measurement.getMeasurementName() == "starTracker"){
+            if (measurement.getMeasurementName() == "starTracker") {
                 starTrackerPayload.valid = true;
                 starTrackerPayload.numberOfObservations = 1;
                 starTrackerPayload.sizeOfObservations = measurement.size();
                 eigenMatrixXd2CArray(measurement.getObservation(), &starTrackerPayload.observation[0]);
                 eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &starTrackerPayload.postFits[0]);
                 eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &starTrackerPayload.preFits[0]);
-                }
-            if (measurement.getMeasurementName() == "gyro"){
+            }
+            if (measurement.getMeasurementName() == "gyro") {
                 gyroPayload.valid = true;
                 gyroPayload.numberOfObservations = 1;
                 gyroPayload.sizeOfObservations = measurement.size();
                 eigenMatrixXd2CArray(measurement.getObservation(), &gyroPayload.observation[0]);
                 eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &gyroPayload.postFits[0]);
                 eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &gyroPayload.preFits[0]);
-                }
+            }
             this->measurements[index].reset();
         }
     }
@@ -120,65 +120,68 @@ void InertialAttitudeUkf::writeOutputMessages(uint64_t currentSimNanos) {
 }
 
 /*! Read current RW speends and populate the accelerations in order to propagate
-* @return void
-* */
-void InertialAttitudeUkf::readRWSpeedData(){
+ * @return void
+ * */
+void InertialAttitudeUkf::readRWSpeedData() {
     RWSpeedMsgPayload rwSpeedPayload = this->rwSpeedMsg();
     uint64_t wheelSpeedTime = this->rwSpeedMsg.timeWritten();
-    if (this->firstFilterPass){
-        this->wheelAccelerations << 0,0,0,0;
+    if (this->firstFilterPass) {
+        this->wheelAccelerations << 0, 0, 0, 0;
         this->previousWheelSpeeds = Eigen::Map<Eigen::Matrix<double, 1, 4>>(rwSpeedPayload.wheelSpeeds);
-        this->previousWheelSpeedTime = wheelSpeedTime*NANO2SEC;
-    }
-    else{
-        double dt = wheelSpeedTime*NANO2SEC - this->previousWheelSpeedTime;
-        this->wheelAccelerations = (Eigen::Map<Eigen::Matrix<double, 1, 4>>(rwSpeedPayload.wheelSpeeds) - this->previousWheelSpeeds)/dt;
+        this->previousWheelSpeedTime = wheelSpeedTime * NANO2SEC;
+    } else {
+        double dt = wheelSpeedTime * NANO2SEC - this->previousWheelSpeedTime;
+        this->wheelAccelerations =
+            (Eigen::Map<Eigen::Matrix<double, 1, 4>>(rwSpeedPayload.wheelSpeeds) - this->previousWheelSpeeds) / dt;
     }
 }
 
 /*! Loop through the all the input star trackers and populate their measurement container if they are foward
  * in time
-* @return void
-* */
-void InertialAttitudeUkf::readStarTrackerData(){
-    for (int index = 0; index < this->numberOfStarTackers; index ++){
+ * @return void
+ * */
+void InertialAttitudeUkf::readStarTrackerData() {
+    for (int index = 0; index < this->numberOfStarTackers; index++) {
         auto starTracker = this->starTrackerMessages[index].starTrackerMsg();
-        if (starTracker.timeTag*NANO2SEC > this->previousFilterTimeTag){
+        if (starTracker.timeTag > this->previousFilterTimeTag) {
             auto starTrackerMeasurement = MeasurementModel();
             starTrackerMeasurement.setMeasurementName("starTracker");
-            starTrackerMeasurement.setTimeTag(starTracker.timeTag*NANO2SEC);
+            starTrackerMeasurement.setTimeTag(starTracker.timeTag);
             starTrackerMeasurement.setValidity(true);
 
-            starTrackerMeasurement.setMeasurementNoise(
-                    this->measNoiseScaling * this->starTrackerMessages[index].measurementNoise);
-            starTrackerMeasurement.setObservation(mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl),
-                    this->mrpSwitchThreshold));
+            starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling *
+                                                       this->starTrackerMessages[index].measurementNoise);
+            starTrackerMeasurement.setObservation(
+                mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
             starTrackerMeasurement.setMeasurementModel(MeasurementModel::mrpStates);
             this->measurements[this->measurementIndex] = starTrackerMeasurement;
             this->measurementIndex += 1;
             this->validStarTracker = true;
             /*! - Only consider the filter started once a Star Tracker image is processed */
-            if (this->firstFilterPass){this->firstFilterPass = false;}
+            if (this->firstFilterPass) {
+                this->firstFilterPass = false;
+            }
+        } else {
+            this->validStarTracker = false;
         }
-        else{this->validStarTracker=false;}
     }
 }
 
 /*! Loop through the entire gyro buffer to find the first index that is in the future compared to the
-* previousFilterTimeTag. This does not assume the data comes in chronological order since the gyro data
-* is a ring buffer and can wrap around
-* @return void
-* */
-void InertialAttitudeUkf::readGyroData(){
+ * previousFilterTimeTag. This does not assume the data comes in chronological order since the gyro data
+ * is a ring buffer and can wrap around
+ * @return void
+ * */
+void InertialAttitudeUkf::readGyroData() {
     IMUSensorMsgPayload gyroBuffer = this->imuSensorDataInMsg();
-    if (gyroBuffer.timeTag*NANO2SEC > this->previousFilterTimeTag) {
+    if (gyroBuffer.timeTag > this->previousFilterTimeTag) {
         auto gyroMeasurement = MeasurementModel();
         gyroMeasurement.setMeasurementName("gyro");
         gyroMeasurement.setTimeTag(gyroBuffer.timeTag);
         gyroMeasurement.setValidity(true);
 
-        gyroMeasurement.setMeasurementNoise(
-                this->measNoiseScaling * this->gyroNoise/std::sqrt(gyroBuffer.numberOfValidGyroMeasurements));
+        gyroMeasurement.setMeasurementNoise(this->measNoiseScaling * this->gyroNoise /
+                                            std::sqrt(gyroBuffer.numberOfValidGyroMeasurements));
         gyroMeasurement.setObservation(cArray2EigenVector3d(gyroBuffer.AngVelPlatform));
         gyroMeasurement.setMeasurementModel(MeasurementModel::velocityStates);
         this->measurements[this->measurementIndex] = gyroMeasurement;
@@ -218,21 +221,17 @@ void InertialAttitudeUkf::readFilterMeasurements() {
     @param Eigen::Matrix3d gyroNoise
     @return void
     */
-void InertialAttitudeUkf::setGyroNoise(const Eigen::Matrix3d &gyroNoiseInput) {
-    this->gyroNoise = gyroNoiseInput;
-}
+void InertialAttitudeUkf::setGyroNoise(const Eigen::Matrix3d &gyroNoiseInput) { this->gyroNoise = gyroNoiseInput; }
 
 /*! Get the gyro measurement noise matrix
     @return Eigen::Matrix3d gyroNoise
     */
-Eigen::Matrix3d InertialAttitudeUkf::getGyroNoise() const {
-    return this->gyroNoise;
-}
+Eigen::Matrix3d InertialAttitudeUkf::getGyroNoise() const { return this->gyroNoise; }
 
 /*! Add a star tracker to the filter solution using the StarTrackerMessage class
     @return StarTrackerMessage starTracker
     */
-void InertialAttitudeUkf::addStarTrackerInput(const StarTrackerMessage &starTracker){
+void InertialAttitudeUkf::addStarTrackerInput(const StarTrackerMessage &starTracker) {
     this->starTrackerMessages[this->numberOfStarTackers] = starTracker;
     this->numberOfStarTackers += 1;
 }
@@ -244,13 +243,4 @@ void InertialAttitudeUkf::addStarTrackerInput(const StarTrackerMessage &starTrac
 Eigen::Matrix3d InertialAttitudeUkf::getStarTrackerNoise(int starTrackerNumber) const {
     assert(starTrackerNumber < this->numberOfStarTackers);
     return this->starTrackerMessages[starTrackerNumber].measurementNoise;
-}
-
-/*! Set the low pass filter parameters for the
-    @param double step
-    @param double frequencyCutOff
-    */
-void InertialAttitudeUkf::setLowPassFilter(double step, double frequencyCutOff){
-    this->hStep = step;
-    this->cutOffFrequency = frequencyCutOff;
 }

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -139,13 +139,15 @@ void InertialAttitudeUkf::readRWSpeedData() {
     uint64_t wheelSpeedTime = this->rwSpeedMsg.timeWritten();
     if (this->firstFilterPass) {
         this->wheelAccelerations = Eigen::VectorXd::Zero(this->rwArrayConfigPayload.numRW);
-		Eigen::MatrixXd wheelSpeed = cArray2EigenMatrixXd(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
+        Eigen::MatrixXd wheelSpeed =
+            cArray2EigenMatrixXd(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
         this->previousWheelSpeeds = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
         this->previousWheelSpeedTime = wheelSpeedTime * NANO2SEC;
     } else {
         double dt = wheelSpeedTime * NANO2SEC - this->previousWheelSpeedTime;
-		Eigen::MatrixXd wheelSpeed = cArray2EigenMatrixXd(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
-		Eigen::VectorXd currentWheelSpeed = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
+        Eigen::MatrixXd wheelSpeed =
+            cArray2EigenMatrixXd(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
+        Eigen::VectorXd currentWheelSpeed = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
         this->wheelAccelerations = (currentWheelSpeed - this->previousWheelSpeeds) / dt;
         this->previousWheelSpeeds = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
         this->previousWheelSpeedTime = wheelSpeedTime * NANO2SEC;
@@ -170,19 +172,22 @@ void InertialAttitudeUkf::readStarTrackerData() {
 
             starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling * dcm_CB.transpose() *
                                                        this->starTrackerMessages[index].measurementNoise_C * dcm_CB);
-            starTrackerMeasurement.setObservation(mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
+            starTrackerMeasurement.setObservation(
+                mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
             starTrackerMeasurement.setMeasurementModel(MeasurementModel::positionStates);
 
-            std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> mrpSub
-                = [](Eigen::VectorXd const& observed, const Eigen::VectorXd& predicted) {
-                     Eigen::VectorXd yMeas = observed - predicted;
-                     if (observed.norm() > 0.95 && predicted.norm() > 0.95) {
-                         const Eigen::VectorXd predictedShadow = mrpShadow(predicted);
-                         Eigen::VectorXd yMeasShadow = observed - predictedShadow;
-                         if (yMeasShadow.norm() < yMeas.norm()) {return yMeasShadow;}
-                     }
-                     return yMeas;
-            };
+            std::function<const Eigen::VectorXd(const Eigen::VectorXd &, const Eigen::VectorXd &)> mrpSub =
+                [](Eigen::VectorXd const &observed, const Eigen::VectorXd &predicted) {
+                    Eigen::VectorXd yMeas = observed - predicted;
+                    if (observed.norm() > 0.95 && predicted.norm() > 0.95) {
+                        const Eigen::VectorXd predictedShadow = mrpShadow(predicted);
+                        Eigen::VectorXd yMeasShadow = observed - predictedShadow;
+                        if (yMeasShadow.norm() < yMeas.norm()) {
+                            return yMeasShadow;
+                        }
+                    }
+                    return yMeas;
+                };
             starTrackerMeasurement.setMeasurementSubtraction(mrpSub);
 
             this->measurements[this->measurementIndex] = starTrackerMeasurement;

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -168,9 +168,21 @@ void InertialAttitudeUkf::readStarTrackerData() {
 
             starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling * dcm_CB.transpose() *
                                                        this->starTrackerMessages[index].measurementNoise_C * dcm_CB);
-            starTrackerMeasurement.setObservation(
-                mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
-            starTrackerMeasurement.setMeasurementModel(MeasurementModel::mrpStates);
+            starTrackerMeasurement.setObservation(mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
+            starTrackerMeasurement.setMeasurementModel(MeasurementModel::positionStates);
+
+            std::function<const Eigen::VectorXd(const Eigen::VectorXd&, const Eigen::VectorXd&)> mrpSub
+                = [](Eigen::VectorXd const& observed, const Eigen::VectorXd& predicted) {
+                     Eigen::VectorXd yMeas = observed - predicted;
+                     if (observed.norm() > 0.95 && predicted.norm() > 0.95) {
+                         const Eigen::VectorXd predictedShadow = mrpShadow(predicted);
+                         Eigen::VectorXd yMeasShadow = observed - predictedShadow;
+                         if (yMeasShadow.norm() < yMeas.norm()) {return yMeasShadow;}
+                     }
+                     return yMeas;
+            };
+            starTrackerMeasurement.setMeasurementSubtraction(mrpSub);
+
             this->measurements[this->measurementIndex] = starTrackerMeasurement;
             this->measurementIndex += 1;
             this->validStarTracker = true;

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -38,7 +38,7 @@ void InertialAttitudeUkf::customreset() {
             Eigen::Vector3d wheelTorque = Eigen::Vector3d::Zero();
             for (int i = 0; i < this->rwArrayConfigPayload.numRW; i++) {
                 Eigen::Vector3d gsMatrix = Eigen::Map<Eigen::Vector3d>(&this->rwArrayConfigPayload.GsMatrix_B[i * 3]);
-                wheelTorque -= this->wheelAccelerations[i] * this->rwArrayConfigPayload.JsList[i] * gsMatrix;
+                wheelTorque += this->wheelAccelerations[i] * this->rwArrayConfigPayload.JsList[i] * gsMatrix;
             }
 
             VelocityState omegaDot;
@@ -126,13 +126,17 @@ void InertialAttitudeUkf::readRWSpeedData() {
     RWSpeedMsgPayload rwSpeedPayload = this->rwSpeedMsg();
     uint64_t wheelSpeedTime = this->rwSpeedMsg.timeWritten();
     if (this->firstFilterPass) {
-        this->wheelAccelerations << 0, 0, 0, 0;
-        this->previousWheelSpeeds = Eigen::Map<Eigen::Matrix<double, 1, 4>>(rwSpeedPayload.wheelSpeeds);
+        this->wheelAccelerations = Eigen::VectorXd::Zero(this->rwArrayConfigPayload.numRW);
+		Eigen::MatrixXd wheelSpeed = cArray2EigenMatrixXd(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
+        this->previousWheelSpeeds = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
         this->previousWheelSpeedTime = wheelSpeedTime * NANO2SEC;
     } else {
         double dt = wheelSpeedTime * NANO2SEC - this->previousWheelSpeedTime;
-        this->wheelAccelerations =
-            (Eigen::Map<Eigen::Matrix<double, 1, 4>>(rwSpeedPayload.wheelSpeeds) - this->previousWheelSpeeds) / dt;
+		Eigen::MatrixXd wheelSpeed = cArray2EigenMatrixXd(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
+		Eigen::VectorXd currentWheelSpeed = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
+        this->wheelAccelerations = (currentWheelSpeed - this->previousWheelSpeeds) / dt;
+        this->previousWheelSpeeds = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
+        this->previousWheelSpeedTime = wheelSpeedTime * NANO2SEC;
     }
 }
 
@@ -150,10 +154,10 @@ void InertialAttitudeUkf::readStarTrackerData() {
             starTrackerMeasurement.setValidity(true);
 
             /*! - Get the mapping from camera frame to inertial for the noise matrix */
-            Eigen::MatrixXd dcm_CB = cArray2EigenMatrix3d(starTracker.dcm_CB);
+            Eigen::Matrix3d dcm_CB = cArray2EigenMatrix3d(starTracker.dcm_CB);
 
-            starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling *
-                                                       dcm_CB.transpose()*this->starTrackerMessages[index].measurementNoise_C*dcm_CB);
+            starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling * dcm_CB.transpose() *
+                                                       this->starTrackerMessages[index].measurementNoise_C * dcm_CB);
             starTrackerMeasurement.setObservation(
                 mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
             starTrackerMeasurement.setMeasurementModel(MeasurementModel::mrpStates);

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -49,6 +49,8 @@ void InertialAttitudeUkf::customreset() {
             return stateDerivative;
         };
     this->dynamics.setDynamics(attitudeDynamics);
+
+    this->firstFilterPass = true;
 }
 
 /*! Before every update, check the MRP norm for a shadow set switch

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -149,8 +149,11 @@ void InertialAttitudeUkf::readStarTrackerData() {
             starTrackerMeasurement.setTimeTag(starTracker.timeTag);
             starTrackerMeasurement.setValidity(true);
 
+            /*! - Get the mapping from camera frame to inertial for the noise matrix */
+            Eigen::MatrixXd dcm_CB = cArray2EigenMatrix3d(starTracker.dcm_CB);
+
             starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling *
-                                                       this->starTrackerMessages[index].measurementNoise);
+                                                       dcm_CB.transpose()*this->starTrackerMessages[index].measurementNoise_C*dcm_CB);
             starTrackerMeasurement.setObservation(
                 mrpSwitch(Eigen::Map<Eigen::Vector3d>(starTracker.MRP_BdyInrtl), this->mrpSwitchThreshold));
             starTrackerMeasurement.setMeasurementModel(MeasurementModel::mrpStates);
@@ -242,5 +245,5 @@ void InertialAttitudeUkf::addStarTrackerInput(const StarTrackerMessage &starTrac
     */
 Eigen::Matrix3d InertialAttitudeUkf::getStarTrackerNoise(int starTrackerNumber) const {
     assert(starTrackerNumber < this->numberOfStarTackers);
-    return this->starTrackerMessages[starTrackerNumber].measurementNoise;
+    return this->starTrackerMessages[starTrackerNumber].measurementNoise_C;
 }

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -54,19 +54,29 @@ void InertialAttitudeUkf::customreset() {
 /*! Before every update, check the MRP norm for a shadow set switch
  @return void
  */
-void InertialAttitudeUkf::customInitializeUpdate() {
-    PositionState mrp;
-    mrp.setValues(mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
-    this->state.setPosition(mrp);
-}
+void InertialAttitudeUkf::customInitializeUpdate() { this->switchStateCovariance(); }
 
 /*! After every update, check the MRP norm for a shadow set switch
  @return void
  */
-void InertialAttitudeUkf::customFinalizeUpdate() {
-    PositionState mrp;
-    mrp.setValues(mrpSwitch(this->state.getPositionStates(), this->mrpSwitchThreshold));
-    this->state.setPosition(mrp);
+void InertialAttitudeUkf::customFinalizeUpdate() { this->switchStateCovariance(); }
+
+/*! Check the norm of the mrp and switch both the position state of the state vector (the mrp) and the covariance
+ * if above the desired threshold
+ @return void
+ */
+void InertialAttitudeUkf::switchStateCovariance() {
+    Eigen::Vector3d sigma = this->state.getPositionStates();
+    if (sigma.norm() > this->mrpSwitchThreshold) {
+        PositionState mrp;
+        mrp.setValues(mrpSwitch(sigma, this->mrpSwitchThreshold));
+        this->state.setPosition(mrp);
+        Eigen::Matrix3d switchMatrix = 2 * std::pow(sigma.norm(), 4) * sigma * sigma.transpose() -
+                                       std::pow(sigma.norm(), 2) * Eigen::Matrix3d::Identity();
+        this->covar.block(0, 0, 3, 3) = switchMatrix * this->covar.block(0, 0, 3, 3) * switchMatrix.transpose();
+        this->covar.block(0, 3, 3, 3) = switchMatrix * this->covar.block(0, 3, 3, 3);
+        this->covar.block(3, 0, 3, 3) = this->covar.block(3, 0, 3, 3) * switchMatrix.transpose();
+    }
 }
 
 /*! Read the message containing the measurement data.

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -36,7 +36,7 @@
 #include "architecture/msgPayloadDefCpp/FilterResidualsMsgPayload.h"
 
 #include "architecture/msgPayloadDefC/STAttMsgPayload.h"
-#include "architecture/msgPayloadDefC/AccDataMsgPayload.h"
+#include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
 #include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
 #include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
@@ -77,7 +77,7 @@ public:
     RWArrayConfigMsgPayload rwArrayConfigPayload;
     ReadFunctor<VehicleConfigMsgPayload> vehicleConfigMsg;
     ReadFunctor<RWSpeedMsgPayload> rwSpeedMsg;
-    ReadFunctor<AccDataMsgPayload> accelDataMsg;
+    ReadFunctor<IMUSensorMsgPayload> imuSensorDataInMsg;
 
     Message<NavAttMsgPayload> navAttitudeOutputMsg;
     Message<FilterMsgPayload> inertialFilterOutputMsg;

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -45,7 +45,7 @@
 class StarTrackerMessage {
    public:
     ReadFunctor<STAttMsgPayload> starTrackerMsg;  //!< star tracker input message
-    Eigen::Matrix3d measurementNoise_C;             //!< [-] Per axis noise on the ST
+    Eigen::Matrix3d measurementNoise_C;           //!< [-] Per axis noise on the ST
 };
 
 enum class AttitudeFilterMethod { StarOnly, GyroWhenDazzled, AllMeasurements };

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -27,39 +27,36 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
+#include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
+#include "architecture/msgPayloadDefC/STAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/FilterMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/FilterResidualsMsgPayload.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 #include "architecture/utilities/signalProcessing.h"
-
-#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
-#include "architecture/msgPayloadDefCpp/FilterMsgPayload.h"
-#include "architecture/msgPayloadDefCpp/FilterResidualsMsgPayload.h"
-
-#include "architecture/msgPayloadDefC/STAttMsgPayload.h"
-#include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
-#include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
-#include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
-#include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
-
-#include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 #include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 
 /*! @brief Star Tracker (ST) sensor container class. Contains the msg input name and Id and sensor noise value. */
-class StarTrackerMessage{
-public:
-    ReadFunctor<STAttMsgPayload> starTrackerMsg;                       //!< star tracker input message
-    Eigen::Matrix3d measurementNoise;                        //!< [-] Per axis noise on the ST
+class StarTrackerMessage {
+   public:
+    ReadFunctor<STAttMsgPayload> starTrackerMsg;  //!< star tracker input message
+    Eigen::Matrix3d measurementNoise;             //!< [-] Per axis noise on the ST
 };
 
-enum class AttitudeFilterMethod {StarOnly, GyroWhenDazzled, AllMeasurements};
+enum class AttitudeFilterMethod { StarOnly, GyroWhenDazzled, AllMeasurements };
 
 /*! @brief Inertial Attitude filter which reads Star Tracker measurements and gyro measurements */
-class InertialAttitudeUkf: public SRukfInterface {
-public:
+class InertialAttitudeUkf : public SRukfInterface {
+   public:
     InertialAttitudeUkf(AttitudeFilterMethod method);
     ~InertialAttitudeUkf() = default;
 
-private:
+   private:
     void customreset() final;
     void readFilterMeasurements() final;
     void writeOutputMessages(uint64_t currentSimNanos) final;
@@ -71,8 +68,7 @@ private:
     void readStarTrackerData();
     void readGyroData();
 
-
-public:
+   public:
     ReadFunctor<RWArrayConfigMsgPayload> rwArrayConfigMsg;
     RWArrayConfigMsgPayload rwArrayConfigPayload;
     ReadFunctor<VehicleConfigMsgPayload> vehicleConfigMsg;
@@ -88,9 +84,8 @@ public:
     Eigen::Matrix3d getGyroNoise() const;
     void addStarTrackerInput(const StarTrackerMessage &starTracker);
     Eigen::Matrix3d getStarTrackerNoise(int starTrackerNumber) const;
-    void setLowPassFilter(double step, double frequencyCutOff);
 
-private:
+   private:
     AttitudeFilterMethod measurementAcceptanceMethod;
     bool firstFilterPass = true;
     bool validStarTracker = false;
@@ -100,15 +95,13 @@ private:
     Eigen::Matrix3d spacecraftInertia;
     Eigen::Matrix3d spacecraftInertiaInverse;
     double previousWheelSpeedTime = 0;
-    double hStep = 0.5;
-    double cutOffFrequency = 15.0/(2*M_PI);
 
     Eigen::Vector3d filteredOmega_BN_B;
     Eigen::Matrix3d gyroNoise;
     std::array<StarTrackerMessage, MAX_ST_VEH_COUNT> starTrackerMessages;
     int numberOfStarTackers = 0;
     int measurementIndex = 0;
-    double mrpSwitchThreshold = 1; //!< [-] Threshold for switching MRP to/from the shadow set
+    double mrpSwitchThreshold = 1;  //!< [-] Threshold for switching MRP to/from the shadow set
 };
 
 #endif

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -90,8 +90,8 @@ class InertialAttitudeUkf : public SRukfInterface {
     bool firstFilterPass = true;
     bool validStarTracker = false;
 
-    Eigen::Vector<double, 4> wheelAccelerations;
-    Eigen::Matrix<double, 1, 4> previousWheelSpeeds;
+    Eigen::VectorXd wheelAccelerations{};
+    Eigen::VectorXd previousWheelSpeeds{};
     Eigen::Matrix3d spacecraftInertia;
     Eigen::Matrix3d spacecraftInertiaInverse;
     double previousWheelSpeedTime = 0;

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -67,6 +67,7 @@ class InertialAttitudeUkf : public SRukfInterface {
     void readRWSpeedData();
     void readStarTrackerData();
     void readGyroData();
+    void switchStateCovariance();
 
    public:
     ReadFunctor<RWArrayConfigMsgPayload> rwArrayConfigMsg;

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.h
@@ -45,7 +45,7 @@
 class StarTrackerMessage {
    public:
     ReadFunctor<STAttMsgPayload> starTrackerMsg;  //!< star tracker input message
-    Eigen::Matrix3d measurementNoise;             //!< [-] Per axis noise on the ST
+    Eigen::Matrix3d measurementNoise_C;             //!< [-] Per axis noise on the ST
 };
 
 enum class AttitudeFilterMethod { StarOnly, GyroWhenDazzled, AllMeasurements };

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.i
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.i
@@ -41,10 +41,8 @@ struct VehicleConfigMsg_C;
 struct RWArrayConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
 struct RWSpeedMsg_C;
-%include "architecture/msgPayloadDefC/AccDataMsgPayload.h"
-struct AccDataMsg_C;
-%include "architecture/msgPayloadDefC/AccPktDataMsgPayload.h"
-struct AccPktDataMsg_C;
+%include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
+struct IMUSensorMsg_C;
 %include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 struct NavAttMsg_C;
 

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.i
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.i
@@ -34,17 +34,11 @@ from Basilisk.architecture.swig_common_model import *
 %include "architecture/msgPayloadDefCpp/FilterResidualsMsgPayload.h"
 
 %include "architecture/msgPayloadDefC/STAttMsgPayload.h"
-struct STAttMsg_C;
 %include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
-struct VehicleConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
-struct RWArrayConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
-struct RWSpeedMsg_C;
 %include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
-struct IMUSensorMsg_C;
 %include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
-struct NavAttMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
@@ -178,8 +178,11 @@ def test_propagation_kf(show_plots):
     accel_measurement = messaging.AccDataMsg().write(accel_data)
     miru_low_pass_filter_converter.imuAccelDataInMsg.subscribeTo(accel_measurement)
 
-    attitude_data_log = intertialAttitudeFilter.inertialFilterOutputMsg.recorder()
+    attitude_data_log = intertialAttitudeFilter.navAttitudeOutputMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, attitude_data_log)
+
+    filter_data_log = intertialAttitudeFilter.inertialFilterOutputMsg.recorder()
+    unit_test_sim.AddModelToTask(unit_task_name, filter_data_log)
 
     sim_time = 100
     time = np.linspace(0, sim_time, sim_time+1)
@@ -193,8 +196,9 @@ def test_propagation_kf(show_plots):
     unit_test_sim.ExecuteSimulation()
 
     num_states = 6
-    state_data_log = add_time_column(attitude_data_log.times(), attitude_data_log.state[:, :num_states])
-    covariance_data_log = add_time_column(attitude_data_log.times(), attitude_data_log.covar[:, :num_states**2])
+    nav_data_log = add_time_column(attitude_data_log.times(), attitude_data_log.sigma_BN)
+    state_data_log = add_time_column(filter_data_log.times(), filter_data_log.state[:, :num_states])
+    covariance_data_log = add_time_column(filter_data_log.times(), filter_data_log.covar[:, :num_states**2])
 
     diff = np.copy(state_data_log)
     diff[:, 1:] -= expected[:, 1:]
@@ -209,6 +213,11 @@ def test_propagation_kf(show_plots):
                                expected[:, 1:],
                                rtol=1E-10,
                                err_msg='state propagation error',
+                               verbose=True)
+    np.testing.assert_allclose(nav_data_log,
+                               state_data_log[:, :4],
+                               rtol=1E-10,
+                               err_msg='nav msg and state are identical',
                                verbose=True)
     return
 

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
@@ -317,7 +317,7 @@ def test_measurements_kf(show_plots, initial_error, method):
     filter_data_log = intertialAttitudeFilter.inertialFilterOutputMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, filter_data_log)
 
-    attitude_data_log = intertialAttitudeFilter.inertialFilterOutputMsg.recorder()
+    attitude_data_log = intertialAttitudeFilter.navAttitudeOutputMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, attitude_data_log)
 
     st_residual_data_log = intertialAttitudeFilter.starTrackerResidualMsg.recorder()
@@ -348,13 +348,13 @@ def test_measurements_kf(show_plots, initial_error, method):
         rw_speeds.write(rw_speeds_data, int((i+1)*1E9))
         if (i > 10*substeps and i< substeps*sim_time/4) or i > substeps*sim_time/2:
             if (time[i]-0.2).is_integer():
-                st_1_data.timeTag = int(time[i] * 1E9)
+                st_1_data.timeTag = time[i]
                 st_1_data.valid = True
                 st_1_data.MRP_BdyInrtl = expected[i, 1:4] + np.random.normal(0, 1e-4, 3)
                 st_1_msg.write(st_1_data, int(time[i]*1E9))
 
             if (time[i]-0.8).is_integer():
-                st_2_data.timeTag = int(time[i]*1e9)
+                st_2_data.timeTag = time[i]
                 st_2_data.valid = True
                 st_2_data.MRP_BdyInrtl = expected[i, 1:4] + np.random.normal(0, 1e-4, 3)
                 st_2_msg.write(st_2_data, int(time[i]*1e9))

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
@@ -90,10 +90,6 @@ def setup_filter_data(filter_object):
                                    [0.0, 0.0, 0.0, 0.0, sigma_rate, 0.0],
                                    [0.0, 0.0, 0.0, 0.0, 0.0, sigma_rate]])
 
-    filter_object.setLowPassFilter(0.5, 15/(2*np.pi))
-
-    return
-
 @pytest.mark.parametrize("show_plots", [False])
 def test_propagation_kf(show_plots):
     """Module Unit Test"""

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/tests/test_inertialAttitudeUkf.py
@@ -161,7 +161,7 @@ def test_propagation_kf(show_plots):
     star_tracker1 = inertialAttitudeUkf.StarTrackerMessage()
     st_1_msg = messaging.STAttMsg().write(st_1_data)
     star_tracker1.starTrackerMsg.subscribeTo(st_1_msg)
-    star_tracker1.measurementNoise = [[1e-3, 0, 0], [0,1e-3,0], [0,0,1e-3]]
+    star_tracker1.measurementNoise_C = [[1e-3, 0, 0], [0,1e-3,0], [0,0,1e-3]]
     intertialAttitudeFilter.addStarTrackerInput(star_tracker1)
 
     st_2_data = messaging.STAttMsgPayload()
@@ -171,7 +171,7 @@ def test_propagation_kf(show_plots):
     star_tracker2 = inertialAttitudeUkf.StarTrackerMessage()
     st_2_msg = messaging.STAttMsg().write(st_2_data)
     star_tracker2.starTrackerMsg.subscribeTo(st_2_msg)
-    star_tracker2.measurementNoise = [[1e-3, 0, 0], [0,1e-3,0], [0,0,1e-3]]
+    star_tracker2.measurementNoise_C = [[1e-3, 0, 0], [0,1e-3,0], [0,0,1e-3]]
     intertialAttitudeFilter.addStarTrackerInput(star_tracker2)
 
     accel_data = messaging.AccDataMsgPayload()
@@ -297,7 +297,7 @@ def test_measurements_kf(show_plots, initial_error, method):
     star_tracker1 = inertialAttitudeUkf.StarTrackerMessage()
     st_1_msg = messaging.STAttMsg().write(st_1_data)
     star_tracker1.starTrackerMsg.subscribeTo(st_1_msg)
-    star_tracker1.measurementNoise = [[1e-4, 0, 0], [0,1e-4,0], [0,0,1e-4]]
+    star_tracker1.measurementNoise_C = [[1e-4, 0, 0], [0,1e-4,0], [0,0,1e-4]]
     intertialAttitudeFilter.addStarTrackerInput(star_tracker1)
 
     st_2_data = messaging.STAttMsgPayload()
@@ -307,7 +307,7 @@ def test_measurements_kf(show_plots, initial_error, method):
     star_tracker2 = inertialAttitudeUkf.StarTrackerMessage()
     st_2_msg = messaging.STAttMsg().write(st_2_data)
     star_tracker2.starTrackerMsg.subscribeTo(st_2_msg)
-    star_tracker2.measurementNoise = [[1e-4, 0, 0], [0,1e-4,0], [0,0,1e-4]]
+    star_tracker2.measurementNoise_C = [[1e-4, 0, 0], [0,1e-4,0], [0,0,1e-4]]
     intertialAttitudeFilter.addStarTrackerInput(star_tracker2)
 
     accel_data = messaging.AccDataMsgPayload()
@@ -338,7 +338,7 @@ def test_measurements_kf(show_plots, initial_error, method):
     expected[int(len(time)/2):, :] = rk4(attitude_dynamics, time[int(len(time)/2):], initial_condition,
                                          np.array(I).reshape([3,3]))
 
-    st_sigma_2 = np.diag(intertialAttitudeFilter.getStarTrackerNoise(1)).mean()
+    st_sigma_2 = np.diag(intertialAttitudeFilter.getStarTrackerNoise(0)).mean()
     gyroSigma = np.diag(intertialAttitudeFilter.getGyroNoise()).mean()
 
     unit_test_sim.InitializeSimulation()

--- a/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.cpp
+++ b/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.cpp
@@ -1,0 +1,63 @@
+#include "miruLowPassFilterConverter.h"
+#include "architecture/utilities/avsEigenSupport.h"
+
+/*! This method checks the input message to ensure it is linked.
+ @return void
+ @param callTime [ns] Time the method is called
+*/
+void MiruLowPassFilterConverter::reset(uint64_t callTime) {
+    if (!this->imuAccelDataInMsg.isLinked()) {
+        this->bskLogger->bskLog(BSK_ERROR, "miruLowPassFilterConverter.imuAccelDataInMsg wasn't connected.");
+    }
+}
+
+/*! This method writes the module output message using the given input message.
+ @return void
+ @param callTime [ns] Time the method is called
+*/
+void MiruLowPassFilterConverter::updateState(uint64_t callTime) {
+    auto lowPass = LowPassFilter();
+    int smallestFutureIndex = 0;
+    int numberOfValidGyroMeasurements = 0;
+    double firstFutureTime = -1;
+    double meanMeasurementTime = 0;
+    AccDataMsgPayload gyrBuffer = this->imuAccelDataInMsg();
+    for (int index = 0; index < MAX_ACC_BUF_PKT; index++) {
+        double gyroMeasuredTime = gyrBuffer.accPkts[index].measTime*NANO2SEC;
+        if (gyroMeasuredTime < firstFutureTime || firstFutureTime<0){
+            smallestFutureIndex = index;
+            firstFutureTime = gyroMeasuredTime;
+        }
+        meanMeasurementTime += gyroMeasuredTime;
+        numberOfValidGyroMeasurements += 1;
+    }
+    lowPass.setFilterCutoff(this->cutOffFrequency);
+    lowPass.setFilterStep(this->hStep);
+    if (numberOfValidGyroMeasurements > 0){
+        meanMeasurementTime /= numberOfValidGyroMeasurements;
+        /*! - Loop through buffer for all future measurements since the previous time to filter omega_BN_B*/
+        for (int index = 0; index < MAX_ACC_BUF_PKT; index++) {
+            int shiftedIndex = (index + smallestFutureIndex) % MAX_ACC_BUF_PKT;
+            auto omega_BN_B = Eigen::Map<Eigen::Vector3d>(gyrBuffer.accPkts[shiftedIndex].gyro_B);
+            /*! - Apply low-pass filter to gyro measurements to get smoothed body rate*/
+            lowPass.processMeasurement(omega_BN_B);
+        }
+    }
+
+    // Write the output message
+    IMUSensorMsgPayload imuSensorOut = IMUSensorMsgPayload();
+    imuSensorOut.timeTag = meanMeasurementTime;
+    imuSensorOut.numberOfValidGyroMeasurements = numberOfValidGyroMeasurements;
+    Eigen::Vector3d omega_BN_B = lowPass.getCurrentState();
+    eigenVector3d2CArray(omega_BN_B, imuSensorOut.AngVelPlatform);
+    this->imuSensorOutMsg.write(&imuSensorOut, moduleID, callTime);
+}
+
+/*! Set the low pass filter parameters
+ @param double step
+ @param double frequencyCutOff
+*/
+void MiruLowPassFilterConverter::setLowPassFilter(double step, double frequencyCutOff) {
+    this->hStep = step;
+    this->cutOffFrequency = frequencyCutOff;
+}

--- a/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.cpp
+++ b/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.cpp
@@ -23,8 +23,8 @@ void MiruLowPassFilterConverter::updateState(uint64_t callTime) {
     double meanMeasurementTime = 0;
     AccDataMsgPayload gyrBuffer = this->imuAccelDataInMsg();
     for (int index = 0; index < MAX_ACC_BUF_PKT; index++) {
-        double gyroMeasuredTime = gyrBuffer.accPkts[index].measTime*NANO2SEC;
-        if (gyroMeasuredTime < firstFutureTime || firstFutureTime<0){
+        double gyroMeasuredTime = gyrBuffer.accPkts[index].measTime * NANO2SEC;
+        if (gyroMeasuredTime < firstFutureTime || firstFutureTime < 0) {
             smallestFutureIndex = index;
             firstFutureTime = gyroMeasuredTime;
         }
@@ -33,7 +33,7 @@ void MiruLowPassFilterConverter::updateState(uint64_t callTime) {
     }
     lowPass.setFilterCutoff(this->cutOffFrequency);
     lowPass.setFilterStep(this->hStep);
-    if (numberOfValidGyroMeasurements > 0){
+    if (numberOfValidGyroMeasurements > 0) {
         meanMeasurementTime /= numberOfValidGyroMeasurements;
         /*! - Loop through buffer for all future measurements since the previous time to filter omega_BN_B*/
         for (int index = 0; index < MAX_ACC_BUF_PKT; index++) {

--- a/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.h
+++ b/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.h
@@ -17,8 +17,8 @@ class MiruLowPassFilterConverter : public SysModel {
     MiruLowPassFilterConverter() = default;   //!< Constructor
     ~MiruLowPassFilterConverter() = default;  //!< Destructor
 
-    void reset(uint64_t currentSimNanos) override;                        //!< Reset member function
-    void updateState(uint64_t currentSimNanos) override;                  //!< Update member function
+    void reset(uint64_t currentSimNanos) override;               //!< Reset member function
+    void updateState(uint64_t currentSimNanos) override;         //!< Update member function
     void setLowPassFilter(double step, double frequencyCutOff);  //!< Setter method for the low pass filter
 
     ReadFunctor<AccDataMsgPayload> imuAccelDataInMsg;  //!< Input msg for the imu data

--- a/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.h
+++ b/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.h
@@ -1,0 +1,34 @@
+#ifndef _MIRULOWPASSFILTERCONVERTER_
+#define _MIRULOWPASSFILTERCONVERTER_
+
+#include <Eigen/Core>
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/AccDataMsgPayload.h"
+#include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/signalProcessing.h"
+
+/*! @brief Convert AccDataMsgPayload to IMUSensorMsgPayload Class */
+class MiruLowPassFilterConverter : public SysModel {
+   public:
+    MiruLowPassFilterConverter() = default;   //!< Constructor
+    ~MiruLowPassFilterConverter() = default;  //!< Destructor
+
+    void reset(uint64_t currentSimNanos) override;                        //!< Reset member function
+    void updateState(uint64_t currentSimNanos) override;                  //!< Update member function
+    void setLowPassFilter(double step, double frequencyCutOff);  //!< Setter method for the low pass filter
+
+    ReadFunctor<AccDataMsgPayload> imuAccelDataInMsg;  //!< Input msg for the imu data
+    Message<IMUSensorMsgPayload> imuSensorOutMsg;      //!< Output msg for the imu data
+
+    BSKLogger *bskLogger;  //!< BSK Logging
+
+   private:
+    double cutOffFrequency = 15.0 / (2 * M_PI);  //!< Low pass filter parameter
+    double hStep = 0.5;                          //!< Low pass filter parameter
+};
+
+#endif

--- a/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.i
+++ b/src/fswAlgorithms/sensorInterfaces/miruLowPassFilterConverter/miruLowPassFilterConverter.i
@@ -1,0 +1,21 @@
+%module miruLowPassFilterConverter
+%{
+    #include "miruLowPassFilterConverter.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+
+%include "sys_model.i"
+%include "miruLowPassFilterConverter.h"
+
+%include "architecture/msgPayloadDefC/AccDataMsgPayload.h"
+%include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -181,7 +181,7 @@ void ImuSensor::writeOutputMessages(uint64_t Clock)
     eigenVector3d2CArray(this->DV_SN_P_out, localOutput.DVFramePlatform);
     eigenVector3d2CArray(this->omega_PN_P_out, localOutput.AngVelPlatform);
     eigenVector3d2CArray(this->prv_PN_out, localOutput.DRFramePlatform);
-
+    localOutput.timeTag = Clock*1E-9;
     this->sensorOutMsg.write(&localOutput, this->moduleID, Clock);
 
     return;

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -17,27 +17,28 @@
 
  */
 #include "simulation/sensors/imuSensor/imuSensor.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
-#include <cstring>
-#include "architecture/utilities/gauss_markov.h"
-#include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
+
 #include <inttypes.h>
 
+#include <cstring>
 
-ImuSensor::ImuSensor()
-{
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/gauss_markov.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+
+ImuSensor::ImuSensor() {
     this->numStates = 3;
     this->setBodyToPlatformDCM(0.0, 0.0, 0.0);
     this->OutputBufferCount = 2;
     this->StatePrevious = this->scStateInMsg.zeroMsgPayload;
     this->StateCurrent = this->scStateInMsg.zeroMsgPayload;
 
-    this->errorModelGyro =  GaussMarkov(this->numStates, this->RNGSeed);
+    this->errorModelGyro = GaussMarkov(this->numStates, this->RNGSeed);
     this->errorModelAccel = GaussMarkov(this->numStates, this->RNGSeed);
 
-    this->aDisc = Discretize((uint8_t) this->numStates);
-    this->oDisc = Discretize((uint8_t) this->numStates);
+    this->aDisc = Discretize((uint8_t)this->numStates);
+    this->oDisc = Discretize((uint8_t)this->numStates);
 
     this->aSat = Saturate(this->numStates);
     this->oSat = Saturate(this->numStates);
@@ -72,42 +73,29 @@ ImuSensor::ImuSensor()
     this->gyroScale.fill(1.);
     this->sensorPos_B.fill(0.0);
     this->dcm_PB.setIdentity();
-
-    return;
 }
 
 /*!
     set body orientation DCM relative to platform
  */
-void ImuSensor::setBodyToPlatformDCM(double yaw, double pitch, double roll)
-{
-    this->dcm_PB = eigenM1(roll)*eigenM2(pitch)*eigenM3(yaw);
-
-    return;
+void ImuSensor::setBodyToPlatformDCM(double yaw, double pitch, double roll) {
+    this->dcm_PB = eigenM1(roll) * eigenM2(pitch) * eigenM3(yaw);
 }
-
-ImuSensor::~ImuSensor()
-{
-    return;
-}
-
 
 /*! Reset the module
  @return void
  @param currentSimNanos current time (ns)
  */
-void ImuSensor::reset(uint64_t currentSimNanos)
-{
+void ImuSensor::reset(uint64_t currentSimNanos) {
     // check if input message has not been included
     if (!this->scStateInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "imuSensor.scStateInMsg was not linked.");
     }
 
-    this->AMatrixAccel.setIdentity(this->numStates,this->numStates);
+    this->AMatrixAccel.setIdentity(this->numStates, this->numStates);
 
     //! - Alert the user if the noise matrix was not the right size.  That'd be bad.
-    if(this->PMatrixAccel.cols() != this->numStates || this->PMatrixAccel.rows() != this->numStates)
-    {
+    if (this->PMatrixAccel.cols() != this->numStates || this->PMatrixAccel.rows() != this->numStates) {
         bskLogger.bskLog(BSK_ERROR, "Your process noise matrix (PMatrixAccel) is not 3*3. Quitting.");
         return;
     }
@@ -118,8 +106,7 @@ void ImuSensor::reset(uint64_t currentSimNanos)
     this->AMatrixGyro.setIdentity(this->numStates, this->numStates);
 
     //! - Alert the user if the noise matrix was not the right size.  That'd be bad.
-    if(this->PMatrixGyro.rows() != this->numStates || this->PMatrixGyro.cols() != this->numStates)
-    {
+    if (this->PMatrixGyro.rows() != this->numStates || this->PMatrixGyro.cols() != this->numStates) {
         bskLogger.bskLog(BSK_ERROR, "Your process noise matrix (PMatrixGyro) is not 3*3. Quitting.");
         return;
     }
@@ -129,36 +116,31 @@ void ImuSensor::reset(uint64_t currentSimNanos)
 
     Eigen::MatrixXd oSatBounds;
     oSatBounds.resize(this->numStates, 2);
-    oSatBounds(0,0) = -this->senRotMax;
-    oSatBounds(0,1) = this->senRotMax;
-    oSatBounds(1,0) = -this->senRotMax;
-    oSatBounds(1,1) = this->senRotMax;
-    oSatBounds(2,0) = -this->senRotMax;
-    oSatBounds(2,1) = this->senRotMax;
+    oSatBounds(0, 0) = -this->senRotMax;
+    oSatBounds(0, 1) = this->senRotMax;
+    oSatBounds(1, 0) = -this->senRotMax;
+    oSatBounds(1, 1) = this->senRotMax;
+    oSatBounds(2, 0) = -this->senRotMax;
+    oSatBounds(2, 1) = this->senRotMax;
     this->oSat.setBounds(oSatBounds);
 
     Eigen::MatrixXd aSatBounds;
     aSatBounds.resize(this->numStates, 2);
-    aSatBounds(0,0) = -this->senTransMax;
-    aSatBounds(0,1) = this->senTransMax;
-    aSatBounds(1,0) = -this->senTransMax;
-    aSatBounds(1,1) = this->senTransMax;
-    aSatBounds(2,0) = -this->senTransMax;
-    aSatBounds(2,1) = this->senTransMax;
+    aSatBounds(0, 0) = -this->senTransMax;
+    aSatBounds(0, 1) = this->senTransMax;
+    aSatBounds(1, 0) = -this->senTransMax;
+    aSatBounds(1, 1) = this->senTransMax;
+    aSatBounds(2, 0) = -this->senTransMax;
+    aSatBounds(2, 1) = this->senTransMax;
     this->aSat.setBounds(aSatBounds);
-
-    return;
 }
-
 
 /*!
     read input messages
  */
-void ImuSensor::readInputMessages()
-{
+void ImuSensor::readInputMessages() {
     this->StateCurrent = this->scStateInMsg.zeroMsgPayload;
-    if(this->scStateInMsg.isLinked())
-    {
+    if (this->scStateInMsg.isLinked()) {
         this->StateCurrent = this->scStateInMsg();
     }
     this->current_sigma_BN = cArray2EigenVector3d(this->StateCurrent.sigma_BN);
@@ -166,121 +148,100 @@ void ImuSensor::readInputMessages()
     this->current_nonConservativeAccelpntB_B = cArray2EigenVector3d(this->StateCurrent.nonConservativeAccelpntB_B);
     this->current_omegaDot_BN_B = cArray2EigenVector3d(this->StateCurrent.omegaDot_BN_B);
     this->current_TotalAccumDV_BN_B = cArray2EigenVector3d(this->StateCurrent.TotalAccumDV_BN_B);
-
-    return;
 }
 
 /*!
     write output messages
  */
-void ImuSensor::writeOutputMessages(uint64_t Clock)
-{
+void ImuSensor::writeOutputMessages(uint64_t Clock) {
     IMUSensorMsgPayload localOutput;
 
     eigenVector3d2CArray(this->accel_SN_P_out, localOutput.AccelPlatform);
     eigenVector3d2CArray(this->DV_SN_P_out, localOutput.DVFramePlatform);
     eigenVector3d2CArray(this->omega_PN_P_out, localOutput.AngVelPlatform);
     eigenVector3d2CArray(this->prv_PN_out, localOutput.DRFramePlatform);
-    localOutput.timeTag = Clock*1E-9;
+    localOutput.timeTag = Clock * NANO2SEC;
     this->sensorOutMsg.write(&localOutput, this->moduleID, Clock);
 
-    return;
 }
 
 /*!
     set LSB values
  */
-void ImuSensor::setLSBs(double LSBa, double LSBo)
-{
+void ImuSensor::setLSBs(double LSBa, double LSBo) {
     this->aDisc.setLSB(Eigen::Vector3d(LSBa, LSBa, LSBa));
     this->oDisc.setLSB(Eigen::Vector3d(LSBo, LSBo, LSBo));
-    return;
-
 }
 
 /*!
     set Carry error value
  */
-void ImuSensor::setCarryError(bool aCarry, bool oCarry)
-{
+void ImuSensor::setCarryError(bool aCarry, bool oCarry) {
     this->aDisc.setCarryError(aCarry);
     this->oDisc.setCarryError(oCarry);
-    return;
 }
 
 /*!
     set round direction value
  */
-void ImuSensor::setRoundDirection(roundDirection_t aRound, roundDirection_t oRound){
-
+void ImuSensor::setRoundDirection(roundDirection_t aRound, roundDirection_t oRound) {
     this->aDisc.setRoundDirection(aRound);
     this->oDisc.setRoundDirection(oRound);
 
-    return;
 }
 
 /*!
     apply sensor direction
     @param CurrentTime
  */
-void ImuSensor::applySensorDiscretization(uint64_t CurrentTime)
-{
+void ImuSensor::applySensorDiscretization(uint64_t CurrentTime) {
+    double dt = (CurrentTime - this->PreviousTime) * 1.0E-9;
 
-    double dt = (CurrentTime - this->PreviousTime)*1.0E-9;
-
-    if(this->aDisc.LSB.any()) //If aLSB has been set.
+    if (this->aDisc.LSB.any())  // If aLSB has been set.
     {
         this->accel_SN_P_out = this->aDisc.discretize(this->accel_SN_P_out);
         this->DV_SN_P_out -= this->aDisc.getDiscretizationErrors() * dt;
     }
 
-    if(this->oDisc.LSB.any()) // If oLSB has been set.
+    if (this->oDisc.LSB.any())  // If oLSB has been set.
     {
         this->omega_PN_P_out = this->oDisc.discretize(this->omega_PN_P_out);
         this->prv_PN_out -= this->oDisc.getDiscretizationErrors() * dt;
     }
 
-    return;
 }
 
 /*!
     set o saturation bounds
     @param oSatBounds
  */
-void ImuSensor::set_oSatBounds(Eigen::MatrixXd oSatBounds){
-    this->oSat.setBounds(oSatBounds);
-}
+void ImuSensor::set_oSatBounds(Eigen::MatrixXd oSatBounds) { this->oSat.setBounds(oSatBounds); }
 
 /*!
     set a saturation bounds
     @param aSatBounds
  */
-void ImuSensor::set_aSatBounds(Eigen::MatrixXd aSatBounds){
-    this->aSat.setBounds(aSatBounds);
-}
+void ImuSensor::set_aSatBounds(Eigen::MatrixXd aSatBounds) { this->aSat.setBounds(aSatBounds); }
 
 /*!
     scale truth method
  */
-void ImuSensor::scaleTruth()
-{
+void ImuSensor::scaleTruth() {
     this->omega_PN_P_out = this->omega_PN_P_out.cwiseProduct(this->gyroScale);
     this->prv_PN_out = this->prv_PN_out.cwiseProduct(this->gyroScale);
     this->accel_SN_P_out = this->accel_SN_P_out.cwiseProduct(this->accelScale);
     this->DV_SN_P_out = this->DV_SN_P_out.cwiseProduct(this->accelScale);
-    return;
 }
 
 /*!
     apply sensor errors
  */
-void ImuSensor::applySensorErrors(uint64_t CurrentTime)
-{
-    Eigen::Vector3d OmegaErrors; //angular noise plus bias
-    Eigen::Vector3d AccelErrors; //linear noise plus bias
-    double dt; //time step
+void ImuSensor::applySensorErrors(uint64_t CurrentTime) {
+    Eigen::Vector3d OmegaErrors;  // angular noise plus bias
+    Eigen::Vector3d AccelErrors;  // linear noise plus bias
+    double dt;                    // time step
 
-    dt = (CurrentTime - this->PreviousTime)*1.0E-9;
+    dt = (CurrentTime - this->PreviousTime) * 1.0E-9;
 
     OmegaErrors = this->navErrorsGyro + this->senRotBias;
     this->omega_PN_P_out += OmegaErrors;
@@ -290,47 +251,42 @@ void ImuSensor::applySensorErrors(uint64_t CurrentTime)
     this->accel_SN_P_out += AccelErrors;
     this->DV_SN_P_out += AccelErrors * dt;
 
-    return;
 }
 
 /*!
  compute sensor errors
  */
-void ImuSensor::computeSensorErrors()
-{
-	this->errorModelAccel.setPropMatrix(this->AMatrixAccel);
-	this->errorModelAccel.computeNextState();
-	this->navErrorsAccel = this->errorModelAccel.getCurrentState();
-	this->errorModelGyro.setPropMatrix(this->AMatrixGyro);
-	this->errorModelGyro.computeNextState();
-	this->navErrorsGyro = this->errorModelGyro.getCurrentState();
+void ImuSensor::computeSensorErrors() {
+    this->errorModelAccel.setPropMatrix(this->AMatrixAccel);
+    this->errorModelAccel.computeNextState();
+    this->navErrorsAccel = this->errorModelAccel.getCurrentState();
+    this->errorModelGyro.setPropMatrix(this->AMatrixGyro);
+    this->errorModelGyro.computeNextState();
+    this->navErrorsGyro = this->errorModelGyro.getCurrentState();
 
-    return;
 }
 
 /*!
     apply sensor saturation
  */
-void ImuSensor::applySensorSaturation(uint64_t CurrentTime)
-{
-	double  dt = (CurrentTime - PreviousTime)*1.0E-9;
+void ImuSensor::applySensorSaturation(uint64_t CurrentTime) {
+    double dt = (CurrentTime - PreviousTime) * 1.0E-9;
 
     Eigen::Vector3d omega_PN_P_in = this->omega_PN_P_out;
     this->omega_PN_P_out = this->oSat.saturate(omega_PN_P_in);
-    for (int64_t i = 0; i < this->numStates; i++){
-        if (this->omega_PN_P_out(i) != omega_PN_P_in(i)){
+    for (int64_t i = 0; i < this->numStates; i++) {
+        if (this->omega_PN_P_out(i) != omega_PN_P_in(i)) {
             this->prv_PN_out(i) = this->omega_PN_P_out(i) * dt;
         }
     }
 
     Eigen::Vector3d accel_SN_P_in = this->accel_SN_P_out;
     this->accel_SN_P_out = this->aSat.saturate(accel_SN_P_in);
-    for (int64_t i = 0; i < this->numStates; i++){
-        if (this->accel_SN_P_out(i) != accel_SN_P_in(i)){
+    for (int64_t i = 0; i < this->numStates; i++) {
+        if (this->accel_SN_P_out(i) != accel_SN_P_in(i)) {
             this->DV_SN_P_out(i) = this->accel_SN_P_out(i) * dt;
         }
     }
-    return;
 }
 
 /*!
@@ -339,22 +295,21 @@ void ImuSensor::applySensorSaturation(uint64_t CurrentTime)
     to get a DR (delta radians or delta rotation) The angular rate is retrieved directly from the
     spacecraft output message and passed through to theother IMU functions which add noise, etc.
  */
-void ImuSensor::computePlatformDR()
-{
-    double dcm_P2P1_cArray[9]; //dcm_P2P1 as cArray for C2PRV conversion
-    double prv_PN_cArray[3]; //cArray of PRV
+void ImuSensor::computePlatformDR() {
+    double dcm_P2P1_cArray[9];  // dcm_P2P1 as cArray for C2PRV conversion
+    double prv_PN_cArray[3];    // cArray of PRV
 
-    //Calculated time averaged cumulative rotation
+    // Calculated time averaged cumulative rotation
     Eigen::Matrix3d dcm_P2P1;  // direction cosine matrix from P at time 1 to P at time 2
-    dcm_P2P1 = this->dcm_PB * this->current_sigma_BN.toRotationMatrix().transpose() * (this->dcm_PB * this->previous_sigma_BN.toRotationMatrix().transpose()).transpose();
-    eigenMatrix3d2CArray(dcm_P2P1, dcm_P2P1_cArray); //makes a 9x1
-    C2PRV(RECAST3X3 dcm_P2P1_cArray, prv_PN_cArray); //makes it back into a 3x3
-    this->prv_PN_out = cArray2EigenVector3d(prv_PN_cArray);//writes it back to the variable to be passed along.
+    dcm_P2P1 = this->dcm_PB * this->current_sigma_BN.toRotationMatrix().transpose() *
+               (this->dcm_PB * this->previous_sigma_BN.toRotationMatrix().transpose()).transpose();
+    eigenMatrix3d2CArray(dcm_P2P1, dcm_P2P1_cArray);         // makes a 9x1
+    C2PRV(RECAST3X3 dcm_P2P1_cArray, prv_PN_cArray);         // makes it back into a 3x3
+    this->prv_PN_out = cArray2EigenVector3d(prv_PN_cArray);  // writes it back to the variable to be passed along.
 
-    //calculate "instantaneous" angular rate
+    // calculate "instantaneous" angular rate
     this->omega_PN_P_out = this->dcm_PB * this->current_omega_BN_B;
 
-    return;
 }
 
 /*!
@@ -365,48 +320,49 @@ void ImuSensor::computePlatformDR()
     to account for CoM offset of the platform frame.
     @param CurrentTime
  */
-void ImuSensor::computePlatformDV(uint64_t CurrentTime)
-{
-    //Calculate "instantaneous" linear acceleration
-    Eigen::Vector3d rDotDot_SN_B;     //sensor non conservative acceleration relative to inertial frame in body frame coordinates
-    rDotDot_SN_B = this->current_nonConservativeAccelpntB_B + this->current_omegaDot_BN_B.cross(this->sensorPos_B) + this->current_omega_BN_B.cross(this->current_omega_BN_B.cross(this->sensorPos_B));
+void ImuSensor::computePlatformDV(uint64_t CurrentTime) {
+    // Calculate "instantaneous" linear acceleration
+    Eigen::Vector3d
+        rDotDot_SN_B;  // sensor non conservative acceleration relative to inertial frame in body frame coordinates
+    rDotDot_SN_B = this->current_nonConservativeAccelpntB_B + this->current_omegaDot_BN_B.cross(this->sensorPos_B) +
+                   this->current_omega_BN_B.cross(this->current_omega_BN_B.cross(this->sensorPos_B));
     this->accel_SN_P_out = this->dcm_PB * rDotDot_SN_B;
 
-    //Calculate time-average cumulative delta v
-    Eigen::Matrix3d dcm_NB_1;      // direction cosine matrix from N to B at time 1
+    // Calculate time-average cumulative delta v
+    Eigen::Matrix3d dcm_NB_1;  // direction cosine matrix from N to B at time 1
     dcm_NB_1 = this->previous_sigma_BN.toRotationMatrix();
-    Eigen::Matrix3d dcm_NB_2;      // direction cosine matrix from N to B at time 2
+    Eigen::Matrix3d dcm_NB_2;  // direction cosine matrix from N to B at time 2
     dcm_NB_2 = this->current_sigma_BN.toRotationMatrix();
 
-    this->DV_SN_P_out =this->dcm_PB * dcm_NB_2.transpose() * ((dcm_NB_2 * this->current_TotalAccumDV_BN_B - dcm_NB_1 * this->previous_TotalAccumDV_BN_B) + ((dcm_NB_2 * this->current_omega_BN_B).cross(dcm_NB_2 * this->sensorPos_B) - (dcm_NB_1 * this->previous_omega_BN_B).cross(dcm_NB_1 * this->sensorPos_B)));
+    this->DV_SN_P_out = this->dcm_PB * dcm_NB_2.transpose() *
+                        ((dcm_NB_2 * this->current_TotalAccumDV_BN_B - dcm_NB_1 * this->previous_TotalAccumDV_BN_B) +
+                         ((dcm_NB_2 * this->current_omega_BN_B).cross(dcm_NB_2 * this->sensorPos_B) -
+                          (dcm_NB_1 * this->previous_omega_BN_B).cross(dcm_NB_1 * this->sensorPos_B)));
 
-    return;
 }
 
 /*!
     update module states
     @param currentSimNanos current time (ns)
  */
-void ImuSensor::updateState(uint64_t currentSimNanos)
-{
+void ImuSensor::updateState(uint64_t currentSimNanos) {
     readInputMessages();
 
-    if(this->NominalReady)
-    {
+    if (this->NominalReady) {
         /* Compute true data */
         this->computePlatformDR();
         this->computePlatformDV(currentSimNanos);
         /* Compute sensed data */
-		this->computeSensorErrors();
+        this->computeSensorErrors();
         this->applySensorErrors(currentSimNanos);
         this->scaleTruth();
         this->applySensorDiscretization(currentSimNanos);
-		this->applySensorSaturation(currentSimNanos);
+        this->applySensorSaturation(currentSimNanos);
         /* Output sensed data */
         this->writeOutputMessages(currentSimNanos);
     }
 
-    //record data from the current spacecraft message which is needed for the next IMU call
+    // record data from the current spacecraft message which is needed for the next IMU call
     this->previous_sigma_BN = this->current_sigma_BN;
     this->previous_omega_BN_B = this->current_omega_BN_B;
     this->previous_TotalAccumDV_BN_B = this->current_TotalAccumDV_BN_B;
@@ -414,5 +370,4 @@ void ImuSensor::updateState(uint64_t currentSimNanos)
 
     this->NominalReady = true;
 
-    return;
 }

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -162,7 +162,6 @@ void ImuSensor::writeOutputMessages(uint64_t Clock) {
     eigenVector3d2CArray(this->prv_PN_out, localOutput.DRFramePlatform);
     localOutput.timeTag = Clock * NANO2SEC;
     this->sensorOutMsg.write(&localOutput, this->moduleID, Clock);
-
 }
 
 /*!
@@ -187,7 +186,6 @@ void ImuSensor::setCarryError(bool aCarry, bool oCarry) {
 void ImuSensor::setRoundDirection(roundDirection_t aRound, roundDirection_t oRound) {
     this->aDisc.setRoundDirection(aRound);
     this->oDisc.setRoundDirection(oRound);
-
 }
 
 /*!
@@ -208,7 +206,6 @@ void ImuSensor::applySensorDiscretization(uint64_t CurrentTime) {
         this->omega_PN_P_out = this->oDisc.discretize(this->omega_PN_P_out);
         this->prv_PN_out -= this->oDisc.getDiscretizationErrors() * dt;
     }
-
 }
 
 /*!
@@ -250,7 +247,6 @@ void ImuSensor::applySensorErrors(uint64_t CurrentTime) {
     AccelErrors = this->navErrorsAccel + this->senTransBias;
     this->accel_SN_P_out += AccelErrors;
     this->DV_SN_P_out += AccelErrors * dt;
-
 }
 
 /*!
@@ -263,7 +259,6 @@ void ImuSensor::computeSensorErrors() {
     this->errorModelGyro.setPropMatrix(this->AMatrixGyro);
     this->errorModelGyro.computeNextState();
     this->navErrorsGyro = this->errorModelGyro.getCurrentState();
-
 }
 
 /*!
@@ -309,7 +304,6 @@ void ImuSensor::computePlatformDR() {
 
     // calculate "instantaneous" angular rate
     this->omega_PN_P_out = this->dcm_PB * this->current_omega_BN_B;
-
 }
 
 /*!
@@ -338,7 +332,6 @@ void ImuSensor::computePlatformDV(uint64_t CurrentTime) {
                         ((dcm_NB_2 * this->current_TotalAccumDV_BN_B - dcm_NB_1 * this->previous_TotalAccumDV_BN_B) +
                          ((dcm_NB_2 * this->current_omega_BN_B).cross(dcm_NB_2 * this->sensorPos_B) -
                           (dcm_NB_1 * this->previous_omega_BN_B).cross(dcm_NB_1 * this->sensorPos_B)));
-
 }
 
 /*!
@@ -369,5 +362,4 @@ void ImuSensor::updateState(uint64_t currentSimNanos) {
     this->PreviousTime = currentSimNanos;
 
     this->NominalReady = true;
-
 }

--- a/src/simulation/sensors/imuSensor/imuSensor.h
+++ b/src/simulation/sensors/imuSensor/imuSensor.h
@@ -20,26 +20,25 @@
 #ifndef IMU_SENSOR_H
 #define IMU_SENSOR_H
 
-#include <vector>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include <random>
-#include "architecture/utilities/gauss_markov.h"
 #include "architecture/utilities/discretize.h"
+#include "architecture/utilities/gauss_markov.h"
 #include "architecture/utilities/saturate.h"
+#include <random>
+#include <vector>
 
-#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
-#include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
 #include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/IMUSensorMsgPayload.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 
-#include <Eigen/Dense>
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/utilities/macroDefinitions.h"
-
+#include <Eigen/Dense>
 
 /*! @brief IMU sensor class */
-class ImuSensor: public SysModel {
-public:
+class ImuSensor : public SysModel {
+   public:
     ImuSensor();
     ~ImuSensor() = default;
 
@@ -52,8 +51,8 @@ public:
     void computePlatformDV(uint64_t CurrentTime);
     void applySensorErrors(uint64_t CurrentTime);
     void applySensorDiscretization(uint64_t CurrentTime);
-	void applySensorSaturation(uint64_t CurrentTime);
-	void computeSensorErrors();
+    void applySensorSaturation(uint64_t CurrentTime);
+    void computeSensorErrors();
     void scaleTruth();
     void setLSBs(double LSBa, double LSBo);
     void setCarryError(bool aCarry, bool oCarry);
@@ -61,61 +60,62 @@ public:
     void set_oSatBounds(Eigen::MatrixXd oSatBounds);
     void set_aSatBounds(Eigen::MatrixXd aSatBounds);
 
-public:
+   public:
     ReadFunctor<SCStatesMsgPayload> scStateInMsg; /*!< input essage name for spacecraft state */
-    Message<IMUSensorMsgPayload> sensorOutMsg;        /*!< output message name for IMU output data */
-    Eigen::Vector3d sensorPos_B;              /*!< [m] IMU sensor location in body */
-    Eigen::Matrix3d dcm_PB;                //!< -- Transform from body to platform
-    Eigen::Vector3d senRotBias;               //!< [r/s] Rotational Sensor bias value
-    Eigen::Vector3d senTransBias;             //!< [m/s2] Translational acceleration sen bias
-	double senRotMax;					//!< [r/s] Gyro saturation value
-	double senTransMax;					//!< [m/s2] Accelerometer saturation value
-    uint64_t OutputBufferCount;         //!< -- number of output msgs stored
-    bool NominalReady;                  //!< -- Flag indicating that system is in run
-    Eigen::Matrix3d PMatrixAccel;   //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
-	Eigen::Matrix3d AMatrixAccel;   //!< [-] AMatrix that we use for error propagation
-	Eigen::Vector3d walkBoundsAccel;//!< [-] "3-sigma" errors to permit for states
-	Eigen::Vector3d navErrorsAccel; //!< [-] Current navigation errors applied to truth
-	Eigen::Matrix3d PMatrixGyro;    //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
-	Eigen::Matrix3d AMatrixGyro;    //!< [-] AMatrix that we use for error propagation
-	Eigen::Vector3d walkBoundsGyro; //!< [-] "3-sigma" errors to permit for states
-	Eigen::Vector3d navErrorsGyro;  //!< [-] Current navigation errors applied to truth
+    Message<IMUSensorMsgPayload> sensorOutMsg;    /*!< output message name for IMU output data */
+    Eigen::Vector3d sensorPos_B;                  /*!< [m] IMU sensor location in body */
+    Eigen::Matrix3d dcm_PB;                       //!< -- Transform from body to platform
+    Eigen::Vector3d senRotBias;                   //!< [r/s] Rotational Sensor bias value
+    Eigen::Vector3d senTransBias;                 //!< [m/s2] Translational acceleration sen bias
+    double senRotMax;                             //!< [r/s] Gyro saturation value
+    double senTransMax;                           //!< [m/s2] Accelerometer saturation value
+    uint64_t OutputBufferCount;                   //!< -- number of output msgs stored
+    bool NominalReady;                            //!< -- Flag indicating that system is in run
+    Eigen::Matrix3d PMatrixAccel;     //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to
+                                      //!< apply errors with
+    Eigen::Matrix3d AMatrixAccel;     //!< [-] AMatrix that we use for error propagation
+    Eigen::Vector3d walkBoundsAccel;  //!< [-] "3-sigma" errors to permit for states
+    Eigen::Vector3d navErrorsAccel;   //!< [-] Current navigation errors applied to truth
+    Eigen::Matrix3d PMatrixGyro;      //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to
+                                      //!< apply errors with
+    Eigen::Matrix3d AMatrixGyro;      //!< [-] AMatrix that we use for error propagation
+    Eigen::Vector3d walkBoundsGyro;   //!< [-] "3-sigma" errors to permit for states
+    Eigen::Vector3d navErrorsGyro;    //!< [-] Current navigation errors applied to truth
 
-    IMUSensorMsgPayload trueValues;         //!< [-] total measurement without perturbations
-    IMUSensorMsgPayload sensedValues;       //!< [-] total measurement including perturbations
+    IMUSensorMsgPayload trueValues;    //!< [-] total measurement without perturbations
+    IMUSensorMsgPayload sensedValues;  //!< [-] total measurement including perturbations
 
-    Eigen::Vector3d accelScale;         //!< (-) scale factor for acceleration axes
-    Eigen::Vector3d gyroScale;          //!< (-) scale factors for acceleration axes
+    Eigen::Vector3d accelScale;  //!< (-) scale factor for acceleration axes
+    Eigen::Vector3d gyroScale;   //!< (-) scale factors for acceleration axes
 
-    Discretize aDisc;                  //!<  (-) instance of discretization utility for linear acceleration
-    Discretize oDisc;                  //!<  (-) instance of idscretization utility for angular rate
-    Saturate aSat;                     //!<  (-) instance of saturate utility for linear acceleration
-    Saturate oSat;                     //!<  (-) instance of saturate utility for angular rate
+    Discretize aDisc;  //!<  (-) instance of discretization utility for linear acceleration
+    Discretize oDisc;  //!<  (-) instance of idscretization utility for angular rate
+    Saturate aSat;     //!<  (-) instance of saturate utility for linear acceleration
+    Saturate oSat;     //!<  (-) instance of saturate utility for angular rate
 
-    BSKLogger bskLogger;                      //!< -- BSK Logging
+    BSKLogger bskLogger;  //!< -- BSK Logging
 
-private:
-    uint64_t PreviousTime;              //!< -- Timestamp from previous frame
-    int64_t numStates;                  //!< -- Number of States for Gauss Markov Models
-    SCStatesMsgPayload StatePrevious;   //!< -- Previous state to delta in IMU
-    SCStatesMsgPayload StateCurrent;    //!< -- Current SSBI-relative state
-    GaussMarkov errorModelAccel;        //!< [-] Gauss-markov error states
-    GaussMarkov errorModelGyro;         //!< [-] Gauss-markov error states
+   private:
+    uint64_t PreviousTime;             //!< -- Timestamp from previous frame
+    int64_t numStates;                 //!< -- Number of States for Gauss Markov Models
+    SCStatesMsgPayload StatePrevious;  //!< -- Previous state to delta in IMU
+    SCStatesMsgPayload StateCurrent;   //!< -- Current SSBI-relative state
+    GaussMarkov errorModelAccel;       //!< [-] Gauss-markov error states
+    GaussMarkov errorModelGyro;        //!< [-] Gauss-markov error states
 
-    Eigen::MRPd previous_sigma_BN;              //!< -- sigma_BN from the previous spacecraft message
-    Eigen::MRPd current_sigma_BN;               //!< -- sigma_BN from the most recent spacecraft message
-    Eigen::Vector3d previous_omega_BN_B;        //!< -- omega_BN_B from the previous spacecraft message
-    Eigen::Vector3d current_omega_BN_B;         //!< -- omega_BN_B from the current spacecraft message
-    Eigen::Vector3d current_nonConservativeAccelpntB_B; //!< -- nonConservativeAccelpntB_B from the current message
-    Eigen::Vector3d current_omegaDot_BN_B;      //!< -- omegaDot_BN_B from the curret spacecraft message
-    Eigen::Vector3d previous_TotalAccumDV_BN_B; //!< -- TotalAccumDV_BN_B from the previous spacecraft message
-    Eigen::Vector3d current_TotalAccumDV_BN_B; //!< -- TotalAccumDV_BN_B from the current spacecraft message
+    Eigen::MRPd previous_sigma_BN;                       //!< -- sigma_BN from the previous spacecraft message
+    Eigen::MRPd current_sigma_BN;                        //!< -- sigma_BN from the most recent spacecraft message
+    Eigen::Vector3d previous_omega_BN_B;                 //!< -- omega_BN_B from the previous spacecraft message
+    Eigen::Vector3d current_omega_BN_B;                  //!< -- omega_BN_B from the current spacecraft message
+    Eigen::Vector3d current_nonConservativeAccelpntB_B;  //!< -- nonConservativeAccelpntB_B from the current message
+    Eigen::Vector3d current_omegaDot_BN_B;               //!< -- omegaDot_BN_B from the curret spacecraft message
+    Eigen::Vector3d previous_TotalAccumDV_BN_B;          //!< -- TotalAccumDV_BN_B from the previous spacecraft message
+    Eigen::Vector3d current_TotalAccumDV_BN_B;           //!< -- TotalAccumDV_BN_B from the current spacecraft message
 
-    Eigen::Vector3d accel_SN_P_out;             //!< -- rDotDot_SN_P for either next method or output messages
-    Eigen::Vector3d DV_SN_P_out;                //!< -- time step deltaV for either next method or output messages
-    Eigen::Vector3d omega_PN_P_out;             //!< -- omega_PN_P for either next method or output messages
-    Eigen::Vector3d prv_PN_out;                 //!< -- time step PRV_PN for either next method or output messages
+    Eigen::Vector3d accel_SN_P_out;  //!< -- rDotDot_SN_P for either next method or output messages
+    Eigen::Vector3d DV_SN_P_out;     //!< -- time step deltaV for either next method or output messages
+    Eigen::Vector3d omega_PN_P_out;  //!< -- omega_PN_P for either next method or output messages
+    Eigen::Vector3d prv_PN_out;      //!< -- time step PRV_PN for either next method or output messages
 };
-
 
 #endif

--- a/src/simulation/sensors/imuSensor/imuSensor.h
+++ b/src/simulation/sensors/imuSensor/imuSensor.h
@@ -34,13 +34,14 @@
 #include <Eigen/Dense>
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
+#include "architecture/utilities/macroDefinitions.h"
 
 
 /*! @brief IMU sensor class */
 class ImuSensor: public SysModel {
 public:
     ImuSensor();
-    ~ImuSensor();
+    ~ImuSensor() = default;
 
     void reset(uint64_t currentSimNanos);
     void updateState(uint64_t currentSimNanos);

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -150,6 +150,7 @@ void StarTracker::computeTrueOutput() {
     write output messages
  */
 void StarTracker::writeOutputMessages(uint64_t currentSimNanos) {
+    this->sensedValues.timeTag = currentSimNanos * NANO2SEC;
     this->sensorOutMsg.write(&this->sensedValues, this->moduleID, currentSimNanos);
 }
 

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -30,6 +30,7 @@
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/utilities/gauss_markov.h"
+#include "architecture/utilities/macroDefinitions.h"
 
 /*! @brief star tracker class */
 class StarTracker : public SysModel {


### PR DESCRIPTION
* **Tickets addressed:** bsk-348
* **Review:** By commit
* **Merge strategy:** Merge (no squash)  

## Description
This PR refactors the `inertialAttitudeUkf` module to accept the `IMUSensorMsgPayload` message. Currently, the `inertialAttitudeUkf` module accepts the `AccDataMsgPayload` message. A separate converter module is also added to this PR to convert from the `AccDataMsgPayload` message to the `IMUSensorMsgPayload` message. The result of this PR is the ability to either subscribe the `imuSensor` module output `IMUSensorMsgPayload` message directly to the `inertialAttitudeUkf` module, or to use the new converter module to convert the more realistic `AccDataMsgPayload` message to the `IMUSensorMsgPayload` message and subsequently subscribe the `IMUSensorMsgPayload` message to the `inertialAttitudeUkf` module.

The first commit of this PR adds two new variables to the IMUSensorMsgPayload: `timeTag` and `numberOfValidGyroMeasurements`. These parameters are required to be known in the `inertialAttitudeUkf` module. The second commit of this PR refactors the `inertialAttitudeUkf` module to accept the `IMUSensorMsgPayload` message. The third commit adds a `miruLowPassFilterConverter` to the `sensorInterfaces` folder that will interface with the `inertialAttitudeUkf` module. The fourth commit adjusts the `inertialAttitudeUkf` unit test file to use the new `IMUSensorMsgPayload` message.

## Verification
N/A

## Documentation
N/A

## Future work
N/A