### PR TITLE
Feature/write first filter messages

### DIFF
--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
@@ -27,9 +27,9 @@ void KalmanFilter::reset(uint64_t currentSimNanos) {
 
     this->state = this->stateInitial.scale(this->unitConversion);
     this->stateLogged = this->state;
-    this->covar = this->unitConversion*this->unitConversion * this->covarInitial;
+    this->covar = this->unitConversion * this->unitConversion * this->covarInitial;
     this->covar.resize(this->state.size(), this->state.size());
-    this->previousFilterTimeTag = (double) currentSimNanos*NANO2SEC;
+    this->previousFilterTimeTag = (double)currentSimNanos * NANO2SEC;
     this->writeOutputMessages(currentSimNanos);
 }
 
@@ -38,8 +38,7 @@ void KalmanFilter::reset(uint64_t currentSimNanos) {
  @return void
  @param currentSimNanos The clock time at which the function was called (nanoseconds)
  */
-void KalmanFilter::updateState(uint64_t currentSimNanos)
-{
+void KalmanFilter::updateState(uint64_t currentSimNanos) {
     this->customInitializeUpdate();
     /*! Read all available measurements, add their information to the Measurement container class, then sort the
      * vector in chronological order */
@@ -47,28 +46,29 @@ void KalmanFilter::updateState(uint64_t currentSimNanos)
     this->orderMeasurementsChronologically();
     /*! Loop through all of the measurements assuming they are in chronological order by first testing if a value
      * has been populated in the measurements array*/
-     for (int index =0 ; index < MAX_MEASUREMENT_NUMBER; ++index) {
-         auto measurement = MeasurementModel();
-         if (!this->measurements[index].has_value()){
-             continue;}
-         else{
-             measurement = this->measurements[index].value();}
-         /*! - If the time tag from a valid measurement is new compared to previous step,
-         propagate and update the filter*/
-         if (measurement.getTimeTag() >= this->previousFilterTimeTag && measurement.getValidity()) {
-             /*! - time update to the measurement time and compute pre-fit residuals*/
-             this->timeUpdate(measurement.getTimeTag());
-             measurement.setPreFitResiduals(this->computeResiduals(measurement));
-             /*! - measurement update and compute post-fit residuals  */
-             this->measurementUpdate(measurement);
-             measurement.setPostFitResiduals(measurement.getObservation() - measurement.model(this->state));
-             this->measurements[index] = measurement;
-         }
-     }
+    for (int index = 0; index < MAX_MEASUREMENT_NUMBER; ++index) {
+        auto measurement = MeasurementModel();
+        if (!this->measurements[index].has_value()) {
+            continue;
+        } else {
+            measurement = this->measurements[index].value();
+        }
+        /*! - If the time tag from a valid measurement is new compared to previous step,
+        propagate and update the filter*/
+        if (measurement.getTimeTag() >= this->previousFilterTimeTag && measurement.getValidity()) {
+            /*! - time update to the measurement time and compute pre-fit residuals*/
+            this->timeUpdate(measurement.getTimeTag());
+            measurement.setPreFitResiduals(this->computeResiduals(measurement));
+            /*! - measurement update and compute post-fit residuals  */
+            this->measurementUpdate(measurement);
+            measurement.setPostFitResiduals(measurement.getObservation() - measurement.model(this->state));
+            this->measurements[index] = measurement;
+        }
+    }
     /*! - If current clock time is further ahead than the last measurement time, then
     propagate to this current time-step*/
-    if ((double) currentSimNanos * NANO2SEC > this->previousFilterTimeTag) {
-        this->timeUpdate((double) currentSimNanos * NANO2SEC);
+    if ((double)currentSimNanos * NANO2SEC > this->previousFilterTimeTag) {
+        this->timeUpdate((double)currentSimNanos * NANO2SEC);
     }
     this->customFinalizeUpdate();
     this->writeOutputMessages(currentSimNanos);
@@ -77,20 +77,25 @@ void KalmanFilter::updateState(uint64_t currentSimNanos)
 /*!- Order the measurements chronologically (standard sort)
  @return void
  */
-void KalmanFilter::orderMeasurementsChronologically(){
-    std::sort(this->measurements.begin(), this->measurements.end(),
-              [](std::optional<MeasurementModel> meas1, std::optional<MeasurementModel> meas2){
-                    if (!meas1.has_value()){return false;}
-                    else if (!meas2.has_value()){return true;}
-                    else {return meas1.value().getTimeTag() < meas2.value().getTimeTag();}
-                                  });
+void KalmanFilter::orderMeasurementsChronologically() {
+    std::sort(this->measurements.begin(),
+              this->measurements.end(),
+              [](std::optional<MeasurementModel> meas1, std::optional<MeasurementModel> meas2) {
+                  if (!meas1.has_value()) {
+                      return false;
+                  } else if (!meas2.has_value()) {
+                      return true;
+                  } else {
+                      return meas1.value().getTimeTag() < meas2.value().getTimeTag();
+                  }
+              });
 }
 
 /*! Set the filter initial state position vector
     @param Eigen::VectorXd initial position vector
     @return void
     */
-void KalmanFilter::setInitialPosition(const Eigen::VectorXd &initialPositionInput){
+void KalmanFilter::setInitialPosition(const Eigen::VectorXd &initialPositionInput) {
     PositionState positionState;
     positionState.setValues(initialPositionInput);
     this->stateInitial.setPosition(positionState);
@@ -101,7 +106,7 @@ void KalmanFilter::setInitialPosition(const Eigen::VectorXd &initialPositionInpu
     */
 std::optional<Eigen::VectorXd> KalmanFilter::getInitialPosition() const {
     std::optional<Eigen::VectorXd> position;
-    if (this->stateInitial.hasPosition()){
+    if (this->stateInitial.hasPosition()) {
         position = this->stateInitial.getPositionStates();
     }
     return position;
@@ -111,7 +116,7 @@ std::optional<Eigen::VectorXd> KalmanFilter::getInitialPosition() const {
     @param Eigen::VectorXd  initial velocity vector
     @return void
     */
-void KalmanFilter::setInitialVelocity(const Eigen::VectorXd &initialVelocityInput){
+void KalmanFilter::setInitialVelocity(const Eigen::VectorXd &initialVelocityInput) {
     VelocityState velocityState;
     velocityState.setValues(initialVelocityInput);
     this->stateInitial.setVelocity(velocityState);
@@ -122,7 +127,7 @@ void KalmanFilter::setInitialVelocity(const Eigen::VectorXd &initialVelocityInpu
     */
 std::optional<Eigen::VectorXd> KalmanFilter::getInitialVelocity() const {
     std::optional<Eigen::VectorXd> velocity;
-    if (this->stateInitial.hasVelocity()){
+    if (this->stateInitial.hasVelocity()) {
         velocity = this->stateInitial.getVelocityStates();
     }
     return velocity;
@@ -132,7 +137,7 @@ std::optional<Eigen::VectorXd> KalmanFilter::getInitialVelocity() const {
     @param  Eigen::VectorXd initial acceleration vector
     @return void
     */
-void KalmanFilter::setInitialAcceleration(const Eigen::VectorXd &initialAccelerationInput){
+void KalmanFilter::setInitialAcceleration(const Eigen::VectorXd &initialAccelerationInput) {
     AccelerationState accelerationState;
     accelerationState.setValues(initialAccelerationInput);
     this->stateInitial.setAcceleration(accelerationState);
@@ -143,7 +148,7 @@ void KalmanFilter::setInitialAcceleration(const Eigen::VectorXd &initialAccelera
     */
 std::optional<Eigen::VectorXd> KalmanFilter::getInitialAcceleration() const {
     std::optional<Eigen::VectorXd> acceleration;
-    if (this->stateInitial.hasAcceleration()){
+    if (this->stateInitial.hasAcceleration()) {
         acceleration = this->stateInitial.getAccelerationStates();
     }
     return acceleration;
@@ -153,7 +158,7 @@ std::optional<Eigen::VectorXd> KalmanFilter::getInitialAcceleration() const {
     @param Eigen::VectorXd  initial bias vector
     @return void
     */
-void KalmanFilter::setInitialBias(const Eigen::VectorXd &initialBiasInput){
+void KalmanFilter::setInitialBias(const Eigen::VectorXd &initialBiasInput) {
     BiasState biasState;
     biasState.setValues(initialBiasInput);
     this->stateInitial.setBias(biasState);
@@ -164,7 +169,7 @@ void KalmanFilter::setInitialBias(const Eigen::VectorXd &initialBiasInput){
     */
 std::optional<Eigen::VectorXd> KalmanFilter::getInitialBias() const {
     std::optional<Eigen::VectorXd> bias;
-    if (this->stateInitial.hasBias()){
+    if (this->stateInitial.hasBias()) {
         bias = this->stateInitial.getBiasStates();
     }
     return bias;
@@ -174,7 +179,7 @@ std::optional<Eigen::VectorXd> KalmanFilter::getInitialBias() const {
     @param Eigen::VectorXd initial consider parameter vector
     @return void
     */
-void KalmanFilter::setInitialConsiderParameters(const Eigen::VectorXd &initialConsiderInput){
+void KalmanFilter::setInitialConsiderParameters(const Eigen::VectorXd &initialConsiderInput) {
     ConsiderState considerState;
     considerState.setValues(initialConsiderInput);
     this->stateInitial.setConsider(considerState);
@@ -185,7 +190,7 @@ void KalmanFilter::setInitialConsiderParameters(const Eigen::VectorXd &initialCo
     */
 std::optional<Eigen::VectorXd> KalmanFilter::getInitialConsiderParameters() const {
     std::optional<Eigen::VectorXd> consider;
-    if (this->stateInitial.hasConsider()){
+    if (this->stateInitial.hasConsider()) {
         consider = this->stateInitial.getConsiderStates();
     }
     return consider;
@@ -195,8 +200,8 @@ std::optional<Eigen::VectorXd> KalmanFilter::getInitialConsiderParameters() cons
     @param Eigen::VectorXd initialStateInput
     @return void
     */
-void KalmanFilter::setFilterDynamics(const std::function<const FilterStateVector(const double, const FilterStateVector&)>&
-        dynamicsPropagator){
+void KalmanFilter::setFilterDynamics(
+    const std::function<const FilterStateVector(const double, const FilterStateVector &)> &dynamicsPropagator) {
     this->dynamics.setDynamics(dynamicsPropagator);
 }
 
@@ -204,7 +209,7 @@ void KalmanFilter::setFilterDynamics(const std::function<const FilterStateVector
     @param Eigen::MatrixXd initialCovarianceInput
     @return void
     */
-void KalmanFilter::setInitialCovariance(const Eigen::MatrixXd &initialCovarianceInput){
+void KalmanFilter::setInitialCovariance(const Eigen::MatrixXd &initialCovarianceInput) {
     this->covarInitial.resize(initialCovarianceInput.rows(), initialCovarianceInput.cols());
     this->covarInitial << initialCovarianceInput;
 }
@@ -212,15 +217,13 @@ void KalmanFilter::setInitialCovariance(const Eigen::MatrixXd &initialCovariance
 /*! Get the filter initial state covariance
     @return Eigen::MatrixXd covarInitial
     */
-Eigen::MatrixXd KalmanFilter::getInitialCovariance() const {
-    return this->covarInitial;
-}
+Eigen::MatrixXd KalmanFilter::getInitialCovariance() const { return this->covarInitial; }
 
 /*! Set the filter process noise
     @param Eigen::MatrixXd processNoiseInput
     @return void
     */
-void KalmanFilter::setProcessNoise(const Eigen::MatrixXd &processNoiseInput){
+void KalmanFilter::setProcessNoise(const Eigen::MatrixXd &processNoiseInput) {
     this->processNoise.resize(processNoiseInput.rows(), processNoiseInput.cols());
     this->processNoise << processNoiseInput;
 }
@@ -228,9 +231,7 @@ void KalmanFilter::setProcessNoise(const Eigen::MatrixXd &processNoiseInput){
 /*! Get the filter process noise
     @return Eigen::MatrixXd processNoise
     */
-Eigen::MatrixXd KalmanFilter::getProcessNoise() const {
-    return this->processNoise;
-}
+Eigen::MatrixXd KalmanFilter::getProcessNoise() const { return this->processNoise; }
 
 /*! Set the filter measurement noise scale factor if desirable
     @param double measurementNoiseScale
@@ -243,22 +244,16 @@ void KalmanFilter::setMeasurementNoiseScale(const double measurementNoiseScale) 
 /*! Get the filter measurement noise scale factor
     @return double measurementNoiseScale
     */
-double KalmanFilter::getMeasurementNoiseScale() const {
-    return this->measNoiseScaling;
-}
+double KalmanFilter::getMeasurementNoiseScale() const { return this->measNoiseScaling; }
 
 /*! Set a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
  * outside facing interface is in SI
     @param double conversion
     */
-void KalmanFilter::setUnitConversionFromSItoState(const double conversion){
-    this->unitConversion = conversion;
-}
+void KalmanFilter::setUnitConversionFromSItoState(const double conversion) { this->unitConversion = conversion; }
 
 /*! Get a unit conversion factor, for instance if desirable to solve for a state in km in the filter, but Basilisk's
  * outside facing interface is in SI
     @return double unitConversion
     */
-double KalmanFilter::getUnitConversionFromSItoState() const{
-    return this->unitConversion;
-}
+double KalmanFilter::getUnitConversionFromSItoState() const { return this->unitConversion; }

--- a/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
+++ b/src/fswAlgorithms/_GeneralModuleFiles/kalmanFilter.cpp
@@ -29,8 +29,8 @@ void KalmanFilter::reset(uint64_t currentSimNanos) {
     this->stateLogged = this->state;
     this->covar = this->unitConversion*this->unitConversion * this->covarInitial;
     this->covar.resize(this->state.size(), this->state.size());
-
     this->previousFilterTimeTag = (double) currentSimNanos*NANO2SEC;
+    this->writeOutputMessages(currentSimNanos);
 }
 
 /*! Take the relative position measurements and output an estimate of the

--- a/src/fswAlgorithms/opticalNavigation/linearODeKF/_UnitTest/test_linearODeKF.py
+++ b/src/fswAlgorithms/opticalNavigation/linearODeKF/_UnitTest/test_linearODeKF.py
@@ -259,6 +259,7 @@ def state_update_flyby(show_plots, filter_type, constant_velocity, errors):
                           0., noise_std**2/np.linalg.norm(expected[0, 1:4])**2, 0.,
                           0., 0., noise_std**2/np.linalg.norm(expected[0, 1:4])**2]
     noise[0, :] = np.diagonal(np.array(input_data.covar_N).reshape([3,3]))
+    np.random.seed(0)
     for i in range(t1):
         if i > 0 and i % 10 == 0:
             input_data.timeTag = (i) * dt

--- a/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
@@ -28,45 +28,45 @@ void LinearODeKF::customreset() {
     /*! - Check if the required message has not been connected */
     assert(this->opNavHeadingMsg.isLinked());
     if (this->constantVelocityInitial) {
-        this->constantVelocity = this->constantVelocityInitial.value()*this->unitConversion;
+        this->constantVelocity = this->constantVelocityInitial.value() * this->unitConversion;
     }
     /*! - Set the dynamics matrix calculator*/
-    std::function<Eigen::MatrixXd(double, const FilterStateVector)> dynamicsMatrixCalculator= [this]
-            (double time, const FilterStateVector &state){
-        Eigen::VectorXd position = state.getPositionStates();
-        Eigen::MatrixXd dynamicsMatrix = Eigen::MatrixXd::Zero(state.size(), state.size());
-        if (!this->constantVelocity) {
-            dynamicsMatrix.block(0, position.size(), position.size(), position.size()) =
+    std::function<Eigen::MatrixXd(double, const FilterStateVector)> dynamicsMatrixCalculator =
+        [this](double time, const FilterStateVector &state) {
+            Eigen::VectorXd position = state.getPositionStates();
+            Eigen::MatrixXd dynamicsMatrix = Eigen::MatrixXd::Zero(state.size(), state.size());
+            if (!this->constantVelocity) {
+                dynamicsMatrix.block(0, position.size(), position.size(), position.size()) =
                     Eigen::MatrixXd::Identity(position.size(), position.size());
-        }
-        return dynamicsMatrix;
-    };
+            }
+            return dynamicsMatrix;
+        };
 
     this->dynamics.setDynamicsMatrix(dynamicsMatrixCalculator);
 
     /*! - Set the filter dynamics (linear) */
-    std::function<FilterStateVector(double, const FilterStateVector)> twoBodyDynamics = [this](double t, const FilterStateVector &state){
-        FilterStateVector XDot;
-        PositionState stateDerivative;
+    std::function<FilterStateVector(double, const FilterStateVector)> twoBodyDynamics =
+        [this](double t, const FilterStateVector &state) {
+            FilterStateVector XDot;
+            PositionState stateDerivative;
 
-        if (this->constantVelocity) {
-            stateDerivative.setValues(this->constantVelocity.value());
-        }
-        else {
-            stateDerivative.setValues(state.getVelocityStates());
-            VelocityState flybyVelocity;
-            flybyVelocity.setValues(Eigen::Vector3d::Zero());
-            XDot.setVelocity(flybyVelocity);
-        }
+            if (this->constantVelocity) {
+                stateDerivative.setValues(this->constantVelocity.value());
+            } else {
+                stateDerivative.setValues(state.getVelocityStates());
+                VelocityState flybyVelocity;
+                flybyVelocity.setValues(Eigen::Vector3d::Zero());
+                XDot.setVelocity(flybyVelocity);
+            }
 
-        XDot.setPosition(stateDerivative);
-        Eigen::MatrixXd stm = state.detachStm();
+            XDot.setPosition(stateDerivative);
+            Eigen::MatrixXd stm = state.detachStm();
 
-        Eigen::MatrixXd dynMatrix = this->dynamics.computeDynamicsMatrix(t, state);
-        XDot.attachStm(dynMatrix*stm);
+            Eigen::MatrixXd dynMatrix = this->dynamics.computeDynamicsMatrix(t, state);
+            XDot.attachStm(dynMatrix * stm);
 
-        return XDot;
-    };
+            return XDot;
+        };
     this->dynamics.setDynamics(twoBodyDynamics);
 }
 
@@ -80,19 +80,20 @@ void LinearODeKF::writeOutputMessages(uint64_t currentSimNanos) {
     FilterResidualsMsgPayload residualsBuffer = this->opNavResidualMsg.zeroMsgPayload;
 
     /*! - Write the flyby OD estimate into the copy of the navigation message structure*/
-    eigenMatrixXd2CArray(this->stateLogged.scale(1/this->unitConversion).getPositionStates(), navTransOutMsgBuffer.r_BN_N);
-    if (this->constantVelocityInitial){
+    eigenMatrixXd2CArray(this->stateLogged.scale(1 / this->unitConversion).getPositionStates(),
+                         navTransOutMsgBuffer.r_BN_N);
+    if (this->constantVelocityInitial) {
         eigenMatrixXd2CArray(constantVelocityInitial.value(), navTransOutMsgBuffer.v_BN_N);
-    }
-    else{
-        eigenMatrixXd2CArray(this->stateLogged.scale(1/this->unitConversion).getVelocityStates(), navTransOutMsgBuffer.v_BN_N);
+    } else {
+        eigenMatrixXd2CArray(this->stateLogged.scale(1 / this->unitConversion).getVelocityStates(),
+                             navTransOutMsgBuffer.v_BN_N);
     }
 
     /*! - Populate the filter states output buffer and write the output message*/
     opNavFilterMsgBuffer.timeTag = this->previousFilterTimeTag;
-    eigenMatrixXd2CArray(this->stateLogged.scale(1/this->unitConversion).returnValues(), opNavFilterMsgBuffer.state);
-    eigenMatrixXd2CArray(1/this->unitConversion*this->stateError, opNavFilterMsgBuffer.stateError);
-    eigenMatrixXd2CArray(1/this->unitConversion/this->unitConversion*this->covar, opNavFilterMsgBuffer.covar);
+    eigenMatrixXd2CArray(this->stateLogged.scale(1 / this->unitConversion).returnValues(), opNavFilterMsgBuffer.state);
+    eigenMatrixXd2CArray(1 / this->unitConversion * this->stateError, opNavFilterMsgBuffer.stateError);
+    eigenMatrixXd2CArray(1 / this->unitConversion / this->unitConversion * this->covar, opNavFilterMsgBuffer.covar);
     opNavFilterMsgBuffer.numberOfStates = this->state.size();
 
     auto optionalMeasurement = this->measurements[0];
@@ -123,13 +124,13 @@ void LinearODeKF::readFilterMeasurements() {
     headingMeasurement.setTimeTag(this->opNavHeadingBuffer.timeTag);
     headingMeasurement.setValidity(this->opNavHeadingBuffer.valid);
 
-    if (headingMeasurement.getValidity() && headingMeasurement.getTimeTag() >= this->previousFilterTimeTag){
+    if (headingMeasurement.getValidity() && headingMeasurement.getTimeTag() >= this->previousFilterTimeTag) {
         /*! - Read measurement and cholesky decomposition its noise*/
         headingMeasurement.setObservation(cArray2EigenVector3d(this->opNavHeadingBuffer.rhat_BN_N).normalized());
-        headingMeasurement.setMeasurementNoise(
-                this->measNoiseScaling * cArray2EigenMatrixXd(this->opNavHeadingBuffer.covar_N,
-                                                                   (int) headingMeasurement.size(),
-                                                                   (int) headingMeasurement.size()));
+        headingMeasurement.setMeasurementNoise(this->measNoiseScaling *
+                                               cArray2EigenMatrixXd(this->opNavHeadingBuffer.covar_N,
+                                                                    (int)headingMeasurement.size(),
+                                                                    (int)headingMeasurement.size()));
         headingMeasurement.setMeasurementModel(MeasurementModel::normalizedPositionStates);
         headingMeasurement.setMeasurementMatrix(LinearODeKF::measurementMatrix);
         this->measurements[0] = headingMeasurement;
@@ -140,13 +141,13 @@ void LinearODeKF::readFilterMeasurements() {
     @param FilterStateVector state
     @return Eigen::MatrixXd
 */
-Eigen::MatrixXd LinearODeKF::measurementMatrix(const FilterStateVector &state){
-
+Eigen::MatrixXd LinearODeKF::measurementMatrix(const FilterStateVector &state) {
     Eigen::Vector3d position = state.getPositionStates();
     Eigen::MatrixXd measurementMatrix = Eigen::MatrixXd::Zero(position.size(), state.size());
     measurementMatrix.block(0, 0, position.size(), position.size()) =
-            1/position.norm()*(Eigen::MatrixXd::Identity(position.size(), position.size())
-            - 1/pow(position.norm(), 2)*position*position.transpose());
+        1 / position.norm() *
+        (Eigen::MatrixXd::Identity(position.size(), position.size()) -
+         1 / pow(position.norm(), 2) * position * position.transpose());
 
     return measurementMatrix;
 }
@@ -154,7 +155,7 @@ Eigen::MatrixXd LinearODeKF::measurementMatrix(const FilterStateVector &state){
 /*! Set a constant velocity vector that will not be estimated. Assert that velocity is not part of the state
     @param Eigen::Vector3d velocity
     */
-void LinearODeKF::setConstantVelocity(const Eigen::Vector3d &velocity){
+void LinearODeKF::setConstantVelocity(const Eigen::Vector3d &velocity) {
     assert(this->state.hasVelocity() == false);
     this->constantVelocityInitial = velocity;
 }
@@ -162,6 +163,4 @@ void LinearODeKF::setConstantVelocity(const Eigen::Vector3d &velocity){
 /*! Get the constant velocity vector
     @return std::optional<Eigen::Vector3d> velocity
     */
-std::optional<Eigen::Vector3d> LinearODeKF::getConstantVelocity() const {
-    return this->constantVelocityInitial;
-}
+std::optional<Eigen::Vector3d> LinearODeKF::getConstantVelocity() const { return this->constantVelocityInitial; }

--- a/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
@@ -81,8 +81,8 @@ void LinearODeKF::writeOutputMessages(uint64_t currentSimNanos) {
 
     /*! - Write the flyby OD estimate into the copy of the navigation message structure*/
     eigenMatrixXd2CArray(this->stateLogged.scale(1/this->unitConversion).getPositionStates(), navTransOutMsgBuffer.r_BN_N);
-    if (this->constantVelocity){
-        eigenMatrixXd2CArray(1/this->unitConversion*this->constantVelocity.value(), navTransOutMsgBuffer.v_BN_N);
+    if (this->constantVelocityInitial){
+        eigenMatrixXd2CArray(constantVelocityInitial.value(), navTransOutMsgBuffer.v_BN_N);
     }
     else{
         eigenMatrixXd2CArray(this->stateLogged.scale(1/this->unitConversion).getVelocityStates(), navTransOutMsgBuffer.v_BN_N);


### PR DESCRIPTION
* **Tickets addressed:** bsk-1278
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
Make all filters write out their initial condition to their messages. This means the first message at time 0 is the initial state and covariance that was given to the filter instead of zeros (as it should be).
The first commit modifies the linearODEKF to write and check the Initial Constant Velocity to messages (if it is set) instead of the running variable which has its units transformed. This is simpler and allows the first message writing to work for this specific filter as well.

## Verification
Tests pass

## Documentation
None

## Future work
None
