### PR TITLE
correct the COB to be in the middle of a pixel

### DIFF
--- a/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
+++ b/src/fswAlgorithms/imageProcessing/centerOfBrightness/centerOfBrightness.cpp
@@ -110,8 +110,8 @@ void CenterOfBrightness::updateState(uint64_t currentSimNanos)
             cobBuffer.valid = true;
             cobBuffer.timeTag = this->sensorTimeTag;
             cobBuffer.cameraID = imageBuffer.cameraID;
-            cobBuffer.centerOfBrightness[0] = cobData.first[0];
-            cobBuffer.centerOfBrightness[1] = cobData.first[1];
+            cobBuffer.centerOfBrightness[0] = cobData.first[0] + 0.5;
+            cobBuffer.centerOfBrightness[1] = cobData.first[1] + 0.5;
             cobBuffer.pixelsFound = static_cast<int32_t> (locations.size());
         }
         cobBuffer.rollingAverageBrightness = averageBrightnessNew;


### PR DESCRIPTION
We were using the top left corner of the pixel before leading to biases in the filter.

* **Tickets addressed:** bsk-1308
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Fix the COB centering 

## Verification
None

## Documentation
None

## Future work
None
