### PR TITLE
Pin github runner cmake version to 3.28

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,8 +58,15 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: "Install swig and cmake"
-        run: sudo apt-get update && sudo apt-get install build-essential cmake gtk2.0 libgtk2.0-dev ninja-build swig -y
+      - name: "Install apt dependencies"
+        run: |
+          sudo apt-get update && \
+          sudo apt-get purge cmake && \
+            sudo apt-get install build-essential gtk2.0 libgtk2.0-dev ninja-build swig -y
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.28.3'
       - name: "Install python packages"
         run: sudo apt-get install python3-setuptools python3-tk
       - name: "Create virtual Environment"


### PR DESCRIPTION
* **Tickets addressed:** #385
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Many of the conan recipes haven't caught up to the fact that CMake 4.0 dropped support for CMake <3.5  functionality. This change forces the addition of cmake 3.28.3 to be on the PATH of the github runner (it's default is 4.0). 

## Verification
CI runs successfully. 

## Documentation
None at the moment as it's being redone anyhow.

## Future work
Getting rid of conan.
