### PR TITLE
Allow functions as dispersion variables

### DIFF
--- a/src/utilities/MonteCarlo/Controller.py
+++ b/src/utilities/MonteCarlo/Controller.py
@@ -826,10 +826,16 @@ class SimulationExecutor:
 
             # apply the dispersions and the random seeds
             for variable, value in list(modifications.items()):
-                disperseStatement = "simInstance." + variable + "=" + value
+                expresion = "simInstance." + variable
+                dispersionExpresion = None
+                if eval("callable(" + expresion + ")"):
+                    dispersionExpresion = expresion + "(" + value + ")"
+                else:
+                    dispersionExpresion = expresion + "=" + value
+
                 if simParams.verbose:
-                    print("Executing parameter modification -> ", disperseStatement)
-                exec(disperseStatement)
+                    print("Executing parameter modification -> ", dispersionExpresion)
+                exec(dispersionExpresion)
 
             # setup data logging
             if len(simParams.retentionPolicies) > 0:
@@ -921,4 +927,3 @@ class SimulationExecutor:
             if ".RNGSeed" in variable:
                 rngStatement = "simInstance." + variable + "=" + value
                 exec(rngStatement)
-


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR makes a small adjustment to allow a function to be passed as a monte carlo dispersion string. The string is `eval`'d and if `callable` the function is called with the accompanying dispersion value as the parameter. This is a really terrible solution. However, with much of the monte carlo infrastructure being significantly refactored soon, it's a temporary blight which will be swept away by the refactor.

## Verification
Tested on multiple monte carlos.

## Documentation
NA 

## Future work
NA
