### PR TITLE
Add clang format hook to pre-commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,9 @@
 ---
-BasedOnStyle: Mozilla
+BasedOnStyle: Google
 ColumnLimit: '120'
 IndentWidth: '4'
 TabWidth:    '4'
+BinPackArguments: false
+BinPackParameters: false
+AllowAllParametersOfDeclarationOnNextLine: false
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
 exclude: '.*\.(tls|bsp|tpc|bc)$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
-      -   id: trailing-whitespace
-      -   id: end-of-file-fixer
-      -   id: check-yaml
       -   id: check-added-large-files
           args: ['--maxkb=10000']
       -   id: check-case-conflict
       -   id: check-merge-conflict
+      -   id: check-yaml
       -   id: debug-statements
+      -   id: end-of-file-fixer
+      -   id: trailing-whitespace
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      -   id: clang-format
+          args: [-i, -style=file]

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -140,9 +140,9 @@ void FacetDragDynamicEffector::plateDrag(){
 selecting the model type based on the settable attribute "modelType."
 */
 void FacetDragDynamicEffector::computeForceTorque(double integTime, double timeStep){
-	updateDragDir();
-	plateDrag();
   return;
+	this->updateDragDir();
+	this->plateDrag();
 }
 
 /*! This method is called to update the local atmospheric conditions at each timestep.

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -33,14 +33,6 @@ FacetDragDynamicEffector::FacetDragDynamicEffector()
 	return;
 }
 
-/*! The destructor.*/
-FacetDragDynamicEffector::~FacetDragDynamicEffector()
-{
-	return;
-}
-
-
-
 void FacetDragDynamicEffector::reset(uint64_t currentSimNanos)
 {
 	// check if input message has not been included

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -50,13 +50,6 @@ void FacetDragDynamicEffector::reset(uint64_t currentSimNanos)
 
     return;
 }
-
-/*! The DragEffector does not write output messages to the rest of the sim.
-@return void
- */
-void FacetDragDynamicEffector::WriteOutputMessages(uint64_t CurrentClock)
-{
-	return;
 }
 
 

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -18,43 +18,35 @@
  */
 
 #include "facetDragDynamicEffector.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/astroConstants.h"
-#include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/avsEigenMRP.h"
 
-FacetDragDynamicEffector::FacetDragDynamicEffector()
-{
+#include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/avsEigenMRP.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/linearAlgebra.h"
+
+FacetDragDynamicEffector::FacetDragDynamicEffector() {
     this->forceExternal_B.fill(0.0);
     this->torqueExternalPntB_B.fill(0.0);
     this->v_B.fill(0.0);
     this->v_hat_B.fill(0.0);
-	this->numFacets = 0;
-	return;
 }
 
-void FacetDragDynamicEffector::reset(uint64_t currentSimNanos)
-{
-	// check if input message has not been included
-	if (!this->atmoDensInMsg.isLinked()) {
-		bskLogger.bskLog(BSK_ERROR, "facetDragDynamicEffector.atmoDensInMsg was not linked.");
-	}
-
-    return;
+void FacetDragDynamicEffector::reset(uint64_t currentSimNanos) {
+    // check if input message has not been included
+    if (!this->atmoDensInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "facetDragDynamicEffector.atmoDensInMsg was not linked.");
+    }
 }
-}
-
 
 /*! This method is used to read the incoming density message and update the internal density/
 atmospheric data.
  @return void
  */
-bool FacetDragDynamicEffector::readInputs()
-{
+bool FacetDragDynamicEffector::readInputs() {
     bool dataGood;
     this->atmoInData = this->atmoDensInMsg();
     dataGood = this->atmoDensInMsg.isWritten();
-    return(dataGood);
+    return dataGood;
 }
 
 /*!
@@ -64,12 +56,15 @@ bool FacetDragDynamicEffector::readInputs()
     @param B_normal_hat
     @param B_location
  */
-void FacetDragDynamicEffector::addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location){
-	this->scGeometry.facetAreas.push_back(area);
-	this->scGeometry.facetCoeffs.push_back(dragCoeff);
-	this->scGeometry.facetNormals_B.push_back(B_normal_hat);
-	this->scGeometry.facetLocations_B.push_back(B_location);
-	this->numFacets = this->numFacets + 1;
+void FacetDragDynamicEffector::addFacet(double area,
+                                        double dragCoeff,
+                                        Eigen::Vector3d B_normal_hat,
+                                        Eigen::Vector3d B_location) {
+    this->scGeometry.facetAreas.push_back(area);
+    this->scGeometry.facetCoeffs.push_back(dragCoeff);
+    this->scGeometry.facetNormals_B.push_back(B_normal_hat);
+    this->scGeometry.facetLocations_B.push_back(B_location);
+    this->numFacets = this->numFacets + 1;
 }
 
 /*! This method is used to link the dragEffector to the hub attitude and velocity,
@@ -78,63 +73,62 @@ which are required for calculating drag forces and torques.
  @param states dynamic parameter states
  */
 
-void FacetDragDynamicEffector::linkInStates(DynParamManager& states){
-	this->hubSigma = states.getStateObject("hubSigma");
-	this->hubVelocity = states.getStateObject("hubVelocity");
+void FacetDragDynamicEffector::linkInStates(DynParamManager& states) {
+    this->hubSigma = states.getStateObject("hubSigma");
+    this->hubVelocity = states.getStateObject("hubVelocity");
 }
 
 /*! This method updates the internal drag direction based on the spacecraft velocity vector.
-*/
-void FacetDragDynamicEffector::updateDragDir(){
+ */
+void FacetDragDynamicEffector::updateDragDir() {
     Eigen::MRPd sigmaBN;
     sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
     Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
-    this->v_B = dcm_BN*this->hubVelocity->getState(); // [m/s] sc velocity
+    this->v_B = dcm_BN * this->hubVelocity->getState();  // [m/s] sc velocity
     this->v_hat_B = this->v_B / this->v_B.norm();
-
-    return;
 }
 
 /*! This method WILL implement a more complex flat-plate aerodynamics model with attitude
 dependence and lift forces.
 */
-void FacetDragDynamicEffector::plateDrag(){
-	Eigen::Vector3d facetDragForce, facetDragTorque;
-	Eigen::Vector3d totalDragForce, totalDragTorque;
+void FacetDragDynamicEffector::plateDrag() {
+    Eigen::Vector3d facetDragForce;
+    Eigen::Vector3d facetDragTorque;
+    Eigen::Vector3d totalDragForce;
+    Eigen::Vector3d totalDragTorque;
 
-	//! - Zero out the structure force/torque for the drag set
+    //! - Zero out the structure force/torque for the drag set
     double projectedArea = 0.0;
     double projectionTerm = 0.0;
-	totalDragForce.setZero();
-	totalDragTorque.setZero();
+    totalDragForce.setZero();
+    totalDragTorque.setZero();
     this->forceExternal_B.setZero();
     this->torqueExternalPntB_B.setZero();
 
-	for(size_t i = 0; i < this->numFacets; i++){
-	    projectionTerm = this->scGeometry.facetNormals_B[i].dot(this->v_hat_B);
-		projectedArea = this->scGeometry.facetAreas[i] * projectionTerm;
-		if(projectedArea > 0.0){
-			facetDragForce = 0.5 * pow(this->v_B.norm(), 2.0) * this->scGeometry.facetCoeffs[i] * projectedArea * this->atmoInData.neutralDensity * (-1.0)*this->v_hat_B;
-			facetDragTorque = (-1)*facetDragForce.cross(this->scGeometry.facetLocations_B[i]);
-			totalDragForce = totalDragForce + facetDragForce;
-			totalDragTorque = totalDragTorque + facetDragTorque;
-		}
-	}
-	this->forceExternal_B = totalDragForce;
-	this->torqueExternalPntB_B = totalDragTorque;
+    for (size_t i = 0; i < this->numFacets; i++) {
+        projectionTerm = this->scGeometry.facetNormals_B[i].dot(this->v_hat_B);
+        projectedArea = this->scGeometry.facetAreas[i] * projectionTerm;
+        if (projectedArea > 0.0) {
+            facetDragForce = 0.5 * pow(this->v_B.norm(), 2.0) * this->scGeometry.facetCoeffs[i] * projectedArea *
+                             this->atmoInData.neutralDensity * (-1.0) * this->v_hat_B;
+            facetDragTorque = (-1) * facetDragForce.cross(this->scGeometry.facetLocations_B[i]);
+            totalDragForce = totalDragForce + facetDragForce;
+            totalDragTorque = totalDragTorque + facetDragTorque;
+        }
+    }
+    this->forceExternal_B = totalDragForce;
+    this->torqueExternalPntB_B = totalDragTorque;
 
-  return;
+    return;
 }
-
 
 /*! This method computes the body forces and torques for the dragEffector in a simulation loop,
 selecting the model type based on the settable attribute "modelType."
 */
-void FacetDragDynamicEffector::computeForceTorque(double integTime, double timeStep){
-  return;
-	this->updateDragDir();
-	this->plateDrag();
+void FacetDragDynamicEffector::computeForceTorque(double integTime, double timeStep) {
+    this->updateDragDir();
+    this->plateDrag();
 }
 
 /*! This method is called to update the local atmospheric conditions at each timestep.
@@ -142,8 +136,4 @@ Naturally, this means that conditions are held piecewise-constant over an integr
  @return void
  @param currentSimNanos The current simulation time in nanoseconds
  */
-void FacetDragDynamicEffector::updateState(uint64_t currentSimNanos)
-{
-	return;
-	this->readInputs();
-}
+void FacetDragDynamicEffector::updateState(uint64_t currentSimNanos) { this->readInputs(); }

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -57,7 +57,7 @@ void FacetDragDynamicEffector::reset(uint64_t currentSimNanos)
 atmospheric data.
  @return void
  */
-bool FacetDragDynamicEffector::ReadInputs()
+bool FacetDragDynamicEffector::readInputs()
 {
     bool dataGood;
     this->atmoInData = this->atmoDensInMsg();
@@ -152,6 +152,6 @@ Naturally, this means that conditions are held piecewise-constant over an integr
  */
 void FacetDragDynamicEffector::updateState(uint64_t currentSimNanos)
 {
-	ReadInputs();
 	return;
+	this->readInputs();
 }

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -33,10 +33,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/bskLogging.h"
 
-
-
-
-
 /*! @brief spacecraft geometry data */
 typedef struct {
   std::vector<double> facetAreas;                   //!< vector of facet areas
@@ -49,8 +45,6 @@ typedef struct {
 /*! @brief faceted atmospheric drag dynamic effector */
 class FacetDragDynamicEffector: public SysModel, public DynamicEffector {
 public:
-
-
     FacetDragDynamicEffector();
     ~FacetDragDynamicEffector();
     void linkInStates(DynParamManager& states);
@@ -61,11 +55,6 @@ public:
     bool ReadInputs();
     void addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location);
 
-private:
-
-    void plateDrag();
-    void updateDragDir();
-public:
     uint64_t numFacets;                             //!< number of facets
     ReadFunctor<AtmoPropsMsgPayload> atmoDensInMsg; //!< atmospheric density input message
     StateData *hubSigma;                            //!< -- Hub/Inertial attitude represented by MRP
@@ -75,9 +64,11 @@ public:
     BSKLogger bskLogger;                            //!< -- BSK Logging
 
 private:
+    void plateDrag();
+    void updateDragDir();
+
     AtmoPropsMsgPayload atmoInData;
     SpacecraftGeometryData scGeometry;              //!< -- Struct to hold spacecraft facet data
-
 };
 
 #endif

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -59,7 +59,6 @@ public:
     StateData *hubVelocity;                         //!< m/s Hub inertial velocity vector
     Eigen::Vector3d v_B;                            //!< m/s local variable to hold the inertial velocity
     Eigen::Vector3d v_hat_B;                        //!< class variable
-    BSKLogger bskLogger;                            //!< -- BSK Logging
 
 private:
     bool readInputs();

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -51,7 +51,6 @@ public:
     void computeForceTorque(double integTime, double timeStep);
     void reset(uint64_t currentSimNanos);               //!< class method
     void updateState(uint64_t currentSimNanos);
-    bool ReadInputs();
     void addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location);
 
     uint64_t numFacets;                             //!< number of facets
@@ -63,6 +62,7 @@ public:
     BSKLogger bskLogger;                            //!< -- BSK Logging
 
 private:
+    bool readInputs();
     void plateDrag();
     void updateDragDir();
 

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -17,34 +17,31 @@
 
  */
 
-
 #ifndef FACET_DRAG_DYNAMIC_EFFECTOR_H
 #define FACET_DRAG_DYNAMIC_EFFECTOR_H
 
 #include <Eigen/Dense>
 #include <vector>
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/AtmoPropsMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 #include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
-#include "architecture/_GeneralModuleFiles/sys_model.h"
-
-#include "architecture/msgPayloadDefC/AtmoPropsMsgPayload.h"
-#include "architecture/messaging/messaging.h"
-
-#include "architecture/utilities/rigidBodyKinematics.h"
-#include "architecture/utilities/bskLogging.h"
 
 /*! @brief spacecraft geometry data */
 typedef struct {
-  std::vector<double> facetAreas;                   //!< vector of facet areas
-  std::vector<double> facetCoeffs;                  //!< vector of facet coefficients
-  std::vector<Eigen::Vector3d> facetNormals_B;      //!< vector of facet normals
-  std::vector<Eigen::Vector3d> facetLocations_B;    //!< vector of facet locations
-}SpacecraftGeometryData;
-
+    std::vector<double> facetAreas;                 //!< vector of facet areas
+    std::vector<double> facetCoeffs;                //!< vector of facet coefficients
+    std::vector<Eigen::Vector3d> facetNormals_B;    //!< vector of facet normals
+    std::vector<Eigen::Vector3d> facetLocations_B;  //!< vector of facet locations
+} SpacecraftGeometryData;
 
 /*! @brief faceted atmospheric drag dynamic effector */
-class FacetDragDynamicEffector: public SysModel, public DynamicEffector {
-public:
+class FacetDragDynamicEffector : public SysModel, public DynamicEffector {
+   public:
     FacetDragDynamicEffector();
     void linkInStates(DynParamManager& states) override;
     void computeForceTorque(double integTime, double timeStep) override;
@@ -52,20 +49,20 @@ public:
     void updateState(uint64_t currentSimNanos) override;
     void addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location);
 
-    uint64_t numFacets=0;                             //!< number of facets
-    ReadFunctor<AtmoPropsMsgPayload> atmoDensInMsg; //!< atmospheric density input message
-    StateData *hubSigma;                            //!< -- Hub/Inertial attitude represented by MRP
-    StateData *hubVelocity;                         //!< m/s Hub inertial velocity vector
-    Eigen::Vector3d v_B;                            //!< m/s local variable to hold the inertial velocity
-    Eigen::Vector3d v_hat_B;                        //!< class variable
+    uint64_t numFacets = 0;                          //!< number of facets
+    ReadFunctor<AtmoPropsMsgPayload> atmoDensInMsg;  //!< atmospheric density input message
+    StateData* hubSigma;                             //!< -- Hub/Inertial attitude represented by MRP
+    StateData* hubVelocity;                          //!< m/s Hub inertial velocity vector
+    Eigen::Vector3d v_B;                             //!< m/s local variable to hold the inertial velocity
+    Eigen::Vector3d v_hat_B;                         //!< class variable
 
-private:
+   private:
     bool readInputs();
     void plateDrag();
     void updateDragDir();
 
     AtmoPropsMsgPayload atmoInData;
-    SpacecraftGeometryData scGeometry;              //!< -- Struct to hold spacecraft facet data
+    SpacecraftGeometryData scGeometry;  //!< -- Struct to hold spacecraft facet data
 };
 
 #endif

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -46,7 +46,6 @@ typedef struct {
 class FacetDragDynamicEffector: public SysModel, public DynamicEffector {
 public:
     FacetDragDynamicEffector();
-    ~FacetDragDynamicEffector();
     void linkInStates(DynParamManager& states) override;
     void computeForceTorque(double integTime, double timeStep) override;
     void reset(uint64_t currentSimNanos) override;

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -51,7 +51,6 @@ public:
     void computeForceTorque(double integTime, double timeStep);
     void reset(uint64_t currentSimNanos);               //!< class method
     void updateState(uint64_t currentSimNanos);
-    void WriteOutputMessages(uint64_t CurrentClock);
     bool ReadInputs();
     void addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location);
 

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -52,7 +52,7 @@ public:
     void updateState(uint64_t currentSimNanos) override;
     void addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location);
 
-    uint64_t numFacets;                             //!< number of facets
+    uint64_t numFacets=0;                             //!< number of facets
     ReadFunctor<AtmoPropsMsgPayload> atmoDensInMsg; //!< atmospheric density input message
     StateData *hubSigma;                            //!< -- Hub/Inertial attitude represented by MRP
     StateData *hubVelocity;                         //!< m/s Hub inertial velocity vector

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -47,10 +47,10 @@ class FacetDragDynamicEffector: public SysModel, public DynamicEffector {
 public:
     FacetDragDynamicEffector();
     ~FacetDragDynamicEffector();
-    void linkInStates(DynParamManager& states);
-    void computeForceTorque(double integTime, double timeStep);
-    void reset(uint64_t currentSimNanos);               //!< class method
-    void updateState(uint64_t currentSimNanos);
+    void linkInStates(DynParamManager& states) override;
+    void computeForceTorque(double integTime, double timeStep) override;
+    void reset(uint64_t currentSimNanos) override;
+    void updateState(uint64_t currentSimNanos) override;
     void addFacet(double area, double dragCoeff, Eigen::Vector3d B_normal_hat, Eigen::Vector3d B_location);
 
     uint64_t numFacets;                             //!< number of facets


### PR DESCRIPTION
* **Tickets addressed:** #366 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Clang-format hook is added to pre-commit. This hook will format C/C++ code according to the clang-format definitions in the `.clang-format` file in the project root. 

## Verification
As an example, the `FacetDragDynamicEffector` module was cleaned up a little and then pre-commit's results are contained in the last commit.

## Documentation
NA

## Future work
NA
