### PR TITLE
Feature/394 port att tracking error to eigen

### DIFF
--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -15,34 +15,17 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-
-#
-#   Unit Test Script
-#   Module Name:        attTrackingError
-#   Author:             Hanspeter Schaub
-#   Creation Date:      January 15, 2016
-#
-
 import inspect
 import os
 
 import numpy as np
 
-# import packages as needed e.g. 'numpy', 'ctypes, 'math' etc.
-
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
-
-
-
-
-
-
-# Import all of the modules that we are going to be called in this simulation
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport              # general support file with common unit test functions
-from Basilisk.fswAlgorithms import attTrackingError                  # import the module that is to be tested
+from Basilisk.utilities import unitTestSupport
+from Basilisk.fswAlgorithms import attTrackingError
 from Basilisk.utilities import macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.architecture import messaging

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -36,11 +36,11 @@ def test_attTrackingError(show_plots):
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
     # Create instance of attTrackingError
-    module = attTrackingError.AttTrackingError()
-    module.modelTag = "attTrackingError"
-    unitTestSim.AddModelToTask(unitTaskName, module)
-    vector = [0.01, 0.05, -0.55]
-    module.sigma_R0R = vector
+    attitudeTrackingError = attTrackingError.AttTrackingError()
+    attitudeTrackingError.modelTag = "attTrackingError"
+    unitTestSim.AddModelToTask(unitTaskName, attitudeTrackingError)
+    sigma_R0R = [0.01, 0.05, -0.55]
+    attitudeTrackingError.sigma_R0R = sigma_R0R
 
     # Create navigation message
     NavStateOutData = messaging.NavAttMsgPayload()
@@ -61,12 +61,12 @@ def test_attTrackingError(show_plots):
     refInMsg = messaging.AttRefMsg().write(RefStateOutData)
 
     # Set up data logging
-    dataLog = module.attGuidOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    attGuidOutMsgLog = attitudeTrackingError.attGuidOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, attGuidOutMsgLog)
 
     # Connect messages
-    module.attNavInMsg.subscribeTo(navStateInMsg)
-    module.attRefInMsg.subscribeTo(refInMsg)
+    attitudeTrackingError.attNavInMsg.subscribeTo(navStateInMsg)
+    attitudeTrackingError.attRefInMsg.subscribeTo(refInMsg)
 
     # Run the simulation
     unitTestSim.InitializeSimulation()
@@ -74,46 +74,46 @@ def test_attTrackingError(show_plots):
     unitTestSim.ExecuteSimulation()
 
     # Check sigma_BR
-    moduleOutput = dataLog.sigma_BR[0]
+    sigma_BR = attGuidOutMsgLog.sigma_BR[0]
 
-    sigma_RN2 = rbk.addMRP(np.array(sigma_RN), -np.array(vector))
-    RN = rbk.MRP2C(sigma_RN2)
-    BN = rbk.MRP2C(np.array(sigma_BN))
-    BR = np.dot(BN, RN.T)
+    sigma_RN2 = rbk.addMRP(np.array(sigma_RN), -np.array(sigma_R0R))
+    dcm_RN = rbk.MRP2C(sigma_RN2)
+    dcm_BN = rbk.MRP2C(np.array(sigma_BN))
+    dcm_BR = np.dot(dcm_BN, dcm_RN.T)
 
     # Set the filtered output truth states
-    trueVector = rbk.C2MRP(BR)
+    sigma_BRTruth = rbk.C2MRP(dcm_BR)
 
-    # Compare the module results to the truth values
+    # Compare the attitudeTrackingError results to the truth values
     accuracy = 1e-12
-    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(sigma_BRTruth, sigma_BR, atol=accuracy, verbose=True)
 
     # Check omega_BR_B
-    moduleOutput = dataLog.omega_BR_B[0]
+    omega_BR_B = attGuidOutMsgLog.omega_BR_B[0]
 
     # Set the filtered output truth states
-    trueVector = np.array(omega_BN_B) - np.dot(BN, np.array(omega_RN_N))
+    omega_BR_BTruth = np.array(omega_BN_B) - np.dot(dcm_BN, np.array(omega_RN_N))
 
-    # Compare the module results to the truth values
-    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
+    # Compare the attitudeTrackingError results to the truth values
+    np.testing.assert_allclose(omega_BR_BTruth, omega_BR_B, atol=accuracy, verbose=True)
 
     # Check omega_RN_B
-    moduleOutput = dataLog.omega_RN_B[0]
+    omega_RN_B = attGuidOutMsgLog.omega_RN_B[0]
 
     # Set the filtered output truth states
-    trueVector = np.dot(BN, np.array(omega_RN_N))
+    omega_RN_BTruth = np.dot(dcm_BN, np.array(omega_RN_N))
 
