### PR TITLE
Convert attTrackingError to adapter

### DIFF
--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.cpp
@@ -22,48 +22,6 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 
-/*! This method performs the attitude computations in order to extract the error.
- @return void
- @param sigma_R0R Reference frame state
- @param nav The spacecraft attitude information
- @param ref The reference attitude
- @param attGuidOut Output attitude guidance message
- */
-void AttTrackingError::computeAttitudeError(Eigen::Vector3d sigma_R0R,
-                                            NavAttMsgPayload nav,
-                                            AttRefMsgPayload ref,
-                                            AttGuidMsgPayload *attGuidOut) {
-    // Compute MRP from the original reference frame R0 to the corrected reference frame R
-    Eigen::Vector3d sigma_RR0 = -1 * sigma_R0R;
-
-    // Compute MRP from inertial to updated reference frame sigma_RN
-    Eigen::Vector3d sigma_RN = cArray2EigenVector3d(ref.sigma_RN);
-    sigma_RN = addMrp(sigma_RN, sigma_RR0);
-
-    // Compute attitude error sigma_BR
-    Eigen::Vector3d sigma_BN = cArray2EigenVector3d(nav.sigma_BN);
-    Eigen::Vector3d sigma_BR = subMrp(sigma_BN, sigma_RN);
-
-    // Compute angular velocity reference body frame components omega_RN_B
-    Eigen::Matrix3d dcm_BN = mrpToDcm(sigma_BN);
-    Eigen::Vector3d omega_RN_N = cArray2EigenVector3d(ref.omega_RN_N);
-    Eigen::Vector3d omega_RN_B = dcm_BN * omega_RN_N;
-
-    // Compute angular velocity error omega_BR
-    Eigen::Vector3d omega_BN_B = cArray2EigenVector3d(nav.omega_BN_B);
-    Eigen::Vector3d omega_BR_B = omega_BN_B - omega_RN_B;
-
-    // Compute reference angular velocity rate in body frame components domega_RN_B
-    Eigen::Vector3d domega_RN_N = cArray2EigenVector3d(ref.domega_RN_N);
-    Eigen::Vector3d domega_RN_B = dcm_BN * domega_RN_N;
-
-    // Write attitude guidance output message
-    eigenVector3d2CArray(omega_RN_B, attGuidOut->omega_RN_B);
-    eigenVector3d2CArray(omega_BR_B, attGuidOut->omega_BR_B);
-    eigenVector3d2CArray(sigma_BR, attGuidOut->sigma_BR);
-    eigenVector3d2CArray(domega_RN_B, attGuidOut->domega_RN_B);
-}
-
 /*! This method performs a complete reset of the module. Local module variables that retain time varying states between
  function calls are reset to their default values.
  @return void
@@ -77,6 +35,8 @@ void AttTrackingError::reset(uint64_t callTime) {
     if (!this->attNavInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: attTrackingError.attNavInMsg wasn't connected.");
     }
+
+    this->algorithm.reset(callTime);
 }
 
 /*! The Update method performs reads the Navigation message (containing the spacecraft attitude information), and the
@@ -87,11 +47,9 @@ void AttTrackingError::reset(uint64_t callTime) {
  */
 void AttTrackingError::updateState(uint64_t callTime) {
     AttRefMsgPayload ref = this->attRefInMsg();
-
     NavAttMsgPayload nav = this->attNavInMsg();
 
-    AttGuidMsgPayload attGuidOut{};  // Guidance message
-    computeAttitudeError(this->sigma_R0R, nav, ref, &attGuidOut);
+    AttGuidMsgPayload attGuidOut = this->algorithm.update(callTime, ref, nav);
     this->attGuidOutMsg.write(&attGuidOut, this->moduleID, callTime);
 }
 
