### PR TITLE
Make numThrusters unsigned

### DIFF
--- a/src/architecture/msgPayloadDefC/THRArrayConfigMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/THRArrayConfigMsgPayload.h
@@ -20,17 +20,13 @@
 #ifndef THR_ARRAY_MESSAGE_H
 #define THR_ARRAY_MESSAGE_H
 
-#include "architecture/utilities/macroDefinitions.h"
 #include "THRConfigMsgPayload.h"
-
-
+#include "architecture/utilities/macroDefinitions.h"
 
 /*! @brief FSW message definition containing the thruster cluster information */
 typedef struct {
-    int numThrusters;                        //!< [-] number of thrusters
+    uint32_t numThrusters;                       //!< [-] number of thrusters
     THRConfigMsgPayload thrusters[MAX_EFF_CNT];  //!< [-] array of thruster configuration information
-}THRArrayConfigMsgPayload;
-
-
+} THRArrayConfigMsgPayload;
 
 #endif

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/_UnitTest/test_sunlineSRuKF.py
@@ -121,7 +121,7 @@ def test_propagation_kf(show_plots):
 
 @pytest.mark.parametrize("initial_error", [False, True])
 def test_measurements_kf(show_plots, initial_error):
-    state_update_flyby(initial_error, True)
+    state_update_flyby(initial_error, False)
 
 
 def state_propagation_flyby(show_plots=False):


### PR DESCRIPTION
* **Tickets addressed:** #398
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The `numThruster` member was change to an unsigned int. A negative number of thrusters makes no physical sense. The first commit adjusts a test that was failing due to having plots shown.

## Verification
CI passes.

## Documentation
NA

## Future work
None
