### PR TITLE
Feature/392 rate control fsw algorithm

### DIFF
--- a/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
+++ b/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
@@ -30,44 +30,34 @@ def test_rateControl(show_plots, setExtTorque):
     r"""
     **Validation Test Description**
 
-    The unit test  for this module is kept as there are no branching code segments to account for different cases.
-    The spacecraft inertia tensor message is setup, as well as a guidance message.  The module is then run for a
-    few time steps and the control torque output message compared to a known answer.  The simulation only variable
-    is if the known external torque is specified, or if the zero default vector is used.
+    This test confirms the functionality of the rateControl fsw algorithm. The spacecraft inertia tensor message is set,
+    as well as a guidance message. An external torque can be toggled on or off. The module is then run for a few time
+    steps and the determined control torque output is compared to the computed truth value.
 
     **Test Parameters**
 
-    The unit test verifies that the module output torque message vector matches expected values.  The test
+    The unit test verifies that the module output torque message vector matches expected values. The test
     method parameters include the following.
 
     :param show_plots: flag to show the test run plots
     :param setExtTorque: flag to set the knownTorquePntB_B variable
     :return: void
-
-
     """
 
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_ProportionalDerivative_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
 
-    unitTaskName = "unitTask"  # arbitrary name (don't change)
-    unitProcessName = "TestProcess"  # arbitrary name (don't change)
-
-    #   Create a sim module as an empty container
+    # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.5)  # update process rate update time
+    testProcessRate = macros.sec2nano(0.5)
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
-    # Construct algorithm and associated C++ container
+    # Create an instance of the rateControl module
     module = rateControl.RateControl()
     module.modelTag = "rateControl"
-
-    # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, module)
 
     # Initialize the test module configuration data
@@ -77,9 +67,7 @@ def test_rateControl(show_plots, setExtTorque):
         knownTorquePntB_B = np.array([0.1, 0.2, 0.3])
         module.setKnownTorquePntB_B(knownTorquePntB_B)
 
-    #   Create input message and size it because the regular creator of that message
-    #   is not part of the test.
-    #   attGuidOut Message:
+    # Create the attitude guidance input message
     guidCmdData = messaging.AttGuidMsgPayload()
     guidCmdData.sigma_BR = np.array([0.3, -0.5, 0.7])
     guidCmdData.omega_BR_B = np.array([0.010, -0.020, 0.015])
@@ -87,31 +75,30 @@ def test_rateControl(show_plots, setExtTorque):
     guidCmdData.domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
     guidInMsg = messaging.AttGuidMsg().write(guidCmdData)
 
-    # vehicleConfig FSW Message:
+    # Create the vehicleConfig fsw message
     vehicleConfigIn = messaging.VehicleConfigMsgPayload()
     vehicleConfigIn.ISCPntB_B = [1000., 0., 0.,
                                   0., 800., 0.,
                                   0., 0., 800.]
     vcInMsg = messaging.VehicleConfigMsg().write(vehicleConfigIn)
 
-    # Setup logging on the test module output message so that we get all the writes to it
+    # Set up data logging
     dataLog = module.cmdTorqueOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    # connect messages
+    # Connect messages
     module.vehConfigInMsg.subscribeTo(vcInMsg)
     module.guidInMsg.subscribeTo(guidInMsg)
 
-    # Need to call the self-init and cross-init methods
+    # Execute the simulation
     unitTestSim.InitializeSimulation()
-
-    # Step the simulation to 3*process rate so 4 total steps including zero
-    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))  # seconds to stop simulation
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
     unitTestSim.ExecuteSimulation()
 
+    # Extract logged data for test check
     trueVector = [findTrueTorques(module, guidCmdData, vehicleConfigIn, knownTorquePntB_B)]*3
 