@@ -99,9 +57,9 @@ void AttTrackingError::updateState(uint64_t callTime) {
  @return void
  @param sigma_R0R
 */
-void AttTrackingError::setSigma_R0R(const Eigen::Vector3d &sigma_R0R) { this->sigma_R0R = sigma_R0R; }
+void AttTrackingError::setSigma_R0R(const Eigen::Vector3d &sigma_R0R) { this->algorithm.setSigma_R0R(sigma_R0R); }
 
 /*! Getter method for sigma_R0R.
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d &AttTrackingError::getSigma_R0R() const { return this->sigma_R0R; }
+const Eigen::Vector3d &AttTrackingError::getSigma_R0R() const { return this->algorithm.getSigma_R0R(); }

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingError.h
@@ -17,8 +17,8 @@
 
  */
 
-#ifndef _ATT_TRACKING_ERROR_
-#define _ATT_TRACKING_ERROR_
+#ifndef BASILISK_ATT_TRACKING_ERROR_H
+#define BASILISK_ATT_TRACKING_ERROR_H
 
 #include <stdint.h>
 
@@ -30,6 +30,7 @@
 #include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
+#include "fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.h"
 
 /*!@brief Data structure for module to compute the attitude tracking error between the spacecraft attitude and the
  * reference.
@@ -40,10 +41,6 @@ class AttTrackingError : public SysModel {
     ~AttTrackingError() = default;  //!< Destructor
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
-    void computeAttitudeError(Eigen::Vector3d sigma_R0R,
-                              NavAttMsgPayload nav,
-                              AttRefMsgPayload ref,
-                              AttGuidMsgPayload *attGuidOut);
     void setSigma_R0R(const Eigen::Vector3d &sigma_R0R);
     const Eigen::Vector3d &getSigma_R0R() const;
 
@@ -53,8 +50,7 @@ class AttTrackingError : public SysModel {
     BSKLogger bskLogger = {};                   //!< BSK Logging
 
    private:
-    Eigen::Vector3d sigma_R0R{};  //!< MRP from corrected reference frame to original reference frame R0. This is the
-                                  //!< same as [BcB] going from primary body frame B to the corrected body frame Bc
+    AttTrackingErrorAlgorithm algorithm;
 };
 
 #endif

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.cpp
@@ -1,0 +1,86 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.h"
+
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.hpp"
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param callTime The clock time at which the function was called (nanoseconds)
+ */
+void AttTrackingErrorAlgorithm::reset(uint64_t callTime) {
+    // Reset the algorithm
+}
+
+/*! This method maps the input thruster command forces into thruster on times using a remainder tracking logic.
+ @return void
+ @param callTime The clock time at which the function was called (nanoseconds)
+ */
+AttGuidMsgPayload AttTrackingErrorAlgorithm::update(uint64_t callTime,
+                                                    AttRefMsgPayload& attRefInMsg,
+                                                    NavAttMsgPayload& attNavInMsg) {
+    AttGuidMsgPayload attGuidOut;
+
+    // Compute MRP from the original reference frame R0 to the corrected reference frame R
+    Eigen::Vector3d sigma_RR0 = -1 * this->sigma_R0R;
+
+    // Compute MRP from inertial to updated reference frame sigma_RN
+    Eigen::Vector3d sigma_RN = cArray2EigenVector3d(attRefInMsg.sigma_RN);
+    sigma_RN = addMrp(sigma_RN, sigma_RR0);
+
+    // Compute attitude error sigma_BR
+    Eigen::Vector3d sigma_BN = cArray2EigenVector3d(attNavInMsg.sigma_BN);
+    Eigen::Vector3d sigma_BR = subMrp(sigma_BN, sigma_RN);
+
+    // Compute angular velocity reference body frame components omega_RN_B
+    Eigen::Matrix3d dcm_BN = mrpToDcm(sigma_BN);
+    Eigen::Vector3d omega_RN_N = cArray2EigenVector3d(attRefInMsg.omega_RN_N);
+    Eigen::Vector3d omega_RN_B = dcm_BN * omega_RN_N;
+
+    // Compute angular velocity error omega_BR
+    Eigen::Vector3d omega_BN_B = cArray2EigenVector3d(attNavInMsg.omega_BN_B);
+    Eigen::Vector3d omega_BR_B = omega_BN_B - omega_RN_B;
+
+    // Compute reference angular velocity rate in body frame components domega_RN_B
+    Eigen::Vector3d domega_RN_N = cArray2EigenVector3d(attRefInMsg.domega_RN_N);
+    Eigen::Vector3d domega_RN_B = dcm_BN * domega_RN_N;
+
+    // Write attitude guidance output message
+    eigenVector3d2CArray(omega_RN_B, attGuidOut.omega_RN_B);
+    eigenVector3d2CArray(omega_BR_B, attGuidOut.omega_BR_B);
+    eigenVector3d2CArray(sigma_BR, attGuidOut.sigma_BR);
+    eigenVector3d2CArray(domega_RN_B, attGuidOut.domega_RN_B);
+
+    return attGuidOut;
+}
+
+/*! Setter method for sigma_R0R.
+ @return void
+ @param sigma_R0R
+*/
+void AttTrackingErrorAlgorithm::setSigma_R0R(const Eigen::Vector3d& sigma_R0R) { this->sigma_R0R = sigma_R0R; }
+
+/*! Getter method for sigma_R0R.
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d& AttTrackingErrorAlgorithm::getSigma_R0R() const { return this->sigma_R0R; }

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.h
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.h
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _ATT_TRACKING_ERROR_ALGORITHM_H
+#define _ATT_TRACKING_ERROR_ALGORITHM_H
+
+#include <Eigen/Core>
+
+#include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+#include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "fswAlgorithms/fswUtilities/fswDefinitions.h"
+
+class AttTrackingErrorAlgorithm {
+   public:
+    void reset(uint64_t callTime);  //!< Method for algorithm reset
+    AttGuidMsgPayload update(uint64_t callTime,
+                             AttRefMsgPayload& attRefInMsg,
+                             NavAttMsgPayload& attNavInMsg);  //!< Algorithm update method
+    void setSigma_R0R(const Eigen::Vector3d& sigma_R0R);      //!< Setter for sigma_R0R variable
+    const Eigen::Vector3d& getSigma_R0R() const;              //!< Getter for sigma_R0R variable
+
+   private:
+    Eigen::Vector3d sigma_R0R{};  //!< MRP from corrected reference frame to original reference frame R0.
+};
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** #407
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
To enable easy relocation of fsw algorithms use the adapter pattern for `attTrackingError`.
This allows for relocation of fsw algorithms and then inclusion of bsk modules in any language with a c ffi/abi.

## Verification
N/A

## Documentation
N/A

## Future work
N/A