### PR TITLE
Pass tuple to figure size parameter

### DIFF
--- a/examples/BskSim/plotting/BSK_Plotting.py
+++ b/examples/BskSim/plotting/BSK_Plotting.py
@@ -271,7 +271,7 @@ def plot_rw_friction(timeData, dataFrictionRW, numRW, dataFaultLog=[],  id=None,
 
 def plot_planet(oe, planet):
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
-    plt.figure(figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    plt.figure(figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.a, oe.a, -b, b]) / 1000 * 1.75)
     # draw the planet
     fig = plt.gcf()

--- a/examples/scenarioAttGuideHyperbolic.py
+++ b/examples/scenarioAttGuideHyperbolic.py
@@ -173,7 +173,7 @@ def plot_orbit(oe, mu, planet_radius, dataPos, dataVel):
     """Plot the spacecraft orbit trajectory."""
     # draw orbit in perifocal frame
     p = oe.a * (1 - oe.e * oe.e)
-    plt.figure(4, figsize=np.array((1.0, 1.)) * 4.75, dpi=100)
+    plt.figure(4, figsize=tuple(np.array((1.0, 1.)) * 4.75), dpi=100)
     # draw the planet
     fig = plt.gcf()
     ax = fig.gca()

--- a/examples/scenarioBasicOrbit.py
+++ b/examples/scenarioBasicOrbit.py
@@ -487,7 +487,7 @@ def plotOrbits(timeAxis, posData, velData, oe, mu, P, orbitCase, useSphericalHar
         # draw orbit in perifocal frame
         b = oe.a * np.sqrt(1 - oe.e * oe.e)
         p = oe.a * (1 - oe.e * oe.e)
-        plt.figure(2, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+        plt.figure(2, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
         plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
         # draw the planet
         fig = plt.gcf()

--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -265,7 +265,7 @@ def run(show_plots, liveStream, timeStep, orbitCase, useSphericalHarmonics, plan
         # draw orbit in perifocal frame
         b = oe.a * np.sqrt(1 - oe.e * oe.e)
         p = oe.a * (1 - oe.e * oe.e)
-        plt.figure(2, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+        plt.figure(2, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
         plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
         # draw the planet
         fig = plt.gcf()

--- a/examples/scenarioCentralBody.py
+++ b/examples/scenarioCentralBody.py
@@ -285,7 +285,7 @@ def run(show_plots, useCentral):
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
-    plt.figure(2, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    plt.figure(2, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet
     fig = plt.gcf()

--- a/examples/scenarioDragDeorbit.py
+++ b/examples/scenarioDragDeorbit.py
@@ -312,7 +312,7 @@ def plotOrbits(timeAxis, posData, velData, dragForce, denseData, oe, mu, planet,
 
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
-    plt.figure(1, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet
     fig, ax = register_fig(1)

--- a/examples/scenarioHaloOrbit.py
+++ b/examples/scenarioHaloOrbit.py
@@ -204,7 +204,7 @@ def run(showPlots=True):
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
 
     # First plot: Draw orbit in inertial frame
-    fig = plt.figure(1, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    fig = plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     ax = fig.gca()
     ax.ticklabel_format(style='scientific', scilimits=[-5, 3])
@@ -241,7 +241,7 @@ def run(showPlots=True):
 
     # Second plot: Draw orbit in frame rotating with the Moon (the center is L2 point)
     # x axis is moon position vector direction and y axis is moon velocity vector direction
-    fig = plt.figure(2, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    fig = plt.figure(2, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-1e5, 5e5, -3e5, 3e5])  * 1.25)
     ax = fig.gca()
     ax.ticklabel_format(style='scientific', scilimits=[-5, 3])
@@ -279,7 +279,7 @@ def run(showPlots=True):
     # Third plot: Draw orbit in frame rotating with the Moon (the center is L2 point)
     # x axis is moon position vector direction and y axis is the cross product direction of the moon position vector and
     # velocity vector
-    fig = plt.figure(3, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    fig = plt.figure(3, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-1e5, 5e5, -3e5, 3e5]) * 1.25)
     ax = fig.gca()
     ax.ticklabel_format(style='scientific', scilimits=[-5, 3])

--- a/examples/scenarioIntegrators.py
+++ b/examples/scenarioIntegrators.py
@@ -328,7 +328,7 @@ def run(show_plots, integratorCase):
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
-    plt.figure(1, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet
     fig = plt.gcf()

--- a/examples/scenarioLagrangePointOrbit.py
+++ b/examples/scenarioLagrangePointOrbit.py
@@ -273,7 +273,7 @@ def run(lagrangePoint, nOrbits, timestep, showPlots=True):
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
 
     # First plot: Draw orbit in inertial frame
-    fig = plt.figure(1, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    fig = plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     ax = fig.gca()
     ax.ticklabel_format(style='scientific', scilimits=[-5, 3])
@@ -317,7 +317,7 @@ def run(lagrangePoint, nOrbits, timestep, showPlots=True):
     figureList[pltName] = plt.figure(1)
 
     # Second plot: Draw orbit in frame rotating with the Moon
-    fig = plt.figure(2, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    fig = plt.figure(2, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     ax = fig.gca()
     ax.ticklabel_format(style='scientific', scilimits=[-5, 3])

--- a/examples/scenarioOrbitMultiBody.py
+++ b/examples/scenarioOrbitMultiBody.py
@@ -336,7 +336,7 @@ def run(show_plots, scCase):
         omega0 = oeData.omega
         b = oeData.a * np.sqrt(1 - oeData.e * oeData.e)
         p = oeData.a * (1 - oeData.e * oeData.e)
-        plt.figure(2, figsize=np.array((1.0, b / oeData.a)) * 4.75, dpi=100)
+        plt.figure(2, figsize=tuple(np.array((1.0, b / oeData.a)) * 4.75), dpi=100)
         plt.axis(np.array([-oeData.rApoap, oeData.rPeriap, -b, b]) / 1000 * 1.25)
 
         # draw the planet

--- a/examples/scenarioPatchedConics.py
+++ b/examples/scenarioPatchedConics.py
@@ -393,7 +393,7 @@ def run(show_plots):
     plt.close("all")  # clears out plots from earlier test runs
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
-    plt.figure(1) #, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    plt.figure(1) #, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     # plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     plt.axis('equal')
     plt.axis([-20000, 50000, -10000, 10000])

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
@@ -210,7 +210,7 @@ def run(doUnitTests, show_plots, integratorCase):
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
-    plt.figure(1, figsize=np.array((1.0, b / oe.a)) * 4.75, dpi=100)
+    plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet
     fig = plt.gcf()

--- a/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
+++ b/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
@@ -301,7 +301,7 @@ def run(show_plots, orbitCase, planetCase):
         # draw orbit in perifocal frame
         b = oe.a*np.sqrt(1-oe.e*oe.e)
         p = oe.a*(1-oe.e*oe.e)
-        plt.figure(2,figsize=np.array((1.0, b/oe.a))*4.75,dpi=100)
+        plt.figure(2,figsize=tuple(np.array((1.0, b/oe.a))*4.75),dpi=100)
         plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b])/1000*1.25)
         # draw the planet
         fig = plt.gcf()


### PR DESCRIPTION
* **Tickets addressed:** #374 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Matplotlib 3.10 requires the `figsize` parameter of the `figure()` function to be strictly of type tuple. This PR changes locations which didn't pass a tuple.

## Verification
All CI runs.

## Documentation
None new, none invalidated.

## Future work
None