-    # Compare the module results to the truth values
+    # Compare the module results to the computed truth value
     accuracy = 1e-12
     np.testing.assert_allclose(trueVector,
                                dataLog.torqueRequestBody,
@@ -132,11 +119,11 @@ def findTrueTorques(module, guidCmdData, vehicleConfigOut, knownTorquePntB_B):
     P = module.getDerivativeGainP()
     L = knownTorquePntB_B
 
-    # Begin Method
     omega_BN_B = omega_BR_B + omega_RN_B
     temp1 = np.dot(I, omega_BN_B)
     temp2 = domega_RN_B - np.cross(omega_BN_B, omega_RN_B)
 
+    # Compute truth control torque
     Lr = P * omega_BR_B - np.cross(omega_RN_B, temp1) - np.dot(I, temp2)
     Lr += L
     Lr *= -1.0

--- a/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
+++ b/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
@@ -1,0 +1,147 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import numpy as np
+import pytest
+
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.fswAlgorithms import rateControl
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+
+@pytest.mark.parametrize("setExtTorque", [False, True])
+
+def test_rateControl(show_plots, setExtTorque):
+    r"""
+    **Validation Test Description**
+
+    The unit test  for this module is kept as there are no branching code segments to account for different cases.
+    The spacecraft inertia tensor message is setup, as well as a guidance message.  The module is then run for a
+    few time steps and the control torque output message compared to a known answer.  The simulation only variable
+    is if the known external torque is specified, or if the zero default vector is used.
+
+    **Test Parameters**
+
+    The unit test verifies that the module output torque message vector matches expected values.  The test
+    method parameters include the following.
+
+    :param show_plots: flag to show the test run plots
+    :param setExtTorque: flag to set the knownTorquePntB_B variable
+    :return: void
+
+
+    """
+
+    # The __tracebackhide__ setting influences pytest showing of tracebacks:
+    # the mrp_ProportionalDerivative_tracking() function will not be shown unless the
+    # --fulltrace command line option is specified.
+    __tracebackhide__ = True
+
+    unitTaskName = "unitTask"  # arbitrary name (don't change)
+    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+
+    #   Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)  # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    module = rateControl.RateControl()
+    module.modelTag = "rateControl"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # Initialize the test module configuration data
+    knownTorquePntB_B = np.array([0.0, 0.0, 0.0])
+    module.setDerivativeGainP(150.0)
+    if setExtTorque:
+        knownTorquePntB_B = np.array([0.1, 0.2, 0.3])
+        module.setKnownTorquePntB_B(knownTorquePntB_B)
+
+    #   Create input message and size it because the regular creator of that message
+    #   is not part of the test.
+    #   attGuidOut Message:
+    guidCmdData = messaging.AttGuidMsgPayload()
+    guidCmdData.sigma_BR = np.array([0.3, -0.5, 0.7])
+    guidCmdData.omega_BR_B = np.array([0.010, -0.020, 0.015])
+    guidCmdData.omega_RN_B = np.array([-0.02, -0.01, 0.005])
+    guidCmdData.domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
+    guidInMsg = messaging.AttGuidMsg().write(guidCmdData)
+
+    # vehicleConfig FSW Message:
+    vehicleConfigIn = messaging.VehicleConfigMsgPayload()
+    vehicleConfigIn.ISCPntB_B = [1000., 0., 0.,
+                                  0., 800., 0.,
+                                  0., 0., 800.]
+    vcInMsg = messaging.VehicleConfigMsg().write(vehicleConfigIn)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = module.cmdTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # connect messages
+    module.vehConfigInMsg.subscribeTo(vcInMsg)
+    module.guidInMsg.subscribeTo(guidInMsg)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Step the simulation to 3*process rate so 4 total steps including zero
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))  # seconds to stop simulation
+    unitTestSim.ExecuteSimulation()
+
+    trueVector = [findTrueTorques(module, guidCmdData, vehicleConfigIn, knownTorquePntB_B)]*3
+
+    # Compare the module results to the truth values
+    accuracy = 1e-12
+    np.testing.assert_allclose(trueVector,
+                               dataLog.torqueRequestBody,
+                               atol=accuracy,
+                               verbose=True)
+
+def findTrueTorques(module, guidCmdData, vehicleConfigOut, knownTorquePntB_B):
+    sigma_BR = np.array(guidCmdData.sigma_BR)
+    omega_BR_B = np.array(guidCmdData.omega_BR_B)
+    omega_RN_B = np.array(guidCmdData.omega_RN_B)
+    domega_RN_B = np.array(guidCmdData.domega_RN_B)
+
+    I = np.identity(3)
+    I[0][0] = vehicleConfigOut.ISCPntB_B[0]
+    I[1][1] = vehicleConfigOut.ISCPntB_B[4]
+    I[2][2] = vehicleConfigOut.ISCPntB_B[8]
+
+    P = module.getDerivativeGainP()
+    L = knownTorquePntB_B
+
+    # Begin Method
+    omega_BN_B = omega_BR_B + omega_RN_B
+    temp1 = np.dot(I, omega_BN_B)
+    temp2 = domega_RN_B - np.cross(omega_BN_B, omega_RN_B)
+
+    Lr = P * omega_BR_B - np.cross(omega_RN_B, temp1) - np.dot(I, temp2)
+    Lr += L
+    Lr *= -1.0
+
+    return Lr
+
+if __name__ == "__main__":
+    test_rateControl(False, False)

