### PR TITLE
Feature/389 add platform angular velocity to star tracker output messages

### DIFF
--- a/src/architecture/msgPayloadDefC/STAttMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/STAttMsgPayload.h
@@ -20,12 +20,11 @@
 #ifndef ST_ATTITUDE_MESSAGE_H
 #define ST_ATTITUDE_MESSAGE_H
 
-
 /*! @brief Output structure for ST attitude measurement in vehicle body frame*/
 typedef struct {
-    uint64_t timeTag;           //!< [ns] Vehicle time code associated with measurement
-    double MRP_BdyInrtl[3];     //!< [-] MRP estimate of inertial to body transformation
-}STAttMsgPayload;
-
+    uint64_t timeTag;        //!< [ns] Vehicle time code associated with measurement
+    double MRP_BdyInrtl[3];  //!< [-] MRP estimate of inertial to body transformation
+    double omega_BN_B[3];    //!< [rad/s] Platform inertial angular velocity
+} STAttMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDefC/STSensorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/STSensorMsgPayload.h
@@ -21,12 +21,11 @@
 #define _ST_HW_OUTPUT_
 #include <stdint.h>
 
-
-/*! @brief Output structure for ST structure in vehicle body frame*/
+/*! @brief Star tracker sensor message */
 typedef struct {
-    uint64_t timeTag;               //!< [ns] Time tag placed on the output state
-    double qInrtl2Case[4];          //!< [-] Quaternion to go from the inertial to case
-}STSensorMsgPayload;
-
+    uint64_t timeTag;       //!< [ns] Time tag placed on the output state
+    double qInrtl2Case[4];  //!< [-] Quaternion to go from the inertial to case
+    double omega_CN_C[3];   //!< [rad/s] Inertial angular velocity in case frame
+} STSensorMsgPayload;
 
 #endif

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -126,6 +126,14 @@ in order to save an unnecessary conversion between types.
 Eigen::Vector3d cArray2EigenVector3d(double *inArray) { return Eigen::Map<Eigen::Vector3d>(inArray, 3, 1); }
 
 /*! This function performs the conversion between an input C array
+4-vector and an output Eigen vector4d. This function is provided
+in order to save an unnecessary conversion between types.
+@return Eigen::Vector4d
+@param inArray The input array (row-major)
+*/
+Eigen::Vector4d cArray2EigenVector4d(double *inArray) { return Eigen::Map<Eigen::Vector4d>(inArray, 4, 1); }
+
+/*! This function performs the conversion between an input C array
 3-vector and an output Eigen MRPd. This function is provided
 in order to save an unnecessary conversion between types.
 @return Eigen::MRPd

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -17,11 +17,14 @@
 
  */
 
-#include <iostream>
-#include <math.h>
 #include "avsEigenSupport.h"
-#include "rigidBodyKinematics.h"
+
+#include <math.h>
+
+#include <iostream>
+
 #include "architecture/utilities/macroDefinitions.h"
+#include "rigidBodyKinematics.h"
 
 /*
 
@@ -37,10 +40,9 @@ in a lot of cases.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array (sized by the user!) we copy into
 */
-void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray)
-{
-	Eigen::MatrixXd tempMat = inMat.transpose();
-	memcpy(outArray, tempMat.data(), inMat.rows()*inMat.cols()*sizeof(double));
+void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray) {
+    Eigen::MatrixXd tempMat = inMat.transpose();
+    memcpy(outArray, tempMat.data(), inMat.rows() * inMat.cols() * sizeof(double));
 }
 
 /*! This function provides a general conversion between an Eigen matrix and
@@ -51,10 +53,9 @@ in a lot of cases.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array (sized by the user!) we copy into
 */
-void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray)
-{
+void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray) {
     Eigen::MatrixXi tempMat = inMat.transpose();
-    memcpy(outArray, tempMat.data(), inMat.rows()*inMat.cols()*sizeof(int));
+    memcpy(outArray, tempMat.data(), inMat.rows() * inMat.cols() * sizeof(int));
 }
 
 /*! This function provides a direct conversion between a 3-vector and an
@@ -64,9 +65,8 @@ and the transpose that would have been performed by the general case.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array we copy into
 */