-    # Compare the module results to the truth values
-    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
+    # Compare the attitudeTrackingError results to the truth values
+    np.testing.assert_allclose(omega_RN_BTruth, omega_RN_B, atol=accuracy, verbose=True)
 
     # Check domega_RN_B
-    moduleOutput = dataLog.domega_RN_B[0]
+    domega_RN_B = attGuidOutMsgLog.domega_RN_B[0]
 
     # Set the filtered output truth states
-    trueVector = np.dot(BN, np.array(domega_RN_N))
+    domega_RN_BTruth = np.dot(dcm_BN, np.array(domega_RN_N))
 
-    # Compare the module results to the truth values
-    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
+    # Compare the attitudeTrackingError results to the truth values
+    np.testing.assert_allclose(domega_RN_BTruth, domega_RN_B, atol=accuracy, verbose=True)
 
 
 if __name__ == "__main__":

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -23,7 +23,7 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.architecture import messaging
 
-def test_attTrackingError(show_plots):
+def test_attTrackingError():
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
 
@@ -98,4 +98,4 @@ def test_attTrackingError(show_plots):
 
 
 if __name__ == "__main__":
-    test_attTrackingError(False)
+    test_attTrackingError()

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -73,46 +73,27 @@ def test_attTrackingError(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(0.3))
     unitTestSim.ExecuteSimulation()
 
-    # Check sigma_BR
+    # Extract logged data
     sigma_BR = attGuidOutMsgLog.sigma_BR[0]
+    omega_BR_B = attGuidOutMsgLog.omega_BR_B[0]
+    omega_RN_B = attGuidOutMsgLog.omega_RN_B[0]
+    domega_RN_B = attGuidOutMsgLog.domega_RN_B[0]
 
+    # Compute truth values for test check
     sigma_RN2 = rbk.addMRP(np.array(sigma_RN), -np.array(sigma_R0R))
     dcm_RN = rbk.MRP2C(sigma_RN2)
     dcm_BN = rbk.MRP2C(np.array(sigma_BN))
     dcm_BR = np.dot(dcm_BN, dcm_RN.T)
-
-    # Set the filtered output truth states
     sigma_BRTruth = rbk.C2MRP(dcm_BR)
-
-    # Compare the attitudeTrackingError results to the truth values
-    accuracy = 1e-12
-    np.testing.assert_allclose(sigma_BRTruth, sigma_BR, atol=accuracy, verbose=True)
-
-    # Check omega_BR_B
-    omega_BR_B = attGuidOutMsgLog.omega_BR_B[0]
-
-    # Set the filtered output truth states
     omega_BR_BTruth = np.array(omega_BN_B) - np.dot(dcm_BN, np.array(omega_RN_N))
-
-    # Compare the attitudeTrackingError results to the truth values
-    np.testing.assert_allclose(omega_BR_BTruth, omega_BR_B, atol=accuracy, verbose=True)
-
-    # Check omega_RN_B
-    omega_RN_B = attGuidOutMsgLog.omega_RN_B[0]
-
-    # Set the filtered output truth states
     omega_RN_BTruth = np.dot(dcm_BN, np.array(omega_RN_N))
-
-    # Compare the attitudeTrackingError results to the truth values
-    np.testing.assert_allclose(omega_RN_BTruth, omega_RN_B, atol=accuracy, verbose=True)
-
-    # Check domega_RN_B
-    domega_RN_B = attGuidOutMsgLog.domega_RN_B[0]
-
-    # Set the filtered output truth states
     domega_RN_BTruth = np.dot(dcm_BN, np.array(domega_RN_N))
 