--- a/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
+++ b/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
@@ -56,24 +56,24 @@ def test_rateControl(show_plots, setExtTorque):
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
     # Create an instance of the rateControl module
-    module = rateControl.RateControl()
-    module.modelTag = "rateControl"
-    unitTestSim.AddModelToTask(unitTaskName, module)
+    rateCntrl = rateControl.RateControl()
+    rateCntrl.setDerivativeGainP(150.0)
+    rateCntrl.modelTag = "rateControl"
+    unitTestSim.AddModelToTask(unitTaskName, rateCntrl)
 
-    # Initialize the test module configuration data
+    # Set the external torque
     knownTorquePntB_B = np.array([0.0, 0.0, 0.0])
-    module.setDerivativeGainP(150.0)
     if setExtTorque:
         knownTorquePntB_B = np.array([0.1, 0.2, 0.3])
-        module.setKnownTorquePntB_B(knownTorquePntB_B)
+        rateCntrl.setKnownTorquePntB_B(knownTorquePntB_B)
 
     # Create the attitude guidance input message
-    guidCmdData = messaging.AttGuidMsgPayload()
-    guidCmdData.sigma_BR = np.array([0.3, -0.5, 0.7])
-    guidCmdData.omega_BR_B = np.array([0.010, -0.020, 0.015])
-    guidCmdData.omega_RN_B = np.array([-0.02, -0.01, 0.005])
-    guidCmdData.domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
-    guidInMsg = messaging.AttGuidMsg().write(guidCmdData)
+    attGuidanceMessageData = messaging.AttGuidMsgPayload()
+    attGuidanceMessageData.sigma_BR = np.array([0.3, -0.5, 0.7])
+    attGuidanceMessageData.omega_BR_B = np.array([0.010, -0.020, 0.015])
+    attGuidanceMessageData.omega_RN_B = np.array([-0.02, -0.01, 0.005])
+    attGuidanceMessageData.domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
+    attGuidanceMessage = messaging.AttGuidMsg().write(attGuidanceMessageData)
 
     # Create the vehicleConfig fsw message
     vehicleConfigIn = messaging.VehicleConfigMsgPayload()
@@ -83,12 +83,12 @@ def test_rateControl(show_plots, setExtTorque):
     vcInMsg = messaging.VehicleConfigMsg().write(vehicleConfigIn)
 
     # Set up data logging
-    dataLog = module.cmdTorqueOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    cmdTorqueOutMsgDataLog = rateCntrl.cmdTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, cmdTorqueOutMsgDataLog)
 
     # Connect messages
-    module.vehConfigInMsg.subscribeTo(vcInMsg)
-    module.guidInMsg.subscribeTo(guidInMsg)
+    rateCntrl.vehConfigInMsg.subscribeTo(vcInMsg)
+    rateCntrl.guidInMsg.subscribeTo(attGuidanceMessage)
 
     # Execute the simulation
     unitTestSim.InitializeSimulation()
@@ -96,39 +96,38 @@ def test_rateControl(show_plots, setExtTorque):
     unitTestSim.ExecuteSimulation()
 
     # Extract logged data for test check
