### PR TITLE
Feature/984 sunline distance bias

### DIFF
--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/sunlineSRuKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/sunlineSRuKF_test_utilities.py
@@ -43,38 +43,44 @@ def states(x, testName):
         t[i] = x[i, 0] * 1E-9
 
     plt.figure(num=None, figsize=(10, 10), dpi=80, facecolor='w', edgecolor='k')
-    plt.subplot(321)
+    plt.subplot(331)
     plt.plot(t, x[:, 1], "b", label='Error Filter')
     plt.legend(loc='lower right')
     plt.title('First sHat component')
     plt.grid()
 
-    plt.subplot(322)
+    plt.subplot(332)
     plt.plot(t, x[:, 4], "b")
     plt.title('First rate component (rad/s)')
     plt.grid()
 
-    plt.subplot(323)
+    plt.subplot(333)
     plt.plot(t, x[:, 2], "b")
     plt.title('Second sHat component')
     plt.grid()
 
-    plt.subplot(324)
+    plt.subplot(334)
     plt.plot(t, x[:, 5], "b")
     plt.xlabel('t(s)')
     plt.title('Second rate component (rad/s)')
     plt.grid()
 
-    plt.subplot(325)
+    plt.subplot(335)
     plt.plot(t, x[:, 3], "b")
     plt.xlabel('t(s)')
     plt.title('Third sHat component')
     plt.grid()
 
-    plt.subplot(326)
+    plt.subplot(336)
     plt.plot(t, x[:, 6], "b")
     plt.xlabel('t(s)')
     plt.title('Third rate component (rad/s)')
+    plt.grid()
+
+    plt.subplot(337)
+    plt.plot(t, x[:, 7], "b")
+    plt.xlabel('t(s)')
+    plt.title('Bias state (-)')
     plt.grid()
 
     return plt
@@ -104,7 +110,7 @@ def state_covar(x, Pflat, testName):
         P[i, :, :] = Pflat[i, 1:(numStates * numStates + 1)].reshape([numStates, numStates])
 
     plt.figure(num=None, figsize=(10, 10), dpi=80, facecolor='w', edgecolor='k')
-    plt.subplot(321)
+    plt.subplot(331)
     plt.plot(t, x[:, 1], "b", label='Error Filter')
     plt.plot(t, x[:, 1] + 3 * np.sqrt(P[:, 0, 0]), 'r--', label='Covar Filter')
     plt.plot(t, x[:, 1] - 3 * np.sqrt(P[:, 0, 0]), 'r--')
@@ -112,21 +118,21 @@ def state_covar(x, Pflat, testName):
     plt.title('First pos component (m)')
     plt.grid()
 
-    plt.subplot(322)
+    plt.subplot(332)
     plt.plot(t, x[:, 4], "b")
     plt.plot(t, x[:, 4] + 3 * np.sqrt(P[:, 3, 3]), 'r--')
     plt.plot(t, x[:, 4] - 3 * np.sqrt(P[:, 3, 3]), 'r--')
     plt.title('Second rate component (m/s)')
     plt.grid()
 
-    plt.subplot(323)
+    plt.subplot(333)
     plt.plot(t, x[:, 2], "b")
     plt.plot(t, x[:, 2] + 3 * np.sqrt(P[:, 1, 1]), 'r--')
     plt.plot(t, x[:, 2] - 3 * np.sqrt(P[:, 1, 1]), 'r--')
     plt.title('Second pos component (m)')
     plt.grid()
 
-    plt.subplot(324)
+    plt.subplot(334)
     plt.plot(t, x[:, 5], "b")
     plt.plot(t, x[:, 5] + 3 * np.sqrt(P[:, 4, 4]), 'r--')
     plt.plot(t, x[:, 5] - 3 * np.sqrt(P[:, 4, 4]), 'r--')
@@ -134,7 +140,7 @@ def state_covar(x, Pflat, testName):
     plt.title('Third rate component (m/s)')
     plt.grid()
 
-    plt.subplot(325)
+    plt.subplot(335)
     plt.plot(t, x[:, 3], "b")
     plt.plot(t, x[:, 3] + 3 * np.sqrt(P[:, 2, 2]), 'r--')
     plt.plot(t, x[:, 3] - 3 * np.sqrt(P[:, 2, 2]), 'r--')
@@ -142,12 +148,20 @@ def state_covar(x, Pflat, testName):
     plt.title('Third pos component (m)')
     plt.grid()
 
-    plt.subplot(326)
+    plt.subplot(336)
     plt.plot(t, x[:, 6], "b")
     plt.plot(t, x[:, 6] + 3 * np.sqrt(P[:, 5, 5]), 'r--')
     plt.plot(t, x[:, 6] - 3 * np.sqrt(P[:, 5, 5]), 'r--')
     plt.xlabel('t(s)')
     plt.title('Third rate component (m/s)')
+    plt.grid()
+
+    plt.subplot(337)
+    plt.plot(t, x[:, 7], "b")
+    plt.plot(t, x[:, 7] + 3 * np.sqrt(P[:, 6, 6]), 'r--')
+    plt.plot(t, x[:, 7] - 3 * np.sqrt(P[:, 6, 6]), 'r--')
+    plt.xlabel('t(s)')
+    plt.title('Bias component (-)')
     plt.grid()
 
     return plt

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -43,7 +43,12 @@ def rk4(f, t, x0, normalizeState=False, mrpShadow=False):
         k4 = h * f(t[i] + h, x[i, 1:] + k3)
         x[i + 1, 1:] = x[i, 1:] + (k1 + 2. * k2 + 2. * k3 + k4) / 6.
         if normalizeState:
+            # Normalize the states and bound the bias state to the default values
             x[i + 1, 1:4] = x[i + 1, 1:4] / np.linalg.norm(x[i + 1, 1:4])
+            if x[i + 1, 7] < 0.5:
+                x[i + 1, 7] = 0.5
+            if x[i + 1, 7] > 1.5:
+                x[i + 1, 7] = 1.5
         if mrpShadow:
             s = np.linalg.norm(x[i + 1, 1:4])**2
             if s > 1:
@@ -54,16 +59,16 @@ def rk4(f, t, x0, normalizeState=False, mrpShadow=False):
 
 def sunline_dynamics(t, x):
     dxdt = np.zeros(np.shape(x))
-    dxdt[0:3] = np.cross(x[:3], x[3:])
-    dxdt[3:] = np.zeros(3)
+    dxdt[0:3] = np.cross(x[:3], x[3:6])
+    dxdt[3:7] = np.zeros(4)
     return dxdt
 
 
 def mrp_integration(t, x):
     dxdt = np.zeros(np.shape(x))
     B = rbk.BmatMRP(x[0:3])
-    dxdt[:3] = 0.25 * np.matmul(B, x[3:])
-    dxdt[3:] = np.zeros(3)
+    dxdt[:3] = 0.25 * np.matmul(B, x[3:6])
+    dxdt[3:6] = np.zeros(3)
     return dxdt
 
 
@@ -73,22 +78,27 @@ def setup_filter_data(filter_object):
 
     filter_object.setInitialPosition([0.0, 0.0, 1.0])
     filter_object.setInitialVelocity([0.02, -0.005, 0.01])
-    filter_object.setInitialCovariance([[0.0001, 0.0, 0.0, 0.0, 0.0, 0.0],
-                                        [0.0, 0.0001, 0.0, 0.0, 0.0, 0.0],
-                                        [0.0, 0.0, 0.0001, 0.0, 0.0, 0.0],
-                                        [0.0, 0.0, 0.0, 0.0001, 0.0, 0.0],
-                                        [0.0, 0.0, 0.0, 0.0, 0.0001, 0.0],
-                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0001]])
+    filter_object.setInitialBias([0.6])
+    filter_object.setInitialCovariance([[0.0001, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0001, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0001, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0001, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0001, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1]])
+
     filter_object.setCssMeasurementNoiseStd(0.01)
     filter_object.setGyroMeasurementNoiseStd(0.001)