-    # Compare the attitudeTrackingError results to the truth values
+    # Check truth values with module output
+    accuracy = 1e-12
+    np.testing.assert_allclose(sigma_BRTruth, sigma_BR, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(omega_BR_BTruth, omega_BR_B, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(omega_RN_BTruth, omega_RN_B, atol=accuracy, verbose=True)
     np.testing.assert_allclose(domega_RN_BTruth, domega_RN_B, atol=accuracy, verbose=True)
 
 

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -15,36 +15,15 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import inspect
-import os
-
 import numpy as np
 
-filename = inspect.getframeinfo(inspect.currentframe()).filename
-path = os.path.dirname(os.path.abspath(filename))
-
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
 from Basilisk.fswAlgorithms import attTrackingError
 from Basilisk.utilities import macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.architecture import messaging
 
-# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
-# @pytest.mark.skipif(conditionstring)
-# uncomment this line if this test has an expected failure, adjust message as needed
-# @pytest.mark.xfail(conditionstring)
-# provide a unique test method name, starting with test_
 def test_attTrackingError(show_plots):
-    """Module Unit Test"""
-    # each test method requires a single assert method to be called
-    [testResults, testMessage] = subModuleTestFunction(show_plots)
-    assert testResults < 1, testMessage
-
-
-def subModuleTestFunction(show_plots):
-    testFailCount = 0                       # zero unit test result counter
-    testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
 
@@ -123,12 +102,9 @@ def subModuleTestFunction(show_plots):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    if not unitTestSupport.isArrayEqual(moduleOutput, trueVector, 3, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED: " + module.modelTag + " Module failed sigma_BR unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_sigBR", "FAILED", path)
-    else:
-        unitTestSupport.writeTeXSnippet("passFail_sigBR", "PASSED", path)
+    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
+
+
 
     #
     # check omega_BR_B
@@ -139,12 +115,7 @@ def subModuleTestFunction(show_plots):
     trueVector = np.array(omega_BN_B) - np.dot(BN, np.array(omega_RN_N))
 
     # compare the module results to the truth values
-    if not unitTestSupport.isArrayEqual(moduleOutput, trueVector, 3, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED: " + module.modelTag + " Module failed omega_BR_B unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_omega_BR_B", "FAILED", path)
-    else:
-        unitTestSupport.writeTeXSnippet("passFail_omega_BR_B", "PASSED", path)
+    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
     #
     # check omega_RN_B
@@ -155,12 +126,7 @@ def subModuleTestFunction(show_plots):
     trueVector = np.dot(BN, np.array(omega_RN_N))
 
     # compare the module results to the truth values
-    if not unitTestSupport.isArrayEqual(moduleOutput,trueVector,3,accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED: " + module.modelTag + " Module failed omega_RN_N unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_omega_RN_B", "FAILED", path)
-    else:
-        unitTestSupport.writeTeXSnippet("passFail_omega_RN_B", "PASSED", path)
+    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
     #
     # check domega_RN_B
@@ -171,26 +137,12 @@ def subModuleTestFunction(show_plots):
     trueVector = np.dot(BN, np.array(domega_RN_N))
 
     # compare the module results to the truth values
-    if not unitTestSupport.isArrayEqual(moduleOutput,trueVector,3,accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED: " + module.modelTag + " Module failed domega_RN_B unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_domega_RN_B", "FAILED", path)
-    else:
-        unitTestSupport.writeTeXSnippet("passFail_domega_RN_B", "PASSED", path)
+    np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
     # Note that we can continue to step the simulation however we feel like.
     # Just because we stop and query data does not mean everything has to stop for good
     unitTestSim.ConfigureStopTime(macros.sec2nano(0.6))    # run an additional 0.6 seconds
     unitTestSim.ExecuteSimulation()
-
-    if testFailCount == 0:
-        print("PASSED: " + "attTrackingError test")
-    else:
-        print(testMessages)
-
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
-    return [testFailCount, ''.join(testMessages)]
 
 
 #

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -24,42 +24,34 @@ from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.architecture import messaging
 
 def test_attTrackingError(show_plots):
-    unitTaskName = "unitTask"               # arbitrary name (don't change)
-    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.5)     # update process rate update time
+    testProcessRate = macros.sec2nano(0.5)
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
-
-    # Construct algorithm and associated C++ container
+    # Create instance of attTrackingError
     module = attTrackingError.AttTrackingError()
     module.modelTag = "attTrackingError"
-
-    # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, module)
-
     vector = [0.01, 0.05, -0.55]
     module.sigma_R0R = vector
 
-    #
-    # Navigation Message
-    #
-    NavStateOutData = messaging.NavAttMsgPayload()  # Create a structure for the input message
+    # Create navigation message
+    NavStateOutData = messaging.NavAttMsgPayload()
     sigma_BN = [0.25, -0.45, 0.75]
     NavStateOutData.sigma_BN = sigma_BN
     omega_BN_B = [-0.015, -0.012, 0.005]
     NavStateOutData.omega_BN_B = omega_BN_B
     navStateInMsg = messaging.NavAttMsg().write(NavStateOutData)
 
-    #
-    # Reference Frame Message
-    #
-    RefStateOutData = messaging.AttRefMsgPayload()  # Create a structure for the input message
+    # Create reference frame message
+    RefStateOutData = messaging.AttRefMsgPayload()
     sigma_RN = [0.35, -0.25, 0.15]
     RefStateOutData.sigma_RN = sigma_RN
     omega_RN_N = [0.018, -0.032, 0.015]
@@ -68,86 +60,61 @@ def test_attTrackingError(show_plots):
     RefStateOutData.domega_RN_N = domega_RN_N
     refInMsg = messaging.AttRefMsg().write(RefStateOutData)
 
-    # Setup logging on the test module output message so that we get all the writes to it
+    # Set up data logging
     dataLog = module.attGuidOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    # connect messages
+    # Connect messages
     module.attNavInMsg.subscribeTo(navStateInMsg)
     module.attRefInMsg.subscribeTo(refInMsg)
 
-    # Need to call the self-init and cross-init methods
+    # Run the simulation
     unitTestSim.InitializeSimulation()
-
-    # Set the simulation time.
-    # NOTE: the total simulation time may be longer than this value. The
-    # simulation is stopped at the next logging event on or after the
-    # simulation end time.
-    unitTestSim.ConfigureStopTime(macros.sec2nano(0.3))        # seconds to stop simulation
-
-    # Begin the simulation time run set above
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.3))
     unitTestSim.ExecuteSimulation()
 
-    #
-    # check sigma_BR
-    #
+    # Check sigma_BR
     moduleOutput = dataLog.sigma_BR[0]
 
     sigma_RN2 = rbk.addMRP(np.array(sigma_RN), -np.array(vector))
     RN = rbk.MRP2C(sigma_RN2)
     BN = rbk.MRP2C(np.array(sigma_BN))
     BR = np.dot(BN, RN.T)
-    # set the filtered output truth states
+
+    # Set the filtered output truth states
     trueVector = rbk.C2MRP(BR)
 
-    # compare the module results to the truth values
+    # Compare the module results to the truth values
     accuracy = 1e-12
     np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
-
-
-    #
-    # check omega_BR_B
-    #
+    # Check omega_BR_B
     moduleOutput = dataLog.omega_BR_B[0]
 
-    # set the filtered output truth states
+    # Set the filtered output truth states
     trueVector = np.array(omega_BN_B) - np.dot(BN, np.array(omega_RN_N))
 
-    # compare the module results to the truth values
+    # Compare the module results to the truth values
     np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
-    #
-    # check omega_RN_B
-    #
+    # Check omega_RN_B
     moduleOutput = dataLog.omega_RN_B[0]
 
-    # set the filtered output truth states
+    # Set the filtered output truth states
     trueVector = np.dot(BN, np.array(omega_RN_N))
 
-    # compare the module results to the truth values
+    # Compare the module results to the truth values
     np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
-    #
-    # check domega_RN_B
-    #
+    # Check domega_RN_B
     moduleOutput = dataLog.domega_RN_B[0]
 
-    # set the filtered output truth states
+    # Set the filtered output truth states
     trueVector = np.dot(BN, np.array(domega_RN_N))
 
-    # compare the module results to the truth values
+    # Compare the module results to the truth values
     np.testing.assert_allclose(trueVector, moduleOutput, atol=accuracy, verbose=True)
 
-    # Note that we can continue to step the simulation however we feel like.
-    # Just because we stop and query data does not mean everything has to stop for good
-    unitTestSim.ConfigureStopTime(macros.sec2nano(0.6))    # run an additional 0.6 seconds
-    unitTestSim.ExecuteSimulation()
 
-
-#
-# This statement below ensures that the unitTestScript can be run as a
-# stand-along python script
-#
 if __name__ == "__main__":
     test_attTrackingError(False)

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -40,7 +40,7 @@ def test_attTrackingError():
     attitudeTrackingError.modelTag = "attTrackingError"
     unitTestSim.AddModelToTask(unitTaskName, attitudeTrackingError)
     sigma_R0R = [0.01, 0.05, -0.55]
-    attitudeTrackingError.sigma_R0R = sigma_R0R
+    attitudeTrackingError.setSigma_R0R(sigma_R0R)
 
     # Create navigation message
     NavStateOutData = messaging.NavAttMsgPayload()

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -16,8 +16,10 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <string.h>
 #include "fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h"
+
+#include <string.h>
+
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 
@@ -31,32 +33,34 @@
 void computeAttitudeError(double sigma_R0R[3],
                           NavAttMsgPayload nav,
                           AttRefMsgPayload ref,
-                          AttGuidMsgPayload *attGuidOut){
-    double      sigma_RR0[3];               /* MRP from the original reference frame R0 to the corrected reference frame R */
-    double      sigma_RN[3];                /* MRP from inertial to updated reference frame */
-    double      dcm_BN[3][3];               /* DCM from inertial to body frame */
+                          AttGuidMsgPayload *attGuidOut) {
+    double sigma_RR0[3]; /* MRP from the original reference frame R0 to the corrected reference frame R */
+    double sigma_RN[3];  /* MRP from inertial to updated reference frame */
+    double dcm_BN[3][3]; /* DCM from inertial to body frame */
 
     /*! - compute the initial reference frame orientation that takes the corrected body frame into account */
     v3Scale(-1.0, sigma_R0R, sigma_RR0);
     addMRP(ref.sigma_RN, sigma_RR0, sigma_RN);
 
-    subMRP(nav.sigma_BN, sigma_RN, attGuidOut->sigma_BR);               /*! - compute attitude error */
+    subMRP(nav.sigma_BN, sigma_RN, attGuidOut->sigma_BR); /*! - compute attitude error */
 
-    MRP2C(nav.sigma_BN, dcm_BN);                                /* [BN] */
-    m33MultV3(dcm_BN, ref.omega_RN_N, attGuidOut->omega_RN_B);              /*! - compute reference omega in body frame components */
+    MRP2C(nav.sigma_BN, dcm_BN);                               /* [BN] */
+    m33MultV3(dcm_BN, ref.omega_RN_N, attGuidOut->omega_RN_B); /*! - compute reference omega in body frame components */
 
-    v3Subtract(nav.omega_BN_B, attGuidOut->omega_RN_B, attGuidOut->omega_BR_B);     /*! - delta_omega = omega_B - [BR].omega.r */
+    v3Subtract(
+        nav.omega_BN_B, attGuidOut->omega_RN_B, attGuidOut->omega_BR_B); /*! - delta_omega = omega_B - [BR].omega.r */
 
-    m33MultV3(dcm_BN, ref.domega_RN_N, attGuidOut->domega_RN_B);            /*! - compute reference d(omega)/dt in body frame components */
-
+    m33MultV3(dcm_BN,
+              ref.domega_RN_N,
+              attGuidOut->domega_RN_B); /*! - compute reference d(omega)/dt in body frame components */
 }
 
-/*! This method performs a complete reset of the module. Local module variables that retain time varying states between function calls are reset to their default values.
+/*! This method performs a complete reset of the module. Local module variables that retain time varying states between
+ function calls are reset to their default values.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void AttTrackingError::reset(uint64_t callTime)
-{
+void AttTrackingError::reset(uint64_t callTime) {
     // check if the required input messages are included
     if (!this->attRefInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: attTrackingError.attRefInMsg wasn't connected.");
@@ -68,15 +72,16 @@ void AttTrackingError::reset(uint64_t callTime)
     return;
 }
 
-/*! The Update method performs reads the Navigation message (containing the spacecraft attitude information), and the Reference message (containing the desired attitude). It computes the attitude error and writes it in the Guidance message.
+/*! The Update method performs reads the Navigation message (containing the spacecraft attitude information), and the
+ Reference message (containing the desired attitude). It computes the attitude error and writes it in the Guidance
+ message.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void AttTrackingError::updateState(uint64_t callTime)
-{
-    AttRefMsgPayload ref;                      /* reference guidance message */
-    NavAttMsgPayload nav;                      /* navigation message */
-    AttGuidMsgPayload attGuidOut = {};              /* Guidance message */
+void AttTrackingError::updateState(uint64_t callTime) {
+    AttRefMsgPayload ref;              /* reference guidance message */
+    NavAttMsgPayload nav;              /* navigation message */
+    AttGuidMsgPayload attGuidOut = {}; /* Guidance message */
 
     ref = this->attRefInMsg();
     nav = this->attNavInMsg();

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -22,7 +22,7 @@
 
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/rigidBodyKinematics.hpp"
 
 /*! This method performs the attitude computations in order to extract the error.
  @return void

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -94,3 +94,14 @@ void AttTrackingError::updateState(uint64_t callTime) {
     computeAttitudeError(this->sigma_R0R, nav, ref, &attGuidOut);
     this->attGuidOutMsg.write(&attGuidOut, this->moduleID, callTime);
 }
+
+/*! Setter method for sigma_R0R.
+ @return void
+ @param sigma_R0R
+*/
+void AttTrackingError::setSigma_R0R(const Eigen::Vector3d &sigma_R0R) { this->sigma_R0R = sigma_R0R; }
+
+/*! Getter method for sigma_R0R.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d &AttTrackingError::getSigma_R0R() const { return this->sigma_R0R; }

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -35,31 +35,34 @@ void AttTrackingError::computeAttitudeError(Eigen::Vector3d sigma_R0R,
                                             NavAttMsgPayload nav,
                                             AttRefMsgPayload ref,
                                             AttGuidMsgPayload *attGuidOut) {
-    Eigen::Vector3d sigma_RR0; /* MRP from the original reference frame R0 to the corrected reference frame R */
-    Eigen::Vector3d sigma_RN;  /* MRP from inertial to updated reference frame */
-    Eigen::Matrix3d dcm_BN;    /* DCM from inertial to body frame */
+    // Compute MRP from the original reference frame R0 to the corrected reference frame R
+    Eigen::Vector3d sigma_RR0 = -1 * sigma_R0R;
 
-    /*! - compute the initial reference frame orientation that takes the corrected body frame into account */
-    sigma_RR0 = -1 * sigma_R0R;
-
-    sigma_RN = cArray2EigenVector3d(ref.sigma_RN);
+    // Compute MRP from inertial to updated reference frame sigma_RN
+    Eigen::Vector3d sigma_RN = cArray2EigenVector3d(ref.sigma_RN);
     sigma_RN = addMrp(sigma_RN, sigma_RR0);
 
+    // Compute attitude error sigma_BR
     Eigen::Vector3d sigma_BN = cArray2EigenVector3d(nav.sigma_BN);
-    Eigen::Vector3d sigma_BR = subMrp(sigma_BN, sigma_RN); /*! - compute attitude error */
-    eigenVector3d2CArray(sigma_BR, attGuidOut->sigma_BR);
+    Eigen::Vector3d sigma_BR = subMrp(sigma_BN, sigma_RN);
 
-    dcm_BN = mrpToDcm(sigma_BN); /* [BN] */
+    // Compute angular velocity reference body frame components omega_RN_B
+    Eigen::Matrix3d dcm_BN = mrpToDcm(sigma_BN);
     Eigen::Vector3d omega_RN_N = cArray2EigenVector3d(ref.omega_RN_N);
-    Eigen::Vector3d omega_RN_B = dcm_BN * omega_RN_N; /*! - compute reference omega in body frame components */
-    eigenVector3d2CArray(omega_RN_B, attGuidOut->omega_RN_B);
+    Eigen::Vector3d omega_RN_B = dcm_BN * omega_RN_N;
 
+    // Compute angular velocity error omega_BR
     Eigen::Vector3d omega_BN_B = cArray2EigenVector3d(nav.omega_BN_B);
-    Eigen::Vector3d omega_BR_B = omega_BN_B - omega_RN_B; /*! - delta_omega = omega_B - [BR].omega.r */
-    eigenVector3d2CArray(omega_BR_B, attGuidOut->omega_BR_B);
+    Eigen::Vector3d omega_BR_B = omega_BN_B - omega_RN_B;
 
+    // Compute reference angular velocity rate in body frame components domega_RN_B
     Eigen::Vector3d domega_RN_N = cArray2EigenVector3d(ref.domega_RN_N);
-    Eigen::Vector3d domega_RN_B = dcm_BN * domega_RN_N; /*! - compute reference d(omega)/dt in body frame components */
+    Eigen::Vector3d domega_RN_B = dcm_BN * domega_RN_N;
+
+    // Write attitude guidance output message
+    eigenVector3d2CArray(omega_RN_B, attGuidOut->omega_RN_B);
+    eigenVector3d2CArray(omega_BR_B, attGuidOut->omega_BR_B);
+    eigenVector3d2CArray(sigma_BR, attGuidOut->sigma_BR);
     eigenVector3d2CArray(domega_RN_B, attGuidOut->domega_RN_B);
 }
 
@@ -87,15 +90,12 @@ void AttTrackingError::reset(uint64_t callTime) {
  @param callTime The clock time at which the function was called (nanoseconds)
  */
 void AttTrackingError::updateState(uint64_t callTime) {
-    AttRefMsgPayload ref;              /* reference guidance message */
-    NavAttMsgPayload nav;              /* navigation message */
-    AttGuidMsgPayload attGuidOut = {}; /* Guidance message */
+    AttRefMsgPayload ref = this->attRefInMsg();
 
-    ref = this->attRefInMsg();
-    nav = this->attNavInMsg();
+    NavAttMsgPayload nav = this->attNavInMsg();
 
+    AttGuidMsgPayload attGuidOut{};  // Guidance message
     computeAttitudeError(this->sigma_R0R, nav, ref, &attGuidOut);
-
     this->attGuidOutMsg.write(&attGuidOut, this->moduleID, callTime);
 
     return;

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -20,6 +20,7 @@
 
 #include <string.h>
 
+#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -18,8 +18,6 @@
 
 #include "fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h"
 
-#include <string.h>
-
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
@@ -79,8 +77,6 @@ void AttTrackingError::reset(uint64_t callTime) {
     if (!this->attNavInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: attTrackingError.attNavInMsg wasn't connected.");
     }
-
-    return;
 }
 
 /*! The Update method performs reads the Navigation message (containing the spacecraft attitude information), and the
@@ -97,6 +93,4 @@ void AttTrackingError::updateState(uint64_t callTime) {
     AttGuidMsgPayload attGuidOut{};  // Guidance message
     computeAttitudeError(this->sigma_R0R, nav, ref, &attGuidOut);
     this->attGuidOutMsg.write(&attGuidOut, this->moduleID, callTime);
-
-    return;
 }

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -31,29 +31,36 @@
  @param ref The reference attitude
  @param attGuidOut Output attitude guidance message
  */
-void computeAttitudeError(double sigma_R0R[3],
-                          NavAttMsgPayload nav,
-                          AttRefMsgPayload ref,
-                          AttGuidMsgPayload *attGuidOut) {
-    double sigma_RR0[3]; /* MRP from the original reference frame R0 to the corrected reference frame R */
-    double sigma_RN[3];  /* MRP from inertial to updated reference frame */
-    double dcm_BN[3][3]; /* DCM from inertial to body frame */
+void AttTrackingError::computeAttitudeError(Eigen::Vector3d sigma_R0R,
+                                            NavAttMsgPayload nav,
+                                            AttRefMsgPayload ref,
+                                            AttGuidMsgPayload *attGuidOut) {
+    Eigen::Vector3d sigma_RR0; /* MRP from the original reference frame R0 to the corrected reference frame R */
+    Eigen::Vector3d sigma_RN;  /* MRP from inertial to updated reference frame */
+    Eigen::Matrix3d dcm_BN;    /* DCM from inertial to body frame */
 
     /*! - compute the initial reference frame orientation that takes the corrected body frame into account */
-    v3Scale(-1.0, sigma_R0R, sigma_RR0);
-    addMRP(ref.sigma_RN, sigma_RR0, sigma_RN);
+    sigma_RR0 = -1 * sigma_R0R;
 
-    subMRP(nav.sigma_BN, sigma_RN, attGuidOut->sigma_BR); /*! - compute attitude error */
+    sigma_RN = cArray2EigenVector3d(ref.sigma_RN);
+    sigma_RN = addMrp(sigma_RN, sigma_RR0);
 
-    MRP2C(nav.sigma_BN, dcm_BN);                               /* [BN] */
-    m33MultV3(dcm_BN, ref.omega_RN_N, attGuidOut->omega_RN_B); /*! - compute reference omega in body frame components */
+    Eigen::Vector3d sigma_BN = cArray2EigenVector3d(nav.sigma_BN);
+    Eigen::Vector3d sigma_BR = subMrp(sigma_BN, sigma_RN); /*! - compute attitude error */
+    eigenVector3d2CArray(sigma_BR, attGuidOut->sigma_BR);
 
-    v3Subtract(
-        nav.omega_BN_B, attGuidOut->omega_RN_B, attGuidOut->omega_BR_B); /*! - delta_omega = omega_B - [BR].omega.r */
+    dcm_BN = mrpToDcm(sigma_BN); /* [BN] */
+    Eigen::Vector3d omega_RN_N = cArray2EigenVector3d(ref.omega_RN_N);
+    Eigen::Vector3d omega_RN_B = dcm_BN * omega_RN_N; /*! - compute reference omega in body frame components */
+    eigenVector3d2CArray(omega_RN_B, attGuidOut->omega_RN_B);
 
-    m33MultV3(dcm_BN,
-              ref.domega_RN_N,
-              attGuidOut->domega_RN_B); /*! - compute reference d(omega)/dt in body frame components */
+    Eigen::Vector3d omega_BN_B = cArray2EigenVector3d(nav.omega_BN_B);
+    Eigen::Vector3d omega_BR_B = omega_BN_B - omega_RN_B; /*! - delta_omega = omega_B - [BR].omega.r */
+    eigenVector3d2CArray(omega_BR_B, attGuidOut->omega_BR_B);
+
+    Eigen::Vector3d domega_RN_N = cArray2EigenVector3d(ref.domega_RN_N);
+    Eigen::Vector3d domega_RN_B = dcm_BN * domega_RN_N; /*! - compute reference d(omega)/dt in body frame components */
+    eigenVector3d2CArray(domega_RN_B, attGuidOut->domega_RN_B);
 }
 
 /*! This method performs a complete reset of the module. Local module variables that retain time varying states between

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
@@ -44,6 +44,8 @@ class AttTrackingError : public SysModel {
                               NavAttMsgPayload nav,
                               AttRefMsgPayload ref,
                               AttGuidMsgPayload *attGuidOut);
+    void setSigma_R0R(const Eigen::Vector3d &sigma_R0R);
+    const Eigen::Vector3d &getSigma_R0R() const;
 
     Message<AttGuidMsgPayload> attGuidOutMsg;   //!< Output attitude guidance message
     ReadFunctor<NavAttMsgPayload> attNavInMsg;  //!< Input msg measured attitude

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include <Eigen/Dense>
+
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
@@ -20,29 +20,29 @@
 #ifndef _ATT_TRACKING_ERROR_
 #define _ATT_TRACKING_ERROR_
 
+#include <stdint.h>
+
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
-#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
-
-#include <stdint.h>
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 
-
-
-/*!@brief Data structure for module to compute the attitude tracking error between the spacecraft attitude and the reference.
+/*!@brief Data structure for module to compute the attitude tracking error between the spacecraft attitude and the
+ * reference.
  */
 class AttTrackingError : public SysModel {
-public:
+   public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 
-    double sigma_R0R[3];                        //!< MRP from corrected reference frame to original reference frame R0. This is the same as [BcB] going from primary body frame B to the corrected body frame Bc
-    Message<AttGuidMsgPayload> attGuidOutMsg;              //!< output msg of attitude guidance
-    ReadFunctor<NavAttMsgPayload> attNavInMsg;                 //!< input msg measured attitude
-    ReadFunctor<AttRefMsgPayload> attRefInMsg;                 //!< input msg of reference attitude
-    BSKLogger bskLogger={};                       //!< BSK Logging
+    double sigma_R0R[3];  //!< MRP from corrected reference frame to original reference frame R0. This is the same as
+                          //!< [BcB] going from primary body frame B to the corrected body frame Bc
+    Message<AttGuidMsgPayload> attGuidOutMsg;   //!< output msg of attitude guidance
+    ReadFunctor<NavAttMsgPayload> attNavInMsg;  //!< input msg measured attitude
+    ReadFunctor<AttRefMsgPayload> attRefInMsg;  //!< input msg of reference attitude
+    BSKLogger bskLogger = {};                   //!< BSK Logging
 };
 
 #endif

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
@@ -36,6 +36,8 @@
  */
 class AttTrackingError : public SysModel {
    public:
+    AttTrackingError() = default;   //!< Constructor
+    ~AttTrackingError() = default;  //!< Destructor
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
     void computeAttitudeError(Eigen::Vector3d sigma_R0R,
@@ -43,12 +45,14 @@ class AttTrackingError : public SysModel {
                               AttRefMsgPayload ref,
                               AttGuidMsgPayload *attGuidOut);
 
-    Eigen::Vector3d sigma_R0R;  //!< MRP from corrected reference frame to original reference frame R0. This is the same
-                                //!< as [BcB] going from primary body frame B to the corrected body frame Bc
-    Message<AttGuidMsgPayload> attGuidOutMsg;   //!< output msg of attitude guidance
-    ReadFunctor<NavAttMsgPayload> attNavInMsg;  //!< input msg measured attitude
-    ReadFunctor<AttRefMsgPayload> attRefInMsg;  //!< input msg of reference attitude
+    Message<AttGuidMsgPayload> attGuidOutMsg;   //!< Output attitude guidance message
+    ReadFunctor<NavAttMsgPayload> attNavInMsg;  //!< Input msg measured attitude
+    ReadFunctor<AttRefMsgPayload> attRefInMsg;  //!< Input msg of reference attitude
     BSKLogger bskLogger = {};                   //!< BSK Logging
+
+   private:
+    Eigen::Vector3d sigma_R0R{};  //!< MRP from corrected reference frame to original reference frame R0. This is the
+                                  //!< same as [BcB] going from primary body frame B to the corrected body frame Bc
 };
 
 #endif

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
@@ -38,9 +38,13 @@ class AttTrackingError : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
+    void computeAttitudeError(Eigen::Vector3d sigma_R0R,
+                              NavAttMsgPayload nav,
+                              AttRefMsgPayload ref,
+                              AttGuidMsgPayload *attGuidOut);
 
-    double sigma_R0R[3];  //!< MRP from corrected reference frame to original reference frame R0. This is the same as
-                          //!< [BcB] going from primary body frame B to the corrected body frame Bc
+    Eigen::Vector3d sigma_R0R;  //!< MRP from corrected reference frame to original reference frame R0. This is the same
+                                //!< as [BcB] going from primary body frame B to the corrected body frame Bc
     Message<AttGuidMsgPayload> attGuidOutMsg;   //!< output msg of attitude guidance
     ReadFunctor<NavAttMsgPayload> attNavInMsg;  //!< input msg measured attitude
     ReadFunctor<AttRefMsgPayload> attRefInMsg;  //!< input msg of reference attitude

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.i
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.i
@@ -27,6 +27,7 @@
 
 %include "sys_model.i"
 %include "swig_conly_data.i"
+%include "swig_eigen.i"
 
 %include "attTrackingError.h"
 


### PR DESCRIPTION
* **Tickets addressed:** #394 
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
This PR ports the `attTrackingError` module to Eigen. After pre-commit changes are added to the module, the module is first blindly converted to Eigen. The module and associated unit test are then cleaned up and formatting is improved. The testing is replaced with `numpy.testing`.

## Verification
The module unit test is checked to pass with these changes.

## Documentation
N/A

## Future work
N/A