-    trueVector = [findTrueTorques(module, guidCmdData, vehicleConfigIn, knownTorquePntB_B)]*3
+    cmdTorqueTruth = [findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigIn, knownTorquePntB_B)]*3
 
     # Compare the module results to the computed truth value
     accuracy = 1e-12
-    np.testing.assert_allclose(trueVector,
-                               dataLog.torqueRequestBody,
+    np.testing.assert_allclose(cmdTorqueTruth,
+                               cmdTorqueOutMsgDataLog.torqueRequestBody,
                                atol=accuracy,
                                verbose=True)
 
-def findTrueTorques(module, guidCmdData, vehicleConfigOut, knownTorquePntB_B):
-    sigma_BR = np.array(guidCmdData.sigma_BR)
-    omega_BR_B = np.array(guidCmdData.omega_BR_B)
-    omega_RN_B = np.array(guidCmdData.omega_RN_B)
-    domega_RN_B = np.array(guidCmdData.domega_RN_B)
+def findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigOut, knownTorquePntB_B):
+    sigma_BR = np.array(attGuidanceMessageData.sigma_BR)
+    omega_BR_B = np.array(attGuidanceMessageData.omega_BR_B)
+    omega_RN_B = np.array(attGuidanceMessageData.omega_RN_B)
+    domega_RN_B = np.array(attGuidanceMessageData.domega_RN_B)
 
-    I = np.identity(3)
-    I[0][0] = vehicleConfigOut.ISCPntB_B[0]
-    I[1][1] = vehicleConfigOut.ISCPntB_B[4]
-    I[2][2] = vehicleConfigOut.ISCPntB_B[8]
+    ISCPntB_B = np.identity(3)
+    ISCPntB_B[0][0] = vehicleConfigOut.ISCPntB_B[0]
+    ISCPntB_B[1][1] = vehicleConfigOut.ISCPntB_B[4]
+    ISCPntB_B[2][2] = vehicleConfigOut.ISCPntB_B[8]
 
-    P = module.getDerivativeGainP()
-    L = knownTorquePntB_B
+    P = rateCntrl.getDerivativeGainP()
 
     omega_BN_B = omega_BR_B + omega_RN_B
-    temp1 = np.dot(I, omega_BN_B)
+    temp1 = np.dot(ISCPntB_B, omega_BN_B)
     temp2 = domega_RN_B - np.cross(omega_BN_B, omega_RN_B)
 
     # Compute truth control torque
-    Lr = P * omega_BR_B - np.cross(omega_RN_B, temp1) - np.dot(I, temp2)
-    Lr += L
-    Lr *= -1.0
+    cmdTorqueTruth = P * omega_BR_B - np.cross(omega_RN_B, temp1) - np.dot(ISCPntB_B, temp2)
+    cmdTorqueTruth += knownTorquePntB_B
+    cmdTorqueTruth *= -1.0
 
-    return Lr
+    return cmdTorqueTruth
 
 if __name__ == "__main__":
     test_rateControl(False, False)

--- a/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
+++ b/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
@@ -26,7 +26,7 @@ from Basilisk.architecture import messaging
 
 @pytest.mark.parametrize("setExtTorque", [False, True])
 
-def test_rateControl(show_plots, setExtTorque):
+def test_rateControl(setExtTorque):
     r"""
     **Validation Test Description**
 
@@ -39,7 +39,6 @@ def test_rateControl(show_plots, setExtTorque):
     The unit test verifies that the module output torque message vector matches expected values. The test
     method parameters include the following.
 
-    :param show_plots: flag to show the test run plots
     :param setExtTorque: flag to set the knownTorquePntB_B variable
     :return: void
     """
@@ -124,4 +123,4 @@ def findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigOut, knownTo
             - knownTorquePntB_B)
 
 if __name__ == "__main__":
-    test_rateControl(False, False)
+    test_rateControl(False)

