### PR TITLE
add missed message update

### DIFF
--- a/src/architecture/msgPayloadDefC/CameraRenderingMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/CameraRenderingMsgPayload.h
@@ -27,7 +27,7 @@
 typedef struct {
     int cameraId;
     double cosmicRayStdDeviation;
-    bool enableStrayLight;
+    double strayLight;
     bool starField;
     char rendering[MAX_STRING_LENGTH];
     bool smear;


### PR DESCRIPTION
this change should have been on 1308-camera-fix but was lost in a merge conflict

* **Tickets addressed:** bsk-1308
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Name and type change for the (unused) stray light parameter

## Verification
Test in incoming branch

## Documentation
None

## Future work
None