-void eigenVector3d2CArray(Eigen::Vector3d & inMat, double *outArray)
-{
-	memcpy(outArray, inMat.data(), 3 * sizeof(double));
+void eigenVector3d2CArray(Eigen::Vector3d &inMat, double *outArray) {
+    memcpy(outArray, inMat.data(), 3 * sizeof(double));
 }
 
 /*! This function provides a direct conversion between an MRP and an
@@ -76,10 +76,7 @@ and the transpose that would have been performed by the general case.
 @param inMat The source Eigen MRP that we are converting
 @param outArray The destination array we copy into
 */
-void eigenMRPd2CArray(Eigen::Vector3d& inMat, double* outArray)
-{
-    memcpy(outArray, inMat.data(), 3 * sizeof(double));
-}
+void eigenMRPd2CArray(Eigen::Vector3d &inMat, double *outArray) { memcpy(outArray, inMat.data(), 3 * sizeof(double)); }
 
 /*! This function provides a direct conversion between a 3x3 matrix and an
 output C array. We are providing this function to save on the inline conversion
@@ -88,10 +85,9 @@ that would have been performed by the general case.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array we copy into
 */
-void eigenMatrix3d2CArray(Eigen::Matrix3d & inMat, double *outArray)
-{
-	Eigen::MatrixXd tempMat = inMat.transpose();
-	memcpy(outArray, tempMat.data(), 9 * sizeof(double));
+void eigenMatrix3d2CArray(Eigen::Matrix3d &inMat, double *outArray) {
+    Eigen::MatrixXd tempMat = inMat.transpose();
+    memcpy(outArray, tempMat.data(), 9 * sizeof(double));
 }
 
 /*! This function performs the general conversion between an input C array
@@ -103,11 +99,10 @@ information to ingest the C array.
 @param nRows
 @param nCols
 */
-Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols)
-{
+Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols) {
     Eigen::MatrixXd outMat;
     outMat.resize(nRows, nCols);
-	outMat = Eigen::Map<Eigen::MatrixXd>(inArray, outMat.rows(), outMat.cols());
+    outMat = Eigen::Map<Eigen::MatrixXd>(inArray, outMat.rows(), outMat.cols());
     return outMat;
 }
 
@@ -117,10 +112,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::Vector3d
 @param inArray The input array (row-major)
 */
-Eigen::Vector3d cArray2EigenVector3d(double *inArray)
-{
-    return Eigen::Map<Eigen::Vector3d>(inArray, 3, 1);
-}
+Eigen::Vector3d cArray2EigenVector3d(double *inArray) { return Eigen::Map<Eigen::Vector3d>(inArray, 3, 1); }
 
 /*! This function performs the conversion between an input C array
 3-vector and an output Eigen MRPd. This function is provided
@@ -128,8 +120,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::MRPd
 @param inArray The input array (row-major)
 */
-Eigen::MRPd cArray2EigenMRPd(double* inArray)
-{
+Eigen::MRPd cArray2EigenMRPd(double *inArray) {
     Eigen::MRPd sigma_Eigen;
     sigma_Eigen = cArray2EigenVector3d(inArray);
 
@@ -142,19 +133,15 @@ in order to save an unnecessary conversion between types.
 @return Eigen::Matrix3d
 @param inArray The input array (row-major)
 */
-Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray)
-{
-	return Eigen::Map<Eigen::Matrix3d>(inArray, 3, 3).transpose();
-}
+Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray) { return Eigen::Map<Eigen::Matrix3d>(inArray, 3, 3).transpose(); }
 
-/*! This function performs the conversion between an input C 3x3 
+/*! This function performs the conversion between an input C 3x3
 2D-array and an output Eigen vector3d. This function is provided
 in order to save an unnecessary conversion between types
 @return Eigen::Matrix3d
 @param in2DArray The input 2D-array
 */
-Eigen::Matrix3d c2DArray2EigenMatrix3d(double in2DArray[3][3])
-{
+Eigen::Matrix3d c2DArray2EigenMatrix3d(double in2DArray[3][3]) {
     Eigen::Matrix3d outMat;
     for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {
@@ -171,16 +158,15 @@ Eigen::Matrix3d c2DArray2EigenMatrix3d(double in2DArray[3][3])
  @return Eigen::Matrix3d
  @param angle The input rotation angle
  */
-Eigen::Matrix3d eigenM1(double angle)
-{
+Eigen::Matrix3d eigenM1(double angle) {
     Eigen::Matrix3d mOut;
 
     mOut.setIdentity();
 
-    mOut(1,1) = cos(angle);
-    mOut(1,2) = sin(angle);
-    mOut(2,1) = -mOut(1,2);
-    mOut(2,2) = mOut(1,1);
+    mOut(1, 1) = cos(angle);
+    mOut(1, 2) = sin(angle);
+    mOut(2, 1) = -mOut(1, 2);
+    mOut(2, 2) = mOut(1, 1);
 
     return mOut;
 }
@@ -191,16 +177,15 @@ Eigen::Matrix3d eigenM1(double angle)
  @return Eigen::Matrix3d
  @param angle The input rotation angle
  */
-Eigen::Matrix3d eigenM2(double angle)
-{
+Eigen::Matrix3d eigenM2(double angle) {
     Eigen::Matrix3d mOut;
 
     mOut.setIdentity();
 
-    mOut(0,0) = cos(angle);
-    mOut(0,2) = -sin(angle);
-    mOut(2,0) = -mOut(0,2);
-    mOut(2,2) = mOut(0,0);
+    mOut(0, 0) = cos(angle);
+    mOut(0, 2) = -sin(angle);
+    mOut(2, 0) = -mOut(0, 2);
+    mOut(2, 2) = mOut(0, 0);
 
     return mOut;
 }
@@ -211,16 +196,15 @@ Eigen::Matrix3d eigenM2(double angle)
  @return Eigen::Matrix3d
  @param angle The input rotation angle
  */
-Eigen::Matrix3d eigenM3(double angle)
-{
+Eigen::Matrix3d eigenM3(double angle) {
     Eigen::Matrix3d mOut;
 
     mOut.setIdentity();
 
-    mOut(0,0) = cos(angle);
-    mOut(0,1) = sin(angle);
-    mOut(1,0) = -mOut(0,1);
-    mOut(1,1) = mOut(0,0);
+    mOut(0, 0) = cos(angle);
+    mOut(0, 1) = sin(angle);
+    mOut(1, 0) = -mOut(0, 1);
+    mOut(1, 1) = mOut(0, 0);
 
     return mOut;
 }
@@ -231,18 +215,17 @@ Eigen::Matrix3d eigenM3(double angle)
  @return Eigen::Matrix3d
  @param vec The input vector
  */
-Eigen::Matrix3d eigenTilde(Eigen::Vector3d vec)
-{
+Eigen::Matrix3d eigenTilde(Eigen::Vector3d vec) {
     Eigen::Matrix3d mOut;
 
-    mOut(0,0) = mOut(1,1) = mOut(2,2) = 0.0;
+    mOut(0, 0) = mOut(1, 1) = mOut(2, 2) = 0.0;
 
-    mOut(0,1) = -vec(2);
-    mOut(1,0) =  vec(2);
-    mOut(0,2) =  vec(1);
-    mOut(2,0) = -vec(1);
-    mOut(1,2) = -vec(0);
-    mOut(2,1) =  vec(0);
+    mOut(0, 1) = -vec(2);
+    mOut(1, 0) = vec(2);
+    mOut(0, 2) = vec(1);
+    mOut(2, 0) = -vec(1);
+    mOut(1, 2) = -vec(0);
+    mOut(2, 1) = vec(0);
 
     return mOut;
 }
@@ -251,8 +234,7 @@ Eigen::Matrix3d eigenTilde(Eigen::Vector3d vec)
  @return Eigen::MRPd
  @param dcm_Eigen The input DCM
  */
-Eigen::MRPd eigenC2MRP(Eigen::Matrix3d dcm_Eigen)
-{
+Eigen::MRPd eigenC2MRP(Eigen::Matrix3d dcm_Eigen) {
     Eigen::MRPd sigma_Eigen;  // output Eigen MRP
     double dcm_Array[9];      // C array DCM
     double sigma_Array[3];    // C array MRP
@@ -268,8 +250,7 @@ Eigen::MRPd eigenC2MRP(Eigen::Matrix3d dcm_Eigen)
  @return Eigen::Vector3d
  @param mrp The input Vector3d variable
  */
-Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd mrp)
-{
+Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd mrp) {
     Eigen::Vector3d vec3d;
 
     vec3d[0] = mrp.x();
@@ -286,16 +267,17 @@ Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd mrp)
 @param f Function to find the zero of
 @param fPrime First derivative of the function
 */
-double newtonRaphsonSolve(const double& initialEstimate, const double& accuracy, const std::function<double(double)>& f, const std::function<double(double)>& fPrime) {
-	double currentEstimate = initialEstimate;
-	for (int i = 0; i < 100; i++) {
-        if (std::abs(f(currentEstimate)) < accuracy)
-            break;
+double newtonRaphsonSolve(const double &initialEstimate,
+                          const double &accuracy,
+                          const std::function<double(double)> &f,
+                          const std::function<double(double)> &fPrime) {
+    double currentEstimate = initialEstimate;
+    for (int i = 0; i < 100; i++) {
+        if (std::abs(f(currentEstimate)) < accuracy) break;
 
-		double functionVal = f(currentEstimate);
-		double functionDeriv = fPrime(currentEstimate);
-		currentEstimate = currentEstimate - functionVal/functionDeriv;
-	}
-	return currentEstimate;
+        double functionVal = f(currentEstimate);
+        double functionDeriv = fPrime(currentEstimate);
+        currentEstimate = currentEstimate - functionVal / functionDeriv;
+    }
+    return currentEstimate;
 }
-

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -69,6 +69,17 @@ void eigenVector3d2CArray(Eigen::Vector3d &inMat, double *outArray) {
     memcpy(outArray, inMat.data(), 3 * sizeof(double));
 }
 
+/*! This function provides a direct conversion between a 4-vector and an
+output C array. We are providing this function to save on the  inline conversion
+and the transpose that would have been performed by the general case.
+@return void
+@param inMat The source Eigen matrix that we are converting
+@param outArray The destination array we copy into
+*/
+void eigenVector4d2CArray(Eigen::Vector4d &inMat, double *outArray) {
+    memcpy(outArray, inMat.data(), 4 * sizeof(double));
+}
+
 /*! This function provides a direct conversion between an MRP and an
 output C array. We are providing this function to save on the inline conversion
 and the transpose that would have been performed by the general case.

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -29,6 +29,8 @@ void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray);
 void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray);
 //!@brief Rapid conversion between 3-vector and output array
 void eigenVector3d2CArray(Eigen::Vector3d &inMat, double *outArray);
+//!@brief Rapid conversion between 4-vector and output array
+void eigenVector4d2CArray(Eigen::Vector4d &inMat, double *outArray);
 //!@brief Rapid conversion between MRP and output array
 void eigenMRPd2CArray(Eigen::Vector3d &inMat, double *outArray);
 //!@brief Rapid conversion between 3x3 matrix and output array

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -39,6 +39,8 @@ void eigenMatrix3d2CArray(Eigen::Matrix3d &inMat, double *outArray);
 Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols);
 //!@brief Specific conversion between a C array and an Eigen 3-vector
 Eigen::Vector3d cArray2EigenVector3d(double *inArray);
+//!@brief Specific conversion between a C array and an Eigen 4-vector
+Eigen::Vector4d cArray2EigenVector4d(double *inArray);
 //!@brief Specific conversion between a C array and an Eigen MRPs
 Eigen::MRPd cArray2EigenMRPd(double *inArray);
 //!@brief Specfici conversion between a C array and an Eigen 3x3 matrix

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -17,34 +17,33 @@
 
  */
 
-
 #ifndef _AVSEIGENSUPPORT_
 #define _AVSEIGENSUPPORT_
 #include <Eigen/Dense>
-#include "avsEigenMRP.h"
 
+#include "avsEigenMRP.h"
 
 //!@brief General conversion between any Eigen matrix and output array
 void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray);
 //!@brief General conversion between any Eigen matrix and output array
 void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray);
 //!@brief Rapid conversion between 3-vector and output array
-void eigenVector3d2CArray(Eigen::Vector3d & inMat, double *outArray);
+void eigenVector3d2CArray(Eigen::Vector3d &inMat, double *outArray);
 //!@brief Rapid conversion between MRP and output array
-void eigenMRPd2CArray(Eigen::Vector3d& inMat, double* outArray);
+void eigenMRPd2CArray(Eigen::Vector3d &inMat, double *outArray);
 //!@brief Rapid conversion between 3x3 matrix and output array
-void eigenMatrix3d2CArray(Eigen::Matrix3d & inMat, double *outArray);
+void eigenMatrix3d2CArray(Eigen::Matrix3d &inMat, double *outArray);
 //!@brief General conversion between a C array and an Eigen matrix
 Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols);
 //!@brief Specific conversion between a C array and an Eigen 3-vector
 Eigen::Vector3d cArray2EigenVector3d(double *inArray);
 //!@brief Specific conversion between a C array and an Eigen MRPs
-Eigen::MRPd cArray2EigenMRPd(double* inArray);
+Eigen::MRPd cArray2EigenMRPd(double *inArray);
 //!@brief Specfici conversion between a C array and an Eigen 3x3 matrix
 Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray);
 //!@brief Specfici conversion between a C 2D array and an Eigen 3x3 matrix
 Eigen::Matrix3d c2DArray2EigenMatrix3d(double in2DArray[3][3]);
-//!@brief returns the first axis DCM with the input angle 
+//!@brief returns the first axis DCM with the input angle
 Eigen::Matrix3d eigenM1(double angle);
 //!@brief returns the second axis DCM with the input angle
 Eigen::Matrix3d eigenM2(double angle);
@@ -58,7 +57,9 @@ Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd vec);
 Eigen::MRPd eigenC2MRP(Eigen::Matrix3d);
 
 //!@brief solves for the zero of the provided function
-double newtonRaphsonSolve(const double& initialEstimate, const double& accuracy, const std::function<double(double)>& f, const std::function<double(double)>& fPrime);
-
+double newtonRaphsonSolve(const double &initialEstimate,
+                          const double &accuracy,
+                          const std::function<double(double)> &f,
+                          const std::function<double(double)> &fPrime);
 
 #endif /* _AVSEIGENSUPPORT_ */

--- a/src/architecture/utilities/rigidBodyKinematics.cpp
+++ b/src/architecture/utilities/rigidBodyKinematics.cpp
@@ -664,7 +664,13 @@ Eigen::Vector4d prvToEp(const Eigen::Vector3d& prv) {
  * @param prv
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d prvToMrp(const Eigen::Vector3d& prv) { return prv / prv.norm() * tan(prv.norm() / 4.); }
+Eigen::Vector3d prvToMrp(const Eigen::Vector3d& prv) {
+    const double norm = prv.norm();
+    if (norm > 1e-12) {
+        return prv.normalized() * std::tan(norm / 4.);
+    }
+    return Eigen::Vector3d::Zero();
+}
 
 /**
  * Translate a principal rotation vector into a 321 Euler angle vector.

--- a/src/architecture/utilities/rigidBodyKinematics.cpp
+++ b/src/architecture/utilities/rigidBodyKinematics.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "rigidBodyKinematics.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -31,7 +32,7 @@ constexpr double eps = std::numeric_limits<double>::epsilon();
  * @param ep2 Eigen::Vector4d
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d addEp(const Eigen::Vector4d& ep1, const Eigen::Vector4d& ep2){
+Eigen::Vector4d addEp(const Eigen::Vector4d& ep1, const Eigen::Vector4d& ep2) {
     Eigen::Vector4d ep;
 
     ep(0) = ep2(0) * ep1(0) - ep2(1) * ep1(1) - ep2(2) * ep1(2) - ep2(3) * ep1(3);
@@ -48,20 +49,20 @@ Eigen::Vector4d addEp(const Eigen::Vector4d& ep1, const Eigen::Vector4d& ep2){
  * @param mrp2 Eigen::Vector3d
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d addMrp(const Eigen::Vector3d& mrp1, const Eigen::Vector3d& mrp2){
+Eigen::Vector3d addMrp(const Eigen::Vector3d& mrp1, const Eigen::Vector3d& mrp2) {
     Eigen::Vector3d sigma1(mrp1);
     double denominator;
-    denominator = 1 + mrp1.dot(mrp1)*mrp2.dot(mrp2) - 2 * mrp1.dot(mrp2);
+    denominator = 1 + mrp1.dot(mrp1) * mrp2.dot(mrp2) - 2 * mrp1.dot(mrp2);
     if (std::abs(denominator) < 0.1) {
-        sigma1 = mrpShadow(mrp1); // Shadow set
+        sigma1 = mrpShadow(mrp1);  // Shadow set
         denominator = (1 + sigma1.dot(sigma1) * mrp2.dot(mrp2) - 2 * sigma1.dot(mrp2));
     }
 
     assert(std::abs(denominator) > eps);
     Eigen::Vector3d numerator;
-    numerator << (1 - sigma1.dot(sigma1))*mrp2 + (1 - mrp2.dot(mrp2))*sigma1 - 2*mrp2.cross(sigma1);
+    numerator << (1 - sigma1.dot(sigma1)) * mrp2 + (1 - mrp2.dot(mrp2)) * sigma1 - 2 * mrp2.cross(sigma1);
 
-    Eigen::Vector3d mrp(numerator/denominator);
+    Eigen::Vector3d mrp(numerator / denominator);
     /* map mrp to inner set */
     mrp = mrpSwitch(mrp, 1);
 
@@ -74,26 +75,30 @@ Eigen::Vector3d addMrp(const Eigen::Vector3d& mrp1, const Eigen::Vector3d& mrp2)
  * @param prv2 Eigen::Vector3d
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d addPrv(const Eigen::Vector3d& prv1, const Eigen::Vector3d& prv2){
-
-    if(prv1.norm() < 1.0E-7 || prv2.norm() < 1.0E-7){return prv1 + prv2;}
+Eigen::Vector3d addPrv(const Eigen::Vector3d& prv1, const Eigen::Vector3d& prv2) {
+    if (prv1.norm() < 1.0E-7 || prv2.norm() < 1.0E-7) {
+        return prv1 + prv2;
+    }
 
     double cosPhi1 = std::cos(prv1.norm() / 2.);
     double cosPhi2 = std::cos(prv2.norm() / 2.);
     double sinPhi1 = std::sin(prv1.norm() / 2.);
     double sinPhi2 = std::sin(prv2.norm() / 2.);
 
-    Eigen::Vector3d unitVector1(prv1/prv1.norm());
-    Eigen::Vector3d unitVector2(prv2/prv2.norm());
+    Eigen::Vector3d unitVector1(prv1 / prv1.norm());
+    Eigen::Vector3d unitVector2(prv2 / prv2.norm());
     assert(std::abs(cosPhi1 * cosPhi2 - sinPhi1 * sinPhi2 * unitVector1.dot(unitVector2)) < 1);
 
     double angle;
     angle = 2 * std::acos(cosPhi1 * cosPhi2 - sinPhi1 * sinPhi2 * unitVector1.dot(unitVector2));
 
     Eigen::Vector3d prv;
-    if(std::abs(angle) < 1.0E-13){return prv.setZero();}
-    prv << cosPhi1*sinPhi2*unitVector2 + cosPhi2*sinPhi1*unitVector1 + sinPhi1*sinPhi2*unitVector1.cross(unitVector2);
-    return prv*angle/std::sin(angle/2);
+    if (std::abs(angle) < 1.0E-13) {
+        return prv.setZero();
+    }
+    prv << cosPhi1 * sinPhi2 * unitVector2 + cosPhi2 * sinPhi1 * unitVector1 +
+               sinPhi1 * sinPhi2 * unitVector1.cross(unitVector2);
+    return prv * angle / std::sin(angle / 2);
 }
 
 /**
@@ -102,8 +107,8 @@ Eigen::Vector3d addPrv(const Eigen::Vector3d& prv1, const Eigen::Vector3d& prv2)
  * @param euler3212 Eigen::Vector3d
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d addEulerAngles321(const Eigen::Vector3d& euler3211, const Eigen::Vector3d& euler3212){
-    return dcmToEulerAngles321(eulerAngles321ToDcm(euler3212)*eulerAngles321ToDcm(euler3211));
+Eigen::Vector3d addEulerAngles321(const Eigen::Vector3d& euler3211, const Eigen::Vector3d& euler3212) {
+    return dcmToEulerAngles321(eulerAngles321ToDcm(euler3212) * eulerAngles321ToDcm(euler3211));
 }
 
 /**
@@ -112,12 +117,10 @@ Eigen::Vector3d addEulerAngles321(const Eigen::Vector3d& euler3211, const Eigen:
  * @param ep const Eigen::Vector4
  * @return Eigen::Matrix<double, 3, 4>
  */
-Eigen::Matrix<double, 3, 4> binvEp(const Eigen::Vector4d& ep){
+Eigen::Matrix<double, 3, 4> binvEp(const Eigen::Vector4d& ep) {
     Eigen::Matrix<double, 3, 4> Binv;
 
-    Binv << -ep(1), ep(0), ep(3), -ep(2),
-    -ep(2), -ep(3), ep(0), ep(1),
-    -ep(3), ep(2), -ep(1), ep(0);
+    Binv << -ep(1), ep(0), ep(3), -ep(2), -ep(2), -ep(3), ep(0), ep(1), -ep(3), ep(2), -ep(1), ep(0);
 
     return Binv;
 }
@@ -128,8 +131,7 @@ Eigen::Matrix<double, 3, 4> binvEp(const Eigen::Vector4d& ep){
  * @param mrp Eigen::Vector3d
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d binvMrp(const Eigen::Vector3d& mrp){
-
+Eigen::Matrix3d binvMrp(const Eigen::Vector3d& mrp) {
     Eigen::Matrix3d Binv;
 
     Binv(0, 0) = 1 - mrp.dot(mrp) + 2 * mrp(0) * mrp(0);
@@ -142,7 +144,7 @@ Eigen::Matrix3d binvMrp(const Eigen::Vector3d& mrp){
     Binv(2, 1) = 2 * (mrp(2) * mrp(1) - mrp(0));
     Binv(2, 2) = 1 - mrp.dot(mrp) + 2 * mrp(2) * mrp(2);
 
-    return Binv/ (1 + mrp.dot(mrp)) / (1 + mrp.dot(mrp));
+    return Binv / (1 + mrp.dot(mrp)) / (1 + mrp.dot(mrp));
 }
 
 /**
@@ -151,7 +153,7 @@ Eigen::Matrix3d binvMrp(const Eigen::Vector3d& mrp){
  * @param prv Eigen::Vector3
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d binvPrv(const Eigen::Vector3d& prv){
+Eigen::Matrix3d binvPrv(const Eigen::Vector3d& prv) {
     double c1 = (1 - std::cos(prv.norm())) / std::pow(prv.norm(), 2);
     double c2 = (prv.norm() - std::sin(prv.norm())) / std::pow(prv.norm(), 3);
 
@@ -175,16 +177,14 @@ Eigen::Matrix3d binvPrv(const Eigen::Vector3d& prv){
  * @param euler321 Eigen::Vector3d
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d binvEulerAngles321(const Eigen::Vector3d& euler321){
+Eigen::Matrix3d binvEulerAngles321(const Eigen::Vector3d& euler321) {
     double sin2 = std::sin(euler321(1));
     double cos2 = std::cos(euler321(1));
     double sin3 = std::sin(euler321(2));
     double cos3 = std::cos(euler321(2));
 
     Eigen::Matrix3d Binv;
-    Binv << -sin2, 0, 1,
-    cos2*sin3, cos3, 0,
-    cos2*cos3, - sin3, 0;
+    Binv << -sin2, 0, 1, cos2 * sin3, cos3, 0, cos2 * cos3, -sin3, 0;
 
     return Binv;
 }
@@ -195,7 +195,7 @@ Eigen::Matrix3d binvEulerAngles321(const Eigen::Vector3d& euler321){
  * @param ep Eigen::Vector4d
  * @return Eigen::Matrix<double, 4, 3>
  */
-Eigen::Matrix<double, 4, 3> bmatEp(const Eigen::Vector4d& ep){
+Eigen::Matrix<double, 4, 3> bmatEp(const Eigen::Vector4d& ep) {
     Eigen::Matrix<double, 4, 3> B;
 
     B(0, 0) = -ep(1);
@@ -220,7 +220,7 @@ Eigen::Matrix<double, 4, 3> bmatEp(const Eigen::Vector4d& ep){
  * @param mrp
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d bmatMrp(const Eigen::Vector3d& mrp){
+Eigen::Matrix3d bmatMrp(const Eigen::Vector3d& mrp) {
     Eigen::Matrix3d B;
 
     B(0, 0) = 1 - mrp.dot(mrp) + 2 * mrp(0) * mrp(0);
@@ -244,18 +244,18 @@ Eigen::Matrix3d bmatMrp(const Eigen::Vector3d& mrp){
  * @param dmrp
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d bmatDotMrp(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dmrp){
+Eigen::Matrix3d bmatDotMrp(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dmrp) {
     Eigen::Matrix3d B;
 
-    B(0, 0) = -2*mrp.dot(dmrp) + 4 * ( mrp(0) * dmrp(0));
+    B(0, 0) = -2 * mrp.dot(dmrp) + 4 * (mrp(0) * dmrp(0));
     B(0, 1) = 2 * (-dmrp(2) + mrp(0) * dmrp(1) + dmrp(0) * mrp(1));
-    B(0, 2) = 2 * ( dmrp(1) + mrp(0) * dmrp(2) + dmrp(0) * mrp(2));
-    B(1, 0) = 2 * ( dmrp(2) + mrp(0) * dmrp(1) + dmrp(0) * mrp(1));
-    B(1, 1) = -2*mrp.dot(dmrp) + 4 * ( mrp(1) * dmrp(1));
+    B(0, 2) = 2 * (dmrp(1) + mrp(0) * dmrp(2) + dmrp(0) * mrp(2));
+    B(1, 0) = 2 * (dmrp(2) + mrp(0) * dmrp(1) + dmrp(0) * mrp(1));
+    B(1, 1) = -2 * mrp.dot(dmrp) + 4 * (mrp(1) * dmrp(1));
     B(1, 2) = 2 * (-dmrp(0) + mrp(1) * dmrp(2) + dmrp(1) * mrp(2));
     B(2, 0) = 2 * (-dmrp(1) + mrp(0) * dmrp(2) + dmrp(0) * mrp(2));
-    B(2, 1) = 2 * ( dmrp(0) + mrp(1) * dmrp(2) + dmrp(1) * mrp(2));
-    B(2, 2) = -2*mrp.dot(dmrp) + 4 * ( mrp(2) * dmrp(2));
+    B(2, 1) = 2 * (dmrp(0) + mrp(1) * dmrp(2) + dmrp(1) * mrp(2));
+    B(2, 2) = -2 * mrp.dot(dmrp) + 4 * (mrp(2) * dmrp(2));
 
     return B;
 }
@@ -266,7 +266,7 @@ Eigen::Matrix3d bmatDotMrp(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dm
  * @param prv
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d bmatPrv(const Eigen::Vector3d& prv){
+Eigen::Matrix3d bmatPrv(const Eigen::Vector3d& prv) {
     double c = 1. / prv.norm() / prv.norm() * (1. - prv.norm() / 2. / std::tan(prv.norm() / 2.));
 
     Eigen::Matrix3d B;
@@ -289,18 +289,16 @@ Eigen::Matrix3d bmatPrv(const Eigen::Vector3d& prv){
  * @param euler321
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d bmatEulerAngles321(const Eigen::Vector3d& euler321){
+Eigen::Matrix3d bmatEulerAngles321(const Eigen::Vector3d& euler321) {
     double sin2 = sin(euler321(1));
     double cos2 = cos(euler321(1));
     double sin3 = sin(euler321(2));
     double cos3 = cos(euler321(2));
 
     Eigen::Matrix3d B;
-    B << 0, sin3, cos3,
-    0, cos2*cos3, -cos2*sin3,
-    cos2, sin2*sin3, sin2*cos3;
+    B << 0, sin3, cos3, 0, cos2 * cos3, -cos2 * sin3, cos2, sin2 * sin3, sin2 * cos3;
 
-    return B/cos2;
+    return B / cos2;
 }
 
 /**
@@ -310,7 +308,7 @@ Eigen::Matrix3d bmatEulerAngles321(const Eigen::Vector3d& euler321){
  * @param dcm
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d dcmToEp(const Eigen::Matrix3d& dcm){
+Eigen::Vector4d dcmToEp(const Eigen::Matrix3d& dcm) {
     Eigen::Vector4d ep;
 
     ep(0) = (1 + dcm.trace()) / 4.;
@@ -321,42 +319,39 @@ Eigen::Vector4d dcmToEp(const Eigen::Matrix3d& dcm){
     std::vector<double> epVector(ep.data(), ep.data() + ep.size());
     double maxVal = *std::max_element(epVector.begin(), epVector.end());
 
-    if (maxVal == ep(0)){
+    if (maxVal == ep(0)) {
         ep(0) = std::sqrt(ep(0));
         ep(1) = (dcm(1, 2) - dcm(2, 1)) / 4 / ep(0);
         ep(2) = (dcm(2, 0) - dcm(0, 2)) / 4 / ep(0);
         ep(3) = (dcm(0, 1) - dcm(1, 0)) / 4 / ep(0);
-        }
-    else if (maxVal == ep(1)){
+    } else if (maxVal == ep(1)) {
         ep(1) = std::sqrt(ep(1));
         ep(0) = (dcm(1, 2) - dcm(2, 1)) / 4 / ep(1);
-        if(ep(0) < 0) {
+        if (ep(0) < 0) {
             ep(1) = -ep(1);
             ep(0) = -ep(0);
         }
         ep(2) = (dcm(0, 1) + dcm(1, 0)) / 4 / ep(1);
         ep(3) = (dcm(2, 0) + dcm(0, 2)) / 4 / ep(1);
-        }
-    else if (maxVal == ep(2)){
+    } else if (maxVal == ep(2)) {
         ep(2) = std::sqrt(ep(2));
         ep(0) = (dcm(2, 0) - dcm(0, 2)) / 4 / ep(2);
-        if(ep(0) < 0) {
+        if (ep(0) < 0) {
             ep(2) = -ep(2);
             ep(0) = -ep(0);
         }
         ep(1) = (dcm(0, 1) + dcm(1, 0)) / 4 / ep(2);
         ep(3) = (dcm(1, 2) + dcm(2, 1)) / 4 / ep(2);
-        }
-    else if (maxVal == ep(3)){
+    } else if (maxVal == ep(3)) {
         ep(3) = std::sqrt(ep(3));
         ep(0) = (dcm(0, 1) - dcm(1, 0)) / 4 / ep(3);
-        if(ep(0) < 0) {
+        if (ep(0) < 0) {
             ep(3) = -ep(3);
             ep(0) = -ep(0);
         }
         ep(1) = (dcm(2, 0) + dcm(0, 2)) / 4 / ep(3);
         ep(2) = (dcm(1, 2) + dcm(2, 1)) / 4 / ep(3);
-        }
+    }
 
     return ep;
 }
@@ -367,9 +362,9 @@ Eigen::Vector4d dcmToEp(const Eigen::Matrix3d& dcm){
  * @param dcm
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d dcmToMrp(const Eigen::Matrix3d& dcm){
+Eigen::Vector3d dcmToMrp(const Eigen::Matrix3d& dcm) {
     Eigen::Vector4d ep(dcmToEp(dcm));
-    return ep.tail(3)/(1 + ep(0));
+    return ep.tail(3) / (1 + ep(0));
 }
 
 /**
@@ -378,21 +373,19 @@ Eigen::Vector3d dcmToMrp(const Eigen::Matrix3d& dcm){
  * @param dcm
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d dcmToPrv(const Eigen::Matrix3d& dcm){
-    return epToPrv(dcmToEp(dcm));
-}
+Eigen::Vector3d dcmToPrv(const Eigen::Matrix3d& dcm) { return epToPrv(dcmToEp(dcm)); }
 
 /**
  * Translate a direction cosine matrix into the corresponding 321 Euler angle set.
  * @param dcm
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d dcmToEulerAngles321(const Eigen::Matrix3d& dcm){
+Eigen::Vector3d dcmToEulerAngles321(const Eigen::Matrix3d& dcm) {
     Eigen::Vector3d euler321;
 
-    euler321[0] = std::atan2(dcm(0,1), dcm(0,0));
-    euler321[1] = std::asin(-dcm(0,2));
-    euler321[2] = std::atan2(dcm(1,2), dcm(2,2));
+    euler321[0] = std::atan2(dcm(0, 1), dcm(0, 0));
+    euler321[1] = std::asin(-dcm(0, 2));
+    euler321[2] = std::atan2(dcm(1, 2), dcm(2, 2));
 
     return euler321;
 }
@@ -404,16 +397,16 @@ Eigen::Vector3d dcmToEulerAngles321(const Eigen::Matrix3d& dcm){
  * @param omega
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d dep(const Eigen::Vector4d& ep, const Eigen::Vector3d& omega){
+Eigen::Vector4d dep(const Eigen::Vector4d& ep, const Eigen::Vector3d& omega) {
     Eigen::Matrix<double, 4, 3> B(bmatEp(ep));
-    Eigen::Vector4d dep(B*omega);
-    for(int i = 0; i < 4; i++) {
+    Eigen::Vector4d dep(B * omega);
+    for (int i = 0; i < 4; i++) {
         dep(i) = 0.;
-        for(int j = 0; j < 3; j++) {
+        for (int j = 0; j < 3; j++) {
             dep(i) += B(i, j) * omega(j);
         }
     }
-    return dep/2;
+    return dep / 2;
 }
 
 /**
@@ -423,9 +416,9 @@ Eigen::Vector4d dep(const Eigen::Vector4d& ep, const Eigen::Vector3d& omega){
  * @param omega
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d dmrp(const Eigen::Vector3d& mrp, const Eigen::Vector3d& omega){
+Eigen::Vector3d dmrp(const Eigen::Vector3d& mrp, const Eigen::Vector3d& omega) {
     Eigen::Matrix3d B(bmatMrp(mrp));
-    return B*omega/4;
+    return B * omega / 4;
 }
 
 /**
@@ -435,9 +428,9 @@ Eigen::Vector3d dmrp(const Eigen::Vector3d& mrp, const Eigen::Vector3d& omega){
  * @param dmrp
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d dmrpToOmega(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dmrp){
+Eigen::Vector3d dmrpToOmega(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dmrp) {
     Eigen::Matrix3d Binv(binvMrp(mrp));
-    return 4*Binv*dmrp;
+    return 4 * Binv * dmrp;
 }
 
 /**
@@ -453,11 +446,11 @@ Eigen::Vector3d dmrpToOmega(const Eigen::Vector3d& mrp, const Eigen::Vector3d& d
 Eigen::Vector3d ddmrp(const Eigen::Vector3d& mrp,
                       const Eigen::Vector3d& dmrp,
                       const Eigen::Vector3d& omega,
-                      const Eigen::Vector3d& domega){
+                      const Eigen::Vector3d& domega) {
     Eigen::Matrix3d B(bmatMrp(mrp));
     Eigen::Matrix3d Bdot(bmatDotMrp(mrp, dmrp));
 
-    return (B*domega + Bdot*omega)/4;
+    return (B * domega + Bdot * omega) / 4;
 }
 
 /**
@@ -468,11 +461,11 @@ Eigen::Vector3d ddmrp(const Eigen::Vector3d& mrp,
  * @param ddmrp
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d ddmrpTodOmega(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dmrp, const Eigen::Vector3d& ddmrp){
+Eigen::Vector3d ddmrpTodOmega(const Eigen::Vector3d& mrp, const Eigen::Vector3d& dmrp, const Eigen::Vector3d& ddmrp) {
     Eigen::Matrix3d Binv(binvMrp(mrp));
     Eigen::Matrix3d Bdot(bmatDotMrp(mrp, dmrp));
-    Eigen::Vector3d diff(ddmrp - Bdot*Binv*dmrp);
-    return 4*Binv*diff;
+    Eigen::Vector3d diff(ddmrp - Bdot * Binv * dmrp);
+    return 4 * Binv * diff;
 }
 
 /**Return the PRV derivative for a given PRV vector and body angular velocity vector.
@@ -481,9 +474,7 @@ Eigen::Vector3d ddmrpTodOmega(const Eigen::Vector3d& mrp, const Eigen::Vector3d&
  * @param omega
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d dprv(const Eigen::Vector3d& prv, const Eigen::Vector3d& omega){
-    return bmatPrv(prv)*omega;
-}
+Eigen::Vector3d dprv(const Eigen::Vector3d& prv, const Eigen::Vector3d& omega) { return bmatPrv(prv) * omega; }
 
 /**
  * Return the 321 Euler angle derivative vector for a given 321 Euler angle vector and body
@@ -493,8 +484,8 @@ Eigen::Vector3d dprv(const Eigen::Vector3d& prv, const Eigen::Vector3d& omega){
  * @param omega
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d deuler321(const Eigen::Vector3d& euler321, const Eigen::Vector3d& omega){
-    return bmatEulerAngles321(euler321)*omega;
+Eigen::Vector3d deuler321(const Eigen::Vector3d& euler321, const Eigen::Vector3d& omega) {
+    return bmatEulerAngles321(euler321) * omega;
 }
 
 /**
@@ -503,7 +494,7 @@ Eigen::Vector3d deuler321(const Eigen::Vector3d& euler321, const Eigen::Vector3d
  * @param ep
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d epToDcm(const Eigen::Vector4d& ep){
+Eigen::Matrix3d epToDcm(const Eigen::Vector4d& ep) {
     Eigen::Matrix3d dcm;
 
     dcm(0, 0) = ep(0) * ep(0) + ep(1) * ep(1) - ep(2) * ep(2) - ep(3) * ep(3);
@@ -524,11 +515,11 @@ Eigen::Matrix3d epToDcm(const Eigen::Vector4d& ep){
  * @param ep
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d epToMrp(const Eigen::Vector4d& ep){
-    if (ep(0) >= 0){
-        return ep.tail(3)/(1 + ep(0));
+Eigen::Vector3d epToMrp(const Eigen::Vector4d& ep) {
+    if (ep(0) >= 0) {
+        return ep.tail(3) / (1 + ep(0));
     } else {
-        return -ep.tail(3)/(1 - ep(0));
+        return -ep.tail(3) / (1 - ep(0));
     }
 }
 
@@ -537,10 +528,12 @@ Eigen::Vector3d epToMrp(const Eigen::Vector4d& ep){
  * @param ep
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d epToPrv(const Eigen::Vector4d& ep){
+Eigen::Vector3d epToPrv(const Eigen::Vector4d& ep) {
     Eigen::Vector3d prv;
-    if (std::abs(std::sin(std::acos(ep(0)))) < eps){return prv.setZero();}
-    prv = ep.tail(3)/ std::sin(std::acos(ep(0))) * 2 * std::acos(ep(0));
+    if (std::abs(std::sin(std::acos(ep(0)))) < eps) {
+        return prv.setZero();
+    }
+    prv = ep.tail(3) / std::sin(std::acos(ep(0))) * 2 * std::acos(ep(0));
     return prv;
 }
 
@@ -549,14 +542,14 @@ Eigen::Vector3d epToPrv(const Eigen::Vector4d& ep){
  * @param ep
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d epToEulerAngles321(const Eigen::Vector4d& ep){
+Eigen::Vector3d epToEulerAngles321(const Eigen::Vector4d& ep) {
     Eigen::Vector3d euler321;
 
-    euler321(0) = std::atan2(2 * (ep(1) * ep(2) + ep(0) * ep(3)),
-                             ep(0) * ep(0) + ep(1) * ep(1) - ep(2) * ep(2) - ep(3) * ep(3));
+    euler321(0) =
+        std::atan2(2 * (ep(1) * ep(2) + ep(0) * ep(3)), ep(0) * ep(0) + ep(1) * ep(1) - ep(2) * ep(2) - ep(3) * ep(3));
     euler321(1) = std::asin(-2 * (ep(1) * ep(3) - ep(0) * ep(2)));
-    euler321(2) = std::atan2(2 * (ep(2) * ep(3) + ep(0) * ep(1)),
-                             ep(0) * ep(0) - ep(1) * ep(1) - ep(2) * ep(2) + ep(3) * ep(3));
+    euler321(2) =
+        std::atan2(2 * (ep(2) * ep(3) + ep(0) * ep(1)), ep(0) * ep(0) - ep(1) * ep(1) - ep(2) * ep(2) + ep(3) * ep(3));
 
     return euler321;
 }
@@ -566,10 +559,10 @@ Eigen::Vector3d epToEulerAngles321(const Eigen::Vector4d& ep){
  * @param mrp
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d mrpToDcm(const Eigen::Vector3d& mrp){
+Eigen::Matrix3d mrpToDcm(const Eigen::Vector3d& mrp) {
     Eigen::Matrix3d dcm;
-    dcm << 8 * tildeMatrix(mrp) * tildeMatrix(mrp) - 4*(1 - mrp.dot(mrp))* tildeMatrix(mrp);
-    dcm << dcm/(1 + mrp.dot(mrp))/(1 + mrp.dot(mrp));
+    dcm << 8 * tildeMatrix(mrp) * tildeMatrix(mrp) - 4 * (1 - mrp.dot(mrp)) * tildeMatrix(mrp);
+    dcm << dcm / (1 + mrp.dot(mrp)) / (1 + mrp.dot(mrp));
     return dcm + Eigen::Matrix3d::Identity();
 }
 
@@ -578,11 +571,11 @@ Eigen::Matrix3d mrpToDcm(const Eigen::Vector3d& mrp){
  * @param mrp
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d mrpToEp(const Eigen::Vector3d& mrp){
+Eigen::Vector4d mrpToEp(const Eigen::Vector3d& mrp) {
     Eigen::Vector4d ep;
     ep(0) = 1 - mrp.dot(mrp);
     ep.tail(3) << 2 * mrp;
-    return ep/ (1 + mrp.dot(mrp));
+    return ep / (1 + mrp.dot(mrp));
 }
 
 /**
@@ -590,10 +583,12 @@ Eigen::Vector4d mrpToEp(const Eigen::Vector3d& mrp){
  * @param mrp
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d mrpToPrv(const Eigen::Vector3d& mrp){
+Eigen::Vector3d mrpToPrv(const Eigen::Vector3d& mrp) {
     Eigen::Vector3d prv;
-    if(mrp.norm() < eps){return prv.setZero();}
-    return mrp/mrp.norm() * 4 * std::atan(mrp.norm());
+    if (mrp.norm() < eps) {
+        return prv.setZero();
+    }
+    return mrp / mrp.norm() * 4 * std::atan(mrp.norm());
 }
 
 /**
@@ -601,9 +596,7 @@ Eigen::Vector3d mrpToPrv(const Eigen::Vector3d& mrp){
  * @param mrp
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d mrpToEulerAngles321(const Eigen::Vector3d& mrp){
-    return epToEulerAngles321(mrpToEp(mrp));
-}
+Eigen::Vector3d mrpToEulerAngles321(const Eigen::Vector3d& mrp) { return epToEulerAngles321(mrpToEp(mrp)); }
 
 /**
  * Check if mrp norm is larger than s. If so, map mrp to its shadow set.
@@ -611,8 +604,8 @@ Eigen::Vector3d mrpToEulerAngles321(const Eigen::Vector3d& mrp){
  * @param s
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d mrpSwitch(const Eigen::Vector3d& mrp, const double s){
-    if(mrp.dot(mrp) > s*s) {
+Eigen::Vector3d mrpSwitch(const Eigen::Vector3d& mrp, const double s) {
+    if (mrp.dot(mrp) > s * s) {
         return mrpShadow(mrp);
     } else {
         return mrp;
@@ -624,18 +617,18 @@ Eigen::Vector3d mrpSwitch(const Eigen::Vector3d& mrp, const double s){
  * @param mrp
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d mrpShadow(const Eigen::Vector3d& mrp){
-    return - mrp/mrp.dot(mrp);
-}
+Eigen::Vector3d mrpShadow(const Eigen::Vector3d& mrp) { return -mrp / mrp.dot(mrp); }
 
 /**
  * Return the direction cosine matrix corresponding to a principal rotation vector
  * @param prv
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d prvToDcm(const Eigen::Vector3d& prv){
-    Eigen::Vector3d unitVector(prv/prv.norm());
-    if(prv.norm() < eps){return  Eigen::Matrix3d::Identity();}
+Eigen::Matrix3d prvToDcm(const Eigen::Vector3d& prv) {
+    Eigen::Vector3d unitVector(prv / prv.norm());
+    if (prv.norm() < eps) {
+        return Eigen::Matrix3d::Identity();
+    }
 
     Eigen::Matrix3d dcm;
     dcm(0, 0) = unitVector(0) * unitVector(0) * (1 - cos(prv.norm())) + cos(prv.norm());
@@ -656,12 +649,12 @@ Eigen::Matrix3d prvToDcm(const Eigen::Vector3d& prv){
  * @param prv
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d prvToEp(const Eigen::Vector3d& prv){
-    Eigen::Vector3d unitVector(prv/prv.norm());
+Eigen::Vector4d prvToEp(const Eigen::Vector3d& prv) {
+    Eigen::Vector3d unitVector(prv / prv.norm());
 
     Eigen::Vector4d ep;
     ep(0) = cos(prv.norm() / 2);
-    ep.tail(3) = unitVector *  sin(prv.norm() / 2);
+    ep.tail(3) = unitVector * sin(prv.norm() / 2);
 
     return ep;
 }
@@ -671,36 +664,31 @@ Eigen::Vector4d prvToEp(const Eigen::Vector3d& prv){
  * @param prv
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d prvToMrp(const Eigen::Vector3d& prv){
-    return prv/prv.norm() * tan(prv.norm() / 4.);
-}
+Eigen::Vector3d prvToMrp(const Eigen::Vector3d& prv) { return prv / prv.norm() * tan(prv.norm() / 4.); }
 
 /**
  * Translate a principal rotation vector into a 321 Euler angle vector.
  * @param prv
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d prvToEulerAngles321(const Eigen::Vector3d& prv){
-    return epToEulerAngles321(prvToEp(prv));
-}
+Eigen::Vector3d prvToEulerAngles321(const Eigen::Vector3d& prv) { return epToEulerAngles321(prvToEp(prv)); }
 
 /**
  * Return the direction cosine matrix corresponding to a 321 Euler angle rotation.
  * @param euler321
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d eulerAngles321ToDcm(const Eigen::Vector3d& euler321){
+Eigen::Matrix3d eulerAngles321ToDcm(const Eigen::Vector3d& euler321) {
     double sin1 = std::sin(euler321(0));
     double sin2 = std::sin(euler321(1));
     double sin3 = std::sin(euler321(2));
     double cos1 = std::cos(euler321(0));
     double cos2 = std::cos(euler321(1));
-    double cos3  = std::cos(euler321(2));
+    double cos3 = std::cos(euler321(2));
 
     Eigen::Matrix3d dcm;
-    dcm << cos2 * cos1, cos2 * sin1, - sin2,
-    sin3 * sin2 * cos1 - cos3 * sin1, sin3 * sin2 * sin1 + cos3 * cos1, sin3 * cos2,
-    cos3 * sin2 * cos1 + sin3 * sin1, cos3 * sin2 * sin1 - sin3 * cos1, cos3 * cos2;
+    dcm << cos2 * cos1, cos2 * sin1, -sin2, sin3 * sin2 * cos1 - cos3 * sin1, sin3 * sin2 * sin1 + cos3 * cos1,
+        sin3 * cos2, cos3 * sin2 * cos1 + sin3 * sin1, cos3 * sin2 * sin1 - sin3 * cos1, cos3 * cos2;
 
     return dcm;
 }
@@ -710,7 +698,7 @@ Eigen::Matrix3d eulerAngles321ToDcm(const Eigen::Vector3d& euler321){
  * @param euler321
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d eulerAngles321ToEp(const Eigen::Vector3d& euler321){
+Eigen::Vector4d eulerAngles321ToEp(const Eigen::Vector3d& euler321) {
     double cos1 = std::cos(euler321(0) / 2);
     double cos2 = std::cos(euler321(1) / 2);
     double cos3 = std::cos(euler321(2) / 2);
@@ -732,18 +720,14 @@ Eigen::Vector4d eulerAngles321ToEp(const Eigen::Vector3d& euler321){
  * @param euler321
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d eulerAngles321ToMrp(const Eigen::Vector3d& euler321){
-    return epToMrp(eulerAngles321ToEp(euler321));
-}
+Eigen::Vector3d eulerAngles321ToMrp(const Eigen::Vector3d& euler321) { return epToMrp(eulerAngles321ToEp(euler321)); }
 
 /**
  * Translate a 321 Euler angle vector into a principal rotation vector.
  * @param euler321
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d eulerAngles321ToPrv(const Eigen::Vector3d& euler321){
-    return epToPrv(eulerAngles321ToEp(euler321));
-}
+Eigen::Vector3d eulerAngles321ToPrv(const Eigen::Vector3d& euler321) { return epToPrv(eulerAngles321ToEp(euler321)); }
 
 /**
  * Provide the Euler parameter vector which corresponds to relative rotation from B2 to B1.
@@ -751,7 +735,7 @@ Eigen::Vector3d eulerAngles321ToPrv(const Eigen::Vector3d& euler321){
  * @param ep2
  * @return Eigen::Vector4d
  */
-Eigen::Vector4d subEp(const Eigen::Vector4d& ep1, const Eigen::Vector4d& ep2){
+Eigen::Vector4d subEp(const Eigen::Vector4d& ep1, const Eigen::Vector4d& ep2) {
     Eigen::Vector4d ep;
 
     ep(0) = ep2(0) * ep1(0) + ep2(1) * ep1(1) + ep2(2) * ep1(2) + ep2(3) * ep1(3);
@@ -768,17 +752,18 @@ Eigen::Vector4d subEp(const Eigen::Vector4d& ep1, const Eigen::Vector4d& ep2){
  * @param mrp2
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d subMrp(const Eigen::Vector3d& mrp1, const Eigen::Vector3d& mrp2){
+Eigen::Vector3d subMrp(const Eigen::Vector3d& mrp1, const Eigen::Vector3d& mrp2) {
     Eigen::Vector3d mrp1Shadow(mrp1);
-    double denominator = 1 + mrp2.dot(mrp2)*mrp1.dot(mrp1) + 2 * mrp2.dot(mrp1);
+    double denominator = 1 + mrp2.dot(mrp2) * mrp1.dot(mrp1) + 2 * mrp2.dot(mrp1);
     if (std::abs(denominator) < 0.1) {
-        mrp1Shadow = mrpShadow(mrp1); // Shadow set
+        mrp1Shadow = mrpShadow(mrp1);  // Shadow set
         denominator = (1 + mrp2.dot(mrp2) * mrp1Shadow.dot(mrp1Shadow) + 2 * mrp2.dot(mrp1Shadow));
     }
     assert(std::abs(denominator) > eps);
     Eigen::Vector3d numerator;
-    numerator << (1. - mrp2.dot(mrp2))*mrp1Shadow - (1. - mrp1Shadow.dot(mrp1Shadow))*mrp2 + 2*mrp1Shadow.cross(mrp2);
-    Eigen::Vector3d mrp(numerator/denominator);
+    numerator << (1. - mrp2.dot(mrp2)) * mrp1Shadow - (1. - mrp1Shadow.dot(mrp1Shadow)) * mrp2 +
+                     2 * mrp1Shadow.cross(mrp2);
+    Eigen::Vector3d mrp(numerator / denominator);
     /* map mrp to inner set */
     mrp = mrpSwitch(mrp, 1);
 
@@ -792,25 +777,29 @@ Eigen::Vector3d subMrp(const Eigen::Vector3d& mrp1, const Eigen::Vector3d& mrp2)
  * @param prv2
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d subPrv(const Eigen::Vector3d& prv1, const Eigen::Vector3d& prv2){
-    if(prv1.norm() < 1.0E-7 || prv2.norm() < 1.0E-7){return prv1 - prv2;}
+Eigen::Vector3d subPrv(const Eigen::Vector3d& prv1, const Eigen::Vector3d& prv2) {
+    if (prv1.norm() < 1.0E-7 || prv2.norm() < 1.0E-7) {
+        return prv1 - prv2;
+    }
 
     double cosPhi1 = std::cos(prv1.norm() / 2.);
     double cosPhi2 = std::cos(prv2.norm() / 2.);
     double sinPhi1 = std::sin(prv1.norm() / 2.);
     double sinPhi2 = std::sin(prv2.norm() / 2.);
 
-    Eigen::Vector3d unitVector1(prv1/prv1.norm());
-    Eigen::Vector3d unitVector2(prv2/prv2.norm());
+    Eigen::Vector3d unitVector1(prv1 / prv1.norm());
+    Eigen::Vector3d unitVector2(prv2 / prv2.norm());
 
     assert(std::abs(cosPhi1 * cosPhi2 + sinPhi1 * sinPhi2 * unitVector1.dot(unitVector2)) < 1);
     double angle = 2 * std::acos(cosPhi1 * cosPhi2 + sinPhi1 * sinPhi2 * unitVector1.dot(unitVector2));
 
     Eigen::Vector3d prv;
-    if(std::abs(angle) < 1.0E-13){return prv.setZero();}
+    if (std::abs(angle) < 1.0E-13) {
+        return prv.setZero();
+    }
     prv << cosPhi2 * sinPhi1 * unitVector1 - cosPhi1 * sinPhi2 * unitVector2 +
-            sinPhi1 * sinPhi2 * unitVector1.cross(unitVector2);
-    return prv*angle/std::sin(angle/2);
+               sinPhi1 * sinPhi2 * unitVector1.cross(unitVector2);
+    return prv * angle / std::sin(angle / 2);
 }
 
 /**
@@ -819,8 +808,8 @@ Eigen::Vector3d subPrv(const Eigen::Vector3d& prv1, const Eigen::Vector3d& prv2)
  * @param euler3212
  * @return Eigen::Vector3d
  */
-Eigen::Vector3d subEulerAngles321(const Eigen::Vector3d& euler3211, const Eigen::Vector3d& euler3212){
-    return dcmToEulerAngles321(eulerAngles321ToDcm(euler3211)*eulerAngles321ToDcm(euler3212).transpose());
+Eigen::Vector3d subEulerAngles321(const Eigen::Vector3d& euler3211, const Eigen::Vector3d& euler3212) {
+    return dcmToEulerAngles321(eulerAngles321ToDcm(euler3211) * eulerAngles321ToDcm(euler3212).transpose());
 }
 
 /**
@@ -829,23 +818,15 @@ Eigen::Vector3d subEulerAngles321(const Eigen::Vector3d& euler3211, const Eigen:
  * @param axis_number
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d rotationMatrix(const double angle, const int axis_number){
+Eigen::Matrix3d rotationMatrix(const double angle, const int axis_number) {
     assert(axis_number > 0 && axis_number < 4);
     Eigen::Matrix3d dcm;
-    if (axis_number == 1){
-        dcm << 1, 0, 0,
-            0, std::cos(angle), std::sin(angle),
-            0, -std::sin(angle), std::cos(angle);
-    }
-    else if (axis_number == 2){
-        dcm << std::cos(angle), 0, -std::sin(angle),
-            0, 1, 0,
-            std::sin(angle), 0, std::cos(angle);
-    }
-    else if (axis_number == 3){
-        dcm << std::cos(angle), std::sin(angle), 0,
-            -std::sin(angle), std::cos(angle), 0,
-            0, 0, 1;
+    if (axis_number == 1) {
+        dcm << 1, 0, 0, 0, std::cos(angle), std::sin(angle), 0, -std::sin(angle), std::cos(angle);
+    } else if (axis_number == 2) {
+        dcm << std::cos(angle), 0, -std::sin(angle), 0, 1, 0, std::sin(angle), 0, std::cos(angle);
+    } else if (axis_number == 3) {
+        dcm << std::cos(angle), std::sin(angle), 0, -std::sin(angle), std::cos(angle), 0, 0, 0, 1;
     }
     return dcm;
 }
@@ -855,10 +836,8 @@ Eigen::Matrix3d rotationMatrix(const double angle, const int axis_number){
  * @param vector
  * @return Eigen::Matrix3d
  */
-Eigen::Matrix3d tildeMatrix(const Eigen::Vector3d& vector){
+Eigen::Matrix3d tildeMatrix(const Eigen::Vector3d& vector) {
     Eigen::Matrix3d tilde;
-    tilde << 0, -vector(2), vector(1),
-            vector(2), 0, -vector(0),
-            -vector(1), vector(0), 0;
+    tilde << 0, -vector(2), vector(1), vector(2), 0, -vector(0), -vector(1), vector(0), 0;
     return tilde;
 }

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -40,7 +40,8 @@ def setRandomWalk(self, senNoiseStd = 0.0, errorBounds = [[1e6],[1e6],[1e6]]):
 @pytest.mark.parametrize("useFlag, testCase", [
     (False, 'basic'),
     (False, 'noise'),
-    (False, 'walk bounds')
+    (False, 'walk bounds'),
+    (False, 'angular velocity check')
 ])
 def test_starTracker(show_plots, useFlag, testCase):
     unitTaskName = "unitTask"
@@ -101,6 +102,12 @@ def test_starTracker(show_plots, useFlag, testCase):
         trueVector['qInrtl2Case'] = [walkBound + noiseStd*3] * 3
         trueVector['timeTag'] = np.arange(0, 0+simStopTime*1E9, unitProcRate_s*1E9)
 
+    # This test checks the computed platform rate
+    elif testCase == 'angular velocity check':
+        simStopTime = unitProcRate_s
+        sigma = np.array([0, 0, 0])
+        scStatesMessageData.sigma_BN = sigma
+
     else:
         raise Exception('invalid test case')
 
@@ -116,14 +123,50 @@ def test_starTracker(show_plots, useFlag, testCase):
     unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
     unitSim.ExecuteSimulation()
 
+    # Run additional simulation chunks for angular velocity test check
+    sigma_BNList = [np.array([0.0, 0.0, 0.0])]
+    if testCase == 'angular velocity check':
+        rotAxis_N = np.array([1.0, 0.0, 0.0])  # Hub rotation axis
+        prvAngleList = np.array([0.0, 0.25, 0.6, 1.0, 1.1])  # Truth hub attitudes
+
+        for idx in range(1, len(prvAngleList)):
+            # Compute hub inertial attitude
+            prv_BN = prvAngleList[idx] * rotAxis_N
+            sigma_BN = np.array(rbk.PRV2MRP(prv_BN))
+            sigma_BNList.append(sigma_BN)
+
+            # Update and connect the sc state message to the star tracker module
+            scStatesMessageData = messaging.SCStatesMsgPayload()
+            scStatesMessageData.r_BN_N = [0, 0, 0]
+            scStatesMessageData.v_BN_N = [0, 0, 0]
+            scStatesMessageData.sigma_BN = sigma_BN
+            scStatesMessageData.omega_BN_B = [0, 0, 0]
+            scStatesMessageData.TotalAccumDVBdy = [0, 0, 0]
+            scStatesMessageData.MRPSwitchCount = 0
+            scStatesMessage = messaging.SCStatesMsg().write(scStatesMessageData)
+            StarTracker.scStateInMsg.subscribeTo(scStatesMessage)
+
+            # Execute simulation chunk for updated spacecraft attitude
+            simStopTime = simStopTime + unitProcRate_s
+            unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
+            unitSim.ExecuteSimulation()
+
+        sigma_BNList = np.vstack(sigma_BNList)
+
     # Extract logged data for test check
+    timespan = macros.NANO2SEC * starTrackerSensorMsgDataLog.times()  # [s]
     beta_CN = starTrackerSensorMsgDataLog.qInrtl2Case
+    omega_CN_C = macros.R2D * starTrackerSensorMsgDataLog.omega_CN_C  # [rad/s]
 
     # Convert quaternion output to prv
     prv_CN = np.zeros([int(simStopTime/unitProcRate_s)+1, 3])
     for i in range(0, int(simStopTime/unitProcRate_s)+1):
-        prv_CN[i] = rbk.EP2PRV(beta_CN[i])
+        if not np.allclose(beta_CN[i], [1.0, 0.0, 0.0, 0.0]):
+            prv_CN[i] = rbk.EP2PRV(beta_CN[i])
+        else:
+            prv_CN[i] = [0.0, 0.0, 0.0]
 
+    accuracy = 1e-6
     if testCase == 'noise':
         boundArray = np.full((int(simStopTime/unitProcRate_s)+1), 0.01)
         for i in range(0, 3):
@@ -134,13 +177,49 @@ def test_starTracker(show_plots, useFlag, testCase):
             np.testing.assert_array_less(np.abs(np.std(prv_CN[:, i]) - trueVector['qInrtl2Case'][i]),
                                          boundArray,
                                          verbose=True)
+
     elif testCase == 'walk bounds':
         for i in range(0, 3):
             np.testing.assert_array_less(np.max(np.abs(np.asarray(prv_CN[i]))),
                                          trueVector['qInrtl2Case'][i],
                                          verbose=True)
+
+    elif testCase == 'angular velocity check':
+        # Check computed platform angular velocity
+        omega_CN_CTruth = [np.zeros((1, 3))]
+        previousSimTime = timespan[0]
+        currentSimTime = timespan[0]
+        for idx in range(1, len(timespan)):
+            # Group quaternion components without beta_0
+            epsilon_CN = np.array(beta_CN[idx, 1:]).reshape(3, 1)
+            epsilonPrevious_CN = np.array(beta_CN[idx-1, 1:]).reshape(3, 1)
+
+            # Determine CRPs (Gibbs Vector)
+            q_CN = epsilon_CN / beta_CN[idx, 0]
+            qPrevious_CN = epsilonPrevious_CN / beta_CN[idx-1, 0]
+
+            # Compute qDot_PN
+            previousSimTime = currentSimTime
+            currentSimTime = timespan[idx]
+            dt = currentSimTime - previousSimTime
+            qDot_CN = (q_CN - qPrevious_CN) / dt
+
+            # Solve for platform rate using Eq. 3.137 from Schaub and Junkins Pg 120
+            qTilde_CN = rbk.v3Tilde(q_CN.flatten())
+            qTilde_CN = np.array(qTilde_CN)
+            I = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+            omega_cn_c = (2.0 / (1.0 + np.dot(q_CN.flatten(), q_CN.flatten()))) * (I - qTilde_CN) @ qDot_CN
+            omega_cn_c = omega_cn_c.reshape(1, 3)
+            omega_CN_CTruth.append(macros.R2D * omega_cn_c)  # [deg]
+
+        omega_CN_CTruth = np.vstack(omega_CN_CTruth)
+
+        np.testing.assert_allclose(omega_CN_C,
+                                   omega_CN_CTruth,
+                                   atol=accuracy,
+                                   verbose=True)
+
     else:
-        accuracy = 1e-6
         for i in range(0, len(trueVector['qInrtl2Case'])):
             np.testing.assert_allclose(beta_CN[i],
                                        trueVector['qInrtl2Case'][i],

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -61,13 +61,13 @@ def test_starTracker(show_plots, useFlag, testCase):
     unitSim.AddModelToTask(unitTaskName, StarTracker)
 
     # Configure starTracker SCState input message
-    OutputStateData = messaging.SCStatesMsgPayload()
-    OutputStateData.r_BN_N = [0, 0, 0]
-    OutputStateData.v_BN_N = [0, 0, 0]
-    OutputStateData.sigma_BN = [0, 0, 0]
-    OutputStateData.omega_BN_B = [0, 0, 0]
-    OutputStateData.TotalAccumDVBdy = [0, 0, 0]
-    OutputStateData.MRPSwitchCount = 0
+    scStatesMessageData = messaging.SCStatesMsgPayload()
+    scStatesMessageData.r_BN_N = [0, 0, 0]
+    scStatesMessageData.v_BN_N = [0, 0, 0]
+    scStatesMessageData.sigma_BN = [0, 0, 0]
+    scStatesMessageData.omega_BN_B = [0, 0, 0]
+    scStatesMessageData.TotalAccumDVBdy = [0, 0, 0]
+    scStatesMessageData.MRPSwitchCount = 0
 
     trueVector = dict()
 
@@ -75,7 +75,7 @@ def test_starTracker(show_plots, useFlag, testCase):
     if testCase == 'basic':
         simStopTime = 0.5
         sigma = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
-        OutputStateData.sigma_BN = sigma
+        scStatesMessageData.sigma_BN = sigma
         trueVector['qInrtl2Case'] = listStack(rbk.MRP2EP(sigma),simStopTime,unitProcRate)
         trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
 
@@ -85,7 +85,7 @@ def test_starTracker(show_plots, useFlag, testCase):
         stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
         setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[1.0e-13], [1.0e-13], [1.0e-13]])
         sigma = np.array([0, 0, 0])
-        OutputStateData.sigma_BN = sigma
+        scStatesMessageData.sigma_BN = sigma
         trueVector['qInrtl2Case'] = [noiseStd] * 3
         trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
 
@@ -97,7 +97,7 @@ def test_starTracker(show_plots, useFlag, testCase):
         walkBound = 0.1
         setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[walkBound], [walkBound], [walkBound]])
         sigma = np.array([0, 0, 0])
-        OutputStateData.sigma_BN = sigma
+        scStatesMessageData.sigma_BN = sigma
         trueVector['qInrtl2Case'] = [walkBound + noiseStd*3] * 3
         trueVector['timeTag'] = np.arange(0, 0+simStopTime*1E9, unitProcRate_s*1E9)
 
@@ -105,19 +105,19 @@ def test_starTracker(show_plots, useFlag, testCase):
         raise Exception('invalid test case')
 
     # Set up data logging
-    dataLog = StarTracker.sensorOutMsg.recorder()
-    unitSim.AddModelToTask(unitTaskName, dataLog)
+    starTrackerSensorMsgDataLog = StarTracker.sensorOutMsg.recorder()
+    unitSim.AddModelToTask(unitTaskName, starTrackerSensorMsgDataLog)
 
     # Configure spacecraft state message
-    scMsg = messaging.SCStatesMsg().write(OutputStateData)
-    StarTracker.scStateInMsg.subscribeTo(scMsg)
+    scStatesMessage = messaging.SCStatesMsg().write(scStatesMessageData)
+    StarTracker.scStateInMsg.subscribeTo(scStatesMessage)
 
     unitSim.InitializeSimulation()
     unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
     unitSim.ExecuteSimulation()
 
     # Extract logged data for test check
-    beta_CN = dataLog.qInrtl2Case
+    beta_CN = starTrackerSensorMsgDataLog.qInrtl2Case
 
     # Convert quaternion output to prv
     prv_CN = np.zeros([int(simStopTime/unitProcRate_s)+1, 3])

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -23,13 +23,12 @@ from Basilisk.simulation import starTracker
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import unitTestSupport
 
 
-# methods
-def listStack(vec,simStopTime,unitProcRate):
+def listStack(vec, simStopTime, unitProcRate):
     # returns a list duplicated the number of times needed to be consistent with module output
-    return [vec] * int(simStopTime/(float(unitProcRate)/float(macros.sec2nano(1))))
+    return [vec] * int(simStopTime / (float(unitProcRate) / float(macros.sec2nano(1))))
 
 def setRandomWalk(self, senNoiseStd = 0.0, errorBounds = [[1e6],[1e6],[1e6]]):
     # sets the module random walk variables
@@ -40,96 +39,88 @@ def setRandomWalk(self, senNoiseStd = 0.0, errorBounds = [[1e6],[1e6],[1e6]]):
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)
 # uncomment this line if this test has an expected failure, adjust message as needed
-
-# The following 'parametrize' function decorator provides the parameters and expected results for each
-#   of the multiple test runs for this test.
 @pytest.mark.parametrize("useFlag, testCase", [
-    (False,'basic'),
-    (False,'noise'),
-    (False,'walk bounds')
+    (False, 'basic'),
+    (False, 'noise'),
+    (False, 'walk bounds')
 ])
 
-# provide a unique test method name, starting with test_
+
 def test_unitSimStarTracker(show_plots, useFlag, testCase):
-    """Module Unit Test"""
-    # each test method requires a single assert method to be called
     [testResults, testMessage] = unitSimStarTracker(show_plots, useFlag, testCase)
     assert testResults < 1, testMessage
 
 
 def unitSimStarTracker(show_plots, useFlag, testCase):
     testFail = False
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty array to store test log messages
-    unitTaskName = "unitTask"  # arbitrary name (don't change)
-    unitProcName = "TestProcess"  # arbitrary name (don't change)
+    testFailCount = 0
+    testMessages = []
+    unitTaskName = "unitTask"
+    unitProcName = "TestProcess"
 
-    # initialize SimulationBaseClass
+    # Create a sim module as an empty container
     unitSim = SimulationBaseClass.SimBaseClass()
 
-    # create the task and specify the integration update time
     unitProcRate = macros.sec2nano(0.1)
     unitProcRate_s = macros.NANO2SEC*unitProcRate
     unitProc = unitSim.CreateNewProcess(unitProcName)
     unitProc.addTask(unitSim.CreateNewTask(unitTaskName, unitProcRate))
 
-    # configure module
+    # Configure the starTracker module
     StarTracker = starTracker.StarTracker()
     StarTracker.modelTag = "StarTracker"
     setRandomWalk(StarTracker)
+    unitSim.AddModelToTask(unitTaskName, StarTracker)
 
-    # configure module input message
+    # Configure starTracker SCState input message
     OutputStateData = messaging.SCStatesMsgPayload()
-    OutputStateData.r_BN_N = [0,0,0]
-    OutputStateData.v_BN_N = [0,0,0]
-    OutputStateData.sigma_BN = [0,0,0]
-    OutputStateData.omega_BN_B = [0,0,0]
-    OutputStateData.TotalAccumDVBdy = [0,0,0]
+    OutputStateData.r_BN_N = [0, 0, 0]
+    OutputStateData.v_BN_N = [0, 0, 0]
+    OutputStateData.sigma_BN = [0, 0, 0]
+    OutputStateData.omega_BN_B = [0, 0, 0]
+    OutputStateData.TotalAccumDVBdy = [0, 0, 0]
     OutputStateData.MRPSwitchCount = 0
 
     trueVector = dict()
-    print(testCase)
+
+    # This test verifies basic input and output
     if testCase == 'basic':
-        # this test verifies basic input and output
         simStopTime = 0.5
         sigma = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
         OutputStateData.sigma_BN = sigma
         trueVector['qInrtl2Case'] = listStack(rbk.MRP2EP(sigma),simStopTime,unitProcRate)
-        trueVector['timeTag'] =  np.arange(0,0+simStopTime*1E9,unitProcRate_s*1E9)
+        trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
 
     elif testCase == 'noise':
         simStopTime = 1000.
         noiseStd = 0.1
-        stdCorrectionFactor = 1.5 # this needs to be used because of the Gauss Markov module. need to fix the GM module
-        setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[1.0e-13],[1.0e-13],[1.0e-13]])
-        sigma = np.array([0,0,0])
+        stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
+        setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[1.0e-13], [1.0e-13], [1.0e-13]])
+        sigma = np.array([0, 0, 0])
         OutputStateData.sigma_BN = sigma
         trueVector['qInrtl2Case'] = [noiseStd] * 3
-        trueVector['timeTag'] =  np.arange(0,0+simStopTime*1E9,unitProcRate_s*1E9)
+        trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
 
+    # This test checks the walk bounds of random walk
     elif testCase == 'walk bounds':
-        # this test checks the walk bounds of random walk
         simStopTime = 1000.
         noiseStd = 0.01
-        stdCorrectionFactor = 1.5 # this needs to be used because of the Gauss Markov module. need to fix the GM module
+        stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
         walkBound = 0.1
-        setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[walkBound],[walkBound],[walkBound]])
-        sigma = np.array([0,0,0])
+        setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[walkBound], [walkBound], [walkBound]])
+        sigma = np.array([0, 0, 0])
         OutputStateData.sigma_BN = sigma
         trueVector['qInrtl2Case'] = [walkBound + noiseStd*3] * 3
-        trueVector['timeTag'] =  np.arange(0,0+simStopTime*1E9,unitProcRate_s*1E9)
+        trueVector['timeTag'] = np.arange(0, 0+simStopTime*1E9, unitProcRate_s*1E9)
 
     else:
         raise Exception('invalid test case')
 
-    # add module to the task
-    unitSim.AddModelToTask(unitTaskName, StarTracker)
-
-    # log module output message
+    # Set up data logging
     dataLog = StarTracker.sensorOutMsg.recorder()
     unitSim.AddModelToTask(unitTaskName, dataLog)
 
-    # configure spacecraft state message
+    # Configure spacecraft state message
     scMsg = messaging.SCStatesMsg().write(OutputStateData)
     StarTracker.scStateInMsg.subscribeTo(scMsg)
 
@@ -137,10 +128,10 @@ def unitSimStarTracker(show_plots, useFlag, testCase):
     unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
     unitSim.ExecuteSimulation()
 
-    # pull message log data and assemble into dict
+    # Extract logged data for test check
     moduleOutput = dataLog.qInrtl2Case
 
-    # convert quaternion output to prv
+    # Convert quaternion output to prv
     moduleOutput2 = np.zeros([int(simStopTime/unitProcRate_s)+1, 3])
     for i in range(0, int(simStopTime/unitProcRate_s)+1):
         moduleOutput2[i] = rbk.EP2PRV(moduleOutput[i])
@@ -149,14 +140,14 @@ def unitSimStarTracker(show_plots, useFlag, testCase):
         accuracy = 1e-6
 
     if testCase == 'noise':
-        for i in range(0,3):
-            if np.abs(np.mean(moduleOutput2[:,i])) > 0.01 \
-                            or np.abs(np.std(moduleOutput2[:,i]) - trueVector['qInrtl2Case'][i]) > 0.01 :
+        for i in range(0, 3):
+            if np.abs(np.mean(moduleOutput2[:, i])) > 0.01 \
+                            or np.abs(np.std(moduleOutput2[:, i]) - trueVector['qInrtl2Case'][i]) > 0.01:
                 testFail = True
                 break
 
     elif testCase == 'walk bounds':
-        for i in range(0,3):
+        for i in range(0, 3):
             print(np.max(np.abs(np.asarray(moduleOutput2[i]))))
             if np.max(np.abs(np.asarray(moduleOutput2[i]))) > trueVector['qInrtl2Case'][i]:
                 testFail = True
@@ -174,22 +165,17 @@ def unitSimStarTracker(show_plots, useFlag, testCase):
 
     np.set_printoptions(precision=16)
 
-    # print out success message if no error were found
     if testFailCount == 0:
         print("PASSED ")
     else:
         print(testMessages)
 
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
     return [testFailCount, ''.join(testMessages)]
 
 
-# This statement below ensures that the unit test script can be run as a
-# stand-along python script
 if __name__ == "__main__":
     test_unitSimStarTracker(
-        False, # show_plots
-        False, # useFlag
-        'walk bounds' # testCase
+        False,  # show_plots
+        False,  # useFlag
+        'walk bounds'  # testCase
     )

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -31,8 +31,8 @@ def listStack(vec, simStopTime, unitProcRate):
 def setRandomWalk(self, senNoiseStd = 0.0, errorBounds = [[1e6],[1e6],[1e6]]):
     # sets the module random walk variables
     PMatrix = [[senNoiseStd, 0., 0.], [0., senNoiseStd, 0.], [0., 0., senNoiseStd]]
-    self.PMatrix = PMatrix
-    self.walkBounds = errorBounds
+    self.setPMatrix(PMatrix)
+    self.setWalkBounds(errorBounds)
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -56,10 +56,10 @@ def test_starTracker(show_plots, useFlag, testCase):
     unitProc.addTask(unitSim.CreateNewTask(unitTaskName, unitProcRate))
 
     # Configure the starTracker module
-    StarTracker = starTracker.StarTracker()
-    StarTracker.modelTag = "StarTracker"
-    setRandomWalk(StarTracker)
-    unitSim.AddModelToTask(unitTaskName, StarTracker)
+    strTracker = starTracker.StarTracker()
+    strTracker.modelTag = "starTracker"
+    setRandomWalk(strTracker)
+    unitSim.AddModelToTask(unitTaskName, strTracker)
 
     # Configure starTracker SCState input message
     scStatesMessageData = messaging.SCStatesMsgPayload()
@@ -77,7 +77,7 @@ def test_starTracker(show_plots, useFlag, testCase):
         simStopTime = 0.5
         prv_CB = [0.0, 0.0, 10.0 * macros.D2R]
         dcm_CB = rbk.PRV2C(prv_CB)
-        StarTracker.setDcmCB(dcm_CB)
+        strTracker.setDcmCB(dcm_CB)
         sigma_BN = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
         sigma_CB = rbk.C2MRP(dcm_CB)
         sigma_CN = rbk.addMRP(sigma_BN, sigma_CB)
@@ -90,7 +90,7 @@ def test_starTracker(show_plots, useFlag, testCase):
         simStopTime = 1000.
         noiseStd = 0.1
         stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
-        setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[1.0e-13], [1.0e-13], [1.0e-13]])
+        setRandomWalk(strTracker, noiseStd*stdCorrectionFactor, [[1.0e-13], [1.0e-13], [1.0e-13]])
         sigma_BN = np.array([0, 0, 0])
         scStatesMessageData.sigma_BN = sigma_BN
         trueVector['qInrtl2Case'] = [noiseStd] * 3
@@ -102,7 +102,7 @@ def test_starTracker(show_plots, useFlag, testCase):
         noiseStd = 0.01
         stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
         walkBound = 0.1
-        setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[walkBound], [walkBound], [walkBound]])
+        setRandomWalk(strTracker, noiseStd*stdCorrectionFactor, [[walkBound], [walkBound], [walkBound]])
         sigma_BN = np.array([0, 0, 0])
         scStatesMessageData.sigma_BN = sigma_BN
         trueVector['qInrtl2Case'] = [walkBound + noiseStd*3] * 3
@@ -112,7 +112,7 @@ def test_starTracker(show_plots, useFlag, testCase):
     elif testCase == 'angular velocity check':
         prv_CB = [0.0, 0.0, 10.0 * macros.D2R]
         dcm_CB = rbk.PRV2C(prv_CB)
-        StarTracker.setDcmCB(dcm_CB)
+        strTracker.setDcmCB(dcm_CB)
         simStopTime = unitProcRate_s
         sigma_BN = np.array([0, 0, 0])
         scStatesMessageData.sigma_BN = sigma_BN
@@ -121,12 +121,12 @@ def test_starTracker(show_plots, useFlag, testCase):
         raise Exception('invalid test case')
 
     # Set up data logging
-    starTrackerSensorMsgDataLog = StarTracker.sensorOutMsg.recorder()
+    starTrackerSensorMsgDataLog = strTracker.sensorOutMsg.recorder()
     unitSim.AddModelToTask(unitTaskName, starTrackerSensorMsgDataLog)
 
     # Configure spacecraft state message
     scStatesMessage = messaging.SCStatesMsg().write(scStatesMessageData)
-    StarTracker.scStateInMsg.subscribeTo(scStatesMessage)
+    strTracker.scStateInMsg.subscribeTo(scStatesMessage)
 
     unitSim.InitializeSimulation()
     unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
@@ -153,7 +153,7 @@ def test_starTracker(show_plots, useFlag, testCase):
             scStatesMessageData.TotalAccumDVBdy = [0, 0, 0]
             scStatesMessageData.MRPSwitchCount = 0
             scStatesMessage = messaging.SCStatesMsg().write(scStatesMessageData)
-            StarTracker.scStateInMsg.subscribeTo(scStatesMessage)
+            strTracker.scStateInMsg.subscribeTo(scStatesMessage)
 
             # Execute simulation chunk for updated spacecraft attitude
             simStopTime = simStopTime + unitProcRate_s

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -75,9 +75,15 @@ def test_starTracker(show_plots, useFlag, testCase):
     # This test verifies basic input and output
     if testCase == 'basic':
         simStopTime = 0.5
-        sigma = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
-        scStatesMessageData.sigma_BN = sigma
-        trueVector['qInrtl2Case'] = listStack(rbk.MRP2EP(sigma),simStopTime,unitProcRate)
+        prv_CB = [0.0, 0.0, 10.0 * macros.D2R]
+        dcm_CB = rbk.PRV2C(prv_CB)
+        StarTracker.setDcmCB(dcm_CB)
+        sigma_BN = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
+        sigma_CB = rbk.C2MRP(dcm_CB)
+        sigma_CN = rbk.addMRP(sigma_BN, sigma_CB)
+        beta_CN = rbk.MRP2EP(sigma_CN)
+        scStatesMessageData.sigma_BN = sigma_BN
+        trueVector['qInrtl2Case'] = listStack(beta_CN, simStopTime, unitProcRate)
         trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
 
     elif testCase == 'noise':
@@ -85,8 +91,8 @@ def test_starTracker(show_plots, useFlag, testCase):
         noiseStd = 0.1
         stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
         setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[1.0e-13], [1.0e-13], [1.0e-13]])
-        sigma = np.array([0, 0, 0])
-        scStatesMessageData.sigma_BN = sigma
+        sigma_BN = np.array([0, 0, 0])
+        scStatesMessageData.sigma_BN = sigma_BN
         trueVector['qInrtl2Case'] = [noiseStd] * 3
         trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
 
@@ -97,16 +103,19 @@ def test_starTracker(show_plots, useFlag, testCase):
         stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
         walkBound = 0.1
         setRandomWalk(StarTracker, noiseStd*stdCorrectionFactor, [[walkBound], [walkBound], [walkBound]])
-        sigma = np.array([0, 0, 0])
-        scStatesMessageData.sigma_BN = sigma
+        sigma_BN = np.array([0, 0, 0])
+        scStatesMessageData.sigma_BN = sigma_BN
         trueVector['qInrtl2Case'] = [walkBound + noiseStd*3] * 3
         trueVector['timeTag'] = np.arange(0, 0+simStopTime*1E9, unitProcRate_s*1E9)
 
     # This test checks the computed platform rate
     elif testCase == 'angular velocity check':
+        prv_CB = [0.0, 0.0, 10.0 * macros.D2R]
+        dcm_CB = rbk.PRV2C(prv_CB)
+        StarTracker.setDcmCB(dcm_CB)
         simStopTime = unitProcRate_s
-        sigma = np.array([0, 0, 0])
-        scStatesMessageData.sigma_BN = sigma
+        sigma_BN = np.array([0, 0, 0])
+        scStatesMessageData.sigma_BN = sigma_BN
 
     else:
         raise Exception('invalid test case')

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -23,8 +23,6 @@ from Basilisk.simulation import starTracker
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
-
 
 def listStack(vec, simStopTime, unitProcRate):
     # returns a list duplicated the number of times needed to be consistent with module output
@@ -44,17 +42,7 @@ def setRandomWalk(self, senNoiseStd = 0.0, errorBounds = [[1e6],[1e6],[1e6]]):
     (False, 'noise'),
     (False, 'walk bounds')
 ])
-
-
-def test_unitSimStarTracker(show_plots, useFlag, testCase):
-    [testResults, testMessage] = unitSimStarTracker(show_plots, useFlag, testCase)
-    assert testResults < 1, testMessage
-
-
-def unitSimStarTracker(show_plots, useFlag, testCase):
-    testFail = False
-    testFailCount = 0
-    testMessages = []
+def test_starTracker(show_plots, useFlag, testCase):
     unitTaskName = "unitTask"
     unitProcName = "TestProcess"
 
@@ -129,52 +117,38 @@ def unitSimStarTracker(show_plots, useFlag, testCase):
     unitSim.ExecuteSimulation()
 
     # Extract logged data for test check
-    moduleOutput = dataLog.qInrtl2Case
+    beta_CN = dataLog.qInrtl2Case
 
     # Convert quaternion output to prv
-    moduleOutput2 = np.zeros([int(simStopTime/unitProcRate_s)+1, 3])
+    prv_CN = np.zeros([int(simStopTime/unitProcRate_s)+1, 3])
     for i in range(0, int(simStopTime/unitProcRate_s)+1):
-        moduleOutput2[i] = rbk.EP2PRV(moduleOutput[i])
-
-    if not 'accuracy' in vars():
-        accuracy = 1e-6
+        prv_CN[i] = rbk.EP2PRV(beta_CN[i])
 
     if testCase == 'noise':
+        boundArray = np.full((int(simStopTime/unitProcRate_s)+1), 0.01)
         for i in range(0, 3):
-            if np.abs(np.mean(moduleOutput2[:, i])) > 0.01 \
-                            or np.abs(np.std(moduleOutput2[:, i]) - trueVector['qInrtl2Case'][i]) > 0.01:
-                testFail = True
-                break
+            np.testing.assert_array_less(np.abs(np.mean(prv_CN[:, i])),
+                                         boundArray,
+                                         verbose=True)
 
+            np.testing.assert_array_less(np.abs(np.std(prv_CN[:, i]) - trueVector['qInrtl2Case'][i]),
+                                         boundArray,
+                                         verbose=True)
     elif testCase == 'walk bounds':
         for i in range(0, 3):
-            print(np.max(np.abs(np.asarray(moduleOutput2[i]))))
-            if np.max(np.abs(np.asarray(moduleOutput2[i]))) > trueVector['qInrtl2Case'][i]:
-                testFail = True
-                break
-
+            np.testing.assert_array_less(np.max(np.abs(np.asarray(prv_CN[i]))),
+                                         trueVector['qInrtl2Case'][i],
+                                         verbose=True)
     else:
-        for i in range(0,len(trueVector['qInrtl2Case'])):
-            if not unitTestSupport.isArrayEqual(moduleOutput[i], trueVector['qInrtl2Case'][i], 3, accuracy):
-                testFail = True
-                break
-
-    if testFail:
-        testFailCount += 1
-        testMessages.append("FAILED: " + StarTracker.modelTag + " Module failed unit test")
-
-    np.set_printoptions(precision=16)
-
-    if testFailCount == 0:
-        print("PASSED ")
-    else:
-        print(testMessages)
-
-    return [testFailCount, ''.join(testMessages)]
-
+        accuracy = 1e-6
+        for i in range(0, len(trueVector['qInrtl2Case'])):
+            np.testing.assert_allclose(beta_CN[i],
+                                       trueVector['qInrtl2Case'][i],
+                                       atol=accuracy,
+                                       verbose=True)
 
 if __name__ == "__main__":
-    test_unitSimStarTracker(
+    test_starTracker(
         False,  # show_plots
         False,  # useFlag
         'walk bounds'  # testCase

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -16,13 +16,6 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-#
-#   Integrated Unit Test Script
-#   Purpose:  Run a test of the star tracker module
-#   Author:  John Alcorn
-#   Creation Date:  October 12, 2016
-#
-
 import numpy as np
 import pytest
 from Basilisk.architecture import messaging

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -166,6 +166,12 @@ void StarTracker::updateState(uint64_t currentSimNanos) {
     this->previousSimTime = currentSimNanos;
 }
 
+/*! Setter method for dcm_CB.
+ @return void
+ @param dcm_CB
+*/
+void StarTracker::setDcmCB(const Eigen::Matrix3d &dcm_CB) { this->dcm_CB = dcm_CB; }
+
 /*! Setter method for PMatrix.
  @return void
  @param PMatrix
@@ -177,6 +183,11 @@ void StarTracker::setPMatrix(const Eigen::Matrix3d &PMatrix) { this->PMatrix = P
  @param walkBounds
 */
 void StarTracker::setWalkBounds(const Eigen::Vector3d &walkBounds) { this->walkBounds = walkBounds; }
+
+/*! Getter method for dcm_CB.
+ @return const Eigen::Matrix3d
+*/
+const Eigen::Matrix3d &StarTracker::getDcmCB() const { return this->dcm_CB; }
 
 /*! Getter method for PMatrix.
  @return const Eigen::Matrix3d

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -103,9 +103,9 @@ void StarTracker::applySensorErrors() {
  */
 void StarTracker::computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* sensorValues) {
     Eigen::Matrix3d dcm_BN; /* dcm, inertial to body frame */
-    Eigen::Matrix3d dcm_CN; /* dcm, inertial to case frame */
-
     dcm_BN = mrpToDcm(*sigma);
+
+    Eigen::Matrix3d dcm_CN; /* dcm, inertial to case frame */
     dcm_CN = this->dcm_CB * dcm_BN;
 
     Eigen::Vector4d beta_CN = dcmToEp(dcm_CN);

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -27,12 +27,10 @@
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 
 StarTracker::StarTracker() {
-    this->sensorTimeTag = 0;
     this->dcm_CB.setIdentity();
     this->errorModel = GaussMarkov(3, this->RNGSeed);
     this->PMatrix.fill(0.0);
     this->AMatrix.fill(0.0);
-    this->walkBounds.fill(0.0);
     return;
 }
 

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -18,8 +18,6 @@
  */
 #include "simulation/sensors/starTracker/starTracker.h"
 
-#include <iostream>
-
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/gauss_markov.h"
 #include "architecture/utilities/linearAlgebra.h"

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -99,7 +99,7 @@ void StarTracker::applySensorErrors() {
     @param sigma
     @param sensorValues
  */
-void StarTracker::computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* sensorValues) {
+void StarTracker::computeQuaternion(Eigen::Vector3d *sigma, STSensorMsgPayload *sensorValues) {
     Eigen::Matrix3d dcm_BN; /* dcm, inertial to body frame */
     dcm_BN = mrpToDcm(*sigma);
 
@@ -165,3 +165,25 @@ void StarTracker::updateState(uint64_t currentSimNanos) {
     this->writeOutputMessages(currentSimNanos);
     this->previousSimTime = currentSimNanos;
 }
+
+/*! Setter method for PMatrix.
+ @return void
+ @param PMatrix
+*/
+void StarTracker::setPMatrix(const Eigen::Matrix3d &PMatrix) { this->PMatrix = PMatrix; }
+
+/*! Setter method for walkBounds.
+ @return void
+ @param walkBounds
+*/
+void StarTracker::setWalkBounds(const Eigen::Vector3d &walkBounds) { this->walkBounds = walkBounds; }
+
+/*! Getter method for PMatrix.
+ @return const Eigen::Matrix3d
+*/
+const Eigen::Matrix3d &StarTracker::getPMatrix() const { return this->PMatrix; }
+
+/*! Getter method for walkBounds.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d &StarTracker::getWalkBounds() const { return this->walkBounds; }

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -20,14 +20,15 @@
 
 #include <iostream>
 
+#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/gauss_markov.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/rigidBodyKinematics.hpp"
 
 StarTracker::StarTracker() {
     this->sensorTimeTag = 0;
-    m33SetIdentity(RECAST3X3 this->dcm_CB);
+    this->dcm_CB.setIdentity();
     this->errorModel = GaussMarkov(3, this->RNGSeed);
     this->PMatrix.fill(0.0);
     this->AMatrix.fill(0.0);
@@ -85,10 +86,12 @@ void StarTracker::computeSensorErrors() {
    apply sensor errors
  */
 void StarTracker::applySensorErrors() {
-    double sigmaSensed[3];
-    PRV2MRP(&(this->navErrors.data()[0]), this->mrpErrors);
-    addMRP(this->scState.sigma_BN, this->mrpErrors, sigmaSensed);
-    this->computeQuaternion(sigmaSensed, &this->sensedValues);
+    this->mrpErrors = prvToMrp(this->navErrors);
+
+    Eigen::Vector3d sigmaSensed;
+    sigmaSensed = addMrp(cArray2EigenVector3d(this->scState.sigma_BN), this->mrpErrors);
+
+    this->computeQuaternion(&sigmaSensed, &this->sensedValues);
     this->sensedValues.timeTag = this->sensorTimeTag;
 }
 
@@ -97,12 +100,15 @@ void StarTracker::applySensorErrors() {
     @param sigma
     @param sensorValues
  */
-void StarTracker::computeQuaternion(double *sigma, STSensorMsgPayload *sensorValues) {
-    double dcm_BN[3][3]; /* dcm, inertial to body frame */
-    double dcm_CN[3][3]; /* dcm, inertial to case frame */
-    MRP2C(sigma, dcm_BN);
-    m33MultM33(RECAST3X3 this->dcm_CB, dcm_BN, dcm_CN);
-    C2EP(dcm_CN, sensorValues->qInrtl2Case);
+void StarTracker::computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* sensorValues) {
+    Eigen::Matrix3d dcm_BN; /* dcm, inertial to body frame */
+    Eigen::Matrix3d dcm_CN; /* dcm, inertial to case frame */
+
+    dcm_BN = mrpToDcm(*sigma);
+    dcm_CN = this->dcm_CB * dcm_BN;
+
+    Eigen::Vector4d beta_CN = dcmToEp(dcm_CN);
+    eigenVector4d2CArray(beta_CN, sensorValues->qInrtl2Case);
 }
 
 /*!
@@ -110,7 +116,8 @@ void StarTracker::computeQuaternion(double *sigma, STSensorMsgPayload *sensorVal
  */
 void StarTracker::computeTrueOutput() {
     this->trueValues.timeTag = this->sensorTimeTag;
-    this->computeQuaternion(this->scState.sigma_BN, &this->trueValues);
+    Eigen::Vector3d sigma_BN = cArray2EigenVector3d(this->scState.sigma_BN);
+    this->computeQuaternion(&sigma_BN, &this->trueValues);
 }
 
 /*!

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -115,6 +115,33 @@ void StarTracker::computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* 
 }
 
 /*!
+    compute platform angular velocity from sensed quaternions
+ */
+void StarTracker::computeAngularVelocity(uint64_t currentSimNanos) {
+    // Group quaternion components without beta_0
+    Eigen::Vector3d epsilon_CN = {
+        this->sensedValues.qInrtl2Case[1], this->sensedValues.qInrtl2Case[2], this->sensedValues.qInrtl2Case[3]};
+    Eigen::Vector3d epsilonPrevious_CN = this->betaPrevious_CN.tail<3>();
+
+    // Determine CRPs (Gibbs Vector)
+    Eigen::Vector3d q_CN = (1 / this->sensedValues.qInrtl2Case[0]) * epsilon_CN;
+    Eigen::Vector3d qPrevious_CN = (1 / this->betaPrevious_CN[0]) * epsilonPrevious_CN;
+
+    // Determine qDot_CN
+    Eigen::Vector3d qDot_CN = Eigen::Vector3d::Zero();
+    if (currentSimNanos != this->previousSimTime) {
+        double dt = (currentSimNanos - this->previousSimTime) * NANO2SEC;
+        qDot_CN = (q_CN - qPrevious_CN) / dt;
+    }
+
+    // Solve for platform rate using Eq. 3.137 from Schaub and Junkins Pg 120
+    Eigen::Matrix3d qTilde_CN = eigenTilde(q_CN);
+    Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
+    Eigen::Vector3d omega_CN_C = (2.0 / (1.0 + q_CN.transpose() * q_CN)) * (I - qTilde_CN) * qDot_CN;
+    eigenVector3d2CArray(omega_CN_C, this->sensedValues.omega_CN_C);
+}
+
+/*!
     compute true output values
  */
 void StarTracker::computeTrueOutput() {
@@ -138,6 +165,7 @@ void StarTracker::updateState(uint64_t currentSimNanos) {
     this->computeSensorErrors();
     this->computeTrueOutput();
     this->applySensorErrors();
+    this->computeAngularVelocity(currentSimNanos);
     this->writeOutputMessages(currentSimNanos);
     this->previousSimTime = currentSimNanos;
 }

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -91,6 +91,9 @@ void StarTracker::applySensorErrors() {
     Eigen::Vector3d sigmaSensed;
     sigmaSensed = addMrp(cArray2EigenVector3d(this->scState.sigma_BN), this->mrpErrors);
 
+    // Save the previous sensed quaternion before computing the current sensed quaternion
+    this->betaPrevious_CN = cArray2EigenVector4d(this->sensedValues.qInrtl2Case);
+
     this->computeQuaternion(&sigmaSensed, &this->sensedValues);
     this->sensedValues.timeTag = this->sensorTimeTag;
 }
@@ -136,4 +139,5 @@ void StarTracker::updateState(uint64_t currentSimNanos) {
     this->computeTrueOutput();
     this->applySensorErrors();
     this->writeOutputMessages(currentSimNanos);
+    this->previousSimTime = currentSimNanos;
 }

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -17,14 +17,15 @@
 
  */
 #include "simulation/sensors/starTracker/starTracker.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
+
+#include <iostream>
+
+#include "architecture/utilities/gauss_markov.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
-#include <iostream>
-#include "architecture/utilities/gauss_markov.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
 
-StarTracker::StarTracker()
-{
+StarTracker::StarTracker() {
     this->sensorTimeTag = 0;
     m33SetIdentity(RECAST3X3 this->dcm_CB);
     this->errorModel = GaussMarkov(3, this->RNGSeed);
@@ -34,17 +35,12 @@ StarTracker::StarTracker()
     return;
 }
 
-StarTracker::~StarTracker()
-{
-    return;
-}
-
+StarTracker::~StarTracker() { return; }
 
 /*! This method is used to reset the module.
  @param currentSimNanos The current simulation time from the architecture
  @return void */
-void StarTracker::reset(uint64_t currentSimNanos)
-{
+void StarTracker::reset(uint64_t currentSimNanos) {
     // check if input message has not been included
     if (!this->scStateInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "starTracker.scStateInMsg was not linked.");
@@ -55,12 +51,11 @@ void StarTracker::reset(uint64_t currentSimNanos)
     this->AMatrix.setIdentity(numStates, numStates);
 
     //! - Alert the user if the noise matrix was not the right size.  That'd be bad.
-    if(this->PMatrix.size() != numStates*numStates)
-    {
+    if (this->PMatrix.size() != numStates * numStates) {
         bskLogger.bskLog(BSK_ERROR, "Your process noise matrix (PMatrix) is not 3*3. Quitting.");
         return;
     }
-    if(this->walkBounds.size() != numStates){
+    if (this->walkBounds.size() != numStates) {
         bskLogger.bskLog(BSK_ERROR, "Your walkbounds is not size 3. Quitting");
         return;
     }
@@ -72,8 +67,7 @@ void StarTracker::reset(uint64_t currentSimNanos)
 /*!
     read input messages
  */
-void StarTracker::readInputMessages()
-{
+void StarTracker::readInputMessages() {
     this->scState = this->scStateInMsg();
     this->sensorTimeTag = this->scStateInMsg.timeWritten();
 }
@@ -81,8 +75,7 @@ void StarTracker::readInputMessages()
 /*!
    compute sensor errors
  */
-void StarTracker::computeSensorErrors()
-{
+void StarTracker::computeSensorErrors() {
     this->errorModel.setPropMatrix(this->AMatrix);
     this->errorModel.computeNextState();
     this->navErrors = this->errorModel.getCurrentState();
@@ -91,8 +84,7 @@ void StarTracker::computeSensorErrors()
 /*!
    apply sensor errors
  */
-void StarTracker::applySensorErrors()
-{
+void StarTracker::applySensorErrors() {
     double sigmaSensed[3];
     PRV2MRP(&(this->navErrors.data()[0]), this->mrpErrors);
     addMRP(this->scState.sigma_BN, this->mrpErrors, sigmaSensed);
@@ -105,10 +97,9 @@ void StarTracker::applySensorErrors()
     @param sigma
     @param sensorValues
  */
-void StarTracker::computeQuaternion(double *sigma, STSensorMsgPayload *sensorValues)
-{
-    double dcm_BN[3][3];            /* dcm, inertial to body frame */
-    double dcm_CN[3][3];            /* dcm, inertial to case frame */
+void StarTracker::computeQuaternion(double *sigma, STSensorMsgPayload *sensorValues) {
+    double dcm_BN[3][3]; /* dcm, inertial to body frame */
+    double dcm_CN[3][3]; /* dcm, inertial to case frame */
     MRP2C(sigma, dcm_BN);
     m33MultM33(RECAST3X3 this->dcm_CB, dcm_BN, dcm_CN);
     C2EP(dcm_CN, sensorValues->qInrtl2Case);
@@ -117,8 +108,7 @@ void StarTracker::computeQuaternion(double *sigma, STSensorMsgPayload *sensorVal
 /*!
     compute true output values
  */
-void StarTracker::computeTrueOutput()
-{
+void StarTracker::computeTrueOutput() {
     this->trueValues.timeTag = this->sensorTimeTag;
     this->computeQuaternion(this->scState.sigma_BN, &this->trueValues);
 }
@@ -126,16 +116,14 @@ void StarTracker::computeTrueOutput()
 /*!
     write output messages
  */
-void StarTracker::writeOutputMessages(uint64_t currentSimNanos)
-{
+void StarTracker::writeOutputMessages(uint64_t currentSimNanos) {
     this->sensorOutMsg.write(&this->sensedValues, this->moduleID, currentSimNanos);
 }
 
 /*!
     update module states
  */
-void StarTracker::updateState(uint64_t currentSimNanos)
-{
+void StarTracker::updateState(uint64_t currentSimNanos) {
     this->readInputMessages();
     this->computeSensorErrors();
     this->computeTrueOutput();

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -66,6 +66,12 @@ class StarTracker : public SysModel {
    private:
     Eigen::Matrix3d AMatrix;  //!< [-] AMatrix that we use for error propagation
     GaussMarkov errorModel;   //!< [-] Gauss-markov error states
+
+    uint64_t previousSimTime = 0;  //!< [ns] Previous sim time
+    Eigen::Vector4d betaPrevious_CN{1.0,
+                                    0.0,
+                                    0.0,
+                                    0.0};  //!< Previous sensed quaternion from inertial to platform case frame
 };
 
 #endif

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -38,7 +38,7 @@ class StarTracker : public SysModel {
     ~StarTracker();
 
     void updateState(uint64_t currentSimNanos);
-    void reset(uint64_t CurrentClock);  //!< Method for reseting the module
+    void reset(uint64_t CurrentClock);
     void readInputMessages();
     void writeOutputMessages(uint64_t Clock);
     void computeSensorErrors();
@@ -49,24 +49,24 @@ class StarTracker : public SysModel {
 
    public:
     uint64_t sensorTimeTag = 0;                    //!< [ns] Current time tag for sensor out
-    ReadFunctor<SCStatesMsgPayload> scStateInMsg;  //!< [-] sc input state message
-    Message<STSensorMsgPayload> sensorOutMsg;      //!< [-] sensor output state message
+    ReadFunctor<SCStatesMsgPayload> scStateInMsg;  //!< Sc input state message
+    Message<STSensorMsgPayload> sensorOutMsg;      //!< Sensor output state message
 
     Eigen::Matrix3d
-        PMatrix;  //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
-    Eigen::Vector3d walkBounds{0.0, 0.0, 0.0};  //!< [-] "3-sigma" errors to permit for states
-    Eigen::Vector3d navErrors{0.0, 0.0, 0.0};   //!< [-] Current navigation errors applied to truth
+        PMatrix;  //!< Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
+    Eigen::Vector3d walkBounds{0.0, 0.0, 0.0};  //!< "3-sigma" errors to permit for states
+    Eigen::Vector3d navErrors{0.0, 0.0, 0.0};   //!< Current navigation errors applied to truth
 
-    Eigen::Matrix3d dcm_CB;                    //!< [-] Transformation matrix from body to case
-    STSensorMsgPayload trueValues;             //!< [-] total measurement without perturbations
-    STSensorMsgPayload sensedValues;           //!< [-] total measurement including perturbations
-    Eigen::Vector3d mrpErrors{0.0, 0.0, 0.0};  //!< [-] Errors to be applied to the input MRP set indicating whether
-    SCStatesMsgPayload scState;                //!< [-] Module variable where the input State Data message is stored
-    BSKLogger bskLogger;                       //!< -- BSK Logging
+    Eigen::Matrix3d dcm_CB;                    //!< Transformation matrix from body to case
+    STSensorMsgPayload trueValues;             //!< Total measurement without perturbations
+    STSensorMsgPayload sensedValues;           //!< Total measurement including perturbations
+    Eigen::Vector3d mrpErrors{0.0, 0.0, 0.0};  //!< Errors to be applied to the input MRP set indicating whether
+    SCStatesMsgPayload scState;                //!< Module variable where the input State Data message is stored
+    BSKLogger bskLogger;                       //!< BSK Logging
 
    private:
-    Eigen::Matrix3d AMatrix;  //!< [-] AMatrix that we use for error propagation
-    GaussMarkov errorModel;   //!< [-] Gauss-markov error states
+    Eigen::Matrix3d AMatrix;  //!< AMatrix that we use for error propagation
+    GaussMarkov errorModel;   //!< Gauss-markov error states
 
     uint64_t previousSimTime = 0;  //!< [ns] Previous sim time
     Eigen::Vector4d betaPrevious_CN{1.0,

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -20,27 +20,25 @@
 #ifndef STAR_TRACKER_H
 #define STAR_TRACKER_H
 
+#include <Eigen/Dense>
 #include <vector>
-#include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/utilities/gauss_markov.h"
 
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/STSensorMsgPayload.h"
-#include "architecture/messaging/messaging.h"
-
-#include <Eigen/Dense>
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
-
+#include "architecture/utilities/gauss_markov.h"
 
 /*! @brief star tracker class */
-class StarTracker: public SysModel {
-public:
+class StarTracker : public SysModel {
+   public:
     StarTracker();
     ~StarTracker();
 
     void updateState(uint64_t currentSimNanos);
-    void reset(uint64_t CurrentClock);          //!< Method for reseting the module
+    void reset(uint64_t CurrentClock);  //!< Method for reseting the module
     void readInputMessages();
     void writeOutputMessages(uint64_t Clock);
     void computeSensorErrors();
@@ -48,30 +46,26 @@ public:
     void computeTrueOutput();
     void computeQuaternion(double *sigma, STSensorMsgPayload *sensorValue);
 
-public:
+   public:
+    uint64_t sensorTimeTag;                        //!< [ns] Current time tag for sensor out
+    ReadFunctor<SCStatesMsgPayload> scStateInMsg;  //!< [-] sc input state message
+    Message<STSensorMsgPayload> sensorOutMsg;      //!< [-] sensor output state message
 
-    uint64_t sensorTimeTag;            //!< [ns] Current time tag for sensor out
-    ReadFunctor<SCStatesMsgPayload> scStateInMsg;    //!< [-] sc input state message
-    Message<STSensorMsgPayload> sensorOutMsg;   //!< [-] sensor output state message
+    Eigen::Matrix3d
+        PMatrix;  //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
+    Eigen::Vector3d walkBounds;  //!< [-] "3-sigma" errors to permit for states
+    Eigen::Vector3d navErrors;   //!< [-] Current navigation errors applied to truth
 
-    Eigen::Matrix3d PMatrix;      //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
-    Eigen::Vector3d walkBounds;   //!< [-] "3-sigma" errors to permit for states
-    Eigen::Vector3d navErrors;    //!< [-] Current navigation errors applied to truth
-
-    double dcm_CB[3][3];                 //!< [-] Transformation matrix from body to case
-    STSensorMsgPayload trueValues;  //!< [-] total measurement without perturbations
-    STSensorMsgPayload sensedValues;//!< [-] total measurement including perturbations
+    double dcm_CB[3][3];              //!< [-] Transformation matrix from body to case
+    STSensorMsgPayload trueValues;    //!< [-] total measurement without perturbations
+    STSensorMsgPayload sensedValues;  //!< [-] total measurement including perturbations
     double mrpErrors[3];              //!< [-] Errors to be applied to the input MRP set indicating whether
-    SCStatesMsgPayload scState;      //!< [-] Module variable where the input State Data message is stored
-    BSKLogger bskLogger;                      //!< -- BSK Logging
+    SCStatesMsgPayload scState;       //!< [-] Module variable where the input State Data message is stored
+    BSKLogger bskLogger;              //!< -- BSK Logging
 
-
-
-
-private:
-    Eigen::Matrix3d AMatrix;      //!< [-] AMatrix that we use for error propagation
-    GaussMarkov errorModel;           //!< [-] Gauss-markov error states
+   private:
+    Eigen::Matrix3d AMatrix;  //!< [-] AMatrix that we use for error propagation
+    GaussMarkov errorModel;   //!< [-] Gauss-markov error states
 };
-
 
 #endif

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -44,31 +44,32 @@ class StarTracker : public SysModel {
     void computeSensorErrors();
     void applySensorErrors();
     void computeTrueOutput();
-    void computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* sensorValue);
+    void computeQuaternion(Eigen::Vector3d *sigma, STSensorMsgPayload *sensorValue);
     void computeAngularVelocity(uint64_t currentSimNanos);
+    void setPMatrix(const Eigen::Matrix3d &PMatrix);
+    void setWalkBounds(const Eigen::Vector3d &walkBounds);
+    const Eigen::Matrix3d &getPMatrix() const;
+    const Eigen::Vector3d &getWalkBounds() const;
 
-   public:
-    uint64_t sensorTimeTag = 0;                    //!< [ns] Current time tag for sensor out
     ReadFunctor<SCStatesMsgPayload> scStateInMsg;  //!< Sc input state message
     Message<STSensorMsgPayload> sensorOutMsg;      //!< Sensor output state message
 
+    BSKLogger bskLogger;  //!< BSK Logging
+
+   private:
+    uint64_t sensorTimeTag = 0;  //!< [ns] Current time tag for sensor out
     Eigen::Matrix3d
         PMatrix;  //!< Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
     Eigen::Vector3d walkBounds{0.0, 0.0, 0.0};  //!< "3-sigma" errors to permit for states
     Eigen::Vector3d navErrors{0.0, 0.0, 0.0};   //!< Current navigation errors applied to truth
-
-    Eigen::Matrix3d dcm_CB;                    //!< Transformation matrix from body to case
-    STSensorMsgPayload trueValues;             //!< Total measurement without perturbations
-    STSensorMsgPayload sensedValues;           //!< Total measurement including perturbations
-    Eigen::Vector3d mrpErrors{0.0, 0.0, 0.0};  //!< Errors to be applied to the input MRP set indicating whether
-    SCStatesMsgPayload scState;                //!< Module variable where the input State Data message is stored
-    BSKLogger bskLogger;                       //!< BSK Logging
-
-   private:
-    Eigen::Matrix3d AMatrix;  //!< AMatrix that we use for error propagation
-    GaussMarkov errorModel;   //!< Gauss-markov error states
-
-    uint64_t previousSimTime = 0;  //!< [ns] Previous sim time
+    Eigen::Matrix3d dcm_CB;                     //!< Transformation matrix from body to case
+    STSensorMsgPayload trueValues;              //!< Total measurement without perturbations
+    STSensorMsgPayload sensedValues;            //!< Total measurement including perturbations
+    Eigen::Vector3d mrpErrors{0.0, 0.0, 0.0};   //!< Errors to be applied to the input MRP set indicating whether
+    SCStatesMsgPayload scState;                 //!< Module variable where the input State Data message is stored
+    Eigen::Matrix3d AMatrix;                    //!< AMatrix that we use for error propagation
+    GaussMarkov errorModel;                     //!< Gauss-markov error states
+    uint64_t previousSimTime = 0;               //!< [ns] Previous sim time
     Eigen::Vector4d betaPrevious_CN{1.0,
                                     0.0,
                                     0.0,

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -44,7 +44,7 @@ class StarTracker : public SysModel {
     void computeSensorErrors();
     void applySensorErrors();
     void computeTrueOutput();
-    void computeQuaternion(double *sigma, STSensorMsgPayload *sensorValue);
+    void computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* sensorValue);
 
    public:
     uint64_t sensorTimeTag;                        //!< [ns] Current time tag for sensor out
@@ -56,10 +56,10 @@ class StarTracker : public SysModel {
     Eigen::Vector3d walkBounds;  //!< [-] "3-sigma" errors to permit for states
     Eigen::Vector3d navErrors;   //!< [-] Current navigation errors applied to truth
 
-    double dcm_CB[3][3];              //!< [-] Transformation matrix from body to case
+    Eigen::Matrix3d dcm_CB;           //!< [-] Transformation matrix from body to case
     STSensorMsgPayload trueValues;    //!< [-] total measurement without perturbations
     STSensorMsgPayload sensedValues;  //!< [-] total measurement including perturbations
-    double mrpErrors[3];              //!< [-] Errors to be applied to the input MRP set indicating whether
+    Eigen::Vector3d mrpErrors;        //!< [-] Errors to be applied to the input MRP set indicating whether
     SCStatesMsgPayload scState;       //!< [-] Module variable where the input State Data message is stored
     BSKLogger bskLogger;              //!< -- BSK Logging
 

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -48,21 +48,21 @@ class StarTracker : public SysModel {
     void computeAngularVelocity(uint64_t currentSimNanos);
 
    public:
-    uint64_t sensorTimeTag;                        //!< [ns] Current time tag for sensor out
+    uint64_t sensorTimeTag = 0;                    //!< [ns] Current time tag for sensor out
     ReadFunctor<SCStatesMsgPayload> scStateInMsg;  //!< [-] sc input state message
     Message<STSensorMsgPayload> sensorOutMsg;      //!< [-] sensor output state message
 
     Eigen::Matrix3d
         PMatrix;  //!< [-] Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
-    Eigen::Vector3d walkBounds;  //!< [-] "3-sigma" errors to permit for states
-    Eigen::Vector3d navErrors;   //!< [-] Current navigation errors applied to truth
+    Eigen::Vector3d walkBounds{0.0, 0.0, 0.0};  //!< [-] "3-sigma" errors to permit for states
+    Eigen::Vector3d navErrors{0.0, 0.0, 0.0};   //!< [-] Current navigation errors applied to truth
 
-    Eigen::Matrix3d dcm_CB;           //!< [-] Transformation matrix from body to case
-    STSensorMsgPayload trueValues;    //!< [-] total measurement without perturbations
-    STSensorMsgPayload sensedValues;  //!< [-] total measurement including perturbations
-    Eigen::Vector3d mrpErrors;        //!< [-] Errors to be applied to the input MRP set indicating whether
-    SCStatesMsgPayload scState;       //!< [-] Module variable where the input State Data message is stored
-    BSKLogger bskLogger;              //!< -- BSK Logging
+    Eigen::Matrix3d dcm_CB;                    //!< [-] Transformation matrix from body to case
+    STSensorMsgPayload trueValues;             //!< [-] total measurement without perturbations
+    STSensorMsgPayload sensedValues;           //!< [-] total measurement including perturbations
+    Eigen::Vector3d mrpErrors{0.0, 0.0, 0.0};  //!< [-] Errors to be applied to the input MRP set indicating whether
+    SCStatesMsgPayload scState;                //!< [-] Module variable where the input State Data message is stored
+    BSKLogger bskLogger;                       //!< -- BSK Logging
 
    private:
     Eigen::Matrix3d AMatrix;  //!< [-] AMatrix that we use for error propagation

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -45,6 +45,7 @@ class StarTracker : public SysModel {
     void applySensorErrors();
     void computeTrueOutput();
     void computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* sensorValue);
+    void computeAngularVelocity(uint64_t currentSimNanos);
 
    public:
     uint64_t sensorTimeTag;                        //!< [ns] Current time tag for sensor out

--- a/src/simulation/sensors/starTracker/starTracker.h
+++ b/src/simulation/sensors/starTracker/starTracker.h
@@ -46,8 +46,10 @@ class StarTracker : public SysModel {
     void computeTrueOutput();
     void computeQuaternion(Eigen::Vector3d *sigma, STSensorMsgPayload *sensorValue);
     void computeAngularVelocity(uint64_t currentSimNanos);
+    void setDcmCB(const Eigen::Matrix3d &dcm_CB);
     void setPMatrix(const Eigen::Matrix3d &PMatrix);
     void setWalkBounds(const Eigen::Vector3d &walkBounds);
+    const Eigen::Matrix3d &getDcmCB() const;
     const Eigen::Matrix3d &getPMatrix() const;
     const Eigen::Vector3d &getWalkBounds() const;
 


### PR DESCRIPTION
* **Tickets addressed:** #389 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
The general purpose of this PR is to add a numeric difference to the `starTracker` module that computes the approximate platform angular velocity. In order to achieve this, there are several changes to the repository:

1. The first two commits refactor the `rigidBodyKinematics.cpp` file based on pre-commit and a check is added for an input zero PRV in the `prv2MRP` function.
2. Commit 3 adds the platform/case angular velocity variable `omega_CN_C` to the `STSensorMsgPayload` message and the hub `omega_BN_B` to the `STAttMsgPayload` message.
3. Pre-commit changes are added to the `starTracker` module and `avsEigenSupport` file in commits 4 and 5.
4. Commits 6 an 7 add two methods to `avsEigenSupport` to convert between cArrays and Eigen::Vector4d.
5. Commit 8 ports the `starTracker` module to Eigen.
6. The final commits add the new functionality computing the platform angular velocity using a numeric difference to the module and a corresponding check is added to the unit test. The module public interface is also constrained and the platform/case attitude relative to the hub `dcm_CB` is set in the unit test. Formatting changes are also applied in several small commits to the module and unit test.

## Verification
The unit test is modified and a check is added to compare the module determined platform rate with the computed truth value.

## Documentation
N/A

## Future work
N/A