--- a/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
+++ b/src/fswAlgorithms/attControl/rateControl/_UnitTest/test_rateControl.py
@@ -106,28 +106,22 @@ def test_rateControl(show_plots, setExtTorque):
                                verbose=True)
 
 def findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigOut, knownTorquePntB_B):
+    P = rateCntrl.getDerivativeGainP()
     sigma_BR = np.array(attGuidanceMessageData.sigma_BR)
     omega_BR_B = np.array(attGuidanceMessageData.omega_BR_B)
     omega_RN_B = np.array(attGuidanceMessageData.omega_RN_B)
     domega_RN_B = np.array(attGuidanceMessageData.domega_RN_B)
+    omega_BN_B = omega_BR_B + omega_RN_B
 
     ISCPntB_B = np.identity(3)
     ISCPntB_B[0][0] = vehicleConfigOut.ISCPntB_B[0]
     ISCPntB_B[1][1] = vehicleConfigOut.ISCPntB_B[4]
     ISCPntB_B[2][2] = vehicleConfigOut.ISCPntB_B[8]
 
-    P = rateCntrl.getDerivativeGainP()
-
-    omega_BN_B = omega_BR_B + omega_RN_B
-    temp1 = np.dot(ISCPntB_B, omega_BN_B)
-    temp2 = domega_RN_B - np.cross(omega_BN_B, omega_RN_B)
-
-    # Compute truth control torque
-    cmdTorqueTruth = P * omega_BR_B - np.cross(omega_RN_B, temp1) - np.dot(ISCPntB_B, temp2)
-    cmdTorqueTruth += knownTorquePntB_B
-    cmdTorqueTruth *= -1.0
-
-    return cmdTorqueTruth
+    return (- P * omega_BR_B
+            + np.cross(omega_RN_B, np.dot(ISCPntB_B, omega_BN_B))
+            + np.dot(ISCPntB_B, domega_RN_B - np.cross(omega_BN_B, omega_RN_B))
+            - knownTorquePntB_B)
 
 if __name__ == "__main__":
     test_rateControl(False, False)

