### PR TITLE
Temporarily disable windows ci

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,12 +20,13 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}
+
   build-linux:
     name: Build Linux
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -87,6 +87,7 @@ jobs:
         if: ${{ always() }}
 
   build-windows:
+    if: 'false'
     name: Build Windows
     runs-on: windows-2022
     strategy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==3.5.2
+bokeh
 conan>=1.40.1, <2.00.0
 datashader==0.16.3
 holoviews==1.19.1


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
For the time being Windows CI (and by consequence, strict support for the OS) is being removed. Windows support has always been tenuous in Basilisk and adding this flag allows us to turn our attention back to first class Windows support at a later date (year's end) following many of the large changes that are arriving to the code base this month.

## Verification
As usual CI will run, but primarily the Windows job will be skipped.

## Documentation
NA

## Future work
Windows support to be returned following the significant build system simplifications that are incoming.
