### PR TITLE
Add missing cpython exported symbol

### DIFF
--- a/src/cmake/cpython-exported-symbols
+++ b/src/cmake/cpython-exported-symbols
@@ -710,6 +710,7 @@
 -U _PyUnicode_AsUCS4Copy
 -U _PyUnicode_AsUTF16String
 -U _PyUnicode_AsUTF32String
+-U _PyUnicode_AsUTF8
 -U _PyUnicode_AsUTF8AndSize
 -U _PyUnicode_AsUTF8String
 -U _PyUnicode_AsUnicodeEscapeString


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
It seems that we missed one symbol from our addition of `src/cmake/cpython-exported-symbols` , specifically `PyUnicode_AsUTF8`. This PR adds it ine.

## Verification
Build tested and CI runs.

## Documentation
NA

## Future work
NA