--- a/src/fswAlgorithms/attControl/rateControl/rateControl.cpp
+++ b/src/fswAlgorithms/attControl/rateControl/rateControl.cpp
@@ -1,0 +1,112 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "rateControl.h"
+
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/linearAlgebra.h"
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param callTime [ns] Time the method is called
+*/
+void RateControl::reset(uint64_t callTime) {
+    // Check if the required input messages are linked
+    if (!this->guidInMsg.isLinked()) {
+        _bskLog(this->bskLogger, BSK_ERROR, "rateControl.guidInMsg wasn't connected.");
+    }
+    if (!this->vehConfigInMsg.isLinked()) {
+        _bskLog(this->bskLogger, BSK_ERROR, "rateControl.vehConfigInMsg wasn't connected.");
+    }
+
+    // Read the VehicleConfigMsgPayload input message
+    if (this->vehConfigInMsg.isWritten()) {
+        VehicleConfigMsgPayload vcInMsg = this->vehConfigInMsg();
+        this->ISCPntB_B = cArray2EigenMatrixXd(vcInMsg.ISCPntB_B, 3, 3);
+    }
+}
+
+/*! This method takes the attitude and rate errors relative to the reference frame, as well as
+the reference frame angular rates and acceleration, and computes the required control torque Lr.
+ @return void
+ @param callTime [ns] Time the method is called
+*/
+void RateControl::updateState(uint64_t callTime) {
+    // Create the buffer messages
+    CmdTorqueBodyMsgPayload torqueCmdMsgPayload;  // Control output request msg
+    AttGuidMsgPayload guidanceMsgPayload;         // Guidance input message
+
+    // Zero the output message
+    torqueCmdMsgPayload = CmdTorqueBodyMsgPayload();
+
+    // Read the guidance input message
+    guidanceMsgPayload = AttGuidMsgPayload();
+    if (this->guidInMsg.isWritten()) {
+        guidanceMsgPayload = this->guidInMsg();
+    }
+
+    // Compute hub inertial angular velocity in B-frame components
+    Eigen::Vector3d omega_BR_B = cArray2EigenVector3d(guidanceMsgPayload.omega_BR_B);
+    Eigen::Vector3d omega_RN_B = cArray2EigenVector3d(guidanceMsgPayload.omega_RN_B);
+    Eigen::Vector3d omega_BN_B = omega_BR_B + omega_RN_B;
+
+    // Compute P*delta_omega
+    Eigen::Vector3d v3_temp1 = this->P * omega_BR_B;
+
+    // Compute omega_r x [I]omega
+    Eigen::Vector3d v3_temp2 = omega_RN_B.cross(this->ISCPntB_B * omega_BN_B);
+
+    // Compute [I](d(omega_r)/dt - omega x omega_r)
+    Eigen::Vector3d domega_RN_B = cArray2EigenVector3d(guidanceMsgPayload.domega_RN_B);
+    Eigen::Vector3d v3_temp3 = this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B));
+
+    // Compute required attitude control torque vector
+    // Lr =  P*delta_omega  - omega_r x [I]omega - [I](d(omega_r)/dt - omega x omega_r) + L
+    Eigen::Vector3d Lr =
+        -v3_temp1 + v3_temp2 + v3_temp3 - this->knownTorquePntB_B;  // [Nm] Required control torque vector
+
+    // Write the output message
+    eigenVector3d2CArray(Lr, torqueCmdMsgPayload.torqueRequestBody);
+    this->cmdTorqueOutMsg.write(&torqueCmdMsgPayload, moduleID, callTime);
+}
+
+/*! Getter method for the derivative gain P.
+ @return const double
+*/
+const double RateControl::getDerivativeGainP() const { return this->P; }
+
+/*! Getter method for the known torque about point B.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d &RateControl::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
+
+/*! Setter method for the derivative gain P.
+ @return void
+ @param P [N*m*s] Rate error feedback gain applied
+*/
+void RateControl::setDerivativeGainP(const double P) { this->P = P; }
+
+/*! Setter method for the known external torque about point B.
+ @return void
+ @param knownTorquePntB_B [N*m] Known external torque expressed in body frame components
+*/
+void RateControl::setKnownTorquePntB_B(const Eigen::Vector3d &knownTorquePntB_B) {
+    this->knownTorquePntB_B = knownTorquePntB_B;
+}

--- a/src/fswAlgorithms/attControl/rateControl/rateControl.cpp
+++ b/src/fswAlgorithms/attControl/rateControl/rateControl.cpp
@@ -28,7 +28,6 @@
  @param callTime [ns] Time the method is called
 */
 void RateControl::reset(uint64_t callTime) {
-    // Check if the required input messages are linked
     if (!this->guidInMsg.isLinked()) {
         _bskLog(this->bskLogger, BSK_ERROR, "rateControl.guidInMsg wasn't connected.");
     }
@@ -49,40 +48,23 @@ the reference frame angular rates and acceleration, and computes the required co
  @param callTime [ns] Time the method is called
 */
 void RateControl::updateState(uint64_t callTime) {
-    // Create the buffer messages
-    CmdTorqueBodyMsgPayload torqueCmdMsgPayload;  // Control output request msg
-    AttGuidMsgPayload guidanceMsgPayload;         // Guidance input message
-
-    // Zero the output message
-    torqueCmdMsgPayload = CmdTorqueBodyMsgPayload();
-
     // Read the guidance input message
-    guidanceMsgPayload = AttGuidMsgPayload();
+    auto guidanceMsgPayload = AttGuidMsgPayload();
     if (this->guidInMsg.isWritten()) {
         guidanceMsgPayload = this->guidInMsg();
     }
 
-    // Compute hub inertial angular velocity in B-frame components
+    // Compute required attitude control torque vector
     Eigen::Vector3d omega_BR_B = cArray2EigenVector3d(guidanceMsgPayload.omega_BR_B);
     Eigen::Vector3d omega_RN_B = cArray2EigenVector3d(guidanceMsgPayload.omega_RN_B);
     Eigen::Vector3d omega_BN_B = omega_BR_B + omega_RN_B;
-
-    // Compute P*delta_omega
-    Eigen::Vector3d v3_temp1 = this->P * omega_BR_B;
-
-    // Compute omega_r x [I]omega
-    Eigen::Vector3d v3_temp2 = omega_RN_B.cross(this->ISCPntB_B * omega_BN_B);
-
-    // Compute [I](d(omega_r)/dt - omega x omega_r)
     Eigen::Vector3d domega_RN_B = cArray2EigenVector3d(guidanceMsgPayload.domega_RN_B);
-    Eigen::Vector3d v3_temp3 = this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B));
+    Eigen::Vector3d Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
+                         this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
+                         this->knownTorquePntB_B;  // [Nm]
 