-    sigmaSun = (1E-12) ** 2
-    sigmaRate = (1E-14) ** 2
-    filter_object.setProcessNoise([[sigmaSun, 0.0, 0.0, 0.0, 0.0, 0.0],
-                                   [0.0, sigmaSun, 0.0, 0.0, 0.0, 0.0],
-                                   [0.0, 0.0, sigmaSun, 0.0, 0.0, 0.0],
-                                   [0.0, 0.0, 0.0, sigmaRate, 0.0, 0.0],
-                                   [0.0, 0.0, 0.0, 0.0, sigmaRate, 0.0],
-                                   [0.0, 0.0, 0.0, 0.0, 0.0, sigmaRate]])
+    sigmaSun = (1E-6) ** 2
+    sigmaRate = (1E-8) ** 2
+    sigmaBias = (1E-5) ** 2
+    filter_object.setProcessNoise([[sigmaSun, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                   [0.0, sigmaSun, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                   [0.0, 0.0, sigmaSun, 0.0, 0.0, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0, sigmaRate, 0.0, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0, 0.0, sigmaRate, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0, 0.0, 0.0, sigmaRate, 0.0],
+                                   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, sigmaBias]])
 
 def setup_css_config_msg(CSSOrientationList, cssConfigDataInMsg):
     numCSS = len(CSSOrientationList)
@@ -111,7 +121,7 @@ def test_propagation_kf(show_plots):
 
 @pytest.mark.parametrize("initial_error", [False, True])
 def test_measurements_kf(show_plots, initial_error):
-    state_update_flyby(initial_error, show_plots)
+    state_update_flyby(initial_error, True)
 
 
 def state_propagation_flyby(show_plots=False):
@@ -137,11 +147,12 @@ def state_propagation_flyby(show_plots=False):
     unit_test_sim.AddModelToTask(unit_task_name, sun_heading_data_log)
 
     simpleNavMsgData = messaging.NavAttMsgPayload()
-    initState = np.zeros(6)
+    initState = np.zeros(7)
     initState[:3] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
-    initState[3:] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    initState[3:6] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    initState[6] = sunHeadingFilter.getInitialBias()[0][0]
     simpleNavMsgData.timeTag = 0
-    simpleNavMsgData.omega_BN_B = initState[3:]
+    simpleNavMsgData.omega_BN_B = initState[3:6]
     simpleNavMsg = messaging.NavAttMsg().write(simpleNavMsgData)
     sunHeadingFilter.navAttInMsg.subscribeTo(simpleNavMsg)
 
@@ -168,16 +179,17 @@ def state_propagation_flyby(show_plots=False):
 
     sim_time = 50
     time = np.linspace(0, sim_time, sim_time+1)
-    expected = np.zeros([len(time), 7])
+    expected = np.zeros([len(time), 8])
     expected[0, 1:4] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
     expected[0, 4:7] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    expected[0, 7] = sunHeadingFilter.getInitialBias()[0][0]
     expected = rk4(sunline_dynamics, time, expected[0, 1:], normalizeState=True)
 
     unit_test_sim.InitializeSimulation()
     unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
     unit_test_sim.ExecuteSimulation()
 
-    num_states = 6
+    num_states = 7
     state_data_log = add_time_column(sun_heading_data_log.times(), sun_heading_data_log.state[:, :num_states])
     covariance_data_log = add_time_column(sun_heading_data_log.times(), sun_heading_data_log.covar[:, :num_states**2])
 
@@ -228,11 +240,13 @@ def state_update_flyby(initial_error, show_plots=False):
     unit_test_sim.AddModelToTask(unit_task_name, nav_att_data_log)
 
     simpleNavMsgData = messaging.NavAttMsgPayload()
-    initState = np.zeros(6)
+    initState = np.zeros(7)
     initState[:3] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
-    initState[3:] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    initState[3:6] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    initState[6] = sunHeadingFilter.getInitialBias()[0][0]
+
     simpleNavMsgData.timeTag = -1
-    simpleNavMsgData.omega_BN_B = initState[3:]
+    simpleNavMsgData.omega_BN_B = initState[3:6]
     simpleNavMsg = messaging.NavAttMsg().write(simpleNavMsgData)
     sunHeadingFilter.navAttInMsg.subscribeTo(simpleNavMsg)
 
@@ -251,20 +265,29 @@ def state_update_flyby(initial_error, show_plots=False):
     setup_css_config_msg(CSSOrientationList, cssConfigMsg)
     sunHeadingFilter.cssConfigInMsg.subscribeTo(cssConfigMsg)
 
-    sim_time = 1000
+    sim_time = 2000
     time = np.linspace(0, sim_time, sim_time+1)
-    expected = np.zeros([len(time), 7])
+    expected = np.zeros([len(time), 8])
     expected[0, 1:4] = np.array(sunHeadingFilter.getInitialPosition()).reshape(3)
     expected[0, 4:7] = np.array(sunHeadingFilter.getInitialVelocity()).reshape(3)
+    expected[0, 7] = sunHeadingFilter.getInitialBias()[0][0]
     expected = rk4(sunline_dynamics, time, expected[0, 1:], normalizeState=True)
 
-    bodyFrame = np.zeros([len(time), 7])
-    bodyFrame[0, 1:] = np.array([0.0, 0.0, 0.0, expected[0, 4], expected[0, 5], expected[0, 6]])
+    bodyFrame = np.zeros([len(time), 8])
+    bodyFrame[0, 1:] = np.array([0.0, 0.0, 0.0, expected[0, 4], expected[0, 5], expected[0, 6], expected[0, 7]])
     bodyFrame = rk4(mrp_integration, time, bodyFrame[0, 1:], mrpShadow=True)
 
     if initial_error:
         sunHeadingFilter.setInitialPosition([1.0, 0.0, 0.0])
         sunHeadingFilter.setInitialVelocity([-0.02, 0.005, -0.01])
+        sunHeadingFilter.setInitialBias([1])
+        sunHeadingFilter.setInitialCovariance([[0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.001, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.001, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.001, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5]])
 
     cssDataMsg = messaging.CSSArraySensorMsgPayload()
     cssMsg = messaging.CSSArraySensorMsg()
@@ -279,9 +302,9 @@ def state_update_flyby(initial_error, show_plots=False):
         for j in range(len(CSSOrientationList)):
             cosList.append((np.dot(CSSOrientationList[j], np.matmul(BN, [0, 0, 1]))
                             + np.random.normal(0, cssSigma, 1))[0])
-        cssDataMsg.CosValue = np.array(cosList)
+        cssDataMsg.CosValue = np.array(cosList)*expected[i, 7]
         cssDataMsg.timeTag = time[i]
-        omega = expected[0, 4:] + np.random.normal(0, gyroSigma, 3)
+        omega = expected[0, 4:7] + np.random.normal(0, gyroSigma, 3)
         simpleNavMsgData.timeTag = time[i]
         simpleNavMsgData.omega_BN_B = omega
         if i % 2 == 0:
@@ -290,7 +313,7 @@ def state_update_flyby(initial_error, show_plots=False):
         unit_test_sim.ConfigureStopTime(macros.sec2nano(time[i+1]))
         unit_test_sim.ExecuteSimulation()
 
-    num_states = 6
+    num_states = 7
     state_data_log = add_time_column(sun_heading_data_log.times(), sun_heading_data_log.state[:, :num_states])
     covariance_data_log = add_time_column(sun_heading_data_log.times(), sun_heading_data_log.covar[:, :num_states**2])
 
@@ -332,20 +355,24 @@ def state_update_flyby(initial_error, show_plots=False):
     # testing that Sun Heading vector estimate is correct within 5 sigma
     np.testing.assert_allclose(state_data_log[half_time:, 1:4],
                                expected[half_time:, 1:4],
-                                rtol=1E-9,
                                 atol=5*cssSigma,
                                 err_msg='heading estimation error',
                                 verbose=True)
     # testing that rate estimate is correct within 5 sigma
-    np.testing.assert_allclose(state_data_log[half_time:, 4:],
-                                expected[half_time:, 4:],
-                               rtol=1E-9,
+    np.testing.assert_allclose(state_data_log[half_time:, 4:7],
+                                expected[half_time:, 4:7],
                                atol=5*gyroSigma,
                                err_msg='rate estimation error',
                                verbose=True)
+    # testing that rate estimate is correct within 5 sigma
+    np.testing.assert_allclose(state_data_log[half_time:, 7],
+                                expected[half_time:, 7],
+                               atol=0.2,
+                               err_msg='bias estimation error',
+                               verbose=True)
     # testing that covariance is shrinking
-    np.testing.assert_array_less(np.diag(covariance_data_log[half_time, 1:].reshape([6, 6])),
-                                np.diag(covariance_data_log[0, 1:].reshape([6, 6])),
+    np.testing.assert_array_less(np.diag(covariance_data_log[half_time, 1:7*7+1].reshape([7, 7])),
+                                np.diag(covariance_data_log[0, 1:7*7+1].reshape([7, 7])),
                                 err_msg='covariance error',
                                 verbose=True)
 

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
@@ -44,6 +44,22 @@ void SunlineSRuKF::customFinalizeUpdate() {
     PositionState heading;
     heading.setValues(this->state.getPositionStates().normalized());
     this->state.setPosition(heading);
+
+    if (state.hasBias()) {
+        BiasState bias;
+        if (state.getBiasStates().value() < this->biasLowerBound) {
+            Eigen::VectorXd lowerSaturateBias(1);
+            lowerSaturateBias(0) = this->biasLowerBound;
+            bias.setValues(lowerSaturateBias);
+            this->state.setBias(bias);
+        }
+        else if (state.getBiasStates().value() > this->biasUpperBound) {
+            Eigen::VectorXd upperSaturateBias(1);
+            upperSaturateBias(0) = this->biasUpperBound;
+            bias.setValues(upperSaturateBias);
+            this->state.setBias(bias);
+        }
+    }
 }
 
 /*! Read the message containing the measurement data.
@@ -164,6 +180,9 @@ void SunlineSRuKF::readCssMeasurements() {
 
     std::function<const Eigen::VectorXd(const FilterStateVector)> linearModel = [hMatrix](const FilterStateVector &state) {
         Eigen::VectorXd observed = hMatrix * state.getPositionStates();
+        if (state.hasBias()) {
+            observed = observed*state.getBiasStates().value();
+        }
         return observed;
     };
 
@@ -211,6 +230,12 @@ FilterStateVector SunlineSRuKF::stateDerivative(const double t, const FilterStat
 
     XDot.setPosition(xDotPosition);
     XDot.setVelocity(xDotVelocity);
+
+    if (state.hasBias()) {
+        BiasState xDotBias;
+        xDotBias.setValues(Eigen::VectorXd::Zero(1));
+        XDot.setBias(xDotBias);
+    }
 
     return XDot;
 };

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
@@ -52,8 +52,7 @@ void SunlineSRuKF::customFinalizeUpdate() {
             lowerSaturateBias(0) = this->biasLowerBound;
             bias.setValues(lowerSaturateBias);
             this->state.setBias(bias);
-        }
-        else if (state.getBiasStates().value() > this->biasUpperBound) {
+        } else if (state.getBiasStates().value() > this->biasUpperBound) {
             Eigen::VectorXd upperSaturateBias(1);
             upperSaturateBias(0) = this->biasUpperBound;
             bias.setValues(upperSaturateBias);
@@ -83,7 +82,7 @@ void SunlineSRuKF::writeOutputMessages(uint64_t currentSimNanos) {
     filterMsgBuffer.numberOfStates = this->state.size();
 
     int i = 0;
-    for(auto optionalMeasurement : this->measurements){
+    for (auto optionalMeasurement : this->measurements) {
         if (optionalMeasurement.has_value() && optionalMeasurement->getMeasurementName() == "gyro") {
             auto measurement = MeasurementModel();
             measurement = optionalMeasurement.value();
@@ -93,8 +92,7 @@ void SunlineSRuKF::writeOutputMessages(uint64_t currentSimNanos) {
             eigenMatrixXd2CArray(measurement.getObservation(), &filterGyroResMsgBuffer.observation[0]);
             eigenMatrixXd2CArray(measurement.getPostFitResiduals(), &filterGyroResMsgBuffer.postFits[0]);
             eigenMatrixXd2CArray(measurement.getPreFitResiduals(), &filterGyroResMsgBuffer.preFits[0]);
-        }
-        else if (optionalMeasurement.has_value() && optionalMeasurement->getMeasurementName() == "css") {
+        } else if (optionalMeasurement.has_value() && optionalMeasurement->getMeasurementName() == "css") {
             auto measurement = MeasurementModel();
             measurement = optionalMeasurement.value();
             filterCssResMsgBuffer.valid = true;
@@ -107,7 +105,6 @@ void SunlineSRuKF::writeOutputMessages(uint64_t currentSimNanos) {
         this->measurements[i].reset();
         i += 1;
     }
-
 
     this->navAttOutMsg.write(&navAttOutMsgBuffer, this->moduleID, currentSimNanos);
     this->filterOutMsg.write(&filterMsgBuffer, this->moduleID, currentSimNanos);
@@ -122,7 +119,7 @@ void SunlineSRuKF::readGyroMeasurements() {
     /*! Read rate gyro measurements */
     NavAttMsgPayload navAttInputBuffer = this->navAttInMsg();
 
-    if (navAttInputBuffer.timeTag >= this->previousFilterTimeTag){
+    if (navAttInputBuffer.timeTag >= this->previousFilterTimeTag) {
         auto gyroMeasurements = MeasurementModel();
         gyroMeasurements.setValidity(true);
         gyroMeasurements.setMeasurementName("gyro");
@@ -161,32 +158,31 @@ void SunlineSRuKF::readCssMeasurements() {
     /*! -# Set inverse noise matrix */
     /*! -# increase the number of valid observations */
     /*! -# Otherwise just continue */
-    for(uint32_t i=0; i<this->cssConfigInputBuffer.nCSS; ++i)
-    {
-        if (cssInputBuffer.CosValue[i] > this->sensorUseThresh)
-        {
+    for (uint32_t i = 0; i < this->cssConfigInputBuffer.nCSS; ++i) {
+        if (cssInputBuffer.CosValue[i] > this->sensorUseThresh) {
             cssMeasurements.setValidity(true);
-            cssObservation.conservativeResize(this->numActiveCss+1);
+            cssObservation.conservativeResize(this->numActiveCss + 1);
             cssObservation(this->numActiveCss) = cssInputBuffer.CosValue[i];
-            hMatrix.conservativeResize(this->numActiveCss+1, 3);
-            for (int j=0; j<3; ++j) {
-                hMatrix(this->numActiveCss,j) = this->cssConfigInputBuffer.cssVals[i].CBias *
-                        this->cssConfigInputBuffer.cssVals[i].nHat_B[j];
+            hMatrix.conservativeResize(this->numActiveCss + 1, 3);
+            for (int j = 0; j < 3; ++j) {
+                hMatrix(this->numActiveCss, j) =
+                    this->cssConfigInputBuffer.cssVals[i].CBias * this->cssConfigInputBuffer.cssVals[i].nHat_B[j];
             }
             cssMeasurements.setTimeTag(cssInputBuffer.timeTag);
             this->numActiveCss += 1;
         }
     }
 
-    std::function<const Eigen::VectorXd(const FilterStateVector)> linearModel = [hMatrix](const FilterStateVector &state) {
-        Eigen::VectorXd observed = hMatrix * state.getPositionStates();
-        if (state.hasBias()) {
-            observed = observed*state.getBiasStates().value();
-        }
-        return observed;
-    };
+    std::function<const Eigen::VectorXd(const FilterStateVector)> linearModel =
+        [hMatrix](const FilterStateVector &state) {
+            Eigen::VectorXd observed = hMatrix * state.getPositionStates();
+            if (state.hasBias()) {
+                observed = observed * state.getBiasStates().value();
+            }
+            return observed;
+        };
 
-    if (cssMeasurements.getValidity() && cssMeasurements.getTimeTag() >= this->previousFilterTimeTag){
+    if (cssMeasurements.getValidity() && cssMeasurements.getTimeTag() >= this->previousFilterTimeTag) {
         /*! - Read measurement and cholesky decomposition its noise*/
         Eigen::MatrixXd I(this->numActiveCss, this->numActiveCss);
         I.setIdentity();
@@ -216,10 +212,10 @@ void SunlineSRuKF::readFilterMeasurements() {
     @return FilterStateVector inputState
     @return FilterStateVector outputState
     */
-FilterStateVector SunlineSRuKF::stateDerivative(const double t, const FilterStateVector &state){
+FilterStateVector SunlineSRuKF::stateDerivative(const double t, const FilterStateVector &state) {
     FilterStateVector XDot;
     /*! Implement propagation with rate derivatives set to zero */
-    Eigen::Vector3d sHat  = state.getPositionStates();
+    Eigen::Vector3d sHat = state.getPositionStates();
     Eigen::Vector3d omega = state.getVelocityStates();
 
     PositionState xDotPosition;
@@ -260,57 +256,41 @@ void SunlineSRuKF::setGyroMeasurementNoiseStd(const double gyroMeasurementNoiseS
     @param double cssMeasurementNoise
     @return void
     */
-double SunlineSRuKF::getCssMeasurementNoiseStd() const {
-    return this->cssMeasNoiseStd;
-}
+double SunlineSRuKF::getCssMeasurementNoiseStd() const { return this->cssMeasNoiseStd; }
 
 /*! Get the gyro measurement noise
     @param double gyroMeasurementNoise
     @return void
     */
-double SunlineSRuKF::getGyroMeasurementNoiseStd() const {
-    return this->gyroMeasNoiseStd;
-}
+double SunlineSRuKF::getGyroMeasurementNoiseStd() const { return this->gyroMeasNoiseStd; }
 
 /*! Set the threshold value to accept a css measurement
     @param double threshold
     @return void
     */
-void SunlineSRuKF::setSensorThreshold(double threshold){
-    this->sensorUseThresh = threshold;
-}
+void SunlineSRuKF::setSensorThreshold(double threshold) { this->sensorUseThresh = threshold; }
 
 /*! Get the threshold value to accept a css measurement
     @return double threshold
     */
-double SunlineSRuKF::getSensorThreshold() const{
-    return this->sensorUseThresh;
-}
+double SunlineSRuKF::getSensorThreshold() const { return this->sensorUseThresh; }
 
 /*! Set the bias upper bound value it is not allowed to exceed
     @param double biasUpperBound
     */
-void SunlineSRuKF::setBiasUpperBound(double biasUpperBound) {
-    this->biasUpperBound = biasUpperBound;
-}
+void SunlineSRuKF::setBiasUpperBound(double biasUpperBound) { this->biasUpperBound = biasUpperBound; }
 
 /*! Get the bias upper bound value it is not allowed to exceed
     @return double biasUpperBound
     */
-double SunlineSRuKF::getBiasUpperBound() const {
-    return this->biasUpperBound;
-}
+double SunlineSRuKF::getBiasUpperBound() const { return this->biasUpperBound; }
 
 /*! Set the bias lower bound value it is not allowed to subceed
     @param double biasUpperBound
     */
-void SunlineSRuKF::setBiasLowerBound(double biasLowerBound) {
-    this->biasLowerBound = biasLowerBound;
-}
+void SunlineSRuKF::setBiasLowerBound(double biasLowerBound) { this->biasLowerBound = biasLowerBound; }
 
 /*! Get the bias lower bound value it is not allowed to subceed
     @return double biasUpperBound
     */
-double SunlineSRuKF::getBiasLowerBound() const {
-    return this->biasLowerBound;
-}
+double SunlineSRuKF::getBiasLowerBound() const { return this->biasLowerBound; }

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
@@ -261,3 +261,31 @@ void SunlineSRuKF::setSensorThreshold(double threshold){
 double SunlineSRuKF::getSensorThreshold() const{
     return this->sensorUseThresh;
 }
+
+/*! Set the bias upper bound value it is not allowed to exceed
+    @param double biasUpperBound
+    */
+void SunlineSRuKF::setBiasUpperBound(double biasUpperBound) {
+    this->biasUpperBound = biasUpperBound;
+}
+
+/*! Get the bias upper bound value it is not allowed to exceed
+    @return double biasUpperBound
+    */
+double SunlineSRuKF::getBiasUpperBound() const {
+    return this->biasUpperBound;
+}
+
+/*! Set the bias lower bound value it is not allowed to subceed
+    @param double biasUpperBound
+    */
+void SunlineSRuKF::setBiasLowerBound(double biasLowerBound) {
+    this->biasLowerBound = biasLowerBound;
+}
+
+/*! Get the bias lower bound value it is not allowed to subceed
+    @return double biasUpperBound
+    */
+double SunlineSRuKF::getBiasLowerBound() const {
+    return this->biasLowerBound;
+}

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
@@ -54,6 +54,9 @@ private:
     double gyroMeasNoiseStd = 0; //!< [rad/s] rate gyro measurement noise std
     CSSConfigMsgPayload cssConfigInputBuffer;
 
+    double biasLowerBound = 0.5;
+    double biasUpperBound = 1.5;
+
 public:
     ReadFunctor<NavAttMsgPayload>         navAttInMsg;
     ReadFunctor<CSSArraySensorMsgPayload> cssDataInMsg;
@@ -69,6 +72,11 @@ public:
     double getGyroMeasurementNoiseStd() const;
     void setSensorThreshold(double threshold);
     double getSensorThreshold() const;
+
+    void setBiasUpperBound(double biasUpperBound);
+    double getBiasUpperBound() const;
+    void setBiasLowerBound(double biasLowerBound);
+    double getBiasLowerBound() const;
 
 };
 

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.h
@@ -23,22 +23,20 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/utilities/orbitalMotion.h"
-#include "architecture/utilities/macroDefinitions.h"
-#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/CSSArraySensorMsgPayload.h"
 #include "architecture/msgPayloadDefC/CSSConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/CSSUnitConfigMsgPayload.h"
-#include "architecture/msgPayloadDefC/CSSArraySensorMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/FilterMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/FilterResidualsMsgPayload.h"
-
-#include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/orbitalMotion.h"
 #include "fswAlgorithms/_GeneralModuleFiles/measurementModels.h"
+#include "fswAlgorithms/_GeneralModuleFiles/srukfInterface.h"
 
-class SunlineSRuKF: public SRukfInterface {
-public:
-
-private:
+class SunlineSRuKF : public SRukfInterface {
+   public:
+   private:
     void customreset() final;
     void readCssMeasurements();
     void readGyroMeasurements();
@@ -47,24 +45,24 @@ private:
     void writeOutputMessages(uint64_t currentSimNanos) final;
     static FilterStateVector stateDerivative(double t, const FilterStateVector &state);
 
-    int filterMeasurement = 0;   //!< [-] Number of measurements of different types being read
-    int numActiveCss = 0;        //!< [-] Number of currently active CSS sensors
-    double sensorUseThresh = 0;  //!< Threshold below which we discount sensors
-    double cssMeasNoiseStd = 0;  //!< [-] CSS measurement noise std
-    double gyroMeasNoiseStd = 0; //!< [rad/s] rate gyro measurement noise std
+    int filterMeasurement = 0;    //!< [-] Number of measurements of different types being read
+    int numActiveCss = 0;         //!< [-] Number of currently active CSS sensors
+    double sensorUseThresh = 0;   //!< Threshold below which we discount sensors
+    double cssMeasNoiseStd = 0;   //!< [-] CSS measurement noise std
+    double gyroMeasNoiseStd = 0;  //!< [rad/s] rate gyro measurement noise std
     CSSConfigMsgPayload cssConfigInputBuffer;
 
     double biasLowerBound = 0.5;
     double biasUpperBound = 1.5;
 
-public:
-    ReadFunctor<NavAttMsgPayload>         navAttInMsg;
+   public:
+    ReadFunctor<NavAttMsgPayload> navAttInMsg;
     ReadFunctor<CSSArraySensorMsgPayload> cssDataInMsg;
-    ReadFunctor<CSSConfigMsgPayload>      cssConfigInMsg;
-    Message<NavAttMsgPayload>             navAttOutMsg;
-    Message<FilterMsgPayload>             filterOutMsg;
-    Message<FilterResidualsMsgPayload>    filterGyroResOutMsg;
-    Message<FilterResidualsMsgPayload>    filterCssResOutMsg;
+    ReadFunctor<CSSConfigMsgPayload> cssConfigInMsg;
+    Message<NavAttMsgPayload> navAttOutMsg;
+    Message<FilterMsgPayload> filterOutMsg;
+    Message<FilterResidualsMsgPayload> filterGyroResOutMsg;
+    Message<FilterResidualsMsgPayload> filterCssResOutMsg;
 
     void setCssMeasurementNoiseStd(double cssMeasurementNoiseStd);
     void setGyroMeasurementNoiseStd(double gyroMeasurementNoiseStd);
@@ -77,7 +75,6 @@ public:
     double getBiasUpperBound() const;
     void setBiasLowerBound(double biasLowerBound);
     double getBiasLowerBound() const;
-
 };
 
 #endif

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.rst
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.rst
@@ -44,6 +44,7 @@ provides information on what this message is used for.
 Detailed Module Description
 ---------------------------
 The estimated state of the filter is a 6-dimensional vector combining the sun heading vector in body-frame coordinates and body-frame rates also in body frame coordinates:
+The optional bias state models the varying solar intensity which scales the measurements.
 
 .. math::
     \boldsymbol{s} = \left\{ \begin{matrix} {}^\mathcal{B}\boldsymbol{\hat{s}} \\ {}^\mathcal{B}\boldsymbol{\omega} \end{matrix} \right\}.
@@ -51,6 +52,7 @@ The estimated state of the filter is a 6-dimensional vector combining the sun he
 Dynamics model
 +++++++++++++++++++++++++++
 The sun heading is fixed in inertial coordinates, it only changes in body-frame coordinates due to the motion of the spacecraft. Therefore, the dynamics of the sun heading is only given by the body-frame derivative of the sun heading unit-direction vector. For simplicity, the derivative of the angular rate vector is set to zero in this module. This gives:
+If the bias state is present, it has no dynamics.
 
 .. math::
     \boldsymbol{\dot{s}} = \left\{ \begin{matrix} {}^\mathcal{B}\boldsymbol{\hat{s}} \times {}^\mathcal{B}\boldsymbol{\omega} \\ \boldsymbol{0} \end{matrix} \right\}.
@@ -64,29 +66,36 @@ For the CSS measurement, the measurement model is constituted by the :math:`n \t
 .. math::
     [\boldsymbol{H}] = \left[ \begin{matrix} {}^\mathcal{B}\boldsymbol{\hat{n}}_1 \\ \vdots \\ {}^\mathcal{B}\boldsymbol{\hat{n}}_n \end{matrix} \right].
 
+If a bias state is present and named :math:`b`, and the current state is :math:`\hat{\boldsymbol{s}}`, the predicted measurements will be given by:
+
+.. math::
+    yMeas = b[\boldsymbol{H}] \hat{\boldsymbol{s}}
+
 
 User Guide
 ----------
 The required module configuration is::
 
-    filter_object = sunlineSRuKF.SunlineSRuKF()
-    filter_object.setAlpha(0.02)
-    filter_object.setBeta(2.0)
-    states = [0.0, 0.0, 1.0, 0.02, -0.005, 0.01]
-    filter_object.setInitialState([[s] for s in states])
-    filter_object.setInitialCovariance([[0.0001, 0.0, 0.0, 0.0, 0.0, 0.0],
-                                        [0.0, 0.0001, 0.0, 0.0, 0.0, 0.0],
-                                        [0.0, 0.0, 0.0001, 0.0, 0.0, 0.0],
-                                        [0.0, 0.0, 0.0, 0.0001, 0.0, 0.0],
-                                        [0.0, 0.0, 0.0, 0.0, 0.0001, 0.0],
-                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0001]])
+    filter_object.setInitialPosition([0.0, 0.0, 1.0])
+    filter_object.setInitialVelocity([0.02, -0.005, 0.01])
+    filter_object.setInitialBias([0.6])
+    filter_object.setInitialCovariance([[0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.001, 0.0, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.001, 0.0, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.001, 0.0],
+                                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5]])
     filter_object.setCssMeasurementNoiseStd(0.01)
     filter_object.setGyroMeasurementNoiseStd(0.001)
-    sigmaSun = (1E-12) ** 2
-    sigmaRate = (1E-14) ** 2
-    filter_object.setProcessNoise([[sigmaSun, 0.0, 0.0, 0.0, 0.0, 0.0],
-                                   [0.0, sigmaSun, 0.0, 0.0, 0.0, 0.0],
-                                   [0.0, 0.0, sigmaSun, 0.0, 0.0, 0.0],
-                                   [0.0, 0.0, 0.0, sigmaRate, 0.0, 0.0],
-                                   [0.0, 0.0, 0.0, 0.0, sigmaRate, 0.0],
-                                   [0.0, 0.0, 0.0, 0.0, 0.0, sigmaRate]])
+    filter_object.setBiasLowerBound(1)
+    sigmaSun = (1E-6) ** 2
+    sigmaRate = (1E-8) ** 2
+    sigmaBias = (1E-5) ** 2
+    filter_object.setProcessNoise([[sigmaSun, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                   [0.0, sigmaSun, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                   [0.0, 0.0, sigmaSun, 0.0, 0.0, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0, sigmaRate, 0.0, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0, 0.0, sigmaRate, 0.0, 0.0],
+                                   [0.0, 0.0, 0.0, 0.0, 0.0, sigmaRate, 0.0],
+                                   [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, sigmaBias]])

--- a/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.cpp
@@ -18,23 +18,23 @@
  */
 
 #include "fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.h"
-#include "architecture/utilities/ukfUtilities.h"
+
+#include <math.h>
+#include <string.h>
+
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <string.h>
-#include <math.h>
+#include "architecture/utilities/ukfUtilities.h"
 
 /*! This method resets the sunline attitude filter to an initial state and
  initializes the internal estimation matrices.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void SunlineSuKF::reset(uint64_t callTime)
-{
-
+void SunlineSuKF::reset(uint64_t callTime) {
     CSSConfigMsgPayload cssConfigInBuffer;
     int32_t badUpdate;
-    double tempMatrix[SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH];
+    double tempMatrix[SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH];
     badUpdate = 0;
 
     /*! - Zero the local configuration data structures and outputs */
@@ -52,14 +52,14 @@ void SunlineSuKF::reset(uint64_t callTime)
     /*! - Read in mass properties and coarse sun sensor configuration information.*/
     cssConfigInBuffer = this->cssConfigInMsg();
     if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
-        this->bskLogger.bskLog(BSK_ERROR, "sunlineSuKF.cssConfigInMsg.nCSS must not be greater than "
-                                                  "MAX_N_CSS_MEAS value.");
+        this->bskLogger.bskLog(BSK_ERROR,
+                               "sunlineSuKF.cssConfigInMsg.nCSS must not be greater than "
+                               "MAX_N_CSS_MEAS value.");
     }
 
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
-    for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i++)
-    {
-        v3Copy(cssConfigInBuffer.cssVals[i].nHat_B, &(this->cssNHat_B[i*3]));
+    for (uint32_t i = 0; i < cssConfigInBuffer.nCSS; i++) {
+        v3Copy(cssConfigInBuffer.cssVals[i].nHat_B, &(this->cssNHat_B[i * 3]));
         this->CBias[i] = cssConfigInBuffer.cssVals[i].CBias;
     }
     /*! - Save the count of sun sensors for later use */
@@ -67,7 +67,7 @@ void SunlineSuKF::reset(uint64_t callTime)
 
     /*! - Initialize filter parameters to max values */
     this->dt = 0.0;
-    this->timeTag = callTime*NANO2SEC;
+    this->timeTag = callTime * NANO2SEC;
     this->numStates = SKF_N_STATES_SWITCH;
     this->countHalfSPs = SKF_N_STATES_SWITCH;
     this->numObs = MAX_N_CSS_MEAS;
@@ -81,53 +81,40 @@ void SunlineSuKF::reset(uint64_t callTime)
     vSetZero(this->wM, this->countHalfSPs * 2 + 1);
     vSetZero(this->wC, this->countHalfSPs * 2 + 1);
     mSetZero(this->sBar, this->numStates, this->numStates);
-    mSetZero(this->SP, this->countHalfSPs * 2 + 1,
-             this->numStates);
+    mSetZero(this->SP, this->countHalfSPs * 2 + 1, this->numStates);
     mSetZero(this->sQnoise, this->numStates, this->numStates);
 
     /*! - Set lambda/gamma to standard value for unscented kalman filters */
-    this->lambdaVal = this->alpha*this->alpha*
-    (this->numStates + this->kappa) - this->numStates;
+    this->lambdaVal = this->alpha * this->alpha * (this->numStates + this->kappa) - this->numStates;
     this->gamma = sqrt(this->numStates + this->lambdaVal);
 
-
     /*! - Set the wM/wC vectors to standard values for unscented kalman filters*/
-    this->wM[0] = this->lambdaVal / (this->numStates +
-                                                 this->lambdaVal);
-    this->wC[0] = this->lambdaVal / (this->numStates +
-                                                 this->lambdaVal) + (1 - this->alpha*this->alpha + this->beta);
-    for (uint32_t i = 1; i<this->countHalfSPs * 2 + 1; i++)
-    {
-        this->wM[i] = 1.0 / 2.0*1.0 / (this->numStates +
-                                             this->lambdaVal);
+    this->wM[0] = this->lambdaVal / (this->numStates + this->lambdaVal);
+    this->wC[0] = this->lambdaVal / (this->numStates + this->lambdaVal) + (1 - this->alpha * this->alpha + this->beta);
+    for (uint32_t i = 1; i < this->countHalfSPs * 2 + 1; i++) {
+        this->wM[i] = 1.0 / 2.0 * 1.0 / (this->numStates + this->lambdaVal);
         this->wC[i] = this->wM[i];
     }
 
     /*! - User a cholesky decomposition to obtain the sBar and sQnoise matrices for use in
           filter at runtime*/
-    mCopy(this->covarInit, this->numStates, this->numStates,
-          this->covar);
+    mCopy(this->covarInit, this->numStates, this->numStates, this->covar);
     mSetZero(this->covarPrev, this->numStates, this->numStates);
     mSetZero(this->sBarPrev, this->numStates, this->numStates);
     vSetZero(this->statePrev, this->numStates);
-    mCopy(this->covar, this->numStates, this->numStates,
-          this->sBar);
-    badUpdate += ukfCholDecomp(this->sBar, (int32_t) this->numStates,
-                               (int32_t) this->numStates, tempMatrix);
-    mCopy(tempMatrix, this->numStates, this->numStates,
-          this->sBar);
-    badUpdate += ukfCholDecomp(this->qNoise, (int32_t)this->numStates,
-                               (int32_t) this->numStates, this->sQnoise);
-    mTranspose(this->sQnoise, this->numStates,
-               this->numStates, this->sQnoise);
+    mCopy(this->covar, this->numStates, this->numStates, this->sBar);
+    badUpdate += ukfCholDecomp(this->sBar, (int32_t)this->numStates, (int32_t)this->numStates, tempMatrix);
+    mCopy(tempMatrix, this->numStates, this->numStates, this->sBar);
+    badUpdate += ukfCholDecomp(this->qNoise, (int32_t)this->numStates, (int32_t)this->numStates, this->sQnoise);
+    mTranspose(this->sQnoise, this->numStates, this->numStates, this->sQnoise);
 
-    if (this->cssDataInMsg.isWritten()){
+    if (this->cssDataInMsg.isWritten()) {
         this->cssSensorInBuffer = this->cssDataInMsg();
     } else {
         this->cssSensorInBuffer = {};
     }
 
-    if (badUpdate <0){
+    if (badUpdate < 0) {
         this->bskLogger.bskLog(BSK_WARNING, "Reset method contained bad update");
     }
 }
@@ -137,8 +124,7 @@ void SunlineSuKF::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void SunlineSuKF::updateState(uint64_t callTime)
-{
+void SunlineSuKF::updateState(uint64_t callTime) {
     double newTimeTag;
     double yBar[MAX_N_CSS_MEAS];
     double tempYVec[MAX_N_CSS_MEAS];
@@ -160,25 +146,21 @@ void SunlineSuKF::updateState(uint64_t callTime)
     sunlineDataOutBuffer = {};
 
     /*! If the filter is not initialized manually, give it an initial guess using the CSS with the strongest signal.*/
-    if(this->filterInitialized==0)
-    {
+    if (this->filterInitialized == 0) {
         vSetZero(this->stateInit, SKF_N_STATES_SWITCH);
         this->stateInit[5] = 1;
         this->stateInit[0] = 1;
         maxSens = 0.0;
         /*! Loop through sensors to find max*/
-        for(i=0; i<this->numCSSTotal; i++)
-        {
-            if(this->cssSensorInBuffer.CosValue[i] > maxSens)
-            {
-                v3Copy(&(this->cssNHat_B[i*3]), this->stateInit);
+        for (i = 0; i < this->numCSSTotal; i++) {
+            if (this->cssSensorInBuffer.CosValue[i] > maxSens) {
+                v3Copy(&(this->cssNHat_B[i * 3]), this->stateInit);
                 maxSens = this->cssSensorInBuffer.CosValue[i];
                 /*! Max sensor reading is initial guess for the kelly factor*/
                 this->stateInit[5] = maxSens;
             }
         }
-        if(maxSens < this->sensorUseThresh)
-        {
+        if (maxSens < this->sensorUseThresh) {
             return;
         }
         /*! The normal of the max activated sensor is the initial state*/
@@ -189,25 +171,22 @@ void SunlineSuKF::updateState(uint64_t callTime)
     v3Normalize(&this->state[0], sunheading_hat);
 
     /*! - Check for switching frames */
-    if (fabs(v3Dot(this->bVec_B, sunheading_hat)) > this->switchTresh)
-    {
+    if (fabs(v3Dot(this->bVec_B, sunheading_hat)) > this->switchTresh) {
         sunlineSuKFSwitch(this->bVec_B, this->state, this->covar);
     }
 
     /*! - If the time tag from the measured data is new compared to previous step,
           propagate and update the filter*/
     newTimeTag = timeOfMsgWritten * NANO2SEC;
-    if(newTimeTag >= this->timeTag && isWritten)
-    {
+    if (newTimeTag >= this->timeTag && isWritten) {
         sunlineSuKFTimeUpdate(this, newTimeTag);
         sunlineSuKFMeasUpdate(this, newTimeTag);
     }
     v3Normalize(this->state, this->state);
     /*! - If current clock time is further ahead than the measured time, then
           propagate to this current time-step*/
-    newTimeTag = callTime*NANO2SEC;
-    if(newTimeTag > this->timeTag)
-    {
+    newTimeTag = callTime * NANO2SEC;
+    if (newTimeTag > this->timeTag) {
         sunlineSuKFTimeUpdate(this, newTimeTag);
     }
 
@@ -216,10 +195,8 @@ void SunlineSuKF::updateState(uint64_t callTime)
 
     /*! - Compute the value for the yBar parameter (equation 23)*/
     vSetZero(yBar, this->numObs);
-    for(i=0; i<this->countHalfSPs*2+1; i++)
-    {
-        vCopy(&(this->yMeas[i*this->numObs]), this->numObs,
-              tempYVec);
+    for (i = 0; i < this->countHalfSPs * 2 + 1; i++) {
+        vCopy(&(this->yMeas[i * this->numObs]), this->numObs, tempYVec);
         vScale(this->wM[i], tempYVec, this->numObs, tempYVec);
         vAdd(yBar, this->numObs, tempYVec, yBar);
     }
@@ -228,23 +205,24 @@ void SunlineSuKF::updateState(uint64_t callTime)
     mSubtract(this->obs, this->numObs, 1, yBar, this->postFits);
 
     /*! - Write the sunline estimate into the copy of the navigation message structure*/
-	v3Copy(this->state, this->outputSunline.vehSunPntBdy);
-    v3Normalize(this->outputSunline.vehSunPntBdy,
-        this->outputSunline.vehSunPntBdy);
+    v3Copy(this->state, this->outputSunline.vehSunPntBdy);
+    v3Normalize(this->outputSunline.vehSunPntBdy, this->outputSunline.vehSunPntBdy);
     this->outputSunline.timeTag = this->timeTag;
     this->navStateOutMsg.write(&this->outputSunline, this->moduleID, callTime);
 
     /*! - Switch the rates back to omega_BN instead of omega_SB */
     vCopy(this->state, SKF_N_STATES_SWITCH, states_BN);
-    vScale(-1, &(states_BN[3]), 2, &(states_BN[3])); /*! The Filter currently outputs omega_SB = -omega_BN (check doc for details)*/
+    vScale(-1,
+           &(states_BN[3]),
+           2,
+           &(states_BN[3])); /*! The Filter currently outputs omega_SB = -omega_BN (check doc for details)*/
 
     /*! - Populate the filter states output buffer and write the output message*/
     sunlineDataOutBuffer.timeTag = this->timeTag;
-    sunlineDataOutBuffer.numObs = (int) this->numObs;
-    memmove(sunlineDataOutBuffer.covar, this->covar,
-            SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH*sizeof(double));
-    memmove(sunlineDataOutBuffer.state, states_BN, SKF_N_STATES_SWITCH*sizeof(double));
-    memmove(sunlineDataOutBuffer.postFitRes, this->postFits, MAX_N_CSS_MEAS*sizeof(double));
+    sunlineDataOutBuffer.numObs = (int)this->numObs;
+    memmove(sunlineDataOutBuffer.covar, this->covar, SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH * sizeof(double));
+    memmove(sunlineDataOutBuffer.state, states_BN, SKF_N_STATES_SWITCH * sizeof(double));
+    memmove(sunlineDataOutBuffer.postFitRes, this->postFits, MAX_N_CSS_MEAS * sizeof(double));
     this->filtDataOutMsg.write(&sunlineDataOutBuffer, this->moduleID, callTime);
 
     return;
@@ -252,14 +230,12 @@ void SunlineSuKF::updateState(uint64_t callTime)
 
 /*! This method propagates a sunline state vector forward in time.  Note
     that the calling parameter is updated in place to save on data copies.
-	@return void
+    @return void
     @param stateInOut The state that is propagated
     @param b_Vec b vector
     @param dt time step (s)
 */
-void sunlineStateProp(double *stateInOut, double *b_Vec, double dt)
-{
-
+void sunlineStateProp(double *stateInOut, double *b_Vec, double dt) {
     double propagatedVel[SKF_N_STATES_HALF];
     double omegaCrossd[SKF_N_STATES_HALF];
     double omega_BN_S[SKF_N_STATES_HALF] = {0, -stateInOut[3], -stateInOut[4]};
@@ -281,25 +257,24 @@ void sunlineStateProp(double *stateInOut, double *b_Vec, double dt)
     v3Add(stateInOut, propagatedVel, stateInOut);
     v3Normalize(stateInOut, stateInOut);
 
-	return;
+    return;
 }
 
 /*! This method performs the time update for the sunline kalman filter.
      It propagates the sigma points forward in time and then gets the current
-	 covariance and state estimates.
-	 @return void
+     covariance and state estimates.
+     @return void
      @param configData The configuration data associated with the CSS estimator
      @param updateTime The time that we need to fix the filter to (seconds)
 */
-int sunlineSuKFTimeUpdate(SunlineSuKF *data, double updateTime)
-{
+int sunlineSuKFTimeUpdate(SunlineSuKF *data, double updateTime) {
     int Index, badUpdate;
-	double sBarT[SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH];
-	double xComp[SKF_N_STATES_SWITCH], AT[(2 * SKF_N_STATES_SWITCH + SKF_N_STATES_SWITCH)*SKF_N_STATES_SWITCH];
-	double aRow[SKF_N_STATES_SWITCH], rAT[SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH], xErr[SKF_N_STATES_SWITCH];
-	double sBarUp[SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH];
-	double *spPtr;
-    double procNoise[SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH];
+    double sBarT[SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH];
+    double xComp[SKF_N_STATES_SWITCH], AT[(2 * SKF_N_STATES_SWITCH + SKF_N_STATES_SWITCH) * SKF_N_STATES_SWITCH];
+    double aRow[SKF_N_STATES_SWITCH], rAT[SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH], xErr[SKF_N_STATES_SWITCH];
+    double sBarUp[SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH];
+    double *spPtr;
+    double procNoise[SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH];
     badUpdate = 0;
 
     vCopy(data->state, data->numStates, data->statePrev);
@@ -308,86 +283,72 @@ int sunlineSuKFTimeUpdate(SunlineSuKF *data, double updateTime)
     data->dt = updateTime - data->timeTag;
     mCopy(data->sQnoise, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, procNoise);
     /*! - Copy over the current state estimate into the 0th Sigma point and propagate by dt*/
-	vCopy(data->state, data->numStates,
-		&(data->SP[0 * data->numStates + 0]));
-	mSetZero(rAT, data->countHalfSPs, data->countHalfSPs);
-	sunlineStateProp(&(data->SP[0]), data->bVec_B, data->dt);
+    vCopy(data->state, data->numStates, &(data->SP[0 * data->numStates + 0]));
+    mSetZero(rAT, data->countHalfSPs, data->countHalfSPs);
+    sunlineStateProp(&(data->SP[0]), data->bVec_B, data->dt);
     /*! - Scale that Sigma point by the appopriate scaling factor (Wm[0])*/
-	vScale(data->wM[0], &(data->SP[0]),
-        data->numStates, data->xBar);
+    vScale(data->wM[0], &(data->SP[0]), data->numStates, data->xBar);
     /*! - Get the transpose of the sBar matrix because it is easier to extract Rows vs columns*/
-    mTranspose(data->sBar, data->numStates, data->numStates,
-               sBarT);
+    mTranspose(data->sBar, data->numStates, data->numStates, sBarT);
     /*! - For each Sigma point, apply sBar-based error, propagate forward, and scale by Wm just like 0th.
           Note that we perform +/- sigma points simultaneously in loop to save loop values.*/
-	for (uint64_t i = 0; i<data->countHalfSPs; i++)
-	{
-		Index = (int) i + 1;
-		spPtr = &(data->SP[Index*(int)data->numStates]);
-		vCopy(&sBarT[i*(int)data->numStates], data->numStates, spPtr);
-		vScale(data->gamma, spPtr, data->numStates, spPtr);
-		vAdd(spPtr, data->numStates, data->state, spPtr);
-		sunlineStateProp(spPtr, data->bVec_B, data->dt);
-		vScale(data->wM[Index], spPtr, data->numStates, xComp);
-		vAdd(xComp, data->numStates, data->xBar, data->xBar);
+    for (uint64_t i = 0; i < data->countHalfSPs; i++) {
+        Index = (int)i + 1;
+        spPtr = &(data->SP[Index * (int)data->numStates]);
+        vCopy(&sBarT[i * (int)data->numStates], data->numStates, spPtr);
+        vScale(data->gamma, spPtr, data->numStates, spPtr);
+        vAdd(spPtr, data->numStates, data->state, spPtr);
+        sunlineStateProp(spPtr, data->bVec_B, data->dt);
+        vScale(data->wM[Index], spPtr, data->numStates, xComp);
+        vAdd(xComp, data->numStates, data->xBar, data->xBar);
 
-		Index = (int) i + 1 + (int) data->countHalfSPs;
-        spPtr = &(data->SP[Index*(int)data->numStates]);
-        vCopy(&sBarT[i*(int) data->numStates], data->numStates, spPtr);
+        Index = (int)i + 1 + (int)data->countHalfSPs;
+        spPtr = &(data->SP[Index * (int)data->numStates]);
+        vCopy(&sBarT[i * (int)data->numStates], data->numStates, spPtr);
         vScale(-data->gamma, spPtr, data->numStates, spPtr);
         vAdd(spPtr, data->numStates, data->state, spPtr);
         sunlineStateProp(spPtr, data->bVec_B, data->dt);
         vScale(data->wM[Index], spPtr, data->numStates, xComp);
         vAdd(xComp, data->numStates, data->xBar, data->xBar);
-	}
+    }
     /*! - Zero the AT matrix prior to assembly*/
-    mSetZero(AT, (2 * data->countHalfSPs + data->numStates),
-        data->countHalfSPs);
-	/*! - Assemble the AT matrix.  Note that data matrix is the internals of
+    mSetZero(AT, (2 * data->countHalfSPs + data->numStates), data->countHalfSPs);
+    /*! - Assemble the AT matrix.  Note that data matrix is the internals of
           the qr decomposition call in the source design documentation.  It is
           the inside of equation 20 in that document*/
-	for (uint64_t i = 0; i<2 * data->countHalfSPs; i++)
-	{
-
+    for (uint64_t i = 0; i < 2 * data->countHalfSPs; i++) {
         vScale(-1.0, data->xBar, data->numStates, aRow);
-        vAdd(aRow, data->numStates,
-             &(data->SP[(i+1)*(int) data->numStates]), aRow);
-        if (data->wC[i+1] <0){return -1;}
-        vScale(sqrt(data->wC[i+1]), aRow, data->numStates, aRow);
-		memcpy((void *)&AT[i*(int) data->numStates], (void *)aRow,
-			data->numStates*sizeof(double));
-	}
+        vAdd(aRow, data->numStates, &(data->SP[(i + 1) * (int)data->numStates]), aRow);
+        if (data->wC[i + 1] < 0) {
+            return -1;
+        }
+        vScale(sqrt(data->wC[i + 1]), aRow, data->numStates, aRow);
+        memcpy((void *)&AT[i * (int)data->numStates], (void *)aRow, data->numStates * sizeof(double));
+    }
 
     /*! - Pop the sQNoise matrix on to the end of AT prior to getting QR decomposition*/
-	memcpy(&AT[2 * data->countHalfSPs*data->numStates],
-		procNoise, data->numStates*data->numStates
-        *sizeof(double));
+    memcpy(
+        &AT[2 * data->countHalfSPs * data->numStates], procNoise, data->numStates * data->numStates * sizeof(double));
     /*! - QR decomposition (only R computed!) of the AT matrix provides the new sBar matrix*/
-    ukfQRDJustR(AT, (int32_t) (2 * data->countHalfSPs + data->numStates),
-                (int32_t) data->countHalfSPs, rAT);
+    ukfQRDJustR(AT, (int32_t)(2 * data->countHalfSPs + data->numStates), (int32_t)data->countHalfSPs, rAT);
     mCopy(rAT, data->numStates, data->numStates, sBarT);
-    mTranspose(sBarT, data->numStates, data->numStates,
-        data->sBar);
+    mTranspose(sBarT, data->numStates, data->numStates, data->sBar);
 
     /*! - Shift the sBar matrix over by the xBar vector using the appropriate weight
           like in equation 21 in design document.*/
     vScale(-1.0, data->xBar, data->numStates, xErr);
     vAdd(xErr, data->numStates, &data->SP[0], xErr);
-    badUpdate += ukfCholDownDate(data->sBar, xErr, data->wC[0],
-                                 (int32_t) data->numStates, sBarUp);
+    badUpdate += ukfCholDownDate(data->sBar, xErr, data->wC[0], (int32_t)data->numStates, sBarUp);
 
     /*! - Save current sBar matrix, covariance, and state estimate off for further use*/
     mCopy(sBarUp, data->numStates, data->numStates, data->sBar);
-    mTranspose(data->sBar, data->numStates, data->numStates,
-        data->covar);
-	mMultM(data->sBar, data->numStates, data->numStates,
-        data->covar, data->numStates, data->numStates,
-           data->covar);
-    vCopy(&(data->SP[0]), data->numStates, data->state );
+    mTranspose(data->sBar, data->numStates, data->numStates, data->covar);
+    mMultM(data->sBar, data->numStates, data->numStates, data->covar, data->numStates, data->numStates, data->covar);
+    vCopy(&(data->SP[0]), data->numStates, data->state);
 
-	data->timeTag = updateTime;
+    data->timeTag = updateTime;
 
-    if (badUpdate<0){
+    if (badUpdate < 0) {
         sunlineSuKFCleanUpdate(data);
         return -1;
     }
@@ -402,8 +363,7 @@ int sunlineSuKFTimeUpdate(SunlineSuKF *data, double updateTime)
  @param configData The configuration data associated with the CSS estimator
 
  */
-void sunlineSuKFMeasModel(SunlineSuKF *data)
-{
+void sunlineSuKFMeasModel(SunlineSuKF *data) {
     uint32_t i, j, obsCounter;
     double sensorNormal[3];
     double normalizedState[3];
@@ -412,55 +372,45 @@ void sunlineSuKFMeasModel(SunlineSuKF *data)
 
     obsCounter = 0;
     /*! - Loop over all available coarse sun sensors and only use ones that meet validity threshold*/
-    for(i=0; i<data->numCSSTotal; i++)
-    {
-        v3Scale(data->CBias[i], &(data->cssNHat_B[i*3]), sensorNormal);
+    for (i = 0; i < data->numCSSTotal; i++) {
+        v3Scale(data->CBias[i], &(data->cssNHat_B[i * 3]), sensorNormal);
         v3Normalize(data->state, normalizedState);
         expectedMeas = v3Dot(normalizedState, sensorNormal);
         expectedMeas = expectedMeas > 0.0 ? expectedMeas : 0.0;
         kellDelta = 1.0;
         /*! - Scale the measurement by the kelly factor.*/
-        if(data->kellFits[i].cssKellFact > 0.0)
-        {
-            kellDelta -= exp(-pow(expectedMeas,data->kellFits[i].cssKellPow) /
-                             data->kellFits[i].cssKellFact);
+        if (data->kellFits[i].cssKellFact > 0.0) {
+            kellDelta -= exp(-pow(expectedMeas, data->kellFits[i].cssKellPow) / data->kellFits[i].cssKellFact);
             expectedMeas *= kellDelta;
             expectedMeas *= data->kellFits[i].cssRelScale;
         }
         expectedMeas *= data->state[5];
         expectedMeas = expectedMeas > 0.0 ? expectedMeas : 0.0;
-        if(data->cssSensorInBuffer.CosValue[i] > data->sensorUseThresh ||
-           expectedMeas > data->sensorUseThresh)
-        {
+        if (data->cssSensorInBuffer.CosValue[i] > data->sensorUseThresh || expectedMeas > data->sensorUseThresh) {
             /*! - For each valid measurement, copy observation value and compute expected obs value
                   on a per sigma-point basis.*/
             data->obs[obsCounter] = data->cssSensorInBuffer.CosValue[i];
-            for(j=0; j<data->countHalfSPs*2+1; j++)
-            {
-                v3Normalize(&(data->SP[j*SKF_N_STATES_SWITCH]), normalizedState);
+            for (j = 0; j < data->countHalfSPs * 2 + 1; j++) {
+                v3Normalize(&(data->SP[j * SKF_N_STATES_SWITCH]), normalizedState);
                 expectedMeas = v3Dot(normalizedState, sensorNormal);
                 expectedMeas = expectedMeas > 0.0 ? expectedMeas : 0.0;
                 kellDelta = 1.0;
                 /*! - Scale the measurement by the kelly factor.*/
-                if(data->kellFits[i].cssKellFact > 0.0)
-                {
-                    kellDelta -= exp(-pow(expectedMeas,data->kellFits[i].cssKellPow) /
-                                     data->kellFits[i].cssKellFact);
+                if (data->kellFits[i].cssKellFact > 0.0) {
+                    kellDelta -= exp(-pow(expectedMeas, data->kellFits[i].cssKellPow) / data->kellFits[i].cssKellFact);
                     expectedMeas *= kellDelta;
                     expectedMeas *= data->kellFits[i].cssRelScale;
                 }
-                expectedMeas *= data->SP[j*SKF_N_STATES_SWITCH+5];
+                expectedMeas *= data->SP[j * SKF_N_STATES_SWITCH + 5];
                 expectedMeas = expectedMeas > 0.0 ? expectedMeas : 0.0;
-                data->yMeas[obsCounter*(data->countHalfSPs*2+1) + j] =
-                    expectedMeas;
+                data->yMeas[obsCounter * (data->countHalfSPs * 2 + 1) + j] = expectedMeas;
             }
             obsCounter++;
         }
     }
     /*! - yMeas matrix was set backwards deliberately so we need to transpose it through*/
-    mTranspose(data->yMeas, obsCounter, data->countHalfSPs*2+1, data->yMeas);
+    mTranspose(data->yMeas, obsCounter, data->countHalfSPs * 2 + 1, data->yMeas);
     data->numObs = obsCounter;
-
 }
 
 /*! This method performs the measurement update for the sunline kalman filter.
@@ -470,17 +420,17 @@ void sunlineSuKFMeasModel(SunlineSuKF *data)
  @param configData The configuration data associated with the CSS estimator
  @param updateTime The time that we need to fix the filter to (seconds)
  */
-int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
-{
+int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime) {
     uint32_t i;
     int32_t badUpdate;
-    double yBar[MAX_N_CSS_MEAS], syInv[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    double kMat[SKF_N_STATES_SWITCH*MAX_N_CSS_MEAS];
-    double xHat[SKF_N_STATES_SWITCH], sBarT[SKF_N_STATES_SWITCH*SKF_N_STATES_SWITCH], tempYVec[MAX_N_CSS_MEAS];
-    double AT[(2 * SKF_N_STATES_SWITCH + MAX_N_CSS_MEAS)*MAX_N_CSS_MEAS], qChol[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    double rAT[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS], syT[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    double sy[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS], Ucol[SKF_N_STATES_SWITCH];
-    double updMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS], pXY[SKF_N_STATES_SWITCH*MAX_N_CSS_MEAS], Umat[SKF_N_STATES_SWITCH*MAX_N_CSS_MEAS];
+    double yBar[MAX_N_CSS_MEAS], syInv[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
+    double kMat[SKF_N_STATES_SWITCH * MAX_N_CSS_MEAS];
+    double xHat[SKF_N_STATES_SWITCH], sBarT[SKF_N_STATES_SWITCH * SKF_N_STATES_SWITCH], tempYVec[MAX_N_CSS_MEAS];
+    double AT[(2 * SKF_N_STATES_SWITCH + MAX_N_CSS_MEAS) * MAX_N_CSS_MEAS], qChol[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
+    double rAT[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS], syT[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
+    double sy[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS], Ucol[SKF_N_STATES_SWITCH];
+    double updMat[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS], pXY[SKF_N_STATES_SWITCH * MAX_N_CSS_MEAS],
+        Umat[SKF_N_STATES_SWITCH * MAX_N_CSS_MEAS];
     badUpdate = 0;
 
     vCopy(data->state, data->numStates, data->statePrev);
@@ -493,10 +443,8 @@ int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
     /*! - Compute the value for the yBar parameter (note that data is equation 23 in the
           time update section of the reference document*/
     vSetZero(yBar, data->numObs);
-    for(i=0; i<data->countHalfSPs*2+1; i++)
-    {
-        vCopy(&(data->yMeas[i*data->numObs]), data->numObs,
-              tempYVec);
+    for (i = 0; i < data->countHalfSPs * 2 + 1; i++) {
+        vCopy(&(data->yMeas[i * data->numObs]), data->numObs, tempYVec);
         vScale(data->wM[i], tempYVec, data->numObs, tempYVec);
         vAdd(yBar, data->numObs, tempYVec, yBar);
     }
@@ -504,17 +452,15 @@ int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
     /*! - Populate the matrix that we perform the QR decomposition on in the measurement
           update section of the code.  This is based on the differenence between the yBar
           parameter and the calculated measurement models.  Equation 24 in driving doc. */
-    mSetZero(AT, data->countHalfSPs*2+data->numObs,
-        data->numObs);
-    for(i=0; i<data->countHalfSPs*2; i++)
-    {
+    mSetZero(AT, data->countHalfSPs * 2 + data->numObs, data->numObs);
+    for (i = 0; i < data->countHalfSPs * 2; i++) {
         vScale(-1.0, yBar, data->numObs, tempYVec);
-        vAdd(tempYVec, data->numObs,
-             &(data->yMeas[(i+1)*data->numObs]), tempYVec);
-        if (data->wC[i+1] <0){return -1;}
-        vScale(sqrt(data->wC[i+1]), tempYVec, data->numObs, tempYVec);
-        memcpy(&(AT[i*data->numObs]), tempYVec,
-               data->numObs*sizeof(double));
+        vAdd(tempYVec, data->numObs, &(data->yMeas[(i + 1) * data->numObs]), tempYVec);
+        if (data->wC[i + 1] < 0) {
+            return -1;
+        }
+        vScale(sqrt(data->wC[i + 1]), tempYVec, data->numObs, tempYVec);
+        memcpy(&(AT[i * data->numObs]), tempYVec, data->numObs * sizeof(double));
     }
 
     /*! - This is the square-root of the Rk matrix which we treat as the Cholesky
@@ -522,23 +468,19 @@ int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
         of observations*/
     mSetZero(data->qObs, data->numCSSTotal, data->numCSSTotal);
     mSetIdentity(data->qObs, data->numObs, data->numObs);
-    mScale(data->qObsVal, data->qObs, data->numObs,
-           data->numObs, data->qObs);
-    ukfCholDecomp(data->qObs, (int32_t) data->numObs, (int32_t) data->numObs, qChol);
-    memcpy(&(AT[2*data->countHalfSPs*data->numObs]),
-           qChol, data->numObs*data->numObs*sizeof(double));
+    mScale(data->qObsVal, data->qObs, data->numObs, data->numObs, data->qObs);
+    ukfCholDecomp(data->qObs, (int32_t)data->numObs, (int32_t)data->numObs, qChol);
+    memcpy(&(AT[2 * data->countHalfSPs * data->numObs]), qChol, data->numObs * data->numObs * sizeof(double));
     /*! - Perform QR decomposition (only R again) of the above matrix to obtain the
           current Sy matrix*/
-    ukfQRDJustR(AT, (int32_t) (2*data->countHalfSPs+data->numObs),
-                (int32_t) data->numObs, rAT);
+    ukfQRDJustR(AT, (int32_t)(2 * data->countHalfSPs + data->numObs), (int32_t)data->numObs, rAT);
     mCopy(rAT, data->numObs, data->numObs, syT);
     mTranspose(syT, data->numObs, data->numObs, sy);
     /*! - Shift the matrix over by the difference between the 0th SP-based measurement
           model and the yBar matrix (cholesky down-date again)*/
     vScale(-1.0, yBar, data->numObs, tempYVec);
     vAdd(tempYVec, data->numObs, &(data->yMeas[0]), tempYVec);
-    badUpdate += ukfCholDownDate(sy, tempYVec, data->wC[0],
-                                 (int32_t) data->numObs, updMat);
+    badUpdate += ukfCholDownDate(sy, tempYVec, data->wC[0], (int32_t)data->numObs, updMat);
     /*! - Shifted matrix represents the Sy matrix */
     mCopy(updMat, data->numObs, data->numObs, sy);
     mTranspose(sy, data->numObs, data->numObs, syT);
@@ -546,16 +488,12 @@ int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
     /*! - Construct the Pxy matrix (equation 26) which multiplies the Sigma-point cloud
           by the measurement model cloud (weighted) to get the total Pxy matrix*/
     mSetZero(pXY, data->numStates, data->numObs);
-    for(i=0; i<2*data->countHalfSPs+1; i++)
-    {
+    for (i = 0; i < 2 * data->countHalfSPs + 1; i++) {
         vScale(-1.0, yBar, data->numObs, tempYVec);
-        vAdd(tempYVec, data->numObs,
-             &(data->yMeas[i*data->numObs]), tempYVec);
-        vSubtract(&(data->SP[i*data->numStates]), data->numStates,
-                  data->xBar, xHat);
+        vAdd(tempYVec, data->numObs, &(data->yMeas[i * data->numObs]), tempYVec);
+        vSubtract(&(data->SP[i * data->numStates]), data->numStates, data->xBar, xHat);
         vScale(data->wC[i], xHat, data->numStates, xHat);
-        mMultM(xHat, data->numStates, 1, tempYVec, 1, data->numObs,
-            kMat);
+        mMultM(xHat, data->numStates, 1, tempYVec, 1, data->numObs, kMat);
         mAdd(pXY, data->numStates, data->numObs, kMat, pXY);
     }
 
@@ -563,50 +501,39 @@ int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
           The Sy matrix is lower triangular, we can do a back-sub inversion instead of
           a full matrix inversion.  That is the ukfUInv and ukfLInv calls below.  Once that
           multiplication is done (equation 27), we have the Kalman Gain.*/
-    badUpdate += ukfUInv(syT, (int32_t) data->numObs, (int32_t) data->numObs, syInv);
+    badUpdate += ukfUInv(syT, (int32_t)data->numObs, (int32_t)data->numObs, syInv);
 
-    mMultM(pXY, data->numStates, data->numObs, syInv,
-           data->numObs, data->numObs, kMat);
-    badUpdate += ukfLInv(sy, (int32_t) data->numObs, (int32_t) data->numObs, syInv);
-    mMultM(kMat, data->numStates, data->numObs, syInv,
-           data->numObs, data->numObs, kMat);
-
+    mMultM(pXY, data->numStates, data->numObs, syInv, data->numObs, data->numObs, kMat);
+    badUpdate += ukfLInv(sy, (int32_t)data->numObs, (int32_t)data->numObs, syInv);
+    mMultM(kMat, data->numStates, data->numObs, syInv, data->numObs, data->numObs, kMat);
 
     /*! - Difference the yBar and the observations to get the observed error and
           multiply by the Kalman Gain to get the state update.  Add the state update
           to the state to get the updated state value (equation 27).*/
     vSubtract(data->obs, data->numObs, yBar, tempYVec);
-    mMultM(kMat, data->numStates, data->numObs, tempYVec,
-        data->numObs, 1, xHat);
+    mMultM(kMat, data->numStates, data->numObs, tempYVec, data->numObs, 1, xHat);
     vAdd(data->state, data->numStates, xHat, data->state);
     /*! - Compute the updated matrix U from equation 28.  Note that I then transpose it
          so that I can extract "columns" from adjacent memory*/
-    mMultM(kMat, data->numStates, data->numObs, sy,
-           data->numObs, data->numObs, Umat);
+    mMultM(kMat, data->numStates, data->numObs, sy, data->numObs, data->numObs, Umat);
     mTranspose(Umat, data->numStates, data->numObs, Umat);
     /*! - For each column in the update matrix, perform a cholesky down-date on it to
      get the total shifted S matrix (called sBar in internal parameters*/
-    for(i=0; i<data->numObs; i++)
-    {
-        vCopy(&(Umat[i*data->numStates]), data->numStates, Ucol);
-        badUpdate += ukfCholDownDate(data->sBar, Ucol, -1.0, (int32_t) data->numStates, sBarT);
-        mCopy(sBarT, data->numStates, data->numStates,
-              data->sBar);
+    for (i = 0; i < data->numObs; i++) {
+        vCopy(&(Umat[i * data->numStates]), data->numStates, Ucol);
+        badUpdate += ukfCholDownDate(data->sBar, Ucol, -1.0, (int32_t)data->numStates, sBarT);
+        mCopy(sBarT, data->numStates, data->numStates, data->sBar);
     }
     /*! - Compute equivalent covariance based on updated sBar matrix*/
-    mTranspose(data->sBar, data->numStates, data->numStates,
-               data->covar);
-    mMultM(data->sBar, data->numStates, data->numStates,
-           data->covar, data->numStates, data->numStates,
-           data->covar);
+    mTranspose(data->sBar, data->numStates, data->numStates, data->covar);
+    mMultM(data->sBar, data->numStates, data->numStates, data->covar, data->numStates, data->numStates, data->covar);
 
-    if (badUpdate<0){
+    if (badUpdate < 0) {
         sunlineSuKFCleanUpdate(data);
         return -1;
     }
     return 0;
 }
-
 
 /*! This method computes the dcms necessary for the switch between the two frames.
  It the switches the states and the covariance, and sets s2 to be the new, different vector of the body frame.
@@ -616,8 +543,7 @@ int sunlineSuKFMeasUpdate(SunlineSuKF *data, double updateTime)
  @param covar Pointer to the covariance
  */
 
-void sunlineSuKFSwitch(double *bVec_B, double *states, double *covar)
-{
+void sunlineSuKFSwitch(double *bVec_B, double *states, double *covar) {
     double dcm_BSold[SKF_N_STATES_HALF][SKF_N_STATES_HALF];
     double dcm_BSnew_T[SKF_N_STATES_HALF][SKF_N_STATES_HALF];
     double dcm_SnewSold[SKF_N_STATES_HALF][SKF_N_STATES_HALF];
@@ -636,13 +562,10 @@ void sunlineSuKFSwitch(double *bVec_B, double *states, double *covar)
     /*! Populate the dcm_BS with the "old" S-frame*/
     sunlineSuKFComputeDCM_BS(sun_heading_norm, bVec_B, &dcm_BSold[0][0]);
 
-    if (v3IsEqual(bVec_B, b1, 1e-10))
-    {
+    if (v3IsEqual(bVec_B, b1, 1e-10)) {
         sunlineSuKFComputeDCM_BS(sun_heading_norm, b2, &dcm_BSnew_T[0][0]);
         v3Copy(b2, bVec_B);
-    }
-    else
-    {
+    } else {
         sunlineSuKFComputeDCM_BS(sun_heading_norm, b1, &dcm_BSnew_T[0][0]);
         v3Copy(b1, bVec_B);
     }
@@ -655,14 +578,25 @@ void sunlineSuKFSwitch(double *bVec_B, double *states, double *covar)
     mSetSubMatrix(&dcm_SnewSold[2][1], 1, 2, &switchMat, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, 4, 3);
 
     mMultV(switchMat, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, states, states);
-    mMultM(switchMat, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, covar, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, switchMatP);
+    mMultM(switchMat,
+           SKF_N_STATES_SWITCH,
+           SKF_N_STATES_SWITCH,
+           covar,
+           SKF_N_STATES_SWITCH,
+           SKF_N_STATES_SWITCH,
+           switchMatP);
     mTranspose(switchMat, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, switchMat);
-    mMultM(switchMatP, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, switchMat, SKF_N_STATES_SWITCH, SKF_N_STATES_SWITCH, covar);
+    mMultM(switchMatP,
+           SKF_N_STATES_SWITCH,
+           SKF_N_STATES_SWITCH,
+           switchMat,
+           SKF_N_STATES_SWITCH,
+           SKF_N_STATES_SWITCH,
+           covar);
     return;
 }
 
-
-void sunlineSuKFComputeDCM_BS(double sunheading[SKF_N_STATES_HALF], double bVec[SKF_N_STATES_HALF], double *dcm){
+void sunlineSuKFComputeDCM_BS(double sunheading[SKF_N_STATES_HALF], double bVec[SKF_N_STATES_HALF], double *dcm) {
     double s1_B[SKF_N_STATES_HALF];
     double s2_B[SKF_N_STATES_HALF];
     double s3_B[SKF_N_STATES_HALF];
@@ -673,20 +607,18 @@ void sunlineSuKFComputeDCM_BS(double sunheading[SKF_N_STATES_HALF], double bVec[
 
     v3Normalize(sunheading, s1_B);
     v3Cross(sunheading, bVec, s2_B);
-    if (v3Norm(s2_B) < 1E-5){
+    if (v3Norm(s2_B) < 1E-5) {
         mSetIdentity(dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF);
+    } else {
+        v3Normalize(s2_B, s2_B);
+        /*! Populate the dcm_BS with the "new" S-frame*/
+        mSetSubMatrix(s1_B, 1, SKF_N_STATES_HALF, dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, 0, 0);
+        mSetSubMatrix(&(s2_B), 1, SKF_N_STATES_HALF, dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, 1, 0);
+        v3Cross(sunheading, s2_B, s3_B);
+        v3Normalize(s3_B, s3_B);
+        mSetSubMatrix(&(s3_B), 1, SKF_N_STATES_HALF, dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, 2, 0);
+        mTranspose(dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, dcm);
     }
-    else{
-    v3Normalize(s2_B, s2_B);
-    /*! Populate the dcm_BS with the "new" S-frame*/
-    mSetSubMatrix(s1_B, 1, SKF_N_STATES_HALF, dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, 0, 0);
-    mSetSubMatrix(&(s2_B), 1, SKF_N_STATES_HALF, dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, 1, 0);
-    v3Cross(sunheading, s2_B, s3_B);
-    v3Normalize(s3_B, s3_B);
-    mSetSubMatrix(&(s3_B), 1, SKF_N_STATES_HALF, dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, 2, 0);
-    mTranspose(dcm, SKF_N_STATES_HALF, SKF_N_STATES_HALF, dcm);
-    }
-
 }
 
 /*! This method cleans the filter states after a bad upadate on the fly.
@@ -695,7 +627,7 @@ void sunlineSuKFComputeDCM_BS(double sunheading[SKF_N_STATES_HALF], double bVec[
  @return void
  @param configData The configuration data associated with the CSS estimator
  */
-void sunlineSuKFCleanUpdate(SunlineSuKF *data){
+void sunlineSuKFCleanUpdate(SunlineSuKF *data) {
     int i;
     /*! - Reset the observations, state, and covariannces to a previous safe value*/
     vSetZero(data->obs, data->numObs);
@@ -704,14 +636,10 @@ void sunlineSuKFCleanUpdate(SunlineSuKF *data){
     mCopy(data->covarPrev, data->numStates, data->numStates, data->covar);
 
     /*! - Reset the wM/wC vectors to standard values for unscented kalman filters*/
-    data->wM[0] = data->lambdaVal / (data->numStates +
-                                                 data->lambdaVal);
-    data->wC[0] = data->lambdaVal / (data->numStates +
-                                                 data->lambdaVal) + (1 - data->alpha*data->alpha + data->beta);
-    for (i = 1; i< ((int)data->countHalfSPs) * 2 + 1; i++)
-    {
-        data->wM[i] = 1.0 / 2.0*1.0 / (data->numStates +
-                                             data->lambdaVal);
+    data->wM[0] = data->lambdaVal / (data->numStates + data->lambdaVal);
+    data->wC[0] = data->lambdaVal / (data->numStates + data->lambdaVal) + (1 - data->alpha * data->alpha + data->beta);
+    for (i = 1; i < ((int)data->countHalfSPs) * 2 + 1; i++) {
+        data->wM[i] = 1.0 / 2.0 * 1.0 / (data->numStates + data->lambdaVal);
         data->wC[i] = data->wM[i];
     }
 

--- a/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.cpp
@@ -20,7 +20,6 @@
 #include "fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.h"
 #include "architecture/utilities/ukfUtilities.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
 #include <math.h>


### PR DESCRIPTION
***Tickets addressed:** bsk-984
***Review:** By commit
***Merge strategy:** Merge (no squash) 

## Description
This PR adds the ability for the sunline filter to estimate a bias in the measurements due to the solar intensity being higher or lower than expected (closer or farther to the sun than 1 AU).
The first commit adds setters and getters in order to bound the bias estimate
The second commit checks if the optional bias state is present in the filter and uses it accordingly in the measurement model and other methods
Finally the unit test is modified to include this bias estimate
Last commits are minor clean up commits

## Verification
Unit test passes and integrated scenarios provide the desired results

## Documentation
Comments were modified and documentation updated

## Future work
None