-    // Compute required attitude control torque vector
-    // Lr =  P*delta_omega  - omega_r x [I]omega - [I](d(omega_r)/dt - omega x omega_r) + L
-    Eigen::Vector3d Lr =
-        -v3_temp1 + v3_temp2 + v3_temp3 - this->knownTorquePntB_B;  // [Nm] Required control torque vector
-
-    // Write the output message
+    // Create and write the output message
+    auto torqueCmdMsgPayload = CmdTorqueBodyMsgPayload();
     eigenVector3d2CArray(Lr, torqueCmdMsgPayload.torqueRequestBody);
     this->cmdTorqueOutMsg.write(&torqueCmdMsgPayload, moduleID, callTime);
 }

--- a/src/fswAlgorithms/attControl/rateControl/rateControl.h
+++ b/src/fswAlgorithms/attControl/rateControl/rateControl.h
@@ -1,0 +1,61 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _RATE_CONTROL_
+#define _RATE_CONTROL_
+
+#include <stdint.h>
+
+#include <Eigen/Dense>
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+#include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
+#include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+
+/*! @brief Rate control class. */
+class RateControl : public SysModel {
+   public:
+    RateControl() = default;   //!< Constructor
+    ~RateControl() = default;  //!< Destructor
+
+    void reset(uint64_t currentSimNanos) override;        //!< Reset member function
+    void updateState(uint64_t currentSimNanos) override;  //!< Update member function
+    const double getDerivativeGainP() const;              //!< Getter method for derivative gain P
+    const Eigen::Vector3d &getKnownTorquePntB_B() const;  //!< Getter method for the known external torque about point B
+    void setDerivativeGainP(const double P);              //!< Setter method for derivative gain P
+    void setKnownTorquePntB_B(
+        const Eigen::Vector3d &knownTorquePntB_B);  //!< Getter method for the known external torque about point B
+
+    ReadFunctor<AttGuidMsgPayload> guidInMsg;             //!< Attitude guidance input message
+    ReadFunctor<VehicleConfigMsgPayload> vehConfigInMsg;  //!< Vehicle configuration input message
+    Message<CmdTorqueBodyMsgPayload> cmdTorqueOutMsg;     //!< Commanded torque output message
+
+    BSKLogger *bskLogger;  //!< BSK Logging
+
+   private:
+    double P{};                           //!< [N*m*s] Rate error feedback gain applied
+    Eigen::Vector3d knownTorquePntB_B{};  //!< [N*m] Known external torque expressed in body frame components
+    Eigen::Matrix3d ISCPntB_B{
+        Eigen::Matrix3d::Identity()};  //!< [kg*m^2] Spacecraft inertia about point B expressed in body frame components
+};
+
+#endif

--- a/src/fswAlgorithms/attControl/rateControl/rateControl.i
+++ b/src/fswAlgorithms/attControl/rateControl/rateControl.i
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module rateControl
+%{
+   #include "rateControl.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "swig_eigen.i"
+
+%include "sys_model.i"
+%include "rateControl.h"
+
+%include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+
+%include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+
+%include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}


### PR DESCRIPTION
* **Tickets addressed:** #392 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description

The `rateControl` fsw algorithm is created by using the `mrpProportionalDerivative` module and setting the proportional gain to zero. The new module and associated unit test is cleaned up and formatting is improved. 

## Verification
The `mrpProportionalDerivative` unit test is equivalently modified with a zero proportional gain and the new test passes.

## Documentation
N/A

## Future work
N/A