### PR TITLE
Decouple safemath from linearalg

### DIFF
--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -19,808 +19,787 @@
 
 /// \cond DO_NOT_DOCUMENT
 
-
 #ifndef EIGEN_MRP_H
 #define EIGEN_MRP_H
 
 #include <Eigen/Geometry>
 
-
 namespace Eigen {
-    template<typename Scalar, int Options = AutoAlign> class MRP;
+template <typename Scalar, int Options = AutoAlign>
+class MRP;
 
+/***************************************************************************
+ * Definition of MRPBase<Derived>
+ * The implementation is at the end of the file
+ ***************************************************************************/
 
-    
-    /***************************************************************************
-     * Definition of MRPBase<Derived>
-     * The implementation is at the end of the file
-     ***************************************************************************/
+namespace internal {
+template <typename Other, int OtherRows = Other::RowsAtCompileTime, int OtherCols = Other::ColsAtCompileTime>
+struct MRPbase_assign_impl;
+}
 
-    namespace internal {
-        template<typename Other,
-        int OtherRows=Other::RowsAtCompileTime,
-        int OtherCols=Other::ColsAtCompileTime>
-        struct MRPbase_assign_impl;
+/** \geometry_module \ingroup Geometry_Module
+ * \class MRPBase
+ * \brief Base class for MRP expressions
+ * \tparam Derived derived type (CRTP)
+ * \sa class MRP
+ */
+template <class Derived>
+class MRPBase : public RotationBase<Derived, 3> {
+    typedef RotationBase<Derived, 3> Base;
+
+   public:
+    using Base::operator*;
+    using Base::derived;
+
+    typedef typename internal::traits<Derived>::Scalar Scalar;              //!< variable
+    typedef typename NumTraits<Scalar>::Real RealScalar;                    //!< variable
+    typedef typename internal::traits<Derived>::Coefficients Coefficients;  //!< variable
+    enum { Flags = Eigen::internal::traits<Derived>::Flags };
+
+    // typedef typename Matrix<Scalar,3,1> Coefficients;
+    /** the type of a 3D vector */
+    typedef Matrix<Scalar, 3, 1> Vector3;
+    /** the equivalent rotation matrix type */
+    typedef Matrix<Scalar, 3, 3> Matrix3;
+    /** the equivalent angle-axis type */
+    typedef AngleAxis<Scalar> AngleAxisType;
+
+    /** default constructor */
+    MRPBase() = default;
+    /** copy constructor */
+    MRPBase(const MRPBase<Derived>& /*rhs*/) = default;
+
+    /** \returns the \c x coefficient */
+    inline Scalar x() const { return this->derived().coeffs().coeff(0); }
+    /** \returns the \c y coefficient */
+    inline Scalar y() const { return this->derived().coeffs().coeff(1); }
+    /** \returns the \c z coefficient */
+    inline Scalar z() const { return this->derived().coeffs().coeff(2); }
+
+    /** \returns a reference to the \c x coefficient */
+    inline Scalar& x() { return this->derived().coeffs().coeffRef(0); }
+    /** \returns a reference to the \c y coefficient */
+    inline Scalar& y() { return this->derived().coeffs().coeffRef(1); }
+    /** \returns a reference to the \c z coefficient */
+    inline Scalar& z() { return this->derived().coeffs().coeffRef(2); }
+
+    /** \returns a read-only vector expression of the imaginary part (x,y,z) */
+    inline const VectorBlock<const Coefficients, 3> vec() const { return coeffs().template head<3>(); }
+
+    /** \returns a vector expression of the imaginary part (x,y,z) */
+    inline VectorBlock<Coefficients, 3> vec() { return coeffs().template head<3>(); }
+
+    /** \returns a read-only vector expression of the coefficients (x,y,z) */
+    inline const typename internal::traits<Derived>::Coefficients& coeffs() const { return derived().coeffs(); }
+
+    /** \returns a vector expression of the coefficients (x,y,z) */
+    inline typename internal::traits<Derived>::Coefficients& coeffs() { return derived().coeffs(); }
+
+    EIGEN_STRONG_INLINE MRPBase<Derived>& operator=(const MRPBase<Derived>& other);  //!< method
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator=(const MRPBase<OtherDerived>& other);  //!< method
+
+    // disabled this copy operator as it is giving very strange compilation errors when compiling
+    // test_stdvector with GCC 4.4.2. This looks like a GCC bug though, so feel free to re-enable it if it's
+    // useful; however notice that we already have the templated operator= above and e.g. in MatrixBase
+    // we didn't have to add, in addition to templated operator=, such a non-templated copy operator.
+    //  Derived& operator=(const MRPBase& other)
+    //  { return operator=<Derived>(other); }
+
+    Derived& operator=(const AngleAxisType& aa);
+    template <class OtherDerived>
+    Derived& operator=(const MatrixBase<OtherDerived>& m);  //!< method
+
+    /** \returns a MRP representing an identity rotation
+     * \sa MatrixBase::Identity()
+     */
+    static inline MRP<Scalar> Identity() { return MRP<Scalar>(Scalar(1), Scalar(0), Scalar(0), Scalar(0)); }
+
+    /** \sa MRPBase::Identity(), MatrixBase::setIdentity()
+     */
+    inline MRPBase& setIdentity() {
+        coeffs() << Scalar(0), Scalar(0), Scalar(0);
+        return *this;
     }
 
-    /** \geometry_module \ingroup Geometry_Module
-     * \class MRPBase
-     * \brief Base class for MRP expressions
-     * \tparam Derived derived type (CRTP)
-     * \sa class MRP
+    /** \returns the squared norm of the MRP's coefficients
+     * \sa MRPBase::norm(), MatrixBase::squaredNorm()
      */
-    template<class Derived>
-    class MRPBase : public RotationBase<Derived, 3>
-    {
-        typedef RotationBase<Derived, 3> Base;
-    public:
-        using Base::operator*;
-        using Base::derived;
+    inline Scalar squaredNorm() const { return coeffs().squaredNorm(); }
 
-        typedef typename internal::traits<Derived>::Scalar Scalar;              //!< variable
-        typedef typename NumTraits<Scalar>::Real RealScalar;                    //!< variable
-        typedef typename internal::traits<Derived>::Coefficients Coefficients;  //!< variable
-        enum {
-            Flags = Eigen::internal::traits<Derived>::Flags
-        };
+    /** \returns the norm of the MRP's coefficients
+     * \sa MRPBase::squaredNorm(), MatrixBase::norm()
+     */
+    inline Scalar norm() const { return coeffs().norm(); }
 
-        // typedef typename Matrix<Scalar,3,1> Coefficients;
-        /** the type of a 3D vector */
-        typedef Matrix<Scalar,3,1> Vector3;
-        /** the equivalent rotation matrix type */
-        typedef Matrix<Scalar,3,3> Matrix3;
-        /** the equivalent angle-axis type */
-        typedef AngleAxis<Scalar> AngleAxisType;
+    /** Normalizes the MRP \c *this
+     * \sa normalized(), MatrixBase::normalize() */
+    inline void normalize() { coeffs().normalize(); }
+    /** \returns a normalized copy of \c *this
+     * \sa normalize(), MatrixBase::normalized() */
+    inline MRP<Scalar> normalized() const { return MRP<Scalar>(coeffs().normalized()); }
 
-        /** default constructor */
-        MRPBase() = default;
-        /** copy constructor */
-        MRPBase(const MRPBase<Derived> &/*rhs*/) = default;
+    /** \returns the dot product of \c *this and \a other
+     * Geometrically speaking, the dot product of two unit MRPs
+     * corresponds to the cosine of half the angle between the two rotations.
+     * \sa angularDistance()
+     */
+    template <class OtherDerived>
+    inline Scalar dot(const MRPBase<OtherDerived>& other) const {
+        return coeffs().dot(other.coeffs());
+    }
 
-        /** \returns the \c x coefficient */
-        inline Scalar x() const { return this->derived().coeffs().coeff(0); }
-        /** \returns the \c y coefficient */
-        inline Scalar y() const { return this->derived().coeffs().coeff(1); }
-        /** \returns the \c z coefficient */
-        inline Scalar z() const { return this->derived().coeffs().coeff(2); }
+    template <class OtherDerived>
+    Scalar angularDistance(const MRPBase<OtherDerived>& other) const;  //!< method
 
-        /** \returns a reference to the \c x coefficient */
-        inline Scalar& x() { return this->derived().coeffs().coeffRef(0); }
-        /** \returns a reference to the \c y coefficient */
-        inline Scalar& y() { return this->derived().coeffs().coeffRef(1); }
-        /** \returns a reference to the \c z coefficient */
-        inline Scalar& z() { return this->derived().coeffs().coeffRef(2); }
+    /** \returns an equivalent 3x3 rotation matrix */
+    Matrix3 toRotationMatrix() const;
 
-        /** \returns a read-only vector expression of the imaginary part (x,y,z) */
-        inline const VectorBlock<const Coefficients,3> vec() const { return coeffs().template head<3>(); }
+    /** \returns the MRP which transform \a a into \a b through a rotation */
+    template <typename Derived1, typename Derived2>
+    Derived& setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
 
-        /** \returns a vector expression of the imaginary part (x,y,z) */
-        inline VectorBlock<Coefficients,3> vec() { return coeffs().template head<3>(); }
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE MRP<Scalar> operator*(const MRPBase<OtherDerived>& q) const;  //!< method
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator*=(const MRPBase<OtherDerived>& q);
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator+=(const MRPBase<OtherDerived>& q);
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator-=(const MRPBase<OtherDerived>& q);
 
-        /** \returns a read-only vector expression of the coefficients (x,y,z) */
-        inline const typename internal::traits<Derived>::Coefficients& coeffs() const { return derived().coeffs(); }
+    /** \returns the MRP describing the shadow set */
+    MRP<Scalar> shadow() const;
 
-        /** \returns a vector expression of the coefficients (x,y,z) */
-        inline typename internal::traits<Derived>::Coefficients& coeffs() { return derived().coeffs(); }
+    /** \returns 3x3 [B] matrix for the MRP differential kinematic equations */
+    Matrix3 Bmat() const;
 
-        EIGEN_STRONG_INLINE MRPBase<Derived>& operator=(const MRPBase<Derived>& other); //!< method
-        template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator=(const MRPBase<OtherDerived>& other); //!< method
+    /** \returns the MRP describing the inverse rotation */
+    MRP<Scalar> inverse() const;
 
-        // disabled this copy operator as it is giving very strange compilation errors when compiling
-        // test_stdvector with GCC 4.4.2. This looks like a GCC bug though, so feel free to re-enable it if it's
-        // useful; however notice that we already have the templated operator= above and e.g. in MatrixBase
-        // we didn't have to add, in addition to templated operator=, such a non-templated copy operator.
-        //  Derived& operator=(const MRPBase& other)
-        //  { return operator=<Derived>(other); }
+    /** \returns the conjugated MRP */
+    MRP<Scalar> conjugate() const;
 
-        Derived& operator=(const AngleAxisType& aa);
-        template<class OtherDerived> Derived& operator=(const MatrixBase<OtherDerived>& m); //!< method
+    //        template<class OtherDerived> MRP<Scalar> slerp(const Scalar& t, const MRPBase<OtherDerived>& other) const;
 
-        /** \returns a MRP representing an identity rotation
-         * \sa MatrixBase::Identity()
-         */
-        static inline MRP<Scalar> Identity() { return MRP<Scalar>(Scalar(1), Scalar(0), Scalar(0), Scalar(0)); }
+    /** \returns \c true if \c *this is approximately equal to \a other, within the precision
+     * determined by \a prec.
+     *
+     * \sa MatrixBase::isApprox() */
+    template <class OtherDerived>
+    bool isApprox(const MRPBase<OtherDerived>& other,
+                  const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const {
+        return coeffs().isApprox(other.coeffs(), prec);
+    }
 
-        /** \sa MRPBase::Identity(), MatrixBase::setIdentity()
-         */
-        inline MRPBase& setIdentity() { coeffs() << Scalar(0), Scalar(0), Scalar(0); return *this; }
+    /** return the result vector of \a v through the rotation*/
+    EIGEN_STRONG_INLINE Vector3 _transformVector(const Vector3& v) const;
 
-        /** \returns the squared norm of the MRP's coefficients
-         * \sa MRPBase::norm(), MatrixBase::squaredNorm()
-         */
-        inline Scalar squaredNorm() const { return coeffs().squaredNorm(); }
+    /** \returns \c *this with scalar type casted to \a NewScalarType
+     *
+     * Note that if \a NewScalarType is equal to the current scalar type of \c *this
+     * then this function smartly returns a const reference to \c *this.
+     */
+    template <typename NewScalarType>
+    inline typename internal::cast_return_type<Derived, MRP<NewScalarType> >::type cast() const {
+        return typename internal::cast_return_type<Derived, MRP<NewScalarType> >::type(derived());
+    }
+};
 
-        /** \returns the norm of the MRP's coefficients
-         * \sa MRPBase::squaredNorm(), MatrixBase::norm()
-         */
-        inline Scalar norm() const { return coeffs().norm(); }
+/***************************************************************************
+ * Definition/implementation of MRP<Scalar>
+ ***************************************************************************/
 
-        /** Normalizes the MRP \c *this
-         * \sa normalized(), MatrixBase::normalize() */
-        inline void normalize() { coeffs().normalize(); }
-        /** \returns a normalized copy of \c *this
-         * \sa normalize(), MatrixBase::normalized() */
-        inline MRP<Scalar> normalized() const { return MRP<Scalar>(coeffs().normalized()); }
+/** \geometry_module \ingroup Geometry_Module
+ *
+ * \class MRP
+ *
+ * \brief The MRP class used to represent 3D orientations and rotations
+ *
+ * \tparam _Scalar the scalar type, i.e., the type of the coefficients
+ * \tparam _Options controls the memory alignment of the coefficients. Can be \# AutoAlign or \# DontAlign. Default is
+ * AutoAlign.
+ *
+ * This class represents a MRP \f$ (x,y,z) \f$ that is a convenient representation of
+ * orientations and rotations of objects in three dimensions. Compared to other representations
+ * like Euler angles or 3x3 matrices, MRPs offer the following advantages:
+ * \li \b compact storage (3 scalars)
+ * \li \b efficient to compose (28 flops),
+ *
+ * The following two typedefs are provided for convenience:
+ * \li \c MRPf for \c float
+ * \li \c MRPd for \c double
+ *
+ * \warning Operations interpreting the MRP as rotation have undefined behavior if the MRP is not normalized.
+ *
+ * \sa  class AngleAxis, class Transform
+ */
 
-        /** \returns the dot product of \c *this and \a other
-         * Geometrically speaking, the dot product of two unit MRPs
-         * corresponds to the cosine of half the angle between the two rotations.
-         * \sa angularDistance()
-         */
-        template<class OtherDerived> inline Scalar dot(const MRPBase<OtherDerived>& other) const { return coeffs().dot(other.coeffs()); }
-
-        template<class OtherDerived> Scalar angularDistance(const MRPBase<OtherDerived>& other) const; //!< method
-
-        /** \returns an equivalent 3x3 rotation matrix */
-        Matrix3 toRotationMatrix() const;
-
-        /** \returns the MRP which transform \a a into \a b through a rotation */
-        template<typename Derived1, typename Derived2>
-        Derived& setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
-
-        template<class OtherDerived> EIGEN_STRONG_INLINE MRP<Scalar> operator* (const MRPBase<OtherDerived>& q) const; //!< method
-        template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator*= (const MRPBase<OtherDerived>& q);
-        template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator+= (const MRPBase<OtherDerived>& q);
-        template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator-= (const MRPBase<OtherDerived>& q);
-
-        /** \returns the MRP describing the shadow set */
-        MRP<Scalar> shadow() const;
-
-        /** \returns 3x3 [B] matrix for the MRP differential kinematic equations */
-        Matrix3 Bmat() const;
-
-        /** \returns the MRP describing the inverse rotation */
-        MRP<Scalar> inverse() const;
-
-        /** \returns the conjugated MRP */
-        MRP<Scalar> conjugate() const;
-
-        //        template<class OtherDerived> MRP<Scalar> slerp(const Scalar& t, const MRPBase<OtherDerived>& other) const;
-
-        /** \returns \c true if \c *this is approximately equal to \a other, within the precision
-         * determined by \a prec.
-         *
-         * \sa MatrixBase::isApprox() */
-        template<class OtherDerived>
-        bool isApprox(const MRPBase<OtherDerived>& other, const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const
-        { return coeffs().isApprox(other.coeffs(), prec); }
-
-        /** return the result vector of \a v through the rotation*/
-        EIGEN_STRONG_INLINE Vector3 _transformVector(const Vector3& v) const;
-
-        /** \returns \c *this with scalar type casted to \a NewScalarType
-         *
-         * Note that if \a NewScalarType is equal to the current scalar type of \c *this
-         * then this function smartly returns a const reference to \c *this.
-         */
-        template<typename NewScalarType>
-        inline typename internal::cast_return_type<Derived, MRP<NewScalarType> >::type cast() const
-        {
-            return typename internal::cast_return_type<Derived,MRP<NewScalarType> >::type(derived());
-        }
-
+namespace internal {
+template <typename _Scalar, int _Options>
+/*! structure definition */
+struct traits<MRP<_Scalar, _Options> > {
+    typedef MRP<_Scalar, _Options> PlainObject;
+    typedef _Scalar Scalar;
+    typedef Matrix<_Scalar, 3, 1, _Options> Coefficients;
+    enum {
+        IsAligned = internal::traits<Coefficients>::Flags & PacketAccessBit,
+        Flags = IsAligned ? (PacketAccessBit | LvalueBit) : LvalueBit
     };
+};
+}  // namespace internal
 
-    /***************************************************************************
-     * Definition/implementation of MRP<Scalar>
-     ***************************************************************************/
+template <typename _Scalar, int _Options>
+class MRP : public MRPBase<MRP<_Scalar, _Options> > {
+    typedef MRPBase<MRP<_Scalar, _Options> > Base;
+    enum { IsAligned = internal::traits<MRP>::IsAligned };
 
-    /** \geometry_module \ingroup Geometry_Module
-     *
-     * \class MRP
-     *
-     * \brief The MRP class used to represent 3D orientations and rotations
-     *
-     * \tparam _Scalar the scalar type, i.e., the type of the coefficients
-     * \tparam _Options controls the memory alignment of the coefficients. Can be \# AutoAlign or \# DontAlign. Default is AutoAlign.
-     *
-     * This class represents a MRP \f$ (x,y,z) \f$ that is a convenient representation of
-     * orientations and rotations of objects in three dimensions. Compared to other representations
-     * like Euler angles or 3x3 matrices, MRPs offer the following advantages:
-     * \li \b compact storage (3 scalars)
-     * \li \b efficient to compose (28 flops),
-     *
-     * The following two typedefs are provided for convenience:
-     * \li \c MRPf for \c float
-     * \li \c MRPd for \c double
-     *
-     * \warning Operations interpreting the MRP as rotation have undefined behavior if the MRP is not normalized.
-     *
-     * \sa  class AngleAxis, class Transform
+   public:
+    typedef _Scalar Scalar;  //!< variable
+
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(MRP)
+    using Base::operator*=;
+
+    typedef typename internal::traits<MRP>::Coefficients Coefficients;  //!< variable
+    typedef typename Base::AngleAxisType AngleAxisType;                 //!< variable
+
+    /** Default constructor leaving the MRP uninitialized. */
+    inline MRP() {}
+
+    /** Constructs and initializes the MRP \f$ (x,y,z) \f$ from
+     * its four coefficients \a x, \a y and \a z.
      */
+    inline MRP(const Scalar& x, const Scalar& y, const Scalar& z) : m_coeffs(x, y, z) {}
 
-    namespace internal {
-        template<typename _Scalar,int _Options>
-        /*! structure definition */
-        struct traits<MRP<_Scalar,_Options> >
-        {
-            typedef MRP<_Scalar,_Options> PlainObject;
-            typedef _Scalar Scalar;
-            typedef Matrix<_Scalar,3,1,_Options> Coefficients;
-            enum{
-                IsAligned = internal::traits<Coefficients>::Flags & PacketAccessBit,
-                Flags = IsAligned ? (PacketAccessBit | LvalueBit) : LvalueBit
-            };
-        };
+    /** Constructs and initialize a MRP from the array data */
+    inline MRP(const Scalar* data) : m_coeffs(data) {}
+
+    /** Copy constructor */
+    template <class Derived>
+    EIGEN_STRONG_INLINE MRP(const MRPBase<Derived>& other) {
+        this->Base::operator=(other);
     }
 
-    template<typename _Scalar, int _Options>
-    class MRP : public MRPBase<MRP<_Scalar,_Options> >
-    {
-        typedef MRPBase<MRP<_Scalar,_Options> > Base;
-        enum { IsAligned = internal::traits<MRP>::IsAligned };
+    /** Constructs and initializes a MRP from the angle-axis \a aa */
+    explicit inline MRP(const AngleAxisType& aa) { *this = aa; }
 
-    public:
-        typedef _Scalar Scalar; //!< variable
+    /** Constructs and initializes a MRP from either:
+     *  - a rotation matrix expression,
+     *  - a 3D vector expression representing MRP coefficients.
+     */
+    template <typename Derived>
+    explicit inline MRP(const MatrixBase<Derived>& other) {
+        *this = other;
+    }
 
-        EIGEN_INHERIT_ASSIGNMENT_OPERATORS(MRP)
-        using Base::operator*=;
+    /** Explicit copy constructor with scalar conversion */
+    //        template<typename OtherScalar, int OtherOptions>
+    //        explicit inline MRP(const MRP<OtherScalar, OtherOptions>& other)
+    //        { m_coeffs = other.coeffs().template cast<Scalar>(); }
 
-        typedef typename internal::traits<MRP>::Coefficients Coefficients;  //!< variable
-        typedef typename Base::AngleAxisType AngleAxisType;                 //!< variable
+    template <typename Derived1, typename Derived2>
+    static MRP FromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
 
-        /** Default constructor leaving the MRP uninitialized. */
-        inline MRP() {}
+    inline Coefficients& coeffs() { return m_coeffs; }              //!< method
+    inline const Coefficients& coeffs() const { return m_coeffs; }  //!< method
 
-        /** Constructs and initializes the MRP \f$ (x,y,z) \f$ from
-         * its four coefficients \a x, \a y and \a z.
-         */
-        inline MRP(const Scalar& x, const Scalar& y, const Scalar& z) : m_coeffs(x, y, z){}
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(bool(IsAligned))
 
-        /** Constructs and initialize a MRP from the array data */
-        inline MRP(const Scalar* data) : m_coeffs(data) {}
-
-        /** Copy constructor */
-        template<class Derived> EIGEN_STRONG_INLINE MRP(const MRPBase<Derived>& other) { this->Base::operator=(other); }
-
-        /** Constructs and initializes a MRP from the angle-axis \a aa */
-        explicit inline MRP(const AngleAxisType& aa) { *this = aa; }
-
-        /** Constructs and initializes a MRP from either:
-         *  - a rotation matrix expression,
-         *  - a 3D vector expression representing MRP coefficients.
-         */
-        template<typename Derived>
-        explicit inline MRP(const MatrixBase<Derived>& other) { *this = other; }
-
-        /** Explicit copy constructor with scalar conversion */
-        //        template<typename OtherScalar, int OtherOptions>
-        //        explicit inline MRP(const MRP<OtherScalar, OtherOptions>& other)
-        //        { m_coeffs = other.coeffs().template cast<Scalar>(); }
-
-        template<typename Derived1, typename Derived2>
-        static MRP FromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
-
-        inline Coefficients& coeffs() { return m_coeffs;} //!< method
-        inline const Coefficients& coeffs() const { return m_coeffs;} //!< method
-
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(bool(IsAligned))
-
-    protected:
-        Coefficients m_coeffs; //!< variable
+   protected:
+    Coefficients m_coeffs;  //!< variable
 
 #ifndef EIGEN_PARSED_BY_DOXYGEN
-        static EIGEN_STRONG_INLINE void _check_template_params()         //!< method
-        {
-            EIGEN_STATIC_ASSERT( (_Options & DontAlign) == _Options,
-                                INVALID_MATRIX_TEMPLATE_PARAMETERS)
-        }
+    static EIGEN_STRONG_INLINE void _check_template_params()  //!< method
+    {
+        EIGEN_STATIC_ASSERT((_Options & DontAlign) == _Options, INVALID_MATRIX_TEMPLATE_PARAMETERS)
+    }
 #endif
-    };
+};
 
-    /** \ingroup Geometry_Module
-     * single precision MRP type */
-    typedef MRP<float> MRPf;
-    /** \ingroup Geometry_Module
-     * double precision MRP type */
-    typedef MRP<double> MRPd;
+/** \ingroup Geometry_Module
+ * single precision MRP type */
+typedef MRP<float> MRPf;
+/** \ingroup Geometry_Module
+ * double precision MRP type */
+typedef MRP<double> MRPd;
 
-    /***************************************************************************
-     * Specialization of Map<MRP<Scalar>>
-     ***************************************************************************/
+/***************************************************************************
+ * Specialization of Map<MRP<Scalar>>
+ ***************************************************************************/
 
-    namespace internal {
-        template<typename _Scalar, int _Options>
-        /*! struct definition */
-        struct traits<Map<MRP<_Scalar>, _Options> > : traits<MRP<_Scalar, (int(_Options)&Aligned)==Aligned ? AutoAlign : DontAlign> >
-        {
-            typedef Map<Matrix<_Scalar,3,1>, _Options> Coefficients;
-        };
-    }
+namespace internal {
+template <typename _Scalar, int _Options>
+/*! struct definition */
+struct traits<Map<MRP<_Scalar>, _Options> >
+    : traits<MRP<_Scalar, (int(_Options) & Aligned) == Aligned ? AutoAlign : DontAlign> > {
+    typedef Map<Matrix<_Scalar, 3, 1>, _Options> Coefficients;
+};
+}  // namespace internal
 
-    namespace internal {
-        template<typename _Scalar, int _Options>
-        /*! struct definition */
-        struct traits<Map<const MRP<_Scalar>, _Options> > : traits<MRP<_Scalar, (int(_Options)&Aligned)==Aligned ? AutoAlign : DontAlign> >
-        {
-            typedef Map<const Matrix<_Scalar,3,1>, _Options> Coefficients;
-            typedef traits<MRP<_Scalar, (int(_Options)&Aligned)==Aligned ? AutoAlign : DontAlign> > TraitsBase;
-            enum {
-                Flags = TraitsBase::Flags & ~LvalueBit
-            };
-        };
-    }
+namespace internal {
+template <typename _Scalar, int _Options>
+/*! struct definition */
+struct traits<Map<const MRP<_Scalar>, _Options> >
+    : traits<MRP<_Scalar, (int(_Options) & Aligned) == Aligned ? AutoAlign : DontAlign> > {
+    typedef Map<const Matrix<_Scalar, 3, 1>, _Options> Coefficients;
+    typedef traits<MRP<_Scalar, (int(_Options) & Aligned) == Aligned ? AutoAlign : DontAlign> > TraitsBase;
+    enum { Flags = TraitsBase::Flags & ~LvalueBit };
+};
+}  // namespace internal
 
-    /** \ingroup Geometry_Module
-     * \brief MRP expression mapping a constant memory buffer
+/** \ingroup Geometry_Module
+ * \brief MRP expression mapping a constant memory buffer
+ *
+ * \tparam _Scalar the type of the MRP coefficients
+ * \tparam _Options see class Map
+ *
+ * This is a specialization of class Map for MRP. This class allows to view
+ * a 3 scalar memory buffer as an Eigen's MRP object.
+ *
+ * \sa class Map, class MRP, class MRPBase
+ */
+template <typename _Scalar, int _Options>
+class Map<const MRP<_Scalar>, _Options> : public MRPBase<Map<const MRP<_Scalar>, _Options> > {
+    typedef MRPBase<Map<const MRP<_Scalar>, _Options> > Base;
+
+   public:
+    typedef _Scalar Scalar;                                             //!< variable
+    typedef typename internal::traits<Map>::Coefficients Coefficients;  //!< variable
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
+    using Base::operator*=;
+
+    /** Constructs a Mapped MRP object from the pointer \a coeffs
      *
-     * \tparam _Scalar the type of the MRP coefficients
-     * \tparam _Options see class Map
+     * The pointer \a coeffs must reference the three coefficients of MRP in the following order:
+     * \code *coeffs == {x, y, z} \endcode
      *
-     * This is a specialization of class Map for MRP. This class allows to view
-     * a 3 scalar memory buffer as an Eigen's MRP object.
+     * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
+    EIGEN_STRONG_INLINE Map(const Scalar* coeffs) : m_coeffs(coeffs) {}
+
+    inline const Coefficients& coeffs() const { return m_coeffs; }  //!< method
+
+   protected:
+    const Coefficients m_coeffs;  //!< variable
+};
+
+/** \ingroup Geometry_Module
+ * \brief Expression of a MRP from a memory buffer
+ *
+ * \tparam _Scalar the type of the MRP coefficients
+ * \tparam _Options see class Map
+ *
+ * This is a specialization of class Map for MRP. This class allows to view
+ * a 3 scalar memory buffer as an Eigen's  MRP object.
+ *
+ * \sa class Map, class MRP, class MRPBase
+ */
+template <typename _Scalar, int _Options>
+class Map<MRP<_Scalar>, _Options> : public MRPBase<Map<MRP<_Scalar>, _Options> > {
+    typedef MRPBase<Map<MRP<_Scalar>, _Options> > Base;
+
+   public:
+    typedef _Scalar Scalar;                                             //!< variable
+    typedef typename internal::traits<Map>::Coefficients Coefficients;  //!< variable
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
+    using Base::operator*=;
+
+    /** Constructs a Mapped MRP object from the pointer \a coeffs
      *
-     * \sa class Map, class MRP, class MRPBase
-     */
-    template<typename _Scalar, int _Options>
-    class Map<const MRP<_Scalar>, _Options >
-    : public MRPBase<Map<const MRP<_Scalar>, _Options> >
-    {
-        typedef MRPBase<Map<const MRP<_Scalar>, _Options> > Base;
-
-    public:
-        typedef _Scalar Scalar;     //!< variable
-        typedef typename internal::traits<Map>::Coefficients Coefficients; //!< variable
-        EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
-        using Base::operator*=;
-
-        /** Constructs a Mapped MRP object from the pointer \a coeffs
-         *
-         * The pointer \a coeffs must reference the three coefficients of MRP in the following order:
-         * \code *coeffs == {x, y, z} \endcode
-         *
-         * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
-        EIGEN_STRONG_INLINE Map(const Scalar* coeffs) : m_coeffs(coeffs) {}
-
-        inline const Coefficients& coeffs() const { return m_coeffs;} //!< method
-
-    protected:
-        const Coefficients m_coeffs; //!< variable
-    };
-
-    /** \ingroup Geometry_Module
-     * \brief Expression of a MRP from a memory buffer
+     * The pointer \a coeffs must reference the three coefficients of MRP in the following order:
+     * \code *coeffs == {x, y, z} \endcode
      *
-     * \tparam _Scalar the type of the MRP coefficients
-     * \tparam _Options see class Map
-     *
-     * This is a specialization of class Map for MRP. This class allows to view
-     * a 3 scalar memory buffer as an Eigen's  MRP object.
-     *
-     * \sa class Map, class MRP, class MRPBase
-     */
-    template<typename _Scalar, int _Options>
-    class Map<MRP<_Scalar>, _Options >
-    : public MRPBase<Map<MRP<_Scalar>, _Options> >
-    {
-        typedef MRPBase<Map<MRP<_Scalar>, _Options> > Base;
+     * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
+    EIGEN_STRONG_INLINE Map(Scalar* coeffs) : m_coeffs(coeffs) {}
 
-    public:
-        typedef _Scalar Scalar; //!< variable
-        typedef typename internal::traits<Map>::Coefficients Coefficients; //!< variable
-        EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
-        using Base::operator*=;
+    inline Coefficients& coeffs() { return m_coeffs; }              //!< method
+    inline const Coefficients& coeffs() const { return m_coeffs; }  //!< method
 
-        /** Constructs a Mapped MRP object from the pointer \a coeffs
-         *
-         * The pointer \a coeffs must reference the three coefficients of MRP in the following order:
-         * \code *coeffs == {x, y, z} \endcode
-         *
-         * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
-        EIGEN_STRONG_INLINE Map(Scalar* coeffs) : m_coeffs(coeffs) {}
+   protected:
+    Coefficients m_coeffs;  //!< variable
+};
 
-        inline Coefficients& coeffs() { return m_coeffs; } //!< method
-        inline const Coefficients& coeffs() const { return m_coeffs; } //!< method
+/** \ingroup Geometry_Module
+ * Map an unaligned array of single precision scalars as a MRP */
+typedef Map<MRP<float>, 0> MRPMapf;
+/** \ingroup Geometry_Module
+ * Map an unaligned array of double precision scalars as a MRP */
+typedef Map<MRP<double>, 0> MRPMapd;
+/** \ingroup Geometry_Module
+ * Map a 16-byte aligned array of single precision scalars as a MRP */
+typedef Map<MRP<float>, Aligned> MRPMapAlignedf;
+/** \ingroup Geometry_Module
+ * Map a 16-byte aligned array of double precision scalars as a MRP */
+typedef Map<MRP<double>, Aligned> MRPMapAlignedd;
 
-    protected:
-        Coefficients m_coeffs; //!< variable
-    };
+/***************************************************************************
+ * Implementation of MRPBase methods
+ ***************************************************************************/
 
-    /** \ingroup Geometry_Module
-     * Map an unaligned array of single precision scalars as a MRP */
-    typedef Map<MRP<float>, 0>         MRPMapf;
-    /** \ingroup Geometry_Module
-     * Map an unaligned array of double precision scalars as a MRP */
-    typedef Map<MRP<double>, 0>        MRPMapd;
-    /** \ingroup Geometry_Module
-     * Map a 16-byte aligned array of single precision scalars as a MRP */
-    typedef Map<MRP<float>, Aligned>   MRPMapAlignedf;
-    /** \ingroup Geometry_Module
-     * Map a 16-byte aligned array of double precision scalars as a MRP */
-    typedef Map<MRP<double>, Aligned>  MRPMapAlignedd;
-
-    /***************************************************************************
-     * Implementation of MRPBase methods
-     ***************************************************************************/
-
-    // Generic MRP * MRP product
-    // This product can be specialized for a given architecture via the Arch template argument.
-    namespace internal {
-        /*! template definition */
-        template<int Arch, class Derived1, class Derived2, typename Scalar, int _Options> struct mrp_product
-        {
-            static EIGEN_STRONG_INLINE MRP<Scalar> run(const MRPBase<Derived1>& a, const MRPBase<Derived2>& b){
-                Scalar det;     //!< variable
-                Scalar s1N2;    //!< variable
-                Scalar s2N2;    //!< variable
-                MRP<Scalar> s2 = b;
-                MRP<Scalar> answer;
-                s1N2 = a.squaredNorm();
-                s2N2 = s2.squaredNorm();
-                det = Scalar(1.0) + s1N2*s2N2 - 2*a.dot(b);
-                if (det < 0.01) {
-                    s2 = s2.shadow();
-                    s2N2 = s2.squaredNorm();
-                    det = Scalar(1.0) + s1N2*s2N2 - 2*a.dot(b);
-                }
-                answer = MRP<Scalar> (((1-s1N2)*s2.vec() + (1-s2N2)*a.vec() - 2*b.vec().cross(a.vec()))/det);
-                if (answer.squaredNorm() > 1)
-                    answer = answer.shadow();
-                return answer;
-            }
-        };
-    }
-
-    /** \returns the concatenation of two rotations as a MRP-MRP product */
-    template <class Derived>
-    template <class OtherDerived>
-    EIGEN_STRONG_INLINE MRP<typename internal::traits<Derived>::Scalar>
-    MRPBase<Derived>::operator* (const MRPBase<OtherDerived>& other) const
-    {
-        EIGEN_STATIC_ASSERT((internal::is_same<typename Derived::Scalar, typename OtherDerived::Scalar>::value),
-                            YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY)
-        return internal::mrp_product<Architecture::Target, Derived, OtherDerived,
-        typename internal::traits<Derived>::Scalar,
-        internal::traits<Derived>::IsAligned && internal::traits<OtherDerived>::IsAligned>::run(*this, other);
-    }
-
-    /** \sa operator*(MRP) */
-    template <class Derived>
-    template <class OtherDerived>
-    EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator*= (const MRPBase<OtherDerived>& other)
-    {
-        derived() = derived() * other.derived();
-        return derived();
-    }
-
-    /** \sa operator*(MRP) */
-    template <class Derived>
-    template <class OtherDerived>
-    EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator+= (const MRPBase<OtherDerived>& other)
-    {
-        derived().coeffs() = derived().coeffs() + other.derived().coeffs();
-        return derived();
-    }
-    /** \sa operator*(MRP) */
-    template <class Derived>
-    template <class OtherDerived>
-    EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator-= (const MRPBase<OtherDerived>& other)
-    {
-        derived().coeffs() = derived().coeffs() - other.derived().coeffs();
-        return derived();
-    }
-
-
-    /** Rotation of a vector by a MRP.
-     * \remarks If the MRP is used to rotate several points (>1)
-     * then it is much more efficient to first convert it to a 3x3 Matrix.
-     * Comparison of the operation cost for n transformations:
-     *   - MRP2:    30n
-     *   - Via a Matrix3: 24 + 15n
-     */
-    template <class Derived>
-    EIGEN_STRONG_INLINE typename MRPBase<Derived>::Vector3
-    MRPBase<Derived>::_transformVector(const Vector3& v) const
-    {
-        // Note that this algorithm comes from the optimization by hand
-        // of the conversion to a Matrix followed by a Matrix/Vector product.
-        // It appears to be much faster than the common algorithm found
-        // in the literature (30 versus 39 flops). It also requires two
-        // Vector3 as temporaries.
-        Vector3 uv = this->vec().cross(v);
-        uv += uv;
-        return v + this->w() * uv + this->vec().cross(uv);
-    }
-
-    template<class Derived>
-    EIGEN_STRONG_INLINE MRPBase<Derived>& MRPBase<Derived>::operator=(const MRPBase<Derived>& other)
-    {
-        coeffs() = other.coeffs();
-        return derived();
-    }
-
-    template<class Derived>
-    template<class OtherDerived>
-    EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const MRPBase<OtherDerived>& other)
-    {
-        coeffs() = other.coeffs();
-        return derived();
-    }
-
-    /** Set \c *this from an angle-axis \a aa and returns a reference to \c *this
-     */
-    template<class Derived>
-    EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const AngleAxisType& aa)
-    {
-        using std::tan;
-        Scalar tanPhi = Scalar(0.25)*aa.angle(); // Scalar(0.25) to suppress precision loss warnings
-        this->vec() = tanPhi * aa.axis();
-        return derived();
-    }
-
-    /** Set \c *this from the expression \a xpr:
-     *   - if \a xpr is a 3x1 vector, then \a xpr is assumed to be a MRP
-     *   - if \a xpr is a 3x3 matrix, then \a xpr is assumed to be rotation matrix
-     *     and \a xpr is converted to a MRP
-     */
-
-    template<class Derived>
-    template<class MatrixDerived>
-    inline Derived& MRPBase<Derived>::operator=(const MatrixBase<MatrixDerived>& xpr)
-    {
-        EIGEN_STATIC_ASSERT((internal::is_same<typename Derived::Scalar, typename MatrixDerived::Scalar>::value),
-                            YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY)
-        internal::MRPbase_assign_impl<MatrixDerived>::run(*this, xpr.derived());
-        return derived();
-    }
-
-    /** Convert the MRP sigma_B/N to a 3x3 rotation matrix [NB].
-     */
-    template<class Derived>
-    inline typename MRPBase<Derived>::Matrix3
-    MRPBase<Derived>::toRotationMatrix(void) const
-    {
-        // NOTE if inlined, then gcc 4.2 and 4.4 get rid of the temporary (not gcc 4.3 !!)
-        // if not inlined then the cost of the return by value is huge ~ +35%,
-        // however, not inlining this function is an order of magnitude slower, so
-        // it has to be inlined, and so the return by value is not an issue
-        Matrix3 res;
-
-        const Scalar ps2   = Scalar(1) + this->coeffs().squaredNorm();
-        const Scalar ms2   = Scalar(1) - this->coeffs().squaredNorm();
-        const Scalar ms2Sq = ms2 * ms2;
-        const Scalar s1s2  = Scalar(8)*this->x()*this->y();
-        const Scalar s1s3  = Scalar(8)*this->x()*this->z();
-        const Scalar s2s3  = Scalar(8)*this->y()*this->z();
-        const Scalar s1Sq  = this->x()*this->x();
-        const Scalar s2Sq  = this->y()*this->y();
-        const Scalar s3Sq  = this->z()*this->z();
-
-        res.coeffRef(0,0) = Scalar(4)*(+s1Sq - s2Sq - s3Sq)+ms2Sq;
-        res.coeffRef(0,1) = s1s2 - Scalar(4)*this->z()*ms2;
-        res.coeffRef(0,2) = s1s3 + Scalar(4)*this->y()*ms2;
-        res.coeffRef(1,0) = s1s2 + Scalar(4)*this->z()*ms2;
-        res.coeffRef(1,1) = Scalar(4)*(-s1Sq + s2Sq - s3Sq)+ms2Sq;
-        res.coeffRef(1,2) = s2s3 - Scalar(4)*this->x()*ms2;
-        res.coeffRef(2,0) = s1s3 - Scalar(4)*this->y()*ms2;
-        res.coeffRef(2,1) = s2s3 + Scalar(4)*this->x()*ms2;
-        res.coeffRef(2,2) = Scalar(4)*(-s1Sq - s2Sq + s3Sq)+ms2Sq;
-        res = res / ps2 / ps2;
-        
-        return res;
-    }
-
-    /** Sets \c *this to be a MRP representing a rotation between
-     * the two arbitrary vectors \a a and \a b. In other words, the built
-     * rotation represent a rotation sending the line of direction \a a
-     * to the line of direction \a b, both lines passing through the origin.
-     *
-     * \returns a reference to \c *this.
-     *
-     * Note that the two input vectors do \b not have to be normalized, and
-     * do not need to have the same norm.
-     */
-    template<class Derived>
-    template<typename Derived1, typename Derived2>
-    inline Derived& MRPBase<Derived>::setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b)
-    {
-        using std::acos;
-        using std::tan;
-
-        Vector3 v0 = a.normalized();
-        Vector3 v1 = b.normalized();
-        Scalar c = v1.dot(v0);
-
-        if (c <= 1 && c >= -1) {
-            Vector3 axis = v0.cross(v1);
-            axis.normalize();
-
-            this->vec() = axis*tan(acos(c)/Scalar(4.0));
-        } else {
-            this->vec() << 0., 0., 0.;
+// Generic MRP * MRP product
+// This product can be specialized for a given architecture via the Arch template argument.
+namespace internal {
+/*! template definition */
+template <int Arch, class Derived1, class Derived2, typename Scalar, int _Options>
+struct mrp_product {
+    static EIGEN_STRONG_INLINE MRP<Scalar> run(const MRPBase<Derived1>& a, const MRPBase<Derived2>& b) {
+        Scalar det;   //!< variable
+        Scalar s1N2;  //!< variable
+        Scalar s2N2;  //!< variable
+        MRP<Scalar> s2 = b;
+        MRP<Scalar> answer;
+        s1N2 = a.squaredNorm();
+        s2N2 = s2.squaredNorm();
+        det = Scalar(1.0) + s1N2 * s2N2 - 2 * a.dot(b);
+        if (det < 0.01) {
+            s2 = s2.shadow();
+            s2N2 = s2.squaredNorm();
+            det = Scalar(1.0) + s1N2 * s2N2 - 2 * a.dot(b);
         }
-        return derived();
+        answer = MRP<Scalar>(((1 - s1N2) * s2.vec() + (1 - s2N2) * a.vec() - 2 * b.vec().cross(a.vec())) / det);
+        if (answer.squaredNorm() > 1) answer = answer.shadow();
+        return answer;
     }
+};
+}  // namespace internal
 
+/** \returns the concatenation of two rotations as a MRP-MRP product */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::operator*(
+    const MRPBase<OtherDerived>& other) const {
+    EIGEN_STATIC_ASSERT(
+        (internal::is_same<typename Derived::Scalar, typename OtherDerived::Scalar>::value),
+        YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY)
+    return internal::mrp_product < Architecture::Target, Derived, OtherDerived,
+           typename internal::traits<Derived>::Scalar,
+           internal::traits<Derived>::IsAligned && internal::traits<OtherDerived>::IsAligned > ::run(*this, other);
+}
 
-    /** Returns a MRP representing a rotation between
-     * the two arbitrary vectors \a a and \a b. In other words, the built
-     * rotation represent a rotation sending the line of direction \a a
-     * to the line of direction \a b, both lines passing through the origin.
-     *
-     * \returns resulting MRP
-     *
-     * Note that the two input vectors do \b not have to be normalized, and
-     * do not need to have the same norm.
-     */
-    template<typename Scalar, int Options>
-    template<typename Derived1, typename Derived2>
-    MRP<Scalar,Options> MRP<Scalar,Options>::FromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b)
-    {
-        MRP sig;
-        sig.setFromTwoVectors(a, b);
-        return sig;
+/** \sa operator*(MRP) */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator*=(const MRPBase<OtherDerived>& other) {
+    derived() = derived() * other.derived();
+    return derived();
+}
+
+/** \sa operator*(MRP) */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator+=(const MRPBase<OtherDerived>& other) {
+    derived().coeffs() = derived().coeffs() + other.derived().coeffs();
+    return derived();
+}
+/** \sa operator*(MRP) */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator-=(const MRPBase<OtherDerived>& other) {
+    derived().coeffs() = derived().coeffs() - other.derived().coeffs();
+    return derived();
+}
+
+/** Rotation of a vector by a MRP.
+ * \remarks If the MRP is used to rotate several points (>1)
+ * then it is much more efficient to first convert it to a 3x3 Matrix.
+ * Comparison of the operation cost for n transformations:
+ *   - MRP2:    30n
+ *   - Via a Matrix3: 24 + 15n
+ */
+template <class Derived>
+EIGEN_STRONG_INLINE typename MRPBase<Derived>::Vector3 MRPBase<Derived>::_transformVector(const Vector3& v) const {
+    // Note that this algorithm comes from the optimization by hand
+    // of the conversion to a Matrix followed by a Matrix/Vector product.
+    // It appears to be much faster than the common algorithm found
+    // in the literature (30 versus 39 flops). It also requires two
+    // Vector3 as temporaries.
+    Vector3 uv = this->vec().cross(v);
+    uv += uv;
+    return v + this->w() * uv + this->vec().cross(uv);
+}
+
+template <class Derived>
+EIGEN_STRONG_INLINE MRPBase<Derived>& MRPBase<Derived>::operator=(const MRPBase<Derived>& other) {
+    coeffs() = other.coeffs();
+    return derived();
+}
+
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const MRPBase<OtherDerived>& other) {
+    coeffs() = other.coeffs();
+    return derived();
+}
+
+/** Set \c *this from an angle-axis \a aa and returns a reference to \c *this
+ */
+template <class Derived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const AngleAxisType& aa) {
+    using std::tan;
+    Scalar tanPhi = Scalar(0.25) * aa.angle();  // Scalar(0.25) to suppress precision loss warnings
+    this->vec() = tanPhi * aa.axis();
+    return derived();
+}
+
+/** Set \c *this from the expression \a xpr:
+ *   - if \a xpr is a 3x1 vector, then \a xpr is assumed to be a MRP
+ *   - if \a xpr is a 3x3 matrix, then \a xpr is assumed to be rotation matrix
+ *     and \a xpr is converted to a MRP
+ */
+
+template <class Derived>
+template <class MatrixDerived>
+inline Derived& MRPBase<Derived>::operator=(const MatrixBase<MatrixDerived>& xpr) {
+    EIGEN_STATIC_ASSERT(
+        (internal::is_same<typename Derived::Scalar, typename MatrixDerived::Scalar>::value),
+        YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY)
+    internal::MRPbase_assign_impl<MatrixDerived>::run(*this, xpr.derived());
+    return derived();
+}
+
+/** Convert the MRP sigma_B/N to a 3x3 rotation matrix [NB].
+ */
+template <class Derived>
+inline typename MRPBase<Derived>::Matrix3 MRPBase<Derived>::toRotationMatrix(void) const {
+    // NOTE if inlined, then gcc 4.2 and 4.4 get rid of the temporary (not gcc 4.3 !!)
+    // if not inlined then the cost of the return by value is huge ~ +35%,
+    // however, not inlining this function is an order of magnitude slower, so
+    // it has to be inlined, and so the return by value is not an issue
+    Matrix3 res;
+
+    const Scalar ps2 = Scalar(1) + this->coeffs().squaredNorm();
+    const Scalar ms2 = Scalar(1) - this->coeffs().squaredNorm();
+    const Scalar ms2Sq = ms2 * ms2;
+    const Scalar s1s2 = Scalar(8) * this->x() * this->y();
+    const Scalar s1s3 = Scalar(8) * this->x() * this->z();
+    const Scalar s2s3 = Scalar(8) * this->y() * this->z();
+    const Scalar s1Sq = this->x() * this->x();
+    const Scalar s2Sq = this->y() * this->y();
+    const Scalar s3Sq = this->z() * this->z();
+
+    res.coeffRef(0, 0) = Scalar(4) * (+s1Sq - s2Sq - s3Sq) + ms2Sq;
+    res.coeffRef(0, 1) = s1s2 - Scalar(4) * this->z() * ms2;
+    res.coeffRef(0, 2) = s1s3 + Scalar(4) * this->y() * ms2;
+    res.coeffRef(1, 0) = s1s2 + Scalar(4) * this->z() * ms2;
+    res.coeffRef(1, 1) = Scalar(4) * (-s1Sq + s2Sq - s3Sq) + ms2Sq;
+    res.coeffRef(1, 2) = s2s3 - Scalar(4) * this->x() * ms2;
+    res.coeffRef(2, 0) = s1s3 - Scalar(4) * this->y() * ms2;
+    res.coeffRef(2, 1) = s2s3 + Scalar(4) * this->x() * ms2;
+    res.coeffRef(2, 2) = Scalar(4) * (-s1Sq - s2Sq + s3Sq) + ms2Sq;
+    res = res / ps2 / ps2;
+
+    return res;
+}
+
+/** Sets \c *this to be a MRP representing a rotation between
+ * the two arbitrary vectors \a a and \a b. In other words, the built
+ * rotation represent a rotation sending the line of direction \a a
+ * to the line of direction \a b, both lines passing through the origin.
+ *
+ * \returns a reference to \c *this.
+ *
+ * Note that the two input vectors do \b not have to be normalized, and
+ * do not need to have the same norm.
+ */
+template <class Derived>
+template <typename Derived1, typename Derived2>
+inline Derived& MRPBase<Derived>::setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b) {
+    using std::acos;
+    using std::tan;
+
+    Vector3 v0 = a.normalized();
+    Vector3 v1 = b.normalized();
+    Scalar c = v1.dot(v0);
+
+    if (c <= 1 && c >= -1) {
+        Vector3 axis = v0.cross(v1);
+        axis.normalize();
+
+        this->vec() = axis * tan(acos(c) / Scalar(4.0));
+    } else {
+        this->vec() << 0., 0., 0.;
     }
+    return derived();
+}
 
-    /** \returns the MRP Shadow set of \c *this
-     *
-     * \sa MRPBase::shadow()
-     */
+/** Returns a MRP representing a rotation between
+ * the two arbitrary vectors \a a and \a b. In other words, the built
+ * rotation represent a rotation sending the line of direction \a a
+ * to the line of direction \a b, both lines passing through the origin.
+ *
+ * \returns resulting MRP
+ *
+ * Note that the two input vectors do \b not have to be normalized, and
+ * do not need to have the same norm.
+ */
+template <typename Scalar, int Options>
+template <typename Derived1, typename Derived2>
+MRP<Scalar, Options> MRP<Scalar, Options>::FromTwoVectors(const MatrixBase<Derived1>& a,
+                                                          const MatrixBase<Derived2>& b) {
+    MRP sig;
+    sig.setFromTwoVectors(a, b);
+    return sig;
+}
+
+/** \returns the MRP Shadow set of \c *this
+ *
+ * \sa MRPBase::shadow()
+ */
+template <class Derived>
+inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::shadow() const {
+    Scalar n2 = this->squaredNorm();
+    if (n2 > Scalar(0))
+        return MRP<Scalar>(-this->coeffs() / n2);
+    else {
+        return MRP<Scalar>(0., 0., 0.);
+    }
+}
+
+/** \returns the MRP [B] matrix of \c *this
+ * This is used in
+ *
+ *  d(sigmda_B/N) = 1/4 [B(sigma_B/N)] omega_BN_B
+ *
+ * \sa MRPBase::shadow()
+ */
+template <class Derived>
+inline typename MRPBase<Derived>::Matrix3 MRPBase<Derived>::Bmat() const {
+    Matrix3 B;
+    Scalar ms2, s1s2, s1s3, s2s3;
+
+    ms2 = Scalar(1) - this->coeffs().squaredNorm();
+    s1s2 = this->x() * this->y();
+    s1s3 = this->x() * this->z();
+    s2s3 = this->y() * this->z();
+
+    B.coeffRef(0, 0) = ms2 + Scalar(2) * this->x() * this->x();
+    B.coeffRef(0, 1) = Scalar(2) * (s1s2 - this->z());
+    B.coeffRef(0, 2) = Scalar(2) * (s1s3 + this->y());
+    B.coeffRef(1, 0) = Scalar(2) * (s1s2 + this->z());
+    B.coeffRef(1, 1) = ms2 + Scalar(2) * this->y() * this->y();
+    B.coeffRef(1, 2) = Scalar(2) * (s2s3 - this->x());
+    B.coeffRef(2, 0) = Scalar(2) * (s1s3 - this->y());
+    B.coeffRef(2, 1) = Scalar(2) * (s2s3 + this->x());
+    B.coeffRef(2, 2) = ms2 + Scalar(2) * this->z() * this->z();
+
+    return B;
+}
+
+/** \returns the multiplicative inverse of \c *this
+ * Note that in most cases, i.e., if you simply want the opposite rotation,
+ * and/or the MRP is normalized, then it is enough to use the conjugate.
+ *
+ * \sa MRPBase::conjugate()
+ */
+template <class Derived>
+inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::inverse() const {
+    return MRP<Scalar>(-this->coeffs());
+}
+
+/** \returns the conjugate of the \c *this which is equal to the multiplicative inverse
+ * if the MRP is normalized.
+ * The conjugate of a MRP represents the opposite rotation.
+ *
+ * \sa MRP2::inverse()
+ */
+template <class Derived>
+inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::conjugate() const {
+    return MRP<Scalar>(-this->coeffs());
+}
+
+/** \returns the angle (in radian) between two rotations
+ * \sa dot()
+ */
+template <class Derived>
+template <class OtherDerived>
+inline typename internal::traits<Derived>::Scalar MRPBase<Derived>::angularDistance(
+    const MRPBase<OtherDerived>& other) const {
+    using std::abs;
+    using std::atan;
+    MRP<Scalar> d = (*this) * other.conjugate();
+    return Scalar(4) * atan(d.norm());
+}
+
+//    /** \returns the spherical linear interpolation between the two MRPs
+//     * \c *this and \a other at the parameter \a t in [0;1].
+//     *
+//     * This represents an interpolation for a constant motion between \c *this and \a other,
+//     * see also http://en.wikipedia.org/wiki/Slerp.
+//     */
+//    template <class Derived>
+//    template <class OtherDerived>
+//    MRP<typename internal::traits<Derived>::Scalar>
+//    MRPBase<Derived>::slerp(const Scalar& t, const MRPBase<OtherDerived>& other) const
+//    {
+//        using std::acos;
+//        using std::sin;
+//        using std::abs;
+//        static const Scalar one = Scalar(1) - NumTraits<Scalar>::epsilon();
+//        Scalar d = this->dot(other);
+//        Scalar absD = abs(d);
+//
+//        Scalar scale0;
+//        Scalar scale1;
+//
+//        if(absD>=one)
+//        {
+//            scale0 = Scalar(1) - t;
+//            scale1 = t;
+//        }
+//        else
+//        {
+//            // theta is the angle between the 2 MRPs
+//            Scalar theta = acos(absD);
+//            Scalar sinTheta = sin(theta);
+//
+//            scale0 = sin( ( Scalar(1) - t ) * theta) / sinTheta;
+//            scale1 = sin( ( t * theta) ) / sinTheta;
+//        }
+//        if(d<Scalar(0)) scale1 = -scale1;
+//
+//        return MRP<Scalar>(scale0 * coeffs() + scale1 * other.coeffs());
+//    }
+
+namespace internal {
+
+// set from a rotation matrix
+// this maps the [NB] DCM to the equivalent sigma_B/N set
+template <typename Other>
+/*! struct definition */
+struct MRPbase_assign_impl<Other, 3, 3> {
+    typedef typename Other::Scalar Scalar;  //!< variable
+    typedef DenseIndex Index;               //!< variable
     template <class Derived>
-    inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::shadow() const
-    {
-        Scalar n2 = this->squaredNorm();
-        if (n2 > Scalar(0))
-            return MRP<Scalar>(-this->coeffs() / n2);
-        else {
-            return MRP<Scalar>(0.,0.,0.);
-        }
-    }
+    static inline void run(MRPBase<Derived>& sig, const Other& mat) {
+        Quaternion<Scalar> q;
+        Scalar num;
 
-    /** \returns the MRP [B] matrix of \c *this
-     * This is used in
-     *
-     *  d(sigmda_B/N) = 1/4 [B(sigma_B/N)] omega_BN_B
-     *
-     * \sa MRPBase::shadow()
-     */
+        /* convert DCM to quaternions */
+        q = mat;
+        num = Scalar(1) + q.w();
+
+        /* convert quaternions to MRP */
+        sig.x() = q.x() / num;
+        sig.y() = q.y() / num;
+        sig.z() = q.z() / num;
+    }
+};
+
+// set from a vector of coefficients assumed to be a MRP
+template <typename Other>
+/*! struct definition */
+struct MRPbase_assign_impl<Other, 3, 1> {
+    typedef typename Other::Scalar Scalar;  //!< variable
     template <class Derived>
-    inline typename MRPBase<Derived>::Matrix3 MRPBase<Derived>::Bmat() const
-    {
-        Matrix3 B;
-        Scalar ms2, s1s2, s1s3, s2s3;
-
-        ms2  = Scalar(1) - this->coeffs().squaredNorm();
-        s1s2 = this->x()*this->y();
-        s1s3 = this->x()*this->z();
-        s2s3 = this->y()*this->z();
-
-        B.coeffRef(0,0) = ms2 + Scalar(2)*this->x()*this->x();
-        B.coeffRef(0,1) = Scalar(2)*(s1s2 - this->z());
-        B.coeffRef(0,2) = Scalar(2)*(s1s3 + this->y());
-        B.coeffRef(1,0) = Scalar(2)*(s1s2 + this->z());
-        B.coeffRef(1,1) = ms2 + Scalar(2)*this->y()*this->y();
-        B.coeffRef(1,2) = Scalar(2)*(s2s3 - this->x());
-        B.coeffRef(2,0) = Scalar(2)*(s1s3 - this->y());
-        B.coeffRef(2,1) = Scalar(2)*(s2s3 + this->x());
-        B.coeffRef(2,2) = ms2 + Scalar(2)*this->z()*this->z();
-
-        return B;
+    static inline void run(MRPBase<Derived>& q, const Other& vec) {
+        q.coeffs() = vec;
     }
+};
 
-    /** \returns the multiplicative inverse of \c *this
-     * Note that in most cases, i.e., if you simply want the opposite rotation,
-     * and/or the MRP is normalized, then it is enough to use the conjugate.
-     *
-     * \sa MRPBase::conjugate()
-     */
-    template <class Derived>
-    inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::inverse() const
-    {
-        return MRP<Scalar>(-this->coeffs());
-    }
+}  // end namespace internal
 
-    /** \returns the conjugate of the \c *this which is equal to the multiplicative inverse
-     * if the MRP is normalized.
-     * The conjugate of a MRP represents the opposite rotation.
-     *
-     * \sa MRP2::inverse()
-     */
-    template <class Derived>
-    inline MRP<typename internal::traits<Derived>::Scalar>
-    MRPBase<Derived>::conjugate() const
-    {
-        return MRP<Scalar>(-this->coeffs());
-    }
+}  // end namespace Eigen
 
-    /** \returns the angle (in radian) between two rotations
-     * \sa dot()
-     */
-    template <class Derived>
-    template <class OtherDerived>
-    inline typename internal::traits<Derived>::Scalar
-    MRPBase<Derived>::angularDistance(const MRPBase<OtherDerived>& other) const
-    {
-        using std::atan;
-        using std::abs;
-        MRP<Scalar> d = (*this) * other.conjugate();
-        return Scalar(4) * atan( d.norm() );
-    }
-
-
-
-    //    /** \returns the spherical linear interpolation between the two MRPs
-    //     * \c *this and \a other at the parameter \a t in [0;1].
-    //     *
-    //     * This represents an interpolation for a constant motion between \c *this and \a other,
-    //     * see also http://en.wikipedia.org/wiki/Slerp.
-    //     */
-    //    template <class Derived>
-    //    template <class OtherDerived>
-    //    MRP<typename internal::traits<Derived>::Scalar>
-    //    MRPBase<Derived>::slerp(const Scalar& t, const MRPBase<OtherDerived>& other) const
-    //    {
-    //        using std::acos;
-    //        using std::sin;
-    //        using std::abs;
-    //        static const Scalar one = Scalar(1) - NumTraits<Scalar>::epsilon();
-    //        Scalar d = this->dot(other);
-    //        Scalar absD = abs(d);
-    //
-    //        Scalar scale0;
-    //        Scalar scale1;
-    //
-    //        if(absD>=one)
-    //        {
-    //            scale0 = Scalar(1) - t;
-    //            scale1 = t;
-    //        }
-    //        else
-    //        {
-    //            // theta is the angle between the 2 MRPs
-    //            Scalar theta = acos(absD);
-    //            Scalar sinTheta = sin(theta);
-    //
-    //            scale0 = sin( ( Scalar(1) - t ) * theta) / sinTheta;
-    //            scale1 = sin( ( t * theta) ) / sinTheta;
-    //        }
-    //        if(d<Scalar(0)) scale1 = -scale1;
-    //
-    //        return MRP<Scalar>(scale0 * coeffs() + scale1 * other.coeffs());
-    //    }
-
-    namespace internal {
-
-        // set from a rotation matrix
-        // this maps the [NB] DCM to the equivalent sigma_B/N set
-        template<typename Other>
-        /*! struct definition */
-        struct MRPbase_assign_impl<Other,3,3>
-        {
-            typedef typename Other::Scalar Scalar; //!< variable
-            typedef DenseIndex Index; //!< variable
-            template<class Derived> static inline void run(MRPBase<Derived>& sig, const Other& mat)
-            {
-                Quaternion<Scalar> q;
-                Scalar num;
-
-                /* convert DCM to quaternions */
-                q = mat;
-                num = Scalar(1) + q.w();
-
-                /* convert quaternions to MRP */
-                sig.x() = q.x()/num;
-                sig.y() = q.y()/num;
-                sig.z() = q.z()/num;
-            }
-        };
-        
-        // set from a vector of coefficients assumed to be a MRP
-        template<typename Other>
-        /*! struct definition */
-        struct MRPbase_assign_impl<Other,3,1>
-        {
-            typedef typename Other::Scalar Scalar; //!< variable
-            template<class Derived> static inline void run(MRPBase<Derived>& q, const Other& vec)
-            {
-                q.coeffs() = vec;
-            }
-        };
-        
-    } // end namespace internal
-    
-} // end namespace Eigen
-
-#endif // EIGEN_MRP_H
+#endif  // EIGEN_MRP_H
 
 /// \endcond

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -23,11 +23,8 @@
 #ifndef EIGEN_MRP_H
 #define EIGEN_MRP_H
 
-//#include <Eigen/Core>
-//#include <Eigen/src/Core//util//DisableStupidWarnings.h>
-//#include <Eigen/SVD>
-//#include <Eigen/LU>
-//#include "Eigen/src/Geometry/Quaternion.h"
+#include <Eigen/Geometry>
+
 
 namespace Eigen {
     template<typename Scalar, int Options = AutoAlign> class MRP;

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -24,7 +24,6 @@
 #include "architecture/utilities/macroDefinitions.h"
 #include "rigidBodyKinematics.h"
 
-
 /*! This function provides a general conversion between an Eigen matrix and
 an output C array. Note that this routine would convert an inbound type
 to a MatrixXd and then transpose the matrix which would be inefficient

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -21,16 +21,9 @@
 
 #include <math.h>
 
-#include <iostream>
-
 #include "architecture/utilities/macroDefinitions.h"
 #include "rigidBodyKinematics.h"
 
-/*
-
- Contains various support algorithms related to using the Eigen Library
-
- */
 
 /*! This function provides a general conversion between an Eigen matrix and
 an output C array. Note that this routine would convert an inbound type
@@ -277,26 +270,4 @@ Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd mrp) {
     vec3d[2] = mrp.z();
 
     return vec3d;
-}
-
-/*! This function solves for the zero of the passed function using the Newton Raphson Method
-@return double
-@param initialEstimate The initial value to use for newton-raphson
-@param accuracy The desired upper bound for the error
-@param f Function to find the zero of
-@param fPrime First derivative of the function
-*/
-double newtonRaphsonSolve(const double &initialEstimate,
-                          const double &accuracy,
-                          const std::function<double(double)> &f,
-                          const std::function<double(double)> &fPrime) {
-    double currentEstimate = initialEstimate;
-    for (int i = 0; i < 100; i++) {
-        if (std::abs(f(currentEstimate)) < accuracy) break;
-
-        double functionVal = f(currentEstimate);
-        double functionDeriv = fPrime(currentEstimate);
-        currentEstimate = currentEstimate - functionVal / functionDeriv;
-    }
-    return currentEstimate;
 }

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -60,5 +60,4 @@ Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd vec);
 //!@brief maps the DCM to MRPs using Eigen variables
 Eigen::MRPd eigenC2MRP(Eigen::Matrix3d);
 
-
 #endif /* _AVSEIGENSUPPORT_ */

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -19,9 +19,9 @@
 
 #ifndef _AVSEIGENSUPPORT_
 #define _AVSEIGENSUPPORT_
-#include <Eigen/Dense>
-
 #include "avsEigenMRP.h"
+
+#include <Eigen/Core>
 
 //!@brief General conversion between any Eigen matrix and output array
 void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray);
@@ -60,10 +60,5 @@ Eigen::Vector3d eigenMRPd2Vector3d(Eigen::MRPd vec);
 //!@brief maps the DCM to MRPs using Eigen variables
 Eigen::MRPd eigenC2MRP(Eigen::Matrix3d);
 
-//!@brief solves for the zero of the provided function
-double newtonRaphsonSolve(const double &initialEstimate,
-                          const double &accuracy,
-                          const std::function<double(double)> &f,
-                          const std::function<double(double)> &fPrime);
 
 #endif /* _AVSEIGENSUPPORT_ */

--- a/src/architecture/utilities/keplerianOrbit.cpp
+++ b/src/architecture/utilities/keplerianOrbit.cpp
@@ -23,123 +23,128 @@
 #include <architecture/utilities/safeMath.h>
 
 /*! This constructor initialized to an arbitrary orbit */
-KeplerianOrbit::KeplerianOrbit()
-{
-    this->change_orbit();
-}
+KeplerianOrbit::KeplerianOrbit() { this->change_orbit(); }
 
 /*! The constructor requires orbital elements and a gravitational constant value */
-KeplerianOrbit::KeplerianOrbit(ClassicElements oe, const double mu) : mu(mu),
-                                                                      semi_major_axis(oe.a),
-                                                                      eccentricity(oe.e),
-                                                                      inclination(oe.i),
-                                                                      argument_of_periapsis(oe.omega),
-                                                                      right_ascension(oe.Omega),
-                                                                      true_anomaly(oe.f){
+KeplerianOrbit::KeplerianOrbit(ClassicElements oe, const double mu)
+    : mu(mu),
+      semi_major_axis(oe.a),
+      eccentricity(oe.e),
+      inclination(oe.i),
+      argument_of_periapsis(oe.omega),
+      right_ascension(oe.Omega),
+      true_anomaly(oe.f) {
     this->change_orbit();
 }
 
 /*! The copy constructor works with python copy*/
-KeplerianOrbit::KeplerianOrbit(const KeplerianOrbit &orig) : mu(orig.mu),
-                                                             semi_major_axis(orig.a()),
-                                                             eccentricity(orig.e()),
-                                                             inclination(orig.i()),
-                                                             argument_of_periapsis(orig.omega()),
-                                                             right_ascension(orig.RAAN()),
-                                                             true_anomaly(orig.f())
-{
+KeplerianOrbit::KeplerianOrbit(const KeplerianOrbit &orig)
+    : mu(orig.mu),
+      semi_major_axis(orig.a()),
+      eccentricity(orig.e()),
+      inclination(orig.i()),
+      argument_of_periapsis(orig.omega()),
+      right_ascension(orig.RAAN()),
+      true_anomaly(orig.f()) {
     this->change_orbit();
 }
 
 /*! Generic Destructor */
-KeplerianOrbit::~KeplerianOrbit()
-{
-}
+KeplerianOrbit::~KeplerianOrbit() {}
 
 /*!
     body position vector relative to planet
  */
-Eigen::Vector3d KeplerianOrbit::r_BP_P() const {
-    return this->position_BP_P;
-}
+Eigen::Vector3d KeplerianOrbit::r_BP_P() const { return this->position_BP_P; }
 
 /*!
     body velocity vector relative to planet
  */
-Eigen::Vector3d KeplerianOrbit::v_BP_P() const{
-    return this->velocity_BP_P;
-
-}
+Eigen::Vector3d KeplerianOrbit::v_BP_P() const { return this->velocity_BP_P; }
 
 /*!
     angular momentum of body relative to planet
  */
-Eigen::Vector3d KeplerianOrbit::h_BP_P() const{
-    return this->orbital_angular_momentum_P;
-}
+Eigen::Vector3d KeplerianOrbit::h_BP_P() const { return this->orbital_angular_momentum_P; }
 
 /*! return mean anomaly angle */
-double KeplerianOrbit::M() const {return this->mean_anomaly;}
+double KeplerianOrbit::M() const { return this->mean_anomaly; }
 /*! return mean orbit rate */
-double KeplerianOrbit::n() const {return this->mean_motion;};                              //!< return mean orbit rate
+double KeplerianOrbit::n() const { return this->mean_motion; };  //!< return mean orbit rate
 /*! return orbit period */
-double KeplerianOrbit::P() const {return this->orbital_period;};                           //!< return orbital period
+double KeplerianOrbit::P() const { return this->orbital_period; };  //!< return orbital period
 /*! return true anomaly */
-double KeplerianOrbit::f() const {return this->true_anomaly;};                             //!< return true anomaly
+double KeplerianOrbit::f() const { return this->true_anomaly; };  //!< return true anomaly
 /*! return true anomaly rate */
-double KeplerianOrbit::fDot() const {return this->true_anomaly_rate;};
+double KeplerianOrbit::fDot() const { return this->true_anomaly_rate; };
 /*! return right ascencion of the ascending node */
-double KeplerianOrbit::RAAN() const {return this->right_ascension;};
+double KeplerianOrbit::RAAN() const { return this->right_ascension; };
 /*! return argument of periapses */
-double KeplerianOrbit::omega() const {return this->argument_of_periapsis;};
+double KeplerianOrbit::omega() const { return this->argument_of_periapsis; };
 /*! return inclination angle */
-double KeplerianOrbit::i() const {return this->inclination;};
+double KeplerianOrbit::i() const { return this->inclination; };
 /*! return eccentricty */
-double KeplerianOrbit::e() const {return this->eccentricity;};
+double KeplerianOrbit::e() const { return this->eccentricity; };
 /*! return semi-major axis */
-double KeplerianOrbit::a() const {return this->semi_major_axis;};
+double KeplerianOrbit::a() const { return this->semi_major_axis; };
 /*! return orbital angular momentum magnitude */
-double KeplerianOrbit::h() const {return this->h_BP_P().norm();};
+double KeplerianOrbit::h() const { return this->h_BP_P().norm(); };
 /*! return orbital energy */
-double KeplerianOrbit::Energy(){return this->orbital_energy;};
+double KeplerianOrbit::Energy() { return this->orbital_energy; };
 /*! return orbit radius */
-double KeplerianOrbit::r() const {return this->r_BP_P().norm();};
+double KeplerianOrbit::r() const { return this->r_BP_P().norm(); };
 /*! return velocity magnitude */
-double KeplerianOrbit::v() const {return this->v_BP_P().norm();};
+double KeplerianOrbit::v() const { return this->v_BP_P().norm(); };
 /*! return radius at apoapses */
-double KeplerianOrbit::r_a() const {return this->r_apogee;};
+double KeplerianOrbit::r_a() const { return this->r_apogee; };
 /*! return radius at periapses */
-double KeplerianOrbit::r_p() const {return this->r_perigee;};
+double KeplerianOrbit::r_p() const { return this->r_perigee; };
 /*! return flight path angle */
-double KeplerianOrbit::fpa() const {return this->flight_path_angle;};
+double KeplerianOrbit::fpa() const { return this->flight_path_angle; };
 /*! return eccentric anomaly angle */
-double KeplerianOrbit::E() const {return this->eccentric_anomaly;};
+double KeplerianOrbit::E() const { return this->eccentric_anomaly; };
 /*! return semi-latus rectum or the parameter */
-double KeplerianOrbit::p() const {return this->semi_parameter;};
+double KeplerianOrbit::p() const { return this->semi_parameter; };
 /*! return radius rate */
-double KeplerianOrbit::rDot() const {return this->radial_rate;};
+double KeplerianOrbit::rDot() const { return this->radial_rate; };
 /*! return escape velocity */
-double KeplerianOrbit::c3() const {return this->v_infinity;};
+double KeplerianOrbit::c3() const { return this->v_infinity; };
 
 /*! set semi-major axis */
-void KeplerianOrbit::set_a(double a){this->semi_major_axis = a; this->change_orbit();};
+void KeplerianOrbit::set_a(double a) {
+    this->semi_major_axis = a;
+    this->change_orbit();
+};
 /*! set eccentricity */
-void KeplerianOrbit::set_e(double e){this->eccentricity = e; this->change_orbit();};
+void KeplerianOrbit::set_e(double e) {
+    this->eccentricity = e;
+    this->change_orbit();
+};
 /*! set inclination angle */
-void KeplerianOrbit::set_i(double i){this->inclination = i; this->change_orbit();};
+void KeplerianOrbit::set_i(double i) {
+    this->inclination = i;
+    this->change_orbit();
+};
 /*! set argument of periapsis */
-void KeplerianOrbit::set_omega(double omega){this->argument_of_periapsis = omega; this->change_orbit();};
+void KeplerianOrbit::set_omega(double omega) {
+    this->argument_of_periapsis = omega;
+    this->change_orbit();
+};
 /*! set right ascension of the ascending node */
-void KeplerianOrbit::set_RAAN(double RAAN){this->right_ascension = RAAN; this->change_orbit();};
+void KeplerianOrbit::set_RAAN(double RAAN) {
+    this->right_ascension = RAAN;
+    this->change_orbit();
+};
 /*! set true anomaly angle */
-void KeplerianOrbit::set_f(double f){this->true_anomaly = f; this->change_f();};
-
-
+void KeplerianOrbit::set_f(double f) {
+    this->true_anomaly = f;
+    this->change_f();
+};
 
 /*! This method returns the orbital element set for the orbit
  @return classicElements oe
  */
-ClassicElements KeplerianOrbit::oe(){
+ClassicElements KeplerianOrbit::oe() {
     ClassicElements elements;
     elements.a = this->semi_major_axis;
     elements.e = this->eccentricity;
@@ -147,7 +152,7 @@ ClassicElements KeplerianOrbit::oe(){
     elements.f = this->true_anomaly;
     elements.omega = this->argument_of_periapsis;
     elements.Omega = this->right_ascension;
-    elements.rApoap= this->r_apogee;
+    elements.rApoap = this->r_apogee;
     elements.rPeriap = this->r_perigee;
     elements.alpha = 1.0 / elements.a;
     elements.rmag = this->orbit_radius;
@@ -156,7 +161,7 @@ ClassicElements KeplerianOrbit::oe(){
 
 /*! This method populates all outputs from orbital elements coherently if any of the
  * classical orbital elements are changed*/
-void KeplerianOrbit::change_orbit(){
+void KeplerianOrbit::change_orbit() {
     this->change_f();
     this->orbital_angular_momentum_P = this->position_BP_P.cross(this->velocity_BP_P);
     this->mean_motion = sqrt(this->mu / pow(this->semi_major_axis, 3));
@@ -168,21 +173,20 @@ void KeplerianOrbit::change_orbit(){
 }
 /*! This method only changes the outputs dependent on true anomaly so that one
  * orbit may be queried at various points along the orbit*/
-void KeplerianOrbit::change_f(){
+void KeplerianOrbit::change_f() {
     double r[3];
     double v[3];
-    ClassicElements oe = this->oe(); //
-    elem2rv(this->mu, &oe, r, v); //
-    this->position_BP_P = cArray2EigenVector3d(r); //
-    this->velocity_BP_P = cArray2EigenVector3d(v); //
-    this->true_anomaly_rate = this->n() * pow(this->a(), 2) * sqrt(1 - pow(this->e(), 2)) / pow(this->r(), 2); //
-    this->radial_rate = this->r() * this->fDot() * this->e() * sin(this->f()) / (1 + this->e() * cos(this->f())); //
-    this->eccentric_anomaly = safeAcos(this->e() + cos(this->f()) / (1 + this->e() * cos(this->f()))); //
-    this->mean_anomaly = this->E() - this->e() * sin(this->E()); //
-    this->flight_path_angle = safeAcos(sqrt((1 - pow(this->e(), 2)) / (1 - pow(this->e(), 2)*pow(cos(this->E()), 2)))); //
+    ClassicElements oe = this->oe();                                                                               //
+    elem2rv(this->mu, &oe, r, v);                                                                                  //
+    this->position_BP_P = cArray2EigenVector3d(r);                                                                 //
+    this->velocity_BP_P = cArray2EigenVector3d(v);                                                                 //
+    this->true_anomaly_rate = this->n() * pow(this->a(), 2) * sqrt(1 - pow(this->e(), 2)) / pow(this->r(), 2);     //
+    this->radial_rate = this->r() * this->fDot() * this->e() * sin(this->f()) / (1 + this->e() * cos(this->f()));  //
+    this->eccentric_anomaly = safeAcos(this->e() + cos(this->f()) / (1 + this->e() * cos(this->f())));             //
+    this->mean_anomaly = this->E() - this->e() * sin(this->E());                                                   //
+    this->flight_path_angle =
+        safeAcos(sqrt((1 - pow(this->e(), 2)) / (1 - pow(this->e(), 2) * pow(cos(this->E()), 2))));  //
 }
 
 /*! This method sets the gravitational constants of the body being orbited */
-void KeplerianOrbit::set_mu(const double mu){
-    this->mu = mu;
-}
+void KeplerianOrbit::set_mu(const double mu) { this->mu = mu; }

--- a/src/architecture/utilities/keplerianOrbit.cpp
+++ b/src/architecture/utilities/keplerianOrbit.cpp
@@ -20,6 +20,7 @@
 #include "keplerianOrbit.h"
 #include <architecture/utilities/avsEigenSupport.h>
 #include <architecture/utilities/linearAlgebra.h>
+#include <architecture/utilities/safeMath.h>
 
 /*! This constructor initialized to an arbitrary orbit */
 KeplerianOrbit::KeplerianOrbit()

--- a/src/architecture/utilities/linearAlgebra.c
+++ b/src/architecture/utilities/linearAlgebra.c
@@ -20,115 +20,87 @@
 #include "linearAlgebra.h"
 #include "safeMath.h"
 #include <assert.h>
+#include <math.h>
 #include <stddef.h>
 #include <string.h>
-#include <math.h>
 
-
-#define MOVE_DOUBLE(source, dim, destination) (memmove((void*)(destination), (void*)(source), sizeof(double)*(dim)))
-
+#define MOVE_DOUBLE(source, dim, destination) (memmove((void *)(destination), (void *)(source), sizeof(double) * (dim)))
 
 #define CHECK_ARRAY_DIMENSIONS(DIM) \
-  assert((DIM) <= LINEAR_ALGEBRA_MAX_ARRAY_SIZE && "Linear Algebra library array dimension input is too large.")
+    assert((DIM) <= LINEAR_ALGEBRA_MAX_ARRAY_SIZE && "Linear Algebra library array dimension input is too large.")
 
-void vElementwiseMult(double *v1, size_t dim,
-                       double *v2, double *result)
-{
+void vElementwiseMult(double *v1, size_t dim, double *v2, double *result) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] * v2[i];
     }
 }
 
-void vCopy(double *v, size_t dim,
-           double *result)
-{
+void vCopy(double *v, size_t dim, double *result) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i];
     }
 }
 
-void vSetZero(double *v,
-              size_t dim)
-{
+void vSetZero(double *v, size_t dim) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         v[i] = 0.0;
     }
 }
 
-void vSetOnes(double *v,
-              size_t dim)
-{
+void vSetOnes(double *v, size_t dim) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         v[i] = 1.0;
     }
 }
 
-void vAdd(double *v1, size_t dim,
-          double *v2,
-          double *result)
-{
+void vAdd(double *v1, size_t dim, double *v2, double *result) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] + v2[i];
     }
 }
 
-void vSubtract(double *v1, size_t dim,
-               double *v2,
-               double *result)
-{
+void vSubtract(double *v1, size_t dim, double *v2, double *result) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] - v2[i];
     }
 }
 
-void vScale(double scaleFactor, double *v,
-            size_t dim,
-            double *result)
-{
+void vScale(double scaleFactor, double *v, size_t dim, double *result) {
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i] * scaleFactor;
     }
 }
 
-double vDot(double *v1, size_t dim,
-            double *v2)
-{
+double vDot(double *v1, size_t dim, double *v2) {
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += v1[i] * v2[i];
     }
 
     return result;
 }
 
-void vOuterProduct(double *v1, size_t dim1,
-                   double *v2, size_t dim2,
-                   void *result)
-{
+void vOuterProduct(double *v1, size_t dim1, double *v2, size_t dim2, void *result) {
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = v1[i] * v2[j];
         }
     }
-
 }
 
-void vtMultM(double *v,
-             void *mx, size_t dim1, size_t dim2,
-             void *result)
-{
+void vtMultM(double *v, void *mx, size_t dim1, size_t dim2, void *result) {
     CHECK_ARRAY_DIMENSIONS(dim1 * dim2);
     size_t dim11 = 1;
     size_t dim12 = dim1;
@@ -140,10 +112,10 @@ void vtMultM(double *v,
     size_t i;
     size_t j;
     size_t k;
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[MXINDEX(dim22, i, j)] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[MXINDEX(dim22, i, j)] += m_mx1[MXINDEX(dim12, i, k)] * m_mx2[MXINDEX(dim22, k, j)];
             }
         }
@@ -152,10 +124,7 @@ void vtMultM(double *v,
     MOVE_DOUBLE(m_result, dim11 * dim22, result);
 }
 
-void vtMultMt(double *v,
-              void *mx, size_t dim1, size_t dim2,
-              void *result)
-{
+void vtMultMt(double *v, void *mx, size_t dim1, size_t dim2, void *result) {
     size_t dim11 = 1;
     size_t dim12 = dim2;
     size_t dim22 = dim1;
@@ -167,10 +136,10 @@ void vtMultMt(double *v,
     size_t i;
     size_t j;
     size_t k;
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[MXINDEX(dim22, i, j)] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[MXINDEX(dim22, i, j)] += m_mx1[MXINDEX(dim12, i, k)] * m_mx2[MXINDEX(dim22, j, k)];
             }
         }
@@ -179,71 +148,59 @@ void vtMultMt(double *v,
     MOVE_DOUBLE(m_result, dim11 * dim22, result);
 }
 
-double vNorm(double *v, size_t dim)
-{
-    return sqrt(vDot(v, dim, v));
-}
+double vNorm(double *v, size_t dim) { return sqrt(vDot(v, dim, v)); }
 
-double vMax(double *array, size_t dim)
-{
+double vMax(double *array, size_t dim) {
     size_t i;
     double result;
 
     result = array[0];
-    for(i=1; i<dim; i++){
-        if (array[i]>result){
+    for (i = 1; i < dim; i++) {
+        if (array[i] > result) {
             result = array[i];
         }
     }
     return result;
 }
 
-
-double vMaxAbs(double *array, size_t dim)
-{
+double vMaxAbs(double *array, size_t dim) {
     size_t i;
     double result;
 
     result = fabs(array[0]);
-    for(i=1; i<dim; i++){
-        if (fabs(array[i])>result){
+    for (i = 1; i < dim; i++) {
+        if (fabs(array[i]) > result) {
             result = fabs(array[i]);
         }
     }
     return result;
 }
 
-
-void vNormalize(double *v, size_t dim, double *result)
-{
+void vNormalize(double *v, size_t dim, double *result) {
     double norm = vNorm(v, dim);
 
-    if(norm > DB0_EPS) {
+    if (norm > DB0_EPS) {
         vScale(1.0 / norm, v, dim, result);
     } else {
         vSetZero(result, dim);
     }
 }
 
-int vIsEqual(double *v1, size_t dim,
-             double *v2,
-             double accuracy)
-{
+int vIsEqual(double *v1, size_t dim, double *v2, double accuracy) {
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v1[i] - v2[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v1[i] - v2[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-int vIsZero(double *v, size_t dim, double accuracy)
-{
+int vIsZero(double *v, size_t dim, double accuracy) {
     size_t i;
     int result = 1;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v[i]) > accuracy) {
             result = 0;
             break;
         }
@@ -252,13 +209,12 @@ int vIsZero(double *v, size_t dim, double accuracy)
     return result;
 }
 
-void vPrint(FILE *pFile, const char *name, double *v, size_t dim)
-{
+void vPrint(FILE *pFile, const char *name, double *v, size_t dim) {
     size_t i;
     fprintf(pFile, "%s = [", name);
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         fprintf(pFile, "%20.15g", v[i]);
-        if(i != dim - 1) {
+        if (i != dim - 1) {
             fprintf(pFile, ", ");
         }
     }
@@ -266,227 +222,168 @@ void vPrint(FILE *pFile, const char *name, double *v, size_t dim)
 }
 
 /*I hope you allocated the output prior to calling this!*/
-void vSort(double *Input, double *Output, size_t dim)
-{
+void vSort(double *Input, double *Output, size_t dim) {
     size_t i, j;
-    memcpy(Output, Input, dim*sizeof(double));
-    for(i=0; i<dim; i++)
-    {
-        for(j=0; j<dim-1; j++)
-        {
-            if(Output[j]>Output[j+1])
-            {
-                double temp = Output[j+1];
-                Output[j+1] = Output[j];
+    memcpy(Output, Input, dim * sizeof(double));
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim - 1; j++) {
+            if (Output[j] > Output[j + 1]) {
+                double temp = Output[j + 1];
+                Output[j + 1] = Output[j];
                 Output[j] = temp;
             }
         }
     }
 }
 
-
-void v2Set(double v0, double v1,
-           double result[2])
-{
+void v2Set(double v0, double v1, double result[2]) {
     result[0] = v0;
     result[1] = v1;
 }
 
-void v2SetZero(double v[2])
-{
+void v2SetZero(double v[2]) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         v[i] = 0.0;
     }
 }
 
-void v2Copy(double v[2],
-            double result[2])
-{
+void v2Copy(double v[2], double result[2]) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i];
     }
 }
 
-void v2Scale(double scaleFactor,
-             double v[2],
-             double result[2])
-{
+void v2Scale(double scaleFactor, double v[2], double result[2]) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i] * scaleFactor;
     }
 }
 
-double v2Dot(double v1[2],
-             double v2[2])
-{
+double v2Dot(double v1[2], double v2[2]) {
     size_t dim = 2;
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += v1[i] * v2[i];
     }
     return result;
 }
 
-int v2IsEqual(double v1[2],
-              double v2[2],
-              double accuracy)
-{
+int v2IsEqual(double v1[2], double v2[2], double accuracy) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v1[i] - v2[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v1[i] - v2[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-int v2IsZero(double v[2],
-             double accuracy)
-{
+int v2IsZero(double v[2], double accuracy) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-void v2Add(double v1[2],
-           double v2[2],
-           double result[2])
-{
+void v2Add(double v1[2], double v2[2], double result[2]) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] + v2[i];
     }
 }
 
-void v2Subtract(double v1[2],
-                double v2[2],
-                double result[2])
-{
+void v2Subtract(double v1[2], double v2[2], double result[2]) {
     size_t dim = 2;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] - v2[i];
     }
 }
 
-double v2Norm(double v[2])
-{
-    return sqrt(v2Dot(v, v));
-}
+double v2Norm(double v[2]) { return sqrt(v2Dot(v, v)); }
 
-void v2Normalize(double v[2], double result[2])
-{
+void v2Normalize(double v[2], double result[2]) {
     double norm = v2Norm(v);
-    if(norm > DB0_EPS) {
+    if (norm > DB0_EPS) {
         v2Scale(1. / norm, v, result);
     } else {
         v2SetZero(result);
     }
 }
 
-
-
-
-
-
-void v3Set(double v0, double v1, double v2,
-           double result[3])
-{
+void v3Set(double v0, double v1, double v2, double result[3]) {
     result[0] = v0;
     result[1] = v1;
     result[2] = v2;
 }
 
-void v3Copy(double v[3],
-            double result[3])
-{
+void v3Copy(double v[3], double result[3]) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i];
     }
 }
 
-void v3SetZero(double v[3])
-{
+void v3SetZero(double v[3]) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         v[i] = 0.0;
     }
 }
 
-void v3Add(double v1[3],
-           double v2[3],
-           double result[3])
-{
+void v3Add(double v1[3], double v2[3], double result[3]) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] + v2[i];
     }
 }
 
-void v3Subtract(double v1[3],
-                double v2[3],
-                double result[3])
-{
+void v3Subtract(double v1[3], double v2[3], double result[3]) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v1[i] - v2[i];
     }
 }
 
-void v3Scale(double scaleFactor,
-             double v[3],
-             double result[3])
-{
+void v3Scale(double scaleFactor, double v[3], double result[3]) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i] * scaleFactor;
     }
 }
 
-double v3Dot(double v1[3],
-             double v2[3])
-{
-    return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
-}
+double v3Dot(double v1[3], double v2[3]) { return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]; }
 
-void v3OuterProduct(double v1[3],
-                    double v2[3],
-                    double result[3][3])
-{
+void v3OuterProduct(double v1[3], double v2[3], double result[3][3]) {
     size_t dim = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             result[i][j] = v1[i] * v2[j];
         }
     }
 }
 
-void v3tMultM33(double v[3],
-                double mx[3][3],
-                double result[3])
-{
+void v3tMultM33(double v[3], double mx[3][3], double result[3]) {
     size_t dim11 = 1;
     size_t dim12 = 3;
     size_t dim22 = 3;
@@ -494,10 +391,10 @@ void v3tMultM33(double v[3],
     size_t j;
     size_t k;
     double m_result[3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[j] += v[k] * mx[k][j];
             }
         }
@@ -505,10 +402,7 @@ void v3tMultM33(double v[3],
     v3Copy(m_result, result);
 }
 
-void v3tMultM33t(double v[3],
-                 double mx[3][3],
-                 double result[3])
-{
+void v3tMultM33t(double v[3], double mx[3][3], double result[3]) {
     size_t dim11 = 1;
     size_t dim12 = 3;
     size_t dim22 = 3;
@@ -516,10 +410,10 @@ void v3tMultM33t(double v[3],
     size_t j;
     size_t k;
     double m_result[3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[j] += v[k] * mx[j][k];
             }
         }
@@ -527,84 +421,66 @@ void v3tMultM33t(double v[3],
     v3Copy(m_result, result);
 }
 
-double v3Norm(double v[3])
-{
-    return sqrt(v3Dot(v, v));
-}
+double v3Norm(double v[3]) { return sqrt(v3Dot(v, v)); }
 
-void v3Normalize(double v[3], double result[3])
-{
+void v3Normalize(double v[3], double result[3]) {
     double norm = v3Norm(v);
-    if(norm > DB0_EPS) {
+    if (norm > DB0_EPS) {
         v3Scale(1. / norm, v, result);
     } else {
         v3SetZero(result);
     }
 }
 
-int v3IsEqual(double v1[3],
-              double v2[3],
-              double accuracy)
-{
+int v3IsEqual(double v1[3], double v2[3], double accuracy) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v1[i] - v2[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v1[i] - v2[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-int v3IsEqualRel(double v1[3],
-              double v2[3],
-              double accuracy)
-{
+int v3IsEqualRel(double v1[3], double v2[3], double accuracy) {
     size_t dim = 3;
     size_t i;
     double norm;
     norm = v3Norm(v1);
-    for(i = 0; i < dim; i++) {
-        if(fabs(v1[i] - v2[i])/norm > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v1[i] - v2[i]) / norm > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-
-
-int v3IsZero(double v[3],
-             double accuracy)
-{
+int v3IsZero(double v[3], double accuracy) {
     size_t dim = 3;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-void v3Print(FILE *pFile, const char *name, double v[3])
-{
+void v3Print(FILE *pFile, const char *name, double v[3]) {
     size_t dim = 3;
     size_t i;
     fprintf(pFile, "%s = [", name);
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         fprintf(pFile, "%20.15g", v[i]);
-        if(i != dim - 1) {
+        if (i != dim - 1) {
             fprintf(pFile, ", ");
         }
     }
     fprintf(pFile, "]\n");
 }
 
-void v3Cross(double v1[3],
-             double v2[3],
-             double result[3])
-{
+void v3Cross(double v1[3], double v2[3], double result[3]) {
     double v1c[3];
     double v2c[3];
     v3Copy(v1, v1c);
@@ -614,31 +490,24 @@ void v3Cross(double v1[3],
     result[2] = v1c[0] * v2c[1] - v1c[1] * v2c[0];
 }
 
-void v3Perpendicular(double v[3],
-                     double result[3])
-{
+void v3Perpendicular(double v[3], double result[3]) {
     if (fabs(v[0]) > DB0_EPS) {
-        result[0] = -(v[1]+v[2]) / v[0];
+        result[0] = -(v[1] + v[2]) / v[0];
         result[1] = 1;
         result[2] = 1;
-    }
-    else if (fabs(v[1]) > DB0_EPS) {
+    } else if (fabs(v[1]) > DB0_EPS) {
         result[0] = 1;
-        result[1] = -(v[0]+v[2]) / v[1];
+        result[1] = -(v[0] + v[2]) / v[1];
         result[2] = 1;
-    }
-    else {
+    } else {
         result[0] = 1;
         result[1] = 1;
-        result[2] = -(v[0]+v[1]) / v[2];
+        result[2] = -(v[0] + v[1]) / v[2];
     }
     v3Normalize(result, result);
 }
 
-
-void v3Tilde(double v[3],
-             double result[3][3])
-{
+void v3Tilde(double v[3], double result[3][3]) {
     result[0][0] = 0.0;
     result[0][1] = -v[2];
     result[0][2] = v[1];
@@ -650,18 +519,16 @@ void v3Tilde(double v[3],
     result[2][2] = 0.0;
 }
 
-void v3Sort(double v[3],
-            double result[3])
-{
+void v3Sort(double v[3], double result[3]) {
     double temp;
     v3Copy(v, result);
-    if(result[0] < result[1]) {
+    if (result[0] < result[1]) {
         temp = result[0];
         result[0] = result[1];
         result[1] = temp;
     }
-    if(result[1] < result[2]) {
-        if(result[0] < result[2]) {
+    if (result[1] < result[2]) {
+        if (result[0] < result[2]) {
             temp = result[2];
             result[2] = result[1];
             result[1] = result[0];
@@ -674,86 +541,68 @@ void v3Sort(double v[3],
     }
 }
 
-void    v3PrintScreen(const char *name, double vec[3])
-{
+void v3PrintScreen(const char *name, double vec[3]) {
     printf("%s (%20.15g, %20.15g, %20.15g)\n", name, vec[0], vec[1], vec[2]);
 }
 
-void v4Set(double v0, double v1, double v2, double v3,
-           double result[4])
-{
+void v4Set(double v0, double v1, double v2, double v3, double result[4]) {
     result[0] = v0;
     result[1] = v1;
     result[2] = v2;
     result[3] = v3;
 }
 
-void v4Copy(double v[4],
-            double result[4])
-{
+void v4Copy(double v[4], double result[4]) {
     size_t dim = 4;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i];
     }
 }
 
-void v4SetZero(double v[4])
-{
+void v4SetZero(double v[4]) {
     size_t dim = 4;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         v[i] = 0.0;
     }
 }
 
-double v4Dot(double v1[4],
-             double v2[4])
-{
+double v4Dot(double v1[4], double v2[4]) {
     size_t dim = 4;
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += v1[i] * v2[i];
     }
     return result;
 }
 
-double v4Norm(double v[4])
-{
-    return sqrt(v4Dot(v, v));
-}
+double v4Norm(double v[4]) { return sqrt(v4Dot(v, v)); }
 
-int v4IsEqual(double v1[4],
-              double v2[4],
-              double accuracy)
-{
+int v4IsEqual(double v1[4], double v2[4], double accuracy) {
     size_t dim = 4;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v1[i] - v2[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v1[i] - v2[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-int v4IsZero(double v[4],
-             double accuracy)
-{
+int v4IsZero(double v[4], double accuracy) {
     size_t dim = 4;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-void v6Set(double v0, double v1, double v2, double v3, double v4, double v5,
-           double result[6])
-{
+void v6Set(double v0, double v1, double v2, double v3, double v4, double v5, double result[6]) {
     result[0] = v0;
     result[1] = v1;
     result[2] = v2;
@@ -762,69 +611,55 @@ void v6Set(double v0, double v1, double v2, double v3, double v4, double v5,
     result[5] = v5;
 }
 
-void v6Copy(double v[6],
-            double result[6])
-{
+void v6Copy(double v[6], double result[6]) {
     size_t dim = 6;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i];
     }
 }
 
-double v6Dot(double v1[6],
-             double v2[6])
-{
+double v6Dot(double v1[6], double v2[6]) {
     size_t dim = 6;
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += v1[i] * v2[i];
     }
     return result;
 }
 
-void v6Scale(double scaleFactor,
-             double v[6],
-             double result[6])
-{
+void v6Scale(double scaleFactor, double v[6], double result[6]) {
     size_t dim = 6;
     size_t i;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result[i] = v[i] * scaleFactor;
     }
 }
 
-void v6OuterProduct(double v1[6],
-                    double v2[6],
-                    double result[6][6])
-{
+void v6OuterProduct(double v1[6], double v2[6], double result[6][6]) {
     size_t dim = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             result[i][j] = v1[i] * v2[j];
         }
     }
 }
 
-int v6IsEqual(double v1[6],
-              double v2[6],
-              double accuracy)
-{
+int v6IsEqual(double v1[6], double v2[6], double accuracy) {
     size_t dim = 6;
     size_t i;
-    for(i = 0; i < dim; i++) {
-        if(fabs(v1[i] - v2[i]) > accuracy) {
+    for (i = 0; i < dim; i++) {
+        if (fabs(v1[i] - v2[i]) > accuracy) {
             return 0;
         }
     }
     return 1;
 }
 
-void mLeastSquaresInverse(void *mx, size_t dim1, size_t dim2, void *result)
-{
+void mLeastSquaresInverse(void *mx, size_t dim1, size_t dim2, void *result) {
     /*
      * Computes the least squares inverse.
      */
@@ -837,11 +672,9 @@ void mLeastSquaresInverse(void *mx, size_t dim1, size_t dim2, void *result)
     mMultM(mxTranspose, dim2, dim1, mx, dim1, dim2, mxGrammian);
     mInverse(mxGrammian, dim2, mxGrammianInverse);
     mMultM(mxGrammianInverse, dim2, dim2, mxTranspose, dim2, dim1, m_result);
-
 }
 
-void mMinimumNormInverse(void *mx, size_t dim1, size_t dim2, void *result)
-{
+void mMinimumNormInverse(void *mx, size_t dim1, size_t dim2, void *result) {
     /*
      * Computes the minumum norm inverse.
      */
@@ -857,72 +690,65 @@ void mMinimumNormInverse(void *mx, size_t dim1, size_t dim2, void *result)
     mMultM(mxTranspose, dim2, dim1, mxMxTransposeInverse, dim1, dim1, m_result);
 }
 
-void mCopy(void *mx, size_t dim1, size_t dim2,
-           void *result)
-{
+void mCopy(void *mx, size_t dim1, size_t dim2, void *result) {
     double *m_mx = (double *)mx;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = m_mx[MXINDEX(dim2, i, j)];
         }
     }
 }
 
-void mSetZero(void *result, size_t dim1, size_t dim2)
-{
+void mSetZero(void *result, size_t dim1, size_t dim2) {
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = 0.0;
         }
     }
 }
 
-void mSetIdentity(void *result, size_t dim1, size_t dim2)
-{
+void mSetIdentity(void *result, size_t dim1, size_t dim2) {
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = (i == j) ? 1.0 : 0.0;
         }
     }
 }
 
-void mDiag(void *v, size_t dim, void *result)
-{
+void mDiag(void *v, size_t dim, void *result) {
     double *m_v = (double *)v;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             m_result[MXINDEX(dim, i, j)] = (i == j) ? m_v[i] : 0.0;
         }
     }
 }
 
-void mTranspose(void *mx, size_t dim1, size_t dim2,
-                void *result)
-{
+void mTranspose(void *mx, size_t dim1, size_t dim2, void *result) {
     double *m_mx = (double *)mx;
     double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     CHECK_ARRAY_DIMENSIONS(dim1 * dim2);
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim1, j, i)] = m_mx[MXINDEX(dim2, i, j)];
         }
     }
@@ -930,60 +756,48 @@ void mTranspose(void *mx, size_t dim1, size_t dim2,
     MOVE_DOUBLE(m_result, dim2 * dim1, result);
 }
 
-void mAdd(void *mx1, size_t dim1, size_t dim2,
-          void *mx2,
-          void *result)
-{
+void mAdd(void *mx1, size_t dim1, size_t dim2, void *mx2, void *result) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = m_mx1[MXINDEX(dim2, i, j)] + m_mx2[MXINDEX(dim2, i, j)];
         }
     }
 }
 
-void mSubtract(void *mx1, size_t dim1, size_t dim2,
-               void *mx2,
-               void *result)
-{
+void mSubtract(void *mx1, size_t dim1, size_t dim2, void *mx2, void *result) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = m_mx1[MXINDEX(dim2, i, j)] - m_mx2[MXINDEX(dim2, i, j)];
         }
     }
 }
 
-void mScale(double scaleFactor,
-            void *mx, size_t dim1, size_t dim2,
-            void *result)
-{
+void mScale(double scaleFactor, void *mx, size_t dim1, size_t dim2, void *result) {
     double *m_mx = (double *)mx;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[MXINDEX(dim2, i, j)] = scaleFactor * m_mx[MXINDEX(dim2, i, j)];
         }
     }
 }
 
-void mMultM(void *mx1, size_t dim11, size_t dim12,
-            void *mx2, size_t dim21, size_t dim22,
-            void *result)
-{
+void mMultM(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
     double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
@@ -992,13 +806,13 @@ void mMultM(void *mx1, size_t dim11, size_t dim12,
     size_t i;
     size_t j;
     size_t k;
-    if(dim12 != dim21) {
+    if (dim12 != dim21) {
         return;
     }
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[MXINDEX(dim22, i, j)] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[MXINDEX(dim22, i, j)] += m_mx1[MXINDEX(dim12, i, k)] * m_mx2[MXINDEX(dim22, k, j)];
             }
         }
@@ -1007,10 +821,7 @@ void mMultM(void *mx1, size_t dim11, size_t dim12,
     MOVE_DOUBLE(m_result, dim11 * dim22, result);
 }
 
-void mtMultM(void *mx1, size_t dim11, size_t dim12,
-             void *mx2, size_t dim21, size_t dim22,
-             void *result)
-{
+void mtMultM(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
     double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
@@ -1019,13 +830,13 @@ void mtMultM(void *mx1, size_t dim11, size_t dim12,
     size_t i;
     size_t j;
     size_t k;
-    if(dim11 != dim21) {
+    if (dim11 != dim21) {
         return;
     }
-    for(i = 0; i < dim12; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim12; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[MXINDEX(dim22, i, j)] = 0.0;
-            for(k = 0; k < dim11; k++) {
+            for (k = 0; k < dim11; k++) {
                 m_result[MXINDEX(dim22, i, j)] += m_mx1[MXINDEX(dim12, k, i)] * m_mx2[MXINDEX(dim22, k, j)];
             }
         }
@@ -1034,10 +845,7 @@ void mtMultM(void *mx1, size_t dim11, size_t dim12,
     MOVE_DOUBLE(m_result, dim12 * dim22, result);
 }
 
-void mMultMt(void *mx1, size_t dim11, size_t dim12,
-             void *mx2, size_t dim21, size_t dim22,
-             void *result)
-{
+void mMultMt(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
     double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
@@ -1046,13 +854,13 @@ void mMultMt(void *mx1, size_t dim11, size_t dim12,
     size_t i;
     size_t j;
     size_t k;
-    if(dim12 != dim22) {
+    if (dim12 != dim22) {
         return;
     }
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim21; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim21; j++) {
             m_result[MXINDEX(dim21, i, j)] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[MXINDEX(dim21, i, j)] += m_mx1[MXINDEX(dim12, i, k)] * m_mx2[MXINDEX(dim22, j, k)];
             }
         }
@@ -1061,10 +869,7 @@ void mMultMt(void *mx1, size_t dim11, size_t dim12,
     MOVE_DOUBLE(m_result, dim11 * dim21, result);
 }
 
-void mtMultMt(void *mx1, size_t dim11, size_t dim12,
-              void *mx2, size_t dim21, size_t dim22,
-              void *result)
-{
+void mtMultMt(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
     double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
@@ -1073,13 +878,13 @@ void mtMultMt(void *mx1, size_t dim11, size_t dim12,
     size_t i;
     size_t j;
     size_t k;
-    if(dim11 != dim22) {
+    if (dim11 != dim22) {
         return;
     }
-    for(i = 0; i < dim12; i++) {
-        for(j = 0; j < dim21; j++) {
+    for (i = 0; i < dim12; i++) {
+        for (j = 0; j < dim21; j++) {
             m_result[MXINDEX(dim21, i, j)] = 0.0;
-            for(k = 0; k < dim11; k++) {
+            for (k = 0; k < dim11; k++) {
                 m_result[MXINDEX(dim21, i, j)] += m_mx1[MXINDEX(dim12, k, i)] * m_mx2[MXINDEX(dim22, j, k)];
             }
         }
@@ -1088,10 +893,7 @@ void mtMultMt(void *mx1, size_t dim11, size_t dim12,
     MOVE_DOUBLE(m_result, dim12 * dim21, result);
 }
 
-void mMultV(void *mx, size_t dim1, size_t dim2,
-            void *v,
-            void *result)
-{
+void mMultV(void *mx, size_t dim1, size_t dim2, void *v, void *result) {
     size_t dim11 = dim1;
     size_t dim12 = dim2;
     size_t dim22 = 1;
@@ -1103,10 +905,10 @@ void mMultV(void *mx, size_t dim1, size_t dim2,
     size_t i;
     size_t j;
     size_t k;
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[MXINDEX(dim22, i, j)] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[MXINDEX(dim22, i, j)] += m_mx1[MXINDEX(dim12, i, k)] * m_mx2[MXINDEX(dim22, k, j)];
             }
         }
@@ -1115,10 +917,7 @@ void mMultV(void *mx, size_t dim1, size_t dim2,
     MOVE_DOUBLE(m_result, dim11 * dim22, result);
 }
 
-void mtMultV(void *mx, size_t dim1, size_t dim2,
-             void *v,
-             void *result)
-{
+void mtMultV(void *mx, size_t dim1, size_t dim2, void *v, void *result) {
     size_t dim11 = dim1;
     size_t dim12 = dim2;
     size_t dim22 = 1;
@@ -1130,10 +929,10 @@ void mtMultV(void *mx, size_t dim1, size_t dim2,
     size_t i;
     size_t j;
     size_t k;
-    for(i = 0; i < dim12; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim12; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[MXINDEX(dim22, i, j)] = 0.0;
-            for(k = 0; k < dim11; k++) {
+            for (k = 0; k < dim11; k++) {
                 m_result[MXINDEX(dim22, i, j)] += m_mx1[MXINDEX(dim12, k, i)] * m_mx2[MXINDEX(dim22, k, j)];
             }
         }
@@ -1142,21 +941,19 @@ void mtMultV(void *mx, size_t dim1, size_t dim2,
     MOVE_DOUBLE(m_result, dim12 * dim22, result);
 }
 
-double mTrace(void *mx, size_t dim)
-{
+double mTrace(void *mx, size_t dim) {
     double *m_mx = (double *)mx;
 
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += m_mx[MXINDEX(dim, i, i)];
     }
 
     return result;
 }
 
-double mDeterminant(void *mx, size_t dim)
-{
+double mDeterminant(void *mx, size_t dim) {
     double *m_mx = (double *)mx;
 
     size_t i;
@@ -1167,19 +964,19 @@ double mDeterminant(void *mx, size_t dim)
     double mxTemp[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     CHECK_ARRAY_DIMENSIONS((dim - 1) * (dim - 1));
 
-    if(dim < 1) {
+    if (dim < 1) {
         return 0;
-    } else if(dim == 1) {
+    } else if (dim == 1) {
         result = m_mx[MXINDEX(dim, 0, 0)];
-    } else if(dim == 2) {
-        result = m_mx[MXINDEX(dim, 0, 0)] * m_mx[MXINDEX(dim, 1, 1)]
-                 - m_mx[MXINDEX(dim, 1, 0)] * m_mx[MXINDEX(dim, 0, 1)];
+    } else if (dim == 2) {
+        result =
+            m_mx[MXINDEX(dim, 0, 0)] * m_mx[MXINDEX(dim, 1, 1)] - m_mx[MXINDEX(dim, 1, 0)] * m_mx[MXINDEX(dim, 0, 1)];
     } else {
-        for(k = 0; k < dim; k++) {
-            for(i = 1; i < dim; i++) {
+        for (k = 0; k < dim; k++) {
+            for (i = 1; i < dim; i++) {
                 ii = 0;
-                for(j = 0; j < dim; j++) {
-                    if(j == k) {
+                for (j = 0; j < dim; j++) {
+                    if (j == k) {
                         continue;
                     }
                     mxTemp[MXINDEX(dim - 1, i - 1, ii)] = m_mx[MXINDEX(dim, i, j)];
@@ -1189,36 +986,35 @@ double mDeterminant(void *mx, size_t dim)
             result += pow(-1.0, 1.0 + k + 1.0) * m_mx[MXINDEX(dim, 0, k)] * mDeterminant(mxTemp, dim - 1);
         }
     }
-    return(result);
+    return (result);
 }
 
-void mCofactor(void *mx, size_t dim, void *result)
-{
+void mCofactor(void *mx, size_t dim, void *result) {
     /* The (j,i)th cofactor of A is defined as (-1)^(i + j)*det(A_(i,j))
        where A_(i,j) is the submatrix of A obtained from A by removing the ith row and jth column */
-    size_t  i;
-    size_t  i0;
-    size_t  i1;
-    size_t  j;
-    size_t  j0;
-    size_t  j1;
+    size_t i;
+    size_t i0;
+    size_t i1;
+    size_t j;
+    size_t j0;
+    size_t j1;
     double *m_mx = (double *)mx;
     double m_mxij[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
     double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
-    double  det;
-    CHECK_ARRAY_DIMENSIONS(dim*dim);
+    double det;
+    CHECK_ARRAY_DIMENSIONS(dim * dim);
 
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             /* Form mx_(i,j) */
             i1 = 0;
-            for(i0 = 0; i0 < dim; i0++) {
-                if(i0 == i) {
+            for (i0 = 0; i0 < dim; i0++) {
+                if (i0 == i) {
                     continue;
                 }
                 j1 = 0;
-                for(j0 = 0; j0 < dim; j0++) {
-                    if(j0 == j) {
+                for (j0 = 0; j0 < dim; j0++) {
+                    if (j0 == j) {
                         continue;
                     }
                     m_mxij[MXINDEX(dim - 1, i1, j1)] = m_mx[MXINDEX(dim, i0, j0)];
@@ -1238,18 +1034,17 @@ void mCofactor(void *mx, size_t dim, void *result)
     MOVE_DOUBLE(m_result, dim * dim, result);
 }
 
-int mInverse(void *mx, size_t dim, void *result)
-{
+int mInverse(void *mx, size_t dim, void *result) {
     /* Inverse of a square matrix A with non zero determinant is adjoint matrix divided by determinant */
     /* The adjoint matrix is the square matrix X such that the (i,j)th entry of X is the (j,i)th cofactor of A */
 
-    size_t  i;
-    size_t  j;
-    int     status = 0;
-    double  det = mDeterminant(mx, dim);
-    double  m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
-    CHECK_ARRAY_DIMENSIONS(dim*dim);
-    if(fabs(det) > DB0_EPS) {
+    size_t i;
+    size_t j;
+    int status = 0;
+    double det = mDeterminant(mx, dim);
+    double m_result[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
+    CHECK_ARRAY_DIMENSIONS(dim * dim);
+    if (fabs(det) > DB0_EPS) {
         /* Find adjoint matrix */
         double m_adjoint[LINEAR_ALGEBRA_MAX_ARRAY_SIZE];
         mCofactor(mx, dim, m_adjoint);
@@ -1257,8 +1052,8 @@ int mInverse(void *mx, size_t dim, void *result)
         /* Find inverse */
         mScale(1.0 / det, m_adjoint, dim, dim, m_result);
     } else {
-        for(i = 0; i < dim; i++) {
-            for(j = 0; j < dim; j++) {
+        for (i = 0; i < dim; i++) {
+            for (j = 0; j < dim; j++) {
                 m_result[MXINDEX(dim, i, j)] = 0.0;
             }
         }
@@ -1269,18 +1064,15 @@ int mInverse(void *mx, size_t dim, void *result)
     return status;
 }
 
-int mIsEqual(void *mx1, size_t dim1, size_t dim2,
-             void *mx2,
-             double accuracy)
-{
+int mIsEqual(void *mx1, size_t dim1, size_t dim2, void *mx2, double accuracy) {
     double *m_mx1 = (double *)mx1;
     double *m_mx2 = (double *)mx2;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(m_mx1[MXINDEX(dim2, i, j)] - m_mx2[MXINDEX(dim2, i, j)]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(m_mx1[MXINDEX(dim2, i, j)] - m_mx2[MXINDEX(dim2, i, j)]) > accuracy) {
                 return 0;
             }
         }
@@ -1288,16 +1080,14 @@ int mIsEqual(void *mx1, size_t dim1, size_t dim2,
     return 1;
 }
 
-int mIsZero(void *mx, size_t dim1, size_t dim2,
-            double accuracy)
-{
+int mIsZero(void *mx, size_t dim1, size_t dim2, double accuracy) {
     double *m_mx = (double *)mx;
 
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(m_mx[MXINDEX(dim2, i, j)]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(m_mx[MXINDEX(dim2, i, j)]) > accuracy) {
                 return 0;
             }
         }
@@ -1305,195 +1095,179 @@ int mIsZero(void *mx, size_t dim1, size_t dim2,
     return 1;
 }
 
-void mPrintScreen(const char *name, void *mx, size_t dim1, size_t dim2)
-{
+void mPrintScreen(const char *name, void *mx, size_t dim1, size_t dim2) {
     double *m_mx = (double *)mx;
 
     size_t i;
     size_t j;
     printf("%s = [", name);
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             printf("%20.15g", m_mx[MXINDEX(dim2, i, j)]);
-            if(j != dim2 - 1) {
+            if (j != dim2 - 1) {
                 printf(", ");
             }
         }
-        if(i != dim1 - 1) {
+        if (i != dim1 - 1) {
             printf(";\n");
         }
     }
     printf("];\n");
 }
 
-
-void mPrint(FILE *pFile, const char *name, void *mx, size_t dim1, size_t dim2)
-{
+void mPrint(FILE *pFile, const char *name, void *mx, size_t dim1, size_t dim2) {
     double *m_mx = (double *)mx;
 
     size_t i;
     size_t j;
     fprintf(pFile, "%s = [", name);
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             fprintf(pFile, "%20.15g", m_mx[MXINDEX(dim2, i, j)]);
-            if(j != dim2 - 1) {
+            if (j != dim2 - 1) {
                 fprintf(pFile, ", ");
             }
         }
-        if(i != dim1 - 1) {
+        if (i != dim1 - 1) {
             fprintf(pFile, ";\n");
         }
     }
     fprintf(pFile, "];\n");
 }
 
-void mGetSubMatrix(void *mx, size_t dim1, size_t dim2,
-                   size_t dim1Start, size_t dim2Start,
-                   size_t dim1Result, size_t dim2Result, void *result)
-{
+void mGetSubMatrix(void *mx,
+                   size_t dim1,
+                   size_t dim2,
+                   size_t dim1Start,
+                   size_t dim2Start,
+                   size_t dim1Result,
+                   size_t dim2Result,
+                   void *result) {
     double *m_mx = (double *)mx;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = dim1Start; i < dim1Start + dim1Result; i++) {
-        for(j = dim2Start; j < dim2Start + dim2Result; j++) {
+    for (i = dim1Start; i < dim1Start + dim1Result; i++) {
+        for (j = dim2Start; j < dim2Start + dim2Result; j++) {
             m_result[MXINDEX(dim2Result, i - dim1Start, j - dim2Start)] = m_mx[MXINDEX(dim2, i, j)];
         }
     }
 }
 
-void mSetSubMatrix(void *mx, size_t dim1, size_t dim2,
-                   void *result, size_t dim1Result, size_t dim2Result,
-                   size_t dim1Start, size_t dim2Start)
-{
+void mSetSubMatrix(void *mx,
+                   size_t dim1,
+                   size_t dim2,
+                   void *result,
+                   size_t dim1Result,
+                   size_t dim2Result,
+                   size_t dim1Start,
+                   size_t dim2Start) {
     double *m_mx = (double *)mx;
     double *m_result = (double *)result;
 
     size_t i;
     size_t j;
-    for(i = dim1Start; i < dim1Start + dim1; i++) {
-        for(j = dim2Start; j < dim2Start + dim2; j++) {
+    for (i = dim1Start; i < dim1Start + dim1; i++) {
+        for (j = dim2Start; j < dim2Start + dim2; j++) {
             m_result[MXINDEX(dim2Result, i, j)] = m_mx[MXINDEX(dim2, i - dim1Start, j - dim2Start)];
         }
     }
 }
 
-void m22Set(double m00, double m01,
-            double m10, double m11,
-            double m[2][2])
-{
+void m22Set(double m00, double m01, double m10, double m11, double m[2][2]) {
     m[0][0] = m00;
     m[0][1] = m01;
     m[1][0] = m10;
     m[1][1] = m11;
 }
 
-void m22Copy(double mx[2][2],
-             double result[2][2])
-{
+void m22Copy(double mx[2][2], double result[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx[i][j];
         }
     }
 }
 
-void m22SetZero(double result[2][2])
-{
+void m22SetZero(double result[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = 0.0;
         }
     }
 }
 
-void m22SetIdentity(double result[2][2])
-{
+void m22SetIdentity(double result[2][2]) {
     size_t dim = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             result[i][j] = (i == j) ? 1.0 : 0.0;
         }
     }
 }
 
-void m22Transpose(double mx[2][2],
-                  double result[2][2])
-{
+void m22Transpose(double mx[2][2], double result[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
     double m_result[2][2];
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[j][i] = mx[i][j];
         }
     }
     m22Copy(m_result, result);
 }
 
-void m22Add(double mx1[2][2],
-            double mx2[2][2],
-            double result[2][2])
-{
+void m22Add(double mx1[2][2], double mx2[2][2], double result[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx1[i][j] + mx2[i][j];
         }
     }
 }
 
-void m22Subtract(double mx1[2][2],
-                 double mx2[2][2],
-                 double result[2][2])
-{
+void m22Subtract(double mx1[2][2], double mx2[2][2], double result[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx1[i][j] - mx2[i][j];
         }
     }
 }
 
-void m22Scale(double scaleFactor,
-              double mx[2][2],
-              double result[2][2])
-{
+void m22Scale(double scaleFactor, double mx[2][2], double result[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = scaleFactor * mx[i][j];
         }
     }
 }
 
-void m22MultM22(double mx1[2][2],
-                double mx2[2][2],
-                double result[2][2])
-{
+void m22MultM22(double mx1[2][2], double mx2[2][2], double result[2][2]) {
     size_t dim11 = 2;
     size_t dim12 = 2;
     size_t dim22 = 2;
@@ -1501,10 +1275,10 @@ void m22MultM22(double mx1[2][2],
     size_t j;
     size_t k;
     double m_result[2][2];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[i][k] * mx2[k][j];
             }
         }
@@ -1512,10 +1286,7 @@ void m22MultM22(double mx1[2][2],
     m22Copy(m_result, result);
 }
 
-void m22tMultM22(double mx1[2][2],
-                 double mx2[2][2],
-                 double result[2][2])
-{
+void m22tMultM22(double mx1[2][2], double mx2[2][2], double result[2][2]) {
     size_t dim11 = 2;
     size_t dim12 = 2;
     size_t dim22 = 2;
@@ -1523,10 +1294,10 @@ void m22tMultM22(double mx1[2][2],
     size_t j;
     size_t k;
     double m_result[2][2];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[k][i] * mx2[k][j];
             }
         }
@@ -1534,10 +1305,7 @@ void m22tMultM22(double mx1[2][2],
     m22Copy(m_result, result);
 }
 
-void m22MultM22t(double mx1[2][2],
-                 double mx2[2][2],
-                 double result[2][2])
-{
+void m22MultM22t(double mx1[2][2], double mx2[2][2], double result[2][2]) {
     size_t dim11 = 2;
     size_t dim12 = 2;
     size_t dim21 = 2;
@@ -1545,10 +1313,10 @@ void m22MultM22t(double mx1[2][2],
     size_t j;
     size_t k;
     double m_result[2][2];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim21; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim21; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[i][k] * mx2[j][k];
             }
         }
@@ -1556,10 +1324,7 @@ void m22MultM22t(double mx1[2][2],
     m22Copy(m_result, result);
 }
 
-void m22MultV2(double mx[2][2],
-               double v[2],
-               double result[2])
-{
+void m22MultV2(double mx[2][2], double v[2], double result[2]) {
     size_t dim11 = 2;
     size_t dim12 = 2;
     size_t dim22 = 1;
@@ -1567,10 +1332,10 @@ void m22MultV2(double mx[2][2],
     size_t j;
     size_t k;
     double m_result[2];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[i][k] * v[k];
             }
         }
@@ -1578,10 +1343,7 @@ void m22MultV2(double mx[2][2],
     v2Copy(m_result, result);
 }
 
-void m22tMultV2(double mx[2][2],
-                double v[2],
-                double result[2])
-{
+void m22tMultV2(double mx[2][2], double v[2], double result[2]) {
     size_t dim11 = 2;
     size_t dim12 = 2;
     size_t dim22 = 1;
@@ -1589,10 +1351,10 @@ void m22tMultV2(double mx[2][2],
     size_t j;
     size_t k;
     double m_result[2];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[k][i] * v[k];
             }
         }
@@ -1600,36 +1362,31 @@ void m22tMultV2(double mx[2][2],
     v2Copy(m_result, result);
 }
 
-double m22Trace(double mx[2][2])
-{
+double m22Trace(double mx[2][2]) {
     size_t dim = 2;
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += mx[i][i];
     }
 
     return result;
 }
 
-double m22Determinant(double mx[2][2])
-{
+double m22Determinant(double mx[2][2]) {
     double value;
     value = mx[0][0] * mx[1][1] - mx[1][0] * mx[0][1];
     return value;
 }
 
-int m22IsEqual(double mx1[2][2],
-               double mx2[2][2],
-               double accuracy)
-{
+int m22IsEqual(double mx1[2][2], double mx2[2][2], double accuracy) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -1637,16 +1394,14 @@ int m22IsEqual(double mx1[2][2],
     return 1;
 }
 
-int m22IsZero(double mx[2][2],
-              double accuracy)
-{
+int m22IsZero(double mx[2][2], double accuracy) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -1654,64 +1409,64 @@ int m22IsZero(double mx[2][2],
     return 1;
 }
 
-void m22Print(FILE *pFile, const char *name, double mx[2][2])
-{
+void m22Print(FILE *pFile, const char *name, double mx[2][2]) {
     size_t dim1 = 2;
     size_t dim2 = 2;
     size_t i;
     size_t j;
     fprintf(pFile, "%s = [", name);
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             fprintf(pFile, "%20.15g", mx[i][j]);
-            if(j != dim2 - 1) {
+            if (j != dim2 - 1) {
                 fprintf(pFile, ", ");
             }
         }
-        if(i != dim1 - 1) {
+        if (i != dim1 - 1) {
             fprintf(pFile, ";\n");
         }
     }
     fprintf(pFile, "]\n");
 }
 
-int m22Inverse(double mx[2][2], double result[2][2])
-{
+int m22Inverse(double mx[2][2], double result[2][2]) {
     double det = m22Determinant(mx);
     double detInv;
     double m_result[2][2];
-    int    status = 0;
+    int status = 0;
 
-    if(fabs(det) > DB0_EPS) {
+    if (fabs(det) > DB0_EPS) {
         detInv = 1.0 / det;
-        m_result[0][0] =  mx[1][1] * detInv;
+        m_result[0][0] = mx[1][1] * detInv;
         m_result[0][1] = -mx[0][1] * detInv;
         m_result[1][0] = -mx[1][0] * detInv;
-        m_result[1][1] =  mx[0][0] * detInv;
+        m_result[1][1] = mx[0][0] * detInv;
     } else {
-        m22Set(0.0, 0.0,
-               0.0, 0.0,
-               m_result);
+        m22Set(0.0, 0.0, 0.0, 0.0, m_result);
         status = 1;
     }
     m22Copy(m_result, result);
     return status;
 }
 
-void    m22PrintScreen(const char *name, double mx[2][2])
-{
+void m22PrintScreen(const char *name, double mx[2][2]) {
     int i;
     printf("%s:\n", name);
-    for (i=0;i<2;i++) {
+    for (i = 0; i < 2; i++) {
         printf("%20.15g, %20.15g\n", mx[i][0], mx[i][1]);
     }
 }
 
-void m33Set(double m00, double m01, double m02,
-            double m10, double m11, double m12,
-            double m20, double m21, double m22,
-            double m[3][3])
-{
+void m33Set(double m00,
+            double m01,
+            double m02,
+            double m10,
+            double m11,
+            double m12,
+            double m20,
+            double m21,
+            double m22,
+            double m[3][3]) {
     m[0][0] = m00;
     m[0][1] = m01;
     m[0][2] = m02;
@@ -1723,110 +1478,92 @@ void m33Set(double m00, double m01, double m02,
     m[2][2] = m22;
 }
 
-void m33Copy(double mx[3][3],
-             double result[3][3])
-{
+void m33Copy(double mx[3][3], double result[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx[i][j];
         }
     }
 }
 
-void m33SetZero(double result[3][3])
-{
+void m33SetZero(double result[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = 0.0;
         }
     }
 }
 
-void m33SetIdentity(double result[3][3])
-{
+void m33SetIdentity(double result[3][3]) {
     size_t dim = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             result[i][j] = (i == j) ? 1.0 : 0.0;
         }
     }
 }
 
-void m33Transpose(double mx[3][3],
-                  double result[3][3])
-{
+void m33Transpose(double mx[3][3], double result[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
     double m_result[3][3];
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[j][i] = mx[i][j];
         }
     }
     m33Copy(m_result, result);
 }
 
-void m33Add(double mx1[3][3],
-            double mx2[3][3],
-            double result[3][3])
-{
+void m33Add(double mx1[3][3], double mx2[3][3], double result[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx1[i][j] + mx2[i][j];
         }
     }
 }
 
-void m33Subtract(double mx1[3][3],
-                 double mx2[3][3],
-                 double result[3][3])
-{
+void m33Subtract(double mx1[3][3], double mx2[3][3], double result[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx1[i][j] - mx2[i][j];
         }
     }
 }
 
-void m33Scale(double scaleFactor,
-              double mx[3][3],
-              double result[3][3])
-{
+void m33Scale(double scaleFactor, double mx[3][3], double result[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = scaleFactor * mx[i][j];
         }
     }
 }
 
-void m33MultM33(double mx1[3][3],
-                double mx2[3][3],
-                double result[3][3])
-{
+void m33MultM33(double mx1[3][3], double mx2[3][3], double result[3][3]) {
     size_t dim11 = 3;
     size_t dim12 = 3;
     size_t dim22 = 3;
@@ -1834,10 +1571,10 @@ void m33MultM33(double mx1[3][3],
     size_t j;
     size_t k;
     double m_result[3][3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[i][k] * mx2[k][j];
             }
         }
@@ -1845,10 +1582,7 @@ void m33MultM33(double mx1[3][3],
     m33Copy(m_result, result);
 }
 
-void m33tMultM33(double mx1[3][3],
-                 double mx2[3][3],
-                 double result[3][3])
-{
+void m33tMultM33(double mx1[3][3], double mx2[3][3], double result[3][3]) {
     size_t dim11 = 3;
     size_t dim12 = 3;
     size_t dim22 = 3;
@@ -1856,10 +1590,10 @@ void m33tMultM33(double mx1[3][3],
     size_t j;
     size_t k;
     double m_result[3][3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[k][i] * mx2[k][j];
             }
         }
@@ -1867,10 +1601,7 @@ void m33tMultM33(double mx1[3][3],
     m33Copy(m_result, result);
 }
 
-void m33MultM33t(double mx1[3][3],
-                 double mx2[3][3],
-                 double result[3][3])
-{
+void m33MultM33t(double mx1[3][3], double mx2[3][3], double result[3][3]) {
     size_t dim11 = 3;
     size_t dim12 = 3;
     size_t dim21 = 3;
@@ -1878,10 +1609,10 @@ void m33MultM33t(double mx1[3][3],
     size_t j;
     size_t k;
     double m_result[3][3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim21; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim21; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[i][k] * mx2[j][k];
             }
         }
@@ -1889,10 +1620,7 @@ void m33MultM33t(double mx1[3][3],
     m33Copy(m_result, result);
 }
 
-void m33MultV3(double mx[3][3],
-               double v[3],
-               double result[3])
-{
+void m33MultV3(double mx[3][3], double v[3], double result[3]) {
     size_t dim11 = 3;
     size_t dim12 = 3;
     size_t dim22 = 1;
@@ -1900,10 +1628,10 @@ void m33MultV3(double mx[3][3],
     size_t j;
     size_t k;
     double m_result[3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[i][k] * v[k];
             }
         }
@@ -1911,10 +1639,7 @@ void m33MultV3(double mx[3][3],
     v3Copy(m_result, result);
 }
 
-void m33tMultV3(double mx[3][3],
-                double v[3],
-                double result[3])
-{
+void m33tMultV3(double mx[3][3], double v[3], double result[3]) {
     size_t dim11 = 3;
     size_t dim12 = 3;
     size_t dim22 = 1;
@@ -1922,10 +1647,10 @@ void m33tMultV3(double mx[3][3],
     size_t j;
     size_t k;
     double m_result[3];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[k][i] * v[k];
             }
         }
@@ -1933,41 +1658,32 @@ void m33tMultV3(double mx[3][3],
     v3Copy(m_result, result);
 }
 
-double m33Trace(double mx[3][3])
-{
+double m33Trace(double mx[3][3]) {
     size_t dim = 3;
     size_t i;
     double result = 0.0;
-    for(i = 0; i < dim; i++) {
+    for (i = 0; i < dim; i++) {
         result += mx[i][i];
     }
 
     return result;
 }
 
-double m33Determinant(double mx[3][3])
-{
+double m33Determinant(double mx[3][3]) {
     double value;
-    value = mx[0][0] * mx[1][1] * mx[2][2]
-            + mx[0][1] * mx[1][2] * mx[2][0]
-            + mx[0][2] * mx[1][0] * mx[2][1]
-            - mx[0][0] * mx[1][2] * mx[2][1]
-            - mx[0][1] * mx[1][0] * mx[2][2]
-            - mx[0][2] * mx[1][1] * mx[2][0];
+    value = mx[0][0] * mx[1][1] * mx[2][2] + mx[0][1] * mx[1][2] * mx[2][0] + mx[0][2] * mx[1][0] * mx[2][1] -
+            mx[0][0] * mx[1][2] * mx[2][1] - mx[0][1] * mx[1][0] * mx[2][2] - mx[0][2] * mx[1][1] * mx[2][0];
     return value;
 }
 
-int m33IsEqual(double mx1[3][3],
-               double mx2[3][3],
-               double accuracy)
-{
+int m33IsEqual(double mx1[3][3], double mx2[3][3], double accuracy) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -1975,16 +1691,14 @@ int m33IsEqual(double mx1[3][3],
     return 1;
 }
 
-int m33IsZero(double mx[3][3],
-              double accuracy)
-{
+int m33IsZero(double mx[3][3], double accuracy) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -1992,35 +1706,33 @@ int m33IsZero(double mx[3][3],
     return 1;
 }
 
-void m33Print(FILE *pFile, const char *name, double mx[3][3])
-{
+void m33Print(FILE *pFile, const char *name, double mx[3][3]) {
     size_t dim1 = 3;
     size_t dim2 = 3;
     size_t i;
     size_t j;
     fprintf(pFile, "%s = [", name);
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             fprintf(pFile, "%20.15g", mx[i][j]);
-            if(j != dim2 - 1) {
+            if (j != dim2 - 1) {
                 fprintf(pFile, ", ");
             }
         }
-        if(i != dim1 - 1) {
+        if (i != dim1 - 1) {
             fprintf(pFile, ";\n");
         }
     }
     fprintf(pFile, "]\n");
 }
 
-int m33Inverse(double mx[3][3], double result[3][3])
-{
+int m33Inverse(double mx[3][3], double result[3][3]) {
     double det = m33Determinant(mx);
     double detInv;
     double m_result[3][3];
-    int    status = 0;
+    int status = 0;
 
-    if(fabs(det) > DB0_EPS) {
+    if (fabs(det) > DB0_EPS) {
         detInv = 1.0 / det;
         m_result[0][0] = (mx[1][1] * mx[2][2] - mx[1][2] * mx[2][1]) * detInv;
         m_result[0][1] = -(mx[0][1] * mx[2][2] - mx[0][2] * mx[2][1]) * detInv;
@@ -2032,37 +1744,32 @@ int m33Inverse(double mx[3][3], double result[3][3])
         m_result[2][1] = -(mx[0][0] * mx[2][1] - mx[0][1] * mx[2][0]) * detInv;
         m_result[2][2] = (mx[0][0] * mx[1][1] - mx[0][1] * mx[1][0]) * detInv;
     } else {
-        m33Set(0.0, 0.0, 0.0,
-               0.0, 0.0, 0.0,
-               0.0, 0.0, 0.0,
-               m_result);
+        m33Set(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, m_result);
         status = 1;
     }
     m33Copy(m_result, result);
     return status;
 }
 
-void m33SingularValues(double mx[3][3], double result[3])
-{
+void m33SingularValues(double mx[3][3], double result[3]) {
     double sv[3];
     double a[3];
     double mxtmx[3][3];
-    int    i;
+    int i;
 
     m33tMultM33(mx, mx, mxtmx);
 
     /* Compute characteristic polynomial */
     a[0] = -m33Determinant(mxtmx);
-    a[1] = mxtmx[0][0] * mxtmx[1][1] - mxtmx[0][1] * mxtmx[1][0]
-           + mxtmx[0][0] * mxtmx[2][2] - mxtmx[0][2] * mxtmx[2][0]
-           + mxtmx[1][1] * mxtmx[2][2] - mxtmx[1][2] * mxtmx[2][1];
+    a[1] = mxtmx[0][0] * mxtmx[1][1] - mxtmx[0][1] * mxtmx[1][0] + mxtmx[0][0] * mxtmx[2][2] -
+           mxtmx[0][2] * mxtmx[2][0] + mxtmx[1][1] * mxtmx[2][2] - mxtmx[1][2] * mxtmx[2][1];
     a[2] = -mxtmx[0][0] - mxtmx[1][1] - mxtmx[2][2];
 
     /* Solve cubic equation */
     cubicRoots(a, sv);
 
     /* take square roots */
-    for(i = 0; i < 3; i++) {
+    for (i = 0; i < 3; i++) {
         sv[i] = sqrt(sv[i]);
     }
 
@@ -2070,16 +1777,14 @@ void m33SingularValues(double mx[3][3], double result[3])
     v3Sort(sv, result);
 }
 
-void m33EigenValues(double mx[3][3], double result[3])
-{
+void m33EigenValues(double mx[3][3], double result[3]) {
     double sv[3];
     double a[3];
 
     /* Compute characteristic polynomial */
     a[0] = -m33Determinant(mx);
-    a[1] = mx[0][0] * mx[1][1] - mx[0][1] * mx[1][0]
-           + mx[0][0] * mx[2][2] - mx[0][2] * mx[2][0]
-           + mx[1][1] * mx[2][2] - mx[1][2] * mx[2][1];
+    a[1] = mx[0][0] * mx[1][1] - mx[0][1] * mx[1][0] + mx[0][0] * mx[2][2] - mx[0][2] * mx[2][0] + mx[1][1] * mx[2][2] -
+           mx[1][2] * mx[2][1];
     a[2] = -mx[0][0] - mx[1][1] - mx[2][2];
 
     /* Solve cubic equation */
@@ -2089,28 +1794,37 @@ void m33EigenValues(double mx[3][3], double result[3])
     v3Sort(sv, result);
 }
 
-double m33ConditionNumber(double mx[3][3])
-{
+double m33ConditionNumber(double mx[3][3]) {
     double sv[3];
     m33SingularValues(mx, sv);
     return (sv[0] / sv[2]);
 }
 
-void    m33PrintScreen(const char *name, double mx[3][3])
-{
+void m33PrintScreen(const char *name, double mx[3][3]) {
     int i;
     printf("%s:\n", name);
-    for (i=0;i<3;i++) {
+    for (i = 0; i < 3; i++) {
         printf("%20.15g, %20.15g, %20.15g\n", mx[i][0], mx[i][1], mx[i][2]);
     }
 }
 
-void m44Set(double m00, double m01, double m02, double m03,
-            double m10, double m11, double m12, double m13,
-            double m20, double m21, double m22, double m23,
-            double m30, double m31, double m32, double m33,
-            double m[4][4])
-{
+void m44Set(double m00,
+            double m01,
+            double m02,
+            double m03,
+            double m10,
+            double m11,
+            double m12,
+            double m13,
+            double m20,
+            double m21,
+            double m22,
+            double m23,
+            double m30,
+            double m31,
+            double m32,
+            double m33,
+            double m[4][4]) {
     m[0][0] = m00;
     m[0][1] = m01;
     m[0][2] = m02;
@@ -2129,37 +1843,31 @@ void m44Set(double m00, double m01, double m02, double m03,
     m[3][3] = m33;
 }
 
-void m44Copy(double mx[4][4],
-             double result[4][4])
-{
+void m44Copy(double mx[4][4], double result[4][4]) {
     size_t dim1 = 4;
     size_t dim2 = 4;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx[i][j];
         }
     }
 }
 
-void m44SetZero(double result[4][4])
-{
+void m44SetZero(double result[4][4]) {
     size_t dim1 = 4;
     size_t dim2 = 4;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = 0.0;
         }
     }
 }
 
-void m44MultV4(double mx[4][4],
-               double v[4],
-               double result[4])
-{
+void m44MultV4(double mx[4][4], double v[4], double result[4]) {
     size_t dim11 = 4;
     size_t dim12 = 4;
     size_t dim22 = 1;
@@ -2167,10 +1875,10 @@ void m44MultV4(double mx[4][4],
     size_t j;
     size_t k;
     double m_result[4];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[i][k] * v[k];
             }
         }
@@ -2178,47 +1886,31 @@ void m44MultV4(double mx[4][4],
     v4Copy(m_result, result);
 }
 
-double m44Determinant(double mx[4][4])
-{
+double m44Determinant(double mx[4][4]) {
     double value;
-    value = mx[0][3] * mx[1][2] * mx[2][1] * mx[3][0]
-            - mx[0][2] * mx[1][3] * mx[2][1] * mx[3][0]
-            - mx[0][3] * mx[1][1] * mx[2][2] * mx[3][0]
-            + mx[0][1] * mx[1][3] * mx[2][2] * mx[3][0]
-            + mx[0][2] * mx[1][1] * mx[2][3] * mx[3][0]
-            - mx[0][1] * mx[1][2] * mx[2][3] * mx[3][0]
-            - mx[0][3] * mx[1][2] * mx[2][0] * mx[3][1]
-            + mx[0][2] * mx[1][3] * mx[2][0] * mx[3][1]
-            + mx[0][3] * mx[1][0] * mx[2][2] * mx[3][1]
-            - mx[0][0] * mx[1][3] * mx[2][2] * mx[3][1]
-            - mx[0][2] * mx[1][0] * mx[2][3] * mx[3][1]
-            + mx[0][0] * mx[1][2] * mx[2][3] * mx[3][1]
-            + mx[0][3] * mx[1][1] * mx[2][0] * mx[3][2]
-            - mx[0][1] * mx[1][3] * mx[2][0] * mx[3][2]
-            - mx[0][3] * mx[1][0] * mx[2][1] * mx[3][2]
-            + mx[0][0] * mx[1][3] * mx[2][1] * mx[3][2]
-            + mx[0][1] * mx[1][0] * mx[2][3] * mx[3][2]
-            - mx[0][0] * mx[1][1] * mx[2][3] * mx[3][2]
-            - mx[0][2] * mx[1][1] * mx[2][0] * mx[3][3]
-            + mx[0][1] * mx[1][2] * mx[2][0] * mx[3][3]
-            + mx[0][2] * mx[1][0] * mx[2][1] * mx[3][3]
-            - mx[0][0] * mx[1][2] * mx[2][1] * mx[3][3]
-            - mx[0][1] * mx[1][0] * mx[2][2] * mx[3][3]
-            + mx[0][0] * mx[1][1] * mx[2][2] * mx[3][3];
+    value = mx[0][3] * mx[1][2] * mx[2][1] * mx[3][0] - mx[0][2] * mx[1][3] * mx[2][1] * mx[3][0] -
+            mx[0][3] * mx[1][1] * mx[2][2] * mx[3][0] + mx[0][1] * mx[1][3] * mx[2][2] * mx[3][0] +
+            mx[0][2] * mx[1][1] * mx[2][3] * mx[3][0] - mx[0][1] * mx[1][2] * mx[2][3] * mx[3][0] -
+            mx[0][3] * mx[1][2] * mx[2][0] * mx[3][1] + mx[0][2] * mx[1][3] * mx[2][0] * mx[3][1] +
+            mx[0][3] * mx[1][0] * mx[2][2] * mx[3][1] - mx[0][0] * mx[1][3] * mx[2][2] * mx[3][1] -
+            mx[0][2] * mx[1][0] * mx[2][3] * mx[3][1] + mx[0][0] * mx[1][2] * mx[2][3] * mx[3][1] +
+            mx[0][3] * mx[1][1] * mx[2][0] * mx[3][2] - mx[0][1] * mx[1][3] * mx[2][0] * mx[3][2] -
+            mx[0][3] * mx[1][0] * mx[2][1] * mx[3][2] + mx[0][0] * mx[1][3] * mx[2][1] * mx[3][2] +
+            mx[0][1] * mx[1][0] * mx[2][3] * mx[3][2] - mx[0][0] * mx[1][1] * mx[2][3] * mx[3][2] -
+            mx[0][2] * mx[1][1] * mx[2][0] * mx[3][3] + mx[0][1] * mx[1][2] * mx[2][0] * mx[3][3] +
+            mx[0][2] * mx[1][0] * mx[2][1] * mx[3][3] - mx[0][0] * mx[1][2] * mx[2][1] * mx[3][3] -
+            mx[0][1] * mx[1][0] * mx[2][2] * mx[3][3] + mx[0][0] * mx[1][1] * mx[2][2] * mx[3][3];
     return value;
 }
 
-int m44IsEqual(double mx1[4][4],
-               double mx2[4][4],
-               double accuracy)
-{
+int m44IsEqual(double mx1[4][4], double mx2[4][4], double accuracy) {
     size_t dim1 = 4;
     size_t dim2 = 4;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -2226,51 +1918,123 @@ int m44IsEqual(double mx1[4][4],
     return 1;
 }
 
-int m44Inverse(double mx[4][4], double result[4][4])
-{
+int m44Inverse(double mx[4][4], double result[4][4]) {
     double det = m44Determinant(mx);
     double detInv;
     double m_result[4][4];
-    int    status = 0;
+    int status = 0;
 
-    if(fabs(det) > DB0_EPS) {
+    if (fabs(det) > DB0_EPS) {
         detInv = 1.0 / det;
-        m_result[0][0] = (mx[1][2] * mx[2][3] * mx[3][1] - mx[1][3] * mx[2][2] * mx[3][1] + mx[1][3] * mx[2][1] * mx[3][2] - mx[1][1] * mx[2][3] * mx[3][2] - mx[1][2] * mx[2][1] * mx[3][3] + mx[1][1] * mx[2][2] * mx[3][3]) * detInv;
-        m_result[0][1] = (mx[0][3] * mx[2][2] * mx[3][1] - mx[0][2] * mx[2][3] * mx[3][1] - mx[0][3] * mx[2][1] * mx[3][2] + mx[0][1] * mx[2][3] * mx[3][2] + mx[0][2] * mx[2][1] * mx[3][3] - mx[0][1] * mx[2][2] * mx[3][3]) * detInv;
-        m_result[0][2] = (mx[0][2] * mx[1][3] * mx[3][1] - mx[0][3] * mx[1][2] * mx[3][1] + mx[0][3] * mx[1][1] * mx[3][2] - mx[0][1] * mx[1][3] * mx[3][2] - mx[0][2] * mx[1][1] * mx[3][3] + mx[0][1] * mx[1][2] * mx[3][3]) * detInv;
-        m_result[0][3] = (mx[0][3] * mx[1][2] * mx[2][1] - mx[0][2] * mx[1][3] * mx[2][1] - mx[0][3] * mx[1][1] * mx[2][2] + mx[0][1] * mx[1][3] * mx[2][2] + mx[0][2] * mx[1][1] * mx[2][3] - mx[0][1] * mx[1][2] * mx[2][3]) * detInv;
-        m_result[1][0] = (mx[1][3] * mx[2][2] * mx[3][0] - mx[1][2] * mx[2][3] * mx[3][0] - mx[1][3] * mx[2][0] * mx[3][2] + mx[1][0] * mx[2][3] * mx[3][2] + mx[1][2] * mx[2][0] * mx[3][3] - mx[1][0] * mx[2][2] * mx[3][3]) * detInv;
-        m_result[1][1] = (mx[0][2] * mx[2][3] * mx[3][0] - mx[0][3] * mx[2][2] * mx[3][0] + mx[0][3] * mx[2][0] * mx[3][2] - mx[0][0] * mx[2][3] * mx[3][2] - mx[0][2] * mx[2][0] * mx[3][3] + mx[0][0] * mx[2][2] * mx[3][3]) * detInv;
-        m_result[1][2] = (mx[0][3] * mx[1][2] * mx[3][0] - mx[0][2] * mx[1][3] * mx[3][0] - mx[0][3] * mx[1][0] * mx[3][2] + mx[0][0] * mx[1][3] * mx[3][2] + mx[0][2] * mx[1][0] * mx[3][3] - mx[0][0] * mx[1][2] * mx[3][3]) * detInv;
-        m_result[1][3] = (mx[0][2] * mx[1][3] * mx[2][0] - mx[0][3] * mx[1][2] * mx[2][0] + mx[0][3] * mx[1][0] * mx[2][2] - mx[0][0] * mx[1][3] * mx[2][2] - mx[0][2] * mx[1][0] * mx[2][3] + mx[0][0] * mx[1][2] * mx[2][3]) * detInv;
-        m_result[2][0] = (mx[1][1] * mx[2][3] * mx[3][0] - mx[1][3] * mx[2][1] * mx[3][0] + mx[1][3] * mx[2][0] * mx[3][1] - mx[1][0] * mx[2][3] * mx[3][1] - mx[1][1] * mx[2][0] * mx[3][3] + mx[1][0] * mx[2][1] * mx[3][3]) * detInv;
-        m_result[2][1] = (mx[0][3] * mx[2][1] * mx[3][0] - mx[0][1] * mx[2][3] * mx[3][0] - mx[0][3] * mx[2][0] * mx[3][1] + mx[0][0] * mx[2][3] * mx[3][1] + mx[0][1] * mx[2][0] * mx[3][3] - mx[0][0] * mx[2][1] * mx[3][3]) * detInv;
-        m_result[2][2] = (mx[0][1] * mx[1][3] * mx[3][0] - mx[0][3] * mx[1][1] * mx[3][0] + mx[0][3] * mx[1][0] * mx[3][1] - mx[0][0] * mx[1][3] * mx[3][1] - mx[0][1] * mx[1][0] * mx[3][3] + mx[0][0] * mx[1][1] * mx[3][3]) * detInv;
-        m_result[2][3] = (mx[0][3] * mx[1][1] * mx[2][0] - mx[0][1] * mx[1][3] * mx[2][0] - mx[0][3] * mx[1][0] * mx[2][1] + mx[0][0] * mx[1][3] * mx[2][1] + mx[0][1] * mx[1][0] * mx[2][3] - mx[0][0] * mx[1][1] * mx[2][3]) * detInv;
-        m_result[3][0] = (mx[1][2] * mx[2][1] * mx[3][0] - mx[1][1] * mx[2][2] * mx[3][0] - mx[1][2] * mx[2][0] * mx[3][1] + mx[1][0] * mx[2][2] * mx[3][1] + mx[1][1] * mx[2][0] * mx[3][2] - mx[1][0] * mx[2][1] * mx[3][2]) * detInv;
-        m_result[3][1] = (mx[0][1] * mx[2][2] * mx[3][0] - mx[0][2] * mx[2][1] * mx[3][0] + mx[0][2] * mx[2][0] * mx[3][1] - mx[0][0] * mx[2][2] * mx[3][1] - mx[0][1] * mx[2][0] * mx[3][2] + mx[0][0] * mx[2][1] * mx[3][2]) * detInv;
-        m_result[3][2] = (mx[0][2] * mx[1][1] * mx[3][0] - mx[0][1] * mx[1][2] * mx[3][0] - mx[0][2] * mx[1][0] * mx[3][1] + mx[0][0] * mx[1][2] * mx[3][1] + mx[0][1] * mx[1][0] * mx[3][2] - mx[0][0] * mx[1][1] * mx[3][2]) * detInv;
-        m_result[3][3] = (mx[0][1] * mx[1][2] * mx[2][0] - mx[0][2] * mx[1][1] * mx[2][0] + mx[0][2] * mx[1][0] * mx[2][1] - mx[0][0] * mx[1][2] * mx[2][1] - mx[0][1] * mx[1][0] * mx[2][2] + mx[0][0] * mx[1][1] * mx[2][2]) * detInv;
+        m_result[0][0] =
+            (mx[1][2] * mx[2][3] * mx[3][1] - mx[1][3] * mx[2][2] * mx[3][1] + mx[1][3] * mx[2][1] * mx[3][2] -
+             mx[1][1] * mx[2][3] * mx[3][2] - mx[1][2] * mx[2][1] * mx[3][3] + mx[1][1] * mx[2][2] * mx[3][3]) *
+            detInv;
+        m_result[0][1] =
+            (mx[0][3] * mx[2][2] * mx[3][1] - mx[0][2] * mx[2][3] * mx[3][1] - mx[0][3] * mx[2][1] * mx[3][2] +
+             mx[0][1] * mx[2][3] * mx[3][2] + mx[0][2] * mx[2][1] * mx[3][3] - mx[0][1] * mx[2][2] * mx[3][3]) *
+            detInv;
+        m_result[0][2] =
+            (mx[0][2] * mx[1][3] * mx[3][1] - mx[0][3] * mx[1][2] * mx[3][1] + mx[0][3] * mx[1][1] * mx[3][2] -
+             mx[0][1] * mx[1][3] * mx[3][2] - mx[0][2] * mx[1][1] * mx[3][3] + mx[0][1] * mx[1][2] * mx[3][3]) *
+            detInv;
+        m_result[0][3] =
+            (mx[0][3] * mx[1][2] * mx[2][1] - mx[0][2] * mx[1][3] * mx[2][1] - mx[0][3] * mx[1][1] * mx[2][2] +
+             mx[0][1] * mx[1][3] * mx[2][2] + mx[0][2] * mx[1][1] * mx[2][3] - mx[0][1] * mx[1][2] * mx[2][3]) *
+            detInv;
+        m_result[1][0] =
+            (mx[1][3] * mx[2][2] * mx[3][0] - mx[1][2] * mx[2][3] * mx[3][0] - mx[1][3] * mx[2][0] * mx[3][2] +
+             mx[1][0] * mx[2][3] * mx[3][2] + mx[1][2] * mx[2][0] * mx[3][3] - mx[1][0] * mx[2][2] * mx[3][3]) *
+            detInv;
+        m_result[1][1] =
+            (mx[0][2] * mx[2][3] * mx[3][0] - mx[0][3] * mx[2][2] * mx[3][0] + mx[0][3] * mx[2][0] * mx[3][2] -
+             mx[0][0] * mx[2][3] * mx[3][2] - mx[0][2] * mx[2][0] * mx[3][3] + mx[0][0] * mx[2][2] * mx[3][3]) *
+            detInv;
+        m_result[1][2] =
+            (mx[0][3] * mx[1][2] * mx[3][0] - mx[0][2] * mx[1][3] * mx[3][0] - mx[0][3] * mx[1][0] * mx[3][2] +
+             mx[0][0] * mx[1][3] * mx[3][2] + mx[0][2] * mx[1][0] * mx[3][3] - mx[0][0] * mx[1][2] * mx[3][3]) *
+            detInv;
+        m_result[1][3] =
+            (mx[0][2] * mx[1][3] * mx[2][0] - mx[0][3] * mx[1][2] * mx[2][0] + mx[0][3] * mx[1][0] * mx[2][2] -
+             mx[0][0] * mx[1][3] * mx[2][2] - mx[0][2] * mx[1][0] * mx[2][3] + mx[0][0] * mx[1][2] * mx[2][3]) *
+            detInv;
+        m_result[2][0] =
+            (mx[1][1] * mx[2][3] * mx[3][0] - mx[1][3] * mx[2][1] * mx[3][0] + mx[1][3] * mx[2][0] * mx[3][1] -
+             mx[1][0] * mx[2][3] * mx[3][1] - mx[1][1] * mx[2][0] * mx[3][3] + mx[1][0] * mx[2][1] * mx[3][3]) *
+            detInv;
+        m_result[2][1] =
+            (mx[0][3] * mx[2][1] * mx[3][0] - mx[0][1] * mx[2][3] * mx[3][0] - mx[0][3] * mx[2][0] * mx[3][1] +
+             mx[0][0] * mx[2][3] * mx[3][1] + mx[0][1] * mx[2][0] * mx[3][3] - mx[0][0] * mx[2][1] * mx[3][3]) *
+            detInv;
+        m_result[2][2] =
+            (mx[0][1] * mx[1][3] * mx[3][0] - mx[0][3] * mx[1][1] * mx[3][0] + mx[0][3] * mx[1][0] * mx[3][1] -
+             mx[0][0] * mx[1][3] * mx[3][1] - mx[0][1] * mx[1][0] * mx[3][3] + mx[0][0] * mx[1][1] * mx[3][3]) *
+            detInv;
+        m_result[2][3] =
+            (mx[0][3] * mx[1][1] * mx[2][0] - mx[0][1] * mx[1][3] * mx[2][0] - mx[0][3] * mx[1][0] * mx[2][1] +
+             mx[0][0] * mx[1][3] * mx[2][1] + mx[0][1] * mx[1][0] * mx[2][3] - mx[0][0] * mx[1][1] * mx[2][3]) *
+            detInv;
+        m_result[3][0] =
+            (mx[1][2] * mx[2][1] * mx[3][0] - mx[1][1] * mx[2][2] * mx[3][0] - mx[1][2] * mx[2][0] * mx[3][1] +
+             mx[1][0] * mx[2][2] * mx[3][1] + mx[1][1] * mx[2][0] * mx[3][2] - mx[1][0] * mx[2][1] * mx[3][2]) *
+            detInv;
+        m_result[3][1] =
+            (mx[0][1] * mx[2][2] * mx[3][0] - mx[0][2] * mx[2][1] * mx[3][0] + mx[0][2] * mx[2][0] * mx[3][1] -
+             mx[0][0] * mx[2][2] * mx[3][1] - mx[0][1] * mx[2][0] * mx[3][2] + mx[0][0] * mx[2][1] * mx[3][2]) *
+            detInv;
+        m_result[3][2] =
+            (mx[0][2] * mx[1][1] * mx[3][0] - mx[0][1] * mx[1][2] * mx[3][0] - mx[0][2] * mx[1][0] * mx[3][1] +
+             mx[0][0] * mx[1][2] * mx[3][1] + mx[0][1] * mx[1][0] * mx[3][2] - mx[0][0] * mx[1][1] * mx[3][2]) *
+            detInv;
+        m_result[3][3] =
+            (mx[0][1] * mx[1][2] * mx[2][0] - mx[0][2] * mx[1][1] * mx[2][0] + mx[0][2] * mx[1][0] * mx[2][1] -
+             mx[0][0] * mx[1][2] * mx[2][1] - mx[0][1] * mx[1][0] * mx[2][2] + mx[0][0] * mx[1][1] * mx[2][2]) *
+            detInv;
     } else {
-        m44Set(0.0, 0.0, 0.0, 0.0,
-               0.0, 0.0, 0.0, 0.0,
-               0.0, 0.0, 0.0, 0.0,
-               0.0, 0.0, 0.0, 0.0,
-               m_result);
+        m44Set(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, m_result);
         status = 1;
     }
     m44Copy(m_result, result);
     return status;
 }
 
-void m66Set(double m00, double m01, double m02, double m03, double m04, double m05,
-            double m10, double m11, double m12, double m13, double m14, double m15,
-            double m20, double m21, double m22, double m23, double m24, double m25,
-            double m30, double m31, double m32, double m33, double m34, double m35,
-            double m40, double m41, double m42, double m43, double m44, double m45,
-            double m50, double m51, double m52, double m53, double m54, double m55,
-            double m[6][6])
-{
+void m66Set(double m00,
+            double m01,
+            double m02,
+            double m03,
+            double m04,
+            double m05,
+            double m10,
+            double m11,
+            double m12,
+            double m13,
+            double m14,
+            double m15,
+            double m20,
+            double m21,
+            double m22,
+            double m23,
+            double m24,
+            double m25,
+            double m30,
+            double m31,
+            double m32,
+            double m33,
+            double m34,
+            double m35,
+            double m40,
+            double m41,
+            double m42,
+            double m43,
+            double m44,
+            double m45,
+            double m50,
+            double m51,
+            double m52,
+            double m53,
+            double m54,
+            double m55,
+            double m[6][6]) {
     m[0][0] = m00;
     m[0][1] = m01;
     m[0][2] = m02;
@@ -2309,138 +2073,114 @@ void m66Set(double m00, double m01, double m02, double m03, double m04, double m
     m[5][5] = m55;
 }
 
-void m66Copy(double mx[6][6],
-             double result[6][6])
-{
+void m66Copy(double mx[6][6], double result[6][6]) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx[i][j];
         }
     }
 }
 
-void m66SetZero(double result[6][6])
-{
+void m66SetZero(double result[6][6]) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = 0.0;
         }
     }
 }
 
-void m66SetIdentity(double result[6][6])
-{
+void m66SetIdentity(double result[6][6]) {
     size_t dim = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim; i++) {
-        for(j = 0; j < dim; j++) {
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < dim; j++) {
             result[i][j] = (i == j) ? 1.0 : 0.0;
         }
     }
 }
 
-void m66Transpose(double mx[6][6],
-                  double result[6][6])
-{
+void m66Transpose(double mx[6][6], double result[6][6]) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
     double m_result[6][6];
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             m_result[j][i] = mx[i][j];
         }
     }
     m66Copy(m_result, result);
 }
 
-void m66Get33Matrix(size_t row, size_t col,
-                    double m[6][6],
-                    double mij[3][3])
-{
+void m66Get33Matrix(size_t row, size_t col, double m[6][6], double mij[3][3]) {
     size_t i;
     size_t j;
     /* WARNING! Doesn't error check that row = 0,1,N-1 and col = 0,1,N-1 */
-    for(i = 0; i < 3; i++) {
-        for(j = 0; j < 3; j++) {
+    for (i = 0; i < 3; i++) {
+        for (j = 0; j < 3; j++) {
             mij[i][j] = m[row * 3 + i][col * 3 + j];
         }
     }
 }
 
-void m66Set33Matrix(size_t row, size_t col,
-                    double mij[3][3],
-                    double m[6][6])
-{
+void m66Set33Matrix(size_t row, size_t col, double mij[3][3], double m[6][6]) {
     size_t i;
     size_t j;
     /* WARNING! Doesn't error check that row = 0,1,N-1 and col = 0,1,N-1 */
-    for(i = 0; i < 3; i++) {
-        for(j = 0; j < 3; j++) {
+    for (i = 0; i < 3; i++) {
+        for (j = 0; j < 3; j++) {
             m[row * 3 + i][col * 3 + j] = mij[i][j];
         }
     }
 }
 
-void m66Scale(double scaleFactor,
-              double mx[6][6],
-              double result[6][6])
-{
+void m66Scale(double scaleFactor, double mx[6][6], double result[6][6]) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = scaleFactor * mx[i][j];
         }
     }
 }
 
-void m66Add(double mx1[6][6],
-            double mx2[6][6],
-            double result[6][6])
-{
+void m66Add(double mx1[6][6], double mx2[6][6], double result[6][6]) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx1[i][j] + mx2[i][j];
         }
     }
 }
 
-void m66Subtract(double mx1[6][6],
-                 double mx2[6][6],
-                 double result[6][6])
-{
+void m66Subtract(double mx1[6][6], double mx2[6][6], double result[6][6]) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = mx1[i][j] - mx2[i][j];
         }
     }
 }
 
-void m66MultM66(double mx1[6][6],
-                double mx2[6][6],
-                double result[6][6])
-{
+void m66MultM66(double mx1[6][6], double mx2[6][6], double result[6][6]) {
     size_t dim11 = 6;
     size_t dim12 = 6;
     size_t dim22 = 6;
@@ -2448,10 +2188,10 @@ void m66MultM66(double mx1[6][6],
     size_t j;
     size_t k;
     double m_result[6][6];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[i][k] * mx2[k][j];
             }
         }
@@ -2459,10 +2199,7 @@ void m66MultM66(double mx1[6][6],
     m66Copy(m_result, result);
 }
 
-void m66tMultM66(double mx1[6][6],
-                 double mx2[6][6],
-                 double result[6][6])
-{
+void m66tMultM66(double mx1[6][6], double mx2[6][6], double result[6][6]) {
     size_t dim11 = 6;
     size_t dim12 = 6;
     size_t dim22 = 6;
@@ -2470,10 +2207,10 @@ void m66tMultM66(double mx1[6][6],
     size_t j;
     size_t k;
     double m_result[6][6];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[k][i] * mx2[k][j];
             }
         }
@@ -2481,10 +2218,7 @@ void m66tMultM66(double mx1[6][6],
     m66Copy(m_result, result);
 }
 
-void m66MultM66t(double mx1[6][6],
-                 double mx2[6][6],
-                 double result[6][6])
-{
+void m66MultM66t(double mx1[6][6], double mx2[6][6], double result[6][6]) {
     size_t dim11 = 6;
     size_t dim12 = 6;
     size_t dim21 = 6;
@@ -2492,10 +2226,10 @@ void m66MultM66t(double mx1[6][6],
     size_t j;
     size_t k;
     double m_result[6][6];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim21; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim21; j++) {
             m_result[i][j] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i][j] += mx1[i][k] * mx2[j][k];
             }
         }
@@ -2503,10 +2237,7 @@ void m66MultM66t(double mx1[6][6],
     m66Copy(m_result, result);
 }
 
-void m66MultV6(double mx[6][6],
-               double v[6],
-               double result[6])
-{
+void m66MultV6(double mx[6][6], double v[6], double result[6]) {
     size_t dim11 = 6;
     size_t dim12 = 6;
     size_t dim22 = 1;
@@ -2514,10 +2245,10 @@ void m66MultV6(double mx[6][6],
     size_t j;
     size_t k;
     double m_result[6];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[i][k] * v[k];
             }
         }
@@ -2525,10 +2256,7 @@ void m66MultV6(double mx[6][6],
     v6Copy(m_result, result);
 }
 
-void m66tMultV6(double mx[6][6],
-                double v[6],
-                double result[6])
-{
+void m66tMultV6(double mx[6][6], double v[6], double result[6]) {
     size_t dim11 = 6;
     size_t dim12 = 6;
     size_t dim22 = 1;
@@ -2536,10 +2264,10 @@ void m66tMultV6(double mx[6][6],
     size_t j;
     size_t k;
     double m_result[6];
-    for(i = 0; i < dim11; i++) {
-        for(j = 0; j < dim22; j++) {
+    for (i = 0; i < dim11; i++) {
+        for (j = 0; j < dim22; j++) {
             m_result[i] = 0.0;
-            for(k = 0; k < dim12; k++) {
+            for (k = 0; k < dim12; k++) {
                 m_result[i] += mx[k][i] * v[k];
             }
         }
@@ -2547,17 +2275,14 @@ void m66tMultV6(double mx[6][6],
     v6Copy(m_result, result);
 }
 
-int m66IsEqual(double mx1[6][6],
-               double mx2[6][6],
-               double accuracy)
-{
+int m66IsEqual(double mx1[6][6], double mx2[6][6], double accuracy) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx1[i][j] - mx2[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -2565,16 +2290,14 @@ int m66IsEqual(double mx1[6][6],
     return 1;
 }
 
-int m66IsZero(double mx[6][6],
-              double accuracy)
-{
+int m66IsZero(double mx[6][6], double accuracy) {
     size_t dim1 = 6;
     size_t dim2 = 6;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
-            if(fabs(mx[i][j]) > accuracy) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
+            if (fabs(mx[i][j]) > accuracy) {
                 return 0;
             }
         }
@@ -2582,21 +2305,19 @@ int m66IsZero(double mx[6][6],
     return 1;
 }
 
-void m99SetZero(double result[9][9])
-{
+void m99SetZero(double result[9][9]) {
     size_t dim1 = 9;
     size_t dim2 = 9;
     size_t i;
     size_t j;
-    for(i = 0; i < dim1; i++) {
-        for(j = 0; j < dim2; j++) {
+    for (i = 0; i < dim1; i++) {
+        for (j = 0; j < dim2; j++) {
             result[i][j] = 0.0;
         }
     }
 }
 
-void cubicRoots(double a[3], double result[3])
-{
+void cubicRoots(double a[3], double result[3]) {
     /* Solve cubic formula for x^3 + a[2]*x^2 + a[1]*x + a[0] = 0 */
     /* see http://mathworld.wolfram.com/CubicFormula.html */
     double a2sq = a[2] * a[2];
@@ -2605,7 +2326,7 @@ void cubicRoots(double a[3], double result[3])
     double R = (a[2] * (9 * a[1] - 2 * a2sq) - 27 * a[0]) / 54.0;
     double RdsqrtnQ3 = R / sqrt(-Q * Q * Q);
 
-    if(Q < 0.0 && fabs(RdsqrtnQ3) < 1.0) {
+    if (Q < 0.0 && fabs(RdsqrtnQ3) < 1.0) {
         /* A = 2*sqrt(-Q)
          * B = a[2]/3
          * result[0] = Acos(t) - B
@@ -2632,5 +2353,4 @@ void cubicRoots(double a[3], double result[3])
         result[1] = -a2d3 - 0.5 * (S + T);
         result[2] = result[1];
     }
-
 }

--- a/src/architecture/utilities/linearAlgebra.c
+++ b/src/architecture/utilities/linearAlgebra.c
@@ -18,11 +18,11 @@
  */
 
 #include "linearAlgebra.h"
+#include "safeMath.h"
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
 #include <math.h>
-
 
 
 #define MOVE_DOUBLE(source, dim, destination) (memmove((void*)(destination), (void*)(source), sizeof(double)*(dim)))
@@ -2633,26 +2633,4 @@ void cubicRoots(double a[3], double result[3])
         result[2] = result[1];
     }
 
-}
-
-double safeAcos (double x) {
-    if (x < -1.0)
-        return acos(-1);
-    else if (x > 1.0)
-        return acos(1) ;
-    return acos (x) ;
-}
-
-double safeAsin (double x) {
-    if (x < -1.0)
-        return asin(-1);
-    else if (x > 1.0)
-        return asin(1) ;
-    return asin (x) ;
-}
-
-double safeSqrt(double x) {
-    if (x < 0.0)
-        return 0.0;
-    return sqrt(x);
 }

--- a/src/architecture/utilities/linearAlgebra.h
+++ b/src/architecture/utilities/linearAlgebra.h
@@ -251,11 +251,6 @@ extern "C" {
     /* additional routines */
     /* Solve cubic formula for x^3 + a[2]*x^2 + a[1]*x + a[0] = 0 */
     void    cubicRoots(double a[3], double result[3]);
-
-    double safeAcos(double x);
-    double safeAsin(double x);
-    double safeSqrt(double x);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/architecture/utilities/linearAlgebra.h
+++ b/src/architecture/utilities/linearAlgebra.h
@@ -20,240 +20,284 @@
 #ifndef _LINEARALGEBRA_H_
 #define _LINEARALGEBRA_H_
 
-#include <stdio.h>
 #include <architecture/utilities/bskLogging.h>
+#include <stdio.h>
 
 /* Divide by zero epsilon value */
 #define DB0_EPS 1e-30
 
 /* define a maximum array size for the functions that need
  to allocate memory within their routine */
-#define LINEAR_ALGEBRA_MAX_ARRAY_SIZE (64*64)
+#define LINEAR_ALGEBRA_MAX_ARRAY_SIZE (64 * 64)
 
-#define MXINDEX(dim2, row, col) ((row)*(dim2) + (col))
+#define MXINDEX(dim2, row, col) ((row) * (dim2) + (col))
 
 /* General vectors */
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    /* N element vectors */
-    void    vElementwiseMult(double *v1, size_t dim, double *v2, double *result);
-    void    vCopy(double *v, size_t dim, double *result);
-    void    vSetZero(double *v, size_t dim);
-    void    vSetOnes(double *v, size_t dim);
-    void    vAdd(double *v1, size_t dim, double *v2, double *result);
-    void    vSubtract(double *v1, size_t dim, double *v2, double *result);
-    void    vScale(double scaleFactor, double *v, size_t dim, double *result);
-    double  vDot(double *v1, size_t dim, double *v2);
-    void    vOuterProduct(double *v1, size_t dim1, double *v2, size_t dim2, void *result);
-    void    vtMultM(double *v, void *mx, size_t dim1, size_t dim2, void *result);
-    void    vtMultMt(double *v, void *mx, size_t dim1, size_t dim2, void *result);
-    double  vNorm(double *v, size_t dim);
-    double  vMax(double *v, size_t dim); /* Non-sorted, non-optimized algorithm for finding the max of a small 1-D array*/
-    double  vMaxAbs(double *v, size_t dim); /* Non-sorted, non-optimized algorithm for finding the max of the absolute values of the elements of a small 1-D array*/
-    void    vNormalize(double *v, size_t dim, double *result);
-    int     vIsEqual(double *v1, size_t dim, double *v2, double accuracy);
-    int     vIsZero(double *v, size_t dim, double accuracy);
-    void    vPrint(FILE *pFile, const char *name, double *v, size_t dim);
-    void    vSort(double *Input, double *Output, size_t dim);
+/* N element vectors */
+void vElementwiseMult(double *v1, size_t dim, double *v2, double *result);
+void vCopy(double *v, size_t dim, double *result);
+void vSetZero(double *v, size_t dim);
+void vSetOnes(double *v, size_t dim);
+void vAdd(double *v1, size_t dim, double *v2, double *result);
+void vSubtract(double *v1, size_t dim, double *v2, double *result);
+void vScale(double scaleFactor, double *v, size_t dim, double *result);
+double vDot(double *v1, size_t dim, double *v2);
+void vOuterProduct(double *v1, size_t dim1, double *v2, size_t dim2, void *result);
+void vtMultM(double *v, void *mx, size_t dim1, size_t dim2, void *result);
+void vtMultMt(double *v, void *mx, size_t dim1, size_t dim2, void *result);
+double vNorm(double *v, size_t dim);
+double vMax(double *v, size_t dim);    /* Non-sorted, non-optimized algorithm for finding the max of a small 1-D array*/
+double vMaxAbs(double *v, size_t dim); /* Non-sorted, non-optimized algorithm for finding the max of the absolute values
+                                          of the elements of a small 1-D array*/
+void vNormalize(double *v, size_t dim, double *result);
+int vIsEqual(double *v1, size_t dim, double *v2, double accuracy);
+int vIsZero(double *v, size_t dim, double accuracy);
+void vPrint(FILE *pFile, const char *name, double *v, size_t dim);
+void vSort(double *Input, double *Output, size_t dim);
 
-    /* 2 element vectors */
-    void    v2Set(double v0, double v1, double result[2]);
-    void    v2Copy(double v[2], double result[2]);
-    void    v2Scale(double scaleFactor, double v[2], double result[2]);
-    void    v2SetZero(double v[2]);
-    double  v2Dot(double v1[2], double v2[2]);
-    int     v2IsEqual(double v1[2], double v2[2], double accuracy);
-    int     v2IsZero(double v[2], double accuracy);
-    void    v2Add(double v1[2], double v2[2], double result[2]);
-    void    v2Subtract(double v1[2], double v2[2], double result[2]);
-    double  v2Norm(double v1[2]);
-    void    v2Normalize(double v1[2], double result[2]);
+/* 2 element vectors */
+void v2Set(double v0, double v1, double result[2]);
+void v2Copy(double v[2], double result[2]);
+void v2Scale(double scaleFactor, double v[2], double result[2]);
+void v2SetZero(double v[2]);
+double v2Dot(double v1[2], double v2[2]);
+int v2IsEqual(double v1[2], double v2[2], double accuracy);
+int v2IsZero(double v[2], double accuracy);
+void v2Add(double v1[2], double v2[2], double result[2]);
+void v2Subtract(double v1[2], double v2[2], double result[2]);
+double v2Norm(double v1[2]);
+void v2Normalize(double v1[2], double result[2]);
 
-    /* 3 element vectors */
-    void    v3Set(double v0, double v1, double v2, double result[3]);
-    void    v3Copy(double v[3], double result[3]);
-    void    v3SetZero(double v[3]);
-    void    v3Add(double v1[3], double v2[3], double result[3]);
-    void    v3Subtract(double v1[3], double v2[3], double result[3]);
-    void    v3Scale(double scaleFactor, double v[3], double result[3]);
-    double  v3Dot(double v1[3], double v2[3]);
-    void    v3OuterProduct(double v1[3], double v2[3], double result[3][3]);
-    void    v3tMultM33(double v[3], double mx[3][3], double result[3]);
-    void    v3tMultM33t(double v[3], double mx[3][3], double result[3]);
-    double  v3Norm(double v[3]);
-    void    v3Normalize(double v[3], double result[3]);
-    int     v3IsEqual(double v1[3], double v2[3], double accuracy);
-    int     v3IsEqualRel(double v1[3], double v2[3], double accuracy);
-    int     v3IsZero(double v[3], double accuracy);
-    void    v3Print(FILE *pFile, const char *name, double v[3]);
-    void    v3Cross(double v1[3], double v2[3], double result[3]);
-    void    v3Perpendicular(double v[3], double result[3]);
-    void    v3Tilde(double v[3], double result[3][3]);
-    void    v3Sort(double v[3], double result[3]);
-    void    v3PrintScreen(const char *name, double v[3]);
+/* 3 element vectors */
+void v3Set(double v0, double v1, double v2, double result[3]);
+void v3Copy(double v[3], double result[3]);
+void v3SetZero(double v[3]);
+void v3Add(double v1[3], double v2[3], double result[3]);
+void v3Subtract(double v1[3], double v2[3], double result[3]);
+void v3Scale(double scaleFactor, double v[3], double result[3]);
+double v3Dot(double v1[3], double v2[3]);
+void v3OuterProduct(double v1[3], double v2[3], double result[3][3]);
+void v3tMultM33(double v[3], double mx[3][3], double result[3]);
+void v3tMultM33t(double v[3], double mx[3][3], double result[3]);
+double v3Norm(double v[3]);
+void v3Normalize(double v[3], double result[3]);
+int v3IsEqual(double v1[3], double v2[3], double accuracy);
+int v3IsEqualRel(double v1[3], double v2[3], double accuracy);
+int v3IsZero(double v[3], double accuracy);
+void v3Print(FILE *pFile, const char *name, double v[3]);
+void v3Cross(double v1[3], double v2[3], double result[3]);
+void v3Perpendicular(double v[3], double result[3]);
+void v3Tilde(double v[3], double result[3][3]);
+void v3Sort(double v[3], double result[3]);
+void v3PrintScreen(const char *name, double v[3]);
 
-    /* 4 element vectors */
-    void    v4Set(double v0, double v1, double v2, double v3, double result[4]);
-    void    v4Copy(double v[4], double result[4]);
-    void    v4SetZero(double v[4]);
-    double  v4Dot(double v1[4], double v2[4]);
-    double  v4Norm(double v[4]);
-    int     v4IsEqual(double v1[4], double v2[4], double accuracy);
-    int     v4IsZero(double v[4], double accuracy);
+/* 4 element vectors */
+void v4Set(double v0, double v1, double v2, double v3, double result[4]);
+void v4Copy(double v[4], double result[4]);
+void v4SetZero(double v[4]);
+double v4Dot(double v1[4], double v2[4]);
+double v4Norm(double v[4]);
+int v4IsEqual(double v1[4], double v2[4], double accuracy);
+int v4IsZero(double v[4], double accuracy);
 
-    /* 6 element vectors */
-    void    v6Set(double v0, double v1, double v2, double v3, double v4, double v5, double result[6]);
-    void    v6Copy(double v[6], double result[6]);
-    double  v6Dot(double v1[6], double v2[6]);
-    void    v6Scale(double scaleFactor, double v[6], double result[6]);
-    void    v6OuterProduct(double v1[6], double v2[6], double result[6][6]);
-    int     v6IsEqual(double v1[6], double v2[6], double accuracy);
+/* 6 element vectors */
+void v6Set(double v0, double v1, double v2, double v3, double v4, double v5, double result[6]);
+void v6Copy(double v[6], double result[6]);
+double v6Dot(double v1[6], double v2[6]);
+void v6Scale(double scaleFactor, double v[6], double result[6]);
+void v6OuterProduct(double v1[6], double v2[6], double result[6][6]);
+int v6IsEqual(double v1[6], double v2[6], double accuracy);
 
-    /* NxM matrices */
-    void    mLeastSquaresInverse(void *mx, size_t dim1, size_t dim2, void *result);
-    void    mMinimumNormInverse(void *mx, size_t dim1, size_t dim2, void *result);
-    void    mCopy(void *mx, size_t dim1, size_t dim2, void *result);
-    void    mSetZero(void *result, size_t dim1, size_t dim2);
-    void    mSetIdentity(void *result, size_t dim1, size_t dim2);
-    void    mDiag(void *v, size_t dim, void *result);
-    void    mTranspose(void *mx, size_t dim1, size_t dim2, void *result);
-    void    mAdd(void *mx1, size_t dim1, size_t dim2, void *mx2, void *result);
-    void    mSubtract(void *mx1, size_t dim1, size_t dim2, void *mx2, void *result);
-    void    mScale(double scaleFactor, void *mx, size_t dim1, size_t dim2, void *result);
-    void    mMultM(void *mx1, size_t dim11, size_t dim12,
-                   void *mx2, size_t dim21, size_t dim22,
+/* NxM matrices */
+void mLeastSquaresInverse(void *mx, size_t dim1, size_t dim2, void *result);
+void mMinimumNormInverse(void *mx, size_t dim1, size_t dim2, void *result);
+void mCopy(void *mx, size_t dim1, size_t dim2, void *result);
+void mSetZero(void *result, size_t dim1, size_t dim2);
+void mSetIdentity(void *result, size_t dim1, size_t dim2);
+void mDiag(void *v, size_t dim, void *result);
+void mTranspose(void *mx, size_t dim1, size_t dim2, void *result);
+void mAdd(void *mx1, size_t dim1, size_t dim2, void *mx2, void *result);
+void mSubtract(void *mx1, size_t dim1, size_t dim2, void *mx2, void *result);
+void mScale(double scaleFactor, void *mx, size_t dim1, size_t dim2, void *result);
+void mMultM(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result);
+void mtMultM(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result);
+void mMultMt(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result);
+void mtMultMt(void *mx1, size_t dim11, size_t dim12, void *mx2, size_t dim21, size_t dim22, void *result);
+void mMultV(void *mx, size_t dim1, size_t dim2, void *v, void *result);
+void mtMultV(void *mx, size_t dim1, size_t dim2, void *v, void *result);
+double mTrace(void *mx, size_t dim);
+double mDeterminant(void *mx, size_t dim);
+void mCofactor(void *mx, size_t dim, void *result);
+int mInverse(void *mx, size_t dim, void *result);
+int mIsEqual(void *mx1, size_t dim1, size_t dim2, void *mx2, double accuracy);
+int mIsZero(void *mx, size_t dim1, size_t dim2, double accuracy);
+void mPrintScreen(const char *name, void *mx, size_t dim1, size_t dim2);
+void mPrint(FILE *pFile, const char *name, void *mx, size_t dim1, size_t dim2);
+void mGetSubMatrix(void *mx,
+                   size_t dim1,
+                   size_t dim2,
+                   size_t dim1Start,
+                   size_t dim2Start,
+                   size_t dim1Result,
+                   size_t dim2Result,
                    void *result);
-    void    mtMultM(void *mx1, size_t dim11, size_t dim12,
-                    void *mx2, size_t dim21, size_t dim22,
-                    void *result);
-    void    mMultMt(void *mx1, size_t dim11, size_t dim12,
-                    void *mx2, size_t dim21, size_t dim22,
-                    void *result);
-    void    mtMultMt(void *mx1, size_t dim11, size_t dim12,
-                     void *mx2, size_t dim21, size_t dim22,
-                     void *result);
-    void    mMultV(void *mx, size_t dim1, size_t dim2,
-                   void *v,
-                   void *result);
-    void    mtMultV(void *mx, size_t dim1, size_t dim2,
-                    void *v,
-                    void *result);
-    double  mTrace(void *mx, size_t dim);
-    double  mDeterminant(void *mx, size_t dim);
-    void    mCofactor(void *mx, size_t dim, void *result);
-    int     mInverse(void *mx, size_t dim, void *result);
-    int     mIsEqual(void *mx1, size_t dim1, size_t dim2, void *mx2, double accuracy);
-    int     mIsZero(void *mx, size_t dim1, size_t dim2, double accuracy);
-    void mPrintScreen(const char *name, void *mx, size_t dim1, size_t dim2);
-    void    mPrint(FILE *pFile, const char *name, void *mx, size_t dim1, size_t dim2);
-    void    mGetSubMatrix(void *mx, size_t dim1, size_t dim2,
-                          size_t dim1Start, size_t dim2Start,
-                          size_t dim1Result, size_t dim2Result, void *result);
-    void    mSetSubMatrix(void *mx, size_t dim1, size_t dim2,
-                          void *result, size_t dim1Result, size_t dim2Result,
-                          size_t dim1Start, size_t dim2Start);
+void mSetSubMatrix(void *mx,
+                   size_t dim1,
+                   size_t dim2,
+                   void *result,
+                   size_t dim1Result,
+                   size_t dim2Result,
+                   size_t dim1Start,
+                   size_t dim2Start);
 
-    /* 2x2 matrices */
-    void    m22Set(double m00, double m01,
-                   double m10, double m11,
-                   double m[2][2]);
-    void    m22Copy(double mx[2][2], double result[2][2]);
-    void    m22SetZero(double result[2][2]);
-    void    m22SetIdentity(double result[2][2]);
-    void    m22Transpose(double mx[2][2], double result[2][2]);
-    void    m22Add(double mx1[2][2], double mx2[2][2], double result[2][2]);
-    void    m22Subtract(double mx1[2][2], double mx2[2][2], double result[2][2]);
-    void    m22Scale(double scaleFactor, double mx[2][2], double result[2][2]);
-    void    m22MultM22(double mx1[2][2], double mx2[2][2], double result[2][2]);
-    void    m22tMultM22(double mx1[2][2], double mx2[2][2], double result[2][2]);
-    void    m22MultM22t(double mx1[2][2], double mx2[2][2], double result[2][2]);
-    void    m22MultV2(double mx[2][2], double v[2], double result[2]);
-    void    m22tMultV2(double mx[2][2], double v[2], double result[2]);
-    double  m22Trace(double mx[2][2]);
-    double  m22Determinant(double mx[2][2]);
-    int     m22IsEqual(double mx1[2][2], double mx2[2][2], double accuracy);
-    int     m22IsZero(double mx[2][2], double accuracy);
-    void    m22Print(FILE *pFile, const char *name, double mx[2][2]);
-    int     m22Inverse(double mx[2][2], double result[2][2]);
-    void    m22PrintScreen(const char *name, double mx[2][2]);
+/* 2x2 matrices */
+void m22Set(double m00, double m01, double m10, double m11, double m[2][2]);
+void m22Copy(double mx[2][2], double result[2][2]);
+void m22SetZero(double result[2][2]);
+void m22SetIdentity(double result[2][2]);
+void m22Transpose(double mx[2][2], double result[2][2]);
+void m22Add(double mx1[2][2], double mx2[2][2], double result[2][2]);
+void m22Subtract(double mx1[2][2], double mx2[2][2], double result[2][2]);
+void m22Scale(double scaleFactor, double mx[2][2], double result[2][2]);
+void m22MultM22(double mx1[2][2], double mx2[2][2], double result[2][2]);
+void m22tMultM22(double mx1[2][2], double mx2[2][2], double result[2][2]);
+void m22MultM22t(double mx1[2][2], double mx2[2][2], double result[2][2]);
+void m22MultV2(double mx[2][2], double v[2], double result[2]);
+void m22tMultV2(double mx[2][2], double v[2], double result[2]);
+double m22Trace(double mx[2][2]);
+double m22Determinant(double mx[2][2]);
+int m22IsEqual(double mx1[2][2], double mx2[2][2], double accuracy);
+int m22IsZero(double mx[2][2], double accuracy);
+void m22Print(FILE *pFile, const char *name, double mx[2][2]);
+int m22Inverse(double mx[2][2], double result[2][2]);
+void m22PrintScreen(const char *name, double mx[2][2]);
 
-    /* 3x3 matrices */
-    void    m33Set(double m00, double m01, double m02,
-                   double m10, double m11, double m12,
-                   double m20, double m21, double m22,
-                   double m[3][3]);
-    void    m33Copy(double mx[3][3], double result[3][3]);
-    void    m33SetZero(double result[3][3]);
-    void    m33SetIdentity(double result[3][3]);
-    void    m33Transpose(double mx[3][3], double result[3][3]);
-    void    m33Add(double mx1[3][3], double mx2[3][3], double result[3][3]);
-    void    m33Subtract(double mx1[3][3], double mx2[3][3], double result[3][3]);
-    void    m33Scale(double scaleFactor, double mx[3][3], double result[3][3]);
-    void    m33MultM33(double mx1[3][3], double mx2[3][3], double result[3][3]);
-    void    m33tMultM33(double mx1[3][3], double mx2[3][3], double result[3][3]);
-    void    m33MultM33t(double mx1[3][3], double mx2[3][3], double result[3][3]);
-    void    m33MultV3(double mx[3][3], double v[3], double result[3]);
-    void    m33tMultV3(double mx[3][3], double v[3], double result[3]);
-    double  m33Trace(double mx[3][3]);
-    double  m33Determinant(double mx[3][3]);
-    int     m33IsEqual(double mx1[3][3], double mx2[3][3], double accuracy);
-    int     m33IsZero(double mx[3][3], double accuracy);
-    void    m33Print(FILE *pfile, const char *name, double mx[3][3]);
-    int     m33Inverse(double mx[3][3], double result[3][3]);
-    void    m33SingularValues(double mx[3][3], double result[3]);
-    void    m33EigenValues(double mx[3][3], double result[3]);
-    double  m33ConditionNumber(double mx[3][3]);
-    void    m33PrintScreen(const char *name, double mx[3][3]);
+/* 3x3 matrices */
+void m33Set(double m00,
+            double m01,
+            double m02,
+            double m10,
+            double m11,
+            double m12,
+            double m20,
+            double m21,
+            double m22,
+            double m[3][3]);
+void m33Copy(double mx[3][3], double result[3][3]);
+void m33SetZero(double result[3][3]);
+void m33SetIdentity(double result[3][3]);
+void m33Transpose(double mx[3][3], double result[3][3]);
+void m33Add(double mx1[3][3], double mx2[3][3], double result[3][3]);
+void m33Subtract(double mx1[3][3], double mx2[3][3], double result[3][3]);
+void m33Scale(double scaleFactor, double mx[3][3], double result[3][3]);
+void m33MultM33(double mx1[3][3], double mx2[3][3], double result[3][3]);
+void m33tMultM33(double mx1[3][3], double mx2[3][3], double result[3][3]);
+void m33MultM33t(double mx1[3][3], double mx2[3][3], double result[3][3]);
+void m33MultV3(double mx[3][3], double v[3], double result[3]);
+void m33tMultV3(double mx[3][3], double v[3], double result[3]);
+double m33Trace(double mx[3][3]);
+double m33Determinant(double mx[3][3]);
+int m33IsEqual(double mx1[3][3], double mx2[3][3], double accuracy);
+int m33IsZero(double mx[3][3], double accuracy);
+void m33Print(FILE *pfile, const char *name, double mx[3][3]);
+int m33Inverse(double mx[3][3], double result[3][3]);
+void m33SingularValues(double mx[3][3], double result[3]);
+void m33EigenValues(double mx[3][3], double result[3]);
+double m33ConditionNumber(double mx[3][3]);
+void m33PrintScreen(const char *name, double mx[3][3]);
 
-    /* 4x4 matrices */
-    void    m44Set(double m00, double m01, double m02, double m03,
-                   double m10, double m11, double m12, double m13,
-                   double m20, double m21, double m22, double m23,
-                   double m30, double m31, double m32, double m33,
-                   double m[4][4]);
-    void    m44Copy(double mx[4][4], double result[4][4]);
-    void    m44SetZero(double result[4][4]);
-    void    m44MultV4(double mx[4][4], double v[4], double result[4]);
-    double  m44Determinant(double mx[4][4]);
-    int     m44IsEqual(double mx1[4][4], double mx2[4][4], double accuracy);
-    int     m44Inverse(double mx[4][4], double result[4][4]);
+/* 4x4 matrices */
+void m44Set(double m00,
+            double m01,
+            double m02,
+            double m03,
+            double m10,
+            double m11,
+            double m12,
+            double m13,
+            double m20,
+            double m21,
+            double m22,
+            double m23,
+            double m30,
+            double m31,
+            double m32,
+            double m33,
+            double m[4][4]);
+void m44Copy(double mx[4][4], double result[4][4]);
+void m44SetZero(double result[4][4]);
+void m44MultV4(double mx[4][4], double v[4], double result[4]);
+double m44Determinant(double mx[4][4]);
+int m44IsEqual(double mx1[4][4], double mx2[4][4], double accuracy);
+int m44Inverse(double mx[4][4], double result[4][4]);
 
-    /* 6x6 matrices */
-    void    m66Set(double m00, double m01, double m02, double m03, double m04, double m05,
-                   double m10, double m11, double m12, double m13, double m14, double m15,
-                   double m20, double m21, double m22, double m23, double m24, double m25,
-                   double m30, double m31, double m32, double m33, double m34, double m35,
-                   double m40, double m41, double m42, double m43, double m44, double m45,
-                   double m50, double m51, double m52, double m53, double m54, double m55,
-                   double m[6][6]);
-    void    m66Copy(double mx[6][6], double result[6][6]);
-    void    m66SetZero(double result[6][6]);
-    void    m66SetIdentity(double result[6][6]);
-    void    m66Transpose(double mx[6][6], double result[6][6]);
-    void    m66Get33Matrix(size_t row, size_t col, double m[6][6], double mij[3][3]);
-    void    m66Set33Matrix(size_t row, size_t col, double mij[3][3], double m[6][6]);
-    void    m66Scale(double scaleFactor, double mx[6][6], double result[6][6]);
-    void    m66Add(double mx1[6][6], double mx2[6][6], double result[6][6]);
-    void    m66Subtract(double mx1[6][6], double mx2[6][6], double result[6][6]);
-    void    m66MultM66(double mx1[6][6], double mx2[6][6], double result[6][6]);
-    void    m66tMultM66(double mx1[6][6], double mx2[6][6], double result[6][6]);
-    void    m66MultM66t(double mx1[6][6], double mx2[6][6], double result[6][6]);
-    void    m66MultV6(double mx[6][6], double v[6], double result[6]);
-    void    m66tMultV6(double mx[6][6], double v[6], double result[6]);
-    int     m66IsEqual(double mx1[6][6], double mx2[6][6], double accuracy);
-    int     m66IsZero(double mx[6][6], double accuracy);
+/* 6x6 matrices */
+void m66Set(double m00,
+            double m01,
+            double m02,
+            double m03,
+            double m04,
+            double m05,
+            double m10,
+            double m11,
+            double m12,
+            double m13,
+            double m14,
+            double m15,
+            double m20,
+            double m21,
+            double m22,
+            double m23,
+            double m24,
+            double m25,
+            double m30,
+            double m31,
+            double m32,
+            double m33,
+            double m34,
+            double m35,
+            double m40,
+            double m41,
+            double m42,
+            double m43,
+            double m44,
+            double m45,
+            double m50,
+            double m51,
+            double m52,
+            double m53,
+            double m54,
+            double m55,
+            double m[6][6]);
+void m66Copy(double mx[6][6], double result[6][6]);
+void m66SetZero(double result[6][6]);
+void m66SetIdentity(double result[6][6]);
+void m66Transpose(double mx[6][6], double result[6][6]);
+void m66Get33Matrix(size_t row, size_t col, double m[6][6], double mij[3][3]);
+void m66Set33Matrix(size_t row, size_t col, double mij[3][3], double m[6][6]);
+void m66Scale(double scaleFactor, double mx[6][6], double result[6][6]);
+void m66Add(double mx1[6][6], double mx2[6][6], double result[6][6]);
+void m66Subtract(double mx1[6][6], double mx2[6][6], double result[6][6]);
+void m66MultM66(double mx1[6][6], double mx2[6][6], double result[6][6]);
+void m66tMultM66(double mx1[6][6], double mx2[6][6], double result[6][6]);
+void m66MultM66t(double mx1[6][6], double mx2[6][6], double result[6][6]);
+void m66MultV6(double mx[6][6], double v[6], double result[6]);
+void m66tMultV6(double mx[6][6], double v[6], double result[6]);
+int m66IsEqual(double mx1[6][6], double mx2[6][6], double accuracy);
+int m66IsZero(double mx[6][6], double accuracy);
 
-    /* 9x9 matrices */
-    void    m99SetZero(double result[9][9]);
+/* 9x9 matrices */
+void m99SetZero(double result[9][9]);
 
-    /* additional routines */
-    /* Solve cubic formula for x^3 + a[2]*x^2 + a[1]*x + a[0] = 0 */
-    void    cubicRoots(double a[3], double result[3]);
+/* additional routines */
+/* Solve cubic formula for x^3 + a[2]*x^2 + a[1]*x + a[0] = 0 */
+void cubicRoots(double a[3], double result[3]);
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/src/architecture/utilities/orbitalMotion.c
+++ b/src/architecture/utilities/orbitalMotion.c
@@ -19,12 +19,13 @@
 
 #include "orbitalMotion.h"
 
+#include "astroConstants.h"
+#include "safeMath.h"
+#include "linearAlgebra.h"
+
 #include <assert.h>
 #include <math.h>
 #include <stdarg.h>
-
-#include "linearAlgebra.h"
-#include "astroConstants.h"
 
 
 /*!

--- a/src/architecture/utilities/orbitalMotion.c
+++ b/src/architecture/utilities/orbitalMotion.c
@@ -20,13 +20,12 @@
 #include "orbitalMotion.h"
 
 #include "astroConstants.h"
-#include "safeMath.h"
 #include "linearAlgebra.h"
+#include "safeMath.h"
 
 #include <assert.h>
 #include <math.h>
 #include <stdarg.h>
-
 
 /*!
  * Purpose: maps inertial position and velocity vectors in the Hill frame DCM HN
@@ -36,12 +35,11 @@
  * Outputs:
  *   HN: Hill frame DCM relative to inertial frame
  */
-void hillFrame(double *rc_N, double *vc_N, double HN[3][3])
-{
-    double ir_N[3];         /* orbit radial unit direction vector */
-    double itheta_N[3];     /* along-track unit direction vector */
-    double ih_N[3];         /* orbit plane normal unit direction vector */
-    double hVec_N[3];       /* orbit angular momentum vector */
+void hillFrame(double *rc_N, double *vc_N, double HN[3][3]) {
+    double ir_N[3];     /* orbit radial unit direction vector */
+    double itheta_N[3]; /* along-track unit direction vector */
+    double ih_N[3];     /* orbit plane normal unit direction vector */
+    double hVec_N[3];   /* orbit angular momentum vector */
 
     v3Normalize(rc_N, ir_N);
     v3Cross(rc_N, vc_N, hVec_N);
@@ -63,21 +61,20 @@ void hillFrame(double *rc_N, double *vc_N, double HN[3][3])
  *   rd_N: deputy inertial position vector
  *   vd_N: deputy inertial velocity vector
  */
-void  hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, double *rd_N, double *vd_N)
-{
-    double HN[3][3];        /* DCM of Hill frame relative to inertial */
-    double NH[3][3];        /* DCM of inertial frame relative to Hill */
-    double hVec_N[3];       /* orbit angular momentum vector */
-    double rc;              /* chief orbit radius */
-    double fDot;            /* chief true anomaly rate */
-    double omega_HN_H[3];   /* Hill frame angular velocity */
-    double rho_N[3];        /* deputy relative to chief vector in N frame components */
+void hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, double *rd_N, double *vd_N) {
+    double HN[3][3];      /* DCM of Hill frame relative to inertial */
+    double NH[3][3];      /* DCM of inertial frame relative to Hill */
+    double hVec_N[3];     /* orbit angular momentum vector */
+    double rc;            /* chief orbit radius */
+    double fDot;          /* chief true anomaly rate */
+    double omega_HN_H[3]; /* Hill frame angular velocity */
+    double rho_N[3];      /* deputy relative to chief vector in N frame components */
 
     hillFrame(rc_N, vc_N, HN);
     m33Transpose(HN, NH);
     v3Cross(rc_N, vc_N, hVec_N);
     rc = v3Norm(rc_N);
-    fDot = v3Norm(hVec_N)/rc/rc;
+    fDot = v3Norm(hVec_N) / rc / rc;
     v3Set(0, 0, fDot, omega_HN_H);
 
     /* compute inertial deputy position */
@@ -91,7 +88,6 @@ void  hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, dou
     v3Add(vd_N, vc_N, vd_N);
 }
 
-
 /*!
  * Purpose: maps inertial frame deputy states to Hill inertial position and velocity vectors
  * Inputs:
@@ -103,21 +99,20 @@ void  hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, dou
  *   rho_H: deputy Hill position vector
  *   rhoPrime_H: deputy Hill velocity vector
  */
-void rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *rho_H, double *rhoPrime_H)
-{
-    double HN[3][3];        /* DCM of Hill frame relative to inertial */
-    double hVec_N[3];       /* orbit angular momentum vector */
-    double rc;              /* chief orbit radius */
-    double fDot;            /* chief true anomaly rate */
-    double omega_HN_H[3];   /* Hill frame angular velocity */
-    double rho_N[3];        /* deputy relative to chief vector in N frame components */
-    double rhoDot_N[3];     /* inertial derivative of deputy/chief vector */
-    double rhoDot_H[3];     /* inertial derivative of deputy/chief vector */
+void rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *rho_H, double *rhoPrime_H) {
+    double HN[3][3];      /* DCM of Hill frame relative to inertial */
+    double hVec_N[3];     /* orbit angular momentum vector */
+    double rc;            /* chief orbit radius */
+    double fDot;          /* chief true anomaly rate */
+    double omega_HN_H[3]; /* Hill frame angular velocity */
+    double rho_N[3];      /* deputy relative to chief vector in N frame components */
+    double rhoDot_N[3];   /* inertial derivative of deputy/chief vector */
+    double rhoDot_H[3];   /* inertial derivative of deputy/chief vector */
 
     hillFrame(rc_N, vc_N, HN);
     v3Cross(rc_N, vc_N, hVec_N);
     rc = v3Norm(rc_N);
-    fDot = v3Norm(hVec_N)/rc/rc;
+    fDot = v3Norm(hVec_N) / rc / rc;
     v3Set(0, 0, fDot, omega_HN_H);
 
     /* compute Hill frame position */
@@ -131,7 +126,6 @@ void rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *rho
     v3Subtract(rhoDot_H, rhoPrime_H, rhoPrime_H);
 }
 
-
 /*!
  * Purpose: Maps eccentric anomaly angles into true anomaly angles.
  *   This function requires the orbit to be either circular or
@@ -142,8 +136,7 @@ void rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *rho
  * Outputs:
  *   f = true anomaly (rad)
  */
-double E2f(double Ecc, double e)
-{
+double E2f(double Ecc, double e) {
     assert(0 <= e && e < 1);
     return 2 * atan2(sqrt(1 + e) * sin(Ecc / 2), sqrt(1 - e) * cos(Ecc / 2));
 }
@@ -158,8 +151,7 @@ double E2f(double Ecc, double e)
  * Outputs:
  *   M = mean elliptic anomaly (rad)
  */
-double E2M(double Ecc, double e)
-{
+double E2M(double Ecc, double e) {
     assert(0 <= e && e < 1);
     return Ecc - e * sin(Ecc);
 }
@@ -174,8 +166,7 @@ double E2M(double Ecc, double e)
  * Outputs:
  *   Ecc = eccentric anomaly (rad)
  */
-double f2E(double f, double e)
-{
+double f2E(double f, double e) {
     assert(0 <= e && e < 1);
     return 2 * atan2(sqrt(1 - e) * sin(f / 2), sqrt(1 + e) * cos(f / 2));
 }
@@ -189,8 +180,7 @@ double f2E(double f, double e)
  * Outputs:
  *   H = hyperbolic anomaly (rad)
  */
-double f2H(double f, double e)
-{
+double f2H(double f, double e) {
     assert(1 < e);
     return 2 * atanh(sqrt((e - 1) / (e + 1)) * tan(f / 2));
 }
@@ -204,8 +194,7 @@ double f2H(double f, double e)
  * Outputs:
  *   f = true anomaly angle (rad)
  */
-double H2f(double H, double e)
-{
+double H2f(double H, double e) {
     assert(1 < e);
     return 2 * atan(sqrt((e + 1) / (e - 1)) * tanh(H / 2));
 }
@@ -219,8 +208,7 @@ double H2f(double H, double e)
  * Outputs:
  *   N = mean hyperbolic anomaly (rad)
  */
-double H2N(double H, double e)
-{
+double H2N(double H, double e) {
     assert(1 < e);
     return e * sinh(H) - H;
 }
@@ -235,13 +223,12 @@ double H2N(double H, double e)
  * Outputs:
  *   Ecc = eccentric anomaly (rad)
  */
-double M2E(double M, double e)
-{
+double M2E(double M, double e) {
     assert(0 <= e && e < 1);
     double small = 1e-13;
     double dE = 10 * small;
     double E1 = M;
-    int    maxIterations = 200;
+    int maxIterations = 200;
 
     for (int iterationCount = 0; iterationCount <= maxIterations; ++iterationCount) {
         if (fabs(dE) <= small) break;
@@ -261,15 +248,13 @@ double M2E(double M, double e)
  * Outputs:
  *   H = hyperbolic anomaly (rad)
  */
-double N2H(double N, double e)
-{
+double N2H(double N, double e) {
     double small = 1e-13;
     double dH = 10 * small;
     double H1 = N;
-    int    maxIterations = 200;
-    if(fabs(H1) > 7.0)
-    {
-        H1 = N/fabs(N)*7.0;
+    int maxIterations = 200;
+    if (fabs(H1) > 7.0) {
+        H1 = N / fabs(N) * 7.0;
     }
 
     assert(1 < e);
@@ -314,21 +299,20 @@ double N2H(double N, double e)
  *   rVec = position vector
  *   vVec = velocity vector
  */
-void elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec)
-{
-    double e;                   /* eccentricty */
-    double a;                   /* semi-major axis */
-    double f;                   /* true anomaly */
-    double r;                   /* orbit radius */
-    double v;                   /* orbit velocity magnitude */
-    double i;                   /* orbit inclination angle */
-    double p;                   /* the parameter or the semi-latus rectum */
-    double AP;                  /* argument of perigee */
-    double AN;                  /* argument of the ascending node */
-    double theta;               /* true latitude theta = omega + f */
-    double h;                   /* orbit angular momentum magnitude */
-    double ir[3];               /* orbit radius unit vector */
-    double eps;                 /* small numerical value parameter */
+void elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec) {
+    double e;     /* eccentricty */
+    double a;     /* semi-major axis */
+    double f;     /* true anomaly */
+    double r;     /* orbit radius */
+    double v;     /* orbit velocity magnitude */
+    double i;     /* orbit inclination angle */
+    double p;     /* the parameter or the semi-latus rectum */
+    double AP;    /* argument of perigee */
+    double AN;    /* argument of the ascending node */
+    double theta; /* true latitude theta = omega + f */
+    double h;     /* orbit angular momentum magnitude */
+    double ir[3]; /* orbit radius unit vector */
+    double eps;   /* small numerical value parameter */
 
     /* define what is a small numerical value */
     eps = 1e-12;
@@ -341,10 +325,10 @@ void elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec)
     AP = elements->omega;
     f = elements->f;
 
-    if((fabs(e-1.0) < eps) && (fabs(a) > eps)) { /* 1D rectilinear elliptic/hyperbolic orbit case */
+    if ((fabs(e - 1.0) < eps) && (fabs(a) > eps)) { /* 1D rectilinear elliptic/hyperbolic orbit case */
 
-        double angle;                 /* eccentric/hyperbolic anomaly */
-        angle = f;                    /* f is treated as ecc/hyp anomaly */
+        double angle; /* eccentric/hyperbolic anomaly */
+        angle = f;    /* f is treated as ecc/hyp anomaly */
         /* orbit radius  */
         if (elements->a > 0.0) {
             r = a * (1 - e * cos(angle));
@@ -356,35 +340,32 @@ void elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec)
         ir[1] = sin(AN) * cos(AP) + cos(AN) * sin(AP) * cos(i);
         ir[2] = sin(AP) * sin(i);
         v3Scale(r, ir, rVec);
-        if(sin(angle) > 0) {
+        if (sin(angle) > 0) {
             v3Scale(v, ir, vVec);
         } else {
             v3Scale(-v, ir, vVec);
         }
     } else { /* general 2D orbit case */
         /* evaluate semi-latus rectum */
-        if(fabs(a) > eps) {
-            p = a * (1 - e * e);        /* elliptic or hyperbolic */
+        if (fabs(a) > eps) {
+            p = a * (1 - e * e); /* elliptic or hyperbolic */
         } else {
-            p = 2 * elements->rPeriap;  /* parabolic */
+            p = 2 * elements->rPeriap; /* parabolic */
         }
 
-        r = p / (1 + e * cos(f));   /* orbit radius */
-        theta = AP + f;             /* true latitude angle */
-        h = sqrt(mu * p);           /* orbit ang. momentum mag. */
+        r = p / (1 + e * cos(f)); /* orbit radius */
+        theta = AP + f;           /* true latitude angle */
+        h = sqrt(mu * p);         /* orbit ang. momentum mag. */
 
         rVec[0] = r * (cos(AN) * cos(theta) - sin(AN) * sin(theta) * cos(i));
         rVec[1] = r * (sin(AN) * cos(theta) + cos(AN) * sin(theta) * cos(i));
         rVec[2] = r * (sin(theta) * sin(i));
 
-        vVec[0] = -mu / h * (cos(AN) * (sin(theta) + e * sin(AP)) + sin(AN) * (cos(
-                                 theta) + e * cos(AP)) * cos(i));
-        vVec[1] = -mu / h * (sin(AN) * (sin(theta) + e * sin(AP)) - cos(AN) * (cos(
-                                 theta) + e * cos(AP)) * cos(i));
+        vVec[0] = -mu / h * (cos(AN) * (sin(theta) + e * sin(AP)) + sin(AN) * (cos(theta) + e * cos(AP)) * cos(i));
+        vVec[1] = -mu / h * (sin(AN) * (sin(theta) + e * sin(AP)) - cos(AN) * (cos(theta) + e * cos(AP)) * cos(i));
         vVec[2] = -mu / h * (-(cos(theta) + e * cos(AP)) * sin(i));
     }
 }
-
 
 /*!
  * Purpose: Translates the orbit elements inertial Cartesian position
@@ -409,23 +390,22 @@ void elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec)
  * Outputs:
  *   elements = orbital elements
  */
-void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
-{
-    double hVec[3];             /* orbit angular momentum vector */
-    double ihHat[3];            /* normalized orbit angular momentum vector */
-    double h;                   /* orbit angular momentum magnitude */
-    double v3[3];               /* temp vector */
-    double n1Hat[3];            /* 1st inertial frame base vector */
-    double n3Hat[3];            /* 3rd inertial frame base vector */
-    double nVec[3];             /* line of nodes vector */
-    double inHat[3];            /* normalized line of nodes vector */
-    double irHat[3];            /* normalized position vector */
-    double r;                   /* current orbit radius */
-    double v;                   /* orbit velocity magnitude */
-    double eVec[3];             /* eccentricity vector */
-    double ieHat[3];            /* normalized eccentricity vector */
-    double p;                   /* the parameter, also called semi-latus rectum */
-    double eps;                 /* small numerical value parameter */
+void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements) {
+    double hVec[3];  /* orbit angular momentum vector */
+    double ihHat[3]; /* normalized orbit angular momentum vector */
+    double h;        /* orbit angular momentum magnitude */
+    double v3[3];    /* temp vector */
+    double n1Hat[3]; /* 1st inertial frame base vector */
+    double n3Hat[3]; /* 3rd inertial frame base vector */
+    double nVec[3];  /* line of nodes vector */
+    double inHat[3]; /* normalized line of nodes vector */
+    double irHat[3]; /* normalized position vector */
+    double r;        /* current orbit radius */
+    double v;        /* orbit velocity magnitude */
+    double eVec[3];  /* eccentricity vector */
+    double ieHat[3]; /* normalized eccentricity vector */
+    double p;        /* the parameter, also called semi-latus rectum */
+    double eps;      /* small numerical value parameter */
 
     /* define what is a small numerical value */
     eps = 1e-12;
@@ -444,7 +424,7 @@ void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
     v3Cross(rVec, vVec, hVec);
     h = v3Norm(hVec);
     v3Normalize(hVec, ihHat);
-	p = h*h / mu;
+    p = h * h / mu;
 
     /* Calculate the line of nodes */
     v3Cross(n3Hat, hVec, nVec);
@@ -460,7 +440,7 @@ void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
     v3Scale(v3Dot(rVec, vVec) / mu, vVec, v3);
     v3Subtract(eVec, v3, eVec);
     elements->e = v3Norm(eVec);
-	elements->rPeriap = p / (1.0 + elements->e);
+    elements->rPeriap = p / (1.0 + elements->e);
 
     /* Orbit eccentricity unit vector */
     if (elements->e > eps) {
@@ -471,8 +451,8 @@ void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
     }
 
     /* compute semi-major axis */
-    elements->alpha = 2.0 / r - v*v / mu;
-    if(fabs(elements->alpha) > eps) {
+    elements->alpha = 2.0 / r - v * v / mu;
+    if (fabs(elements->alpha) > eps) {
         /* elliptic or hyperbolic case */
         elements->a = 1.0 / elements->alpha;
         elements->rApoap = p / (1.0 - elements->e);
@@ -489,21 +469,21 @@ void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
     v3Cross(n1Hat, inHat, v3);
     elements->Omega = atan2(v3[2], inHat[0]);
     if (elements->Omega < 0.0) {
-        elements->Omega += 2*M_PI;
+        elements->Omega += 2 * M_PI;
     }
 
     /* Calculate Argument of Periapses omega */
     v3Cross(inHat, ieHat, v3);
-    elements->omega = atan2(v3Dot(ihHat,v3), v3Dot(inHat, ieHat));
+    elements->omega = atan2(v3Dot(ihHat, v3), v3Dot(inHat, ieHat));
     if (elements->omega < 0.0) {
-        elements->omega += 2*M_PI;
+        elements->omega += 2 * M_PI;
     }
 
     /* Calculate true anomaly angle f */
     v3Cross(ieHat, irHat, v3);
-    elements->f = atan2(v3Dot(ihHat,v3), v3Dot(ieHat, irHat));
+    elements->f = atan2(v3Dot(ihHat, v3), v3Dot(ieHat, irHat));
     if (elements->f < 0.0) {
-        elements->f += 2*M_PI;
+        elements->f += 2 * M_PI;
     }
 }
 
@@ -519,14 +499,13 @@ void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
  * Outputs:
  *   density = density at the given altitude in kg/m^3
  */
-double atmosphericDensity(double alt)
-{
+double atmosphericDensity(double alt) {
     double logdensity;
     double density;
     double val;
 
     /* Smooth exponential drop-off after 1000 km */
-    if(alt > 1000.) {
+    if (alt > 1000.) {
         logdensity = (-7e-05) * alt - 14.464;
         density = pow(10., logdensity);
         return density;
@@ -534,8 +513,8 @@ double atmosphericDensity(double alt)
 
     /* Calculating the density based on a scaled 6th order polynomial fit to the log of density */
     val = (alt - 526.8000) / 292.8563;
-    logdensity = 0.34047 * pow(val, 6) - 0.5889 * pow(val, 5) - 0.5269 * pow(val, 4)
-                 + 1.0036 * pow(val, 3) + 0.60713 * pow(val, 2) - 2.3024 * val - 12.575;
+    logdensity = 0.34047 * pow(val, 6) - 0.5889 * pow(val, 5) - 0.5269 * pow(val, 4) + 1.0036 * pow(val, 3) +
+                 0.60713 * pow(val, 2) - 2.3024 * val - 12.575;
 
     /* Calculating density by raising 10 to the log of density */
     density = pow(10., logdensity);
@@ -553,35 +532,30 @@ double atmosphericDensity(double alt)
  * Outputs:
  *   debye = debye length given in m
  */
-double debyeLength(double alt)
-{
+double debyeLength(double alt) {
     assert((200.0 <= alt) && (alt <= 35000.0));
-    double debyedist=0;
-    double a=0;
-    double X[N_DEBYE_PARAMETERS] = {200, 250, 300, 350, 400, 450, 500, 550,
-                                    600, 650, 700, 750, 800, 850, 900, 950, 1000, 1050, 1100, 1150,
-                                    1200, 1250, 1300, 1350, 1400, 1450, 1500, 1550, 1600, 1650, 1700,
-                                    1750, 1800, 1850, 1900, 1950, 2000
-                                   };
-    double Y[N_DEBYE_PARAMETERS] = {5.64E-03, 3.92E-03, 3.24E-03, 3.59E-03,
-                                    4.04E-03, 4.28E-03, 4.54E-03, 5.30E-03, 6.55E-03, 7.30E-03, 8.31E-03,
-                                    8.38E-03, 8.45E-03, 9.84E-03, 1.22E-02, 1.37E-02, 1.59E-02, 1.75E-02,
-                                    1.95E-02, 2.09E-02, 2.25E-02, 2.25E-02, 2.25E-02, 2.47E-02, 2.76E-02,
-                                    2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 3.21E-02,
-                                    3.96E-02, 3.96E-02, 3.96E-02, 3.96E-02, 3.96E-02
-                                   };
+    double debyedist = 0;
+    double a = 0;
+    double X[N_DEBYE_PARAMETERS] = {200,  250,  300,  350,  400,  450,  500,  550,  600,  650,  700,  750,  800,
+                                    850,  900,  950,  1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350, 1400, 1450,
+                                    1500, 1550, 1600, 1650, 1700, 1750, 1800, 1850, 1900, 1950, 2000};
+    double Y[N_DEBYE_PARAMETERS] = {5.64E-03, 3.92E-03, 3.24E-03, 3.59E-03, 4.04E-03, 4.28E-03, 4.54E-03, 5.30E-03,
+                                    6.55E-03, 7.30E-03, 8.31E-03, 8.38E-03, 8.45E-03, 9.84E-03, 1.22E-02, 1.37E-02,
+                                    1.59E-02, 1.75E-02, 1.95E-02, 2.09E-02, 2.25E-02, 2.25E-02, 2.25E-02, 2.47E-02,
+                                    2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 2.76E-02, 3.21E-02,
+                                    3.96E-02, 3.96E-02, 3.96E-02, 3.96E-02, 3.96E-02};
 
     /* Flat debyeLength length for altitudes above 2000 km */
-    if((alt > 2000.0) && (alt <= 30000.0)) {
+    if ((alt > 2000.0) && (alt <= 30000.0)) {
         alt = 2000.0;
-    } else if((alt > 30000.0) && (alt <= 35000.0)) {
+    } else if ((alt > 30000.0) && (alt <= 35000.0)) {
         debyedist = 0.1 * alt - 2999.7;
         return debyedist;
     }
 
     /* Interpolation of data */
-    for(int i = 0; i < N_DEBYE_PARAMETERS - 1; ++i) {
-        if(X[i + 1] < alt) continue;
+    for (int i = 0; i < N_DEBYE_PARAMETERS - 1; ++i) {
+        if (X[i + 1] < alt) continue;
         a = (alt - X[i]) / (X[i + 1] - X[i]);
         debyedist = Y[i] + a * (Y[i + 1] - Y[i]);
         break;
@@ -606,9 +580,7 @@ double debyeLength(double alt)
  *   advec = The inertial acceleration vector due to atmospheric
  *             drag in km/sec^2
  */
-void atmosphericDrag(double Cd, double A, double m, double *rvec, double *vvec,
-                     double *advec)
-{
+void atmosphericDrag(double Cd, double A, double m, double *rvec, double *vvec, double *advec) {
     double r;
     double v;
     double alt;
@@ -646,8 +618,7 @@ void atmosphericDrag(double Cd, double A, double m, double *rvec, double *vvec,
  *   ajtot = The total acceleration vector due to the J
  *             perturbations in km/sec^2 [accelx;accely;accelz]
  */
-void jPerturb(double *rvec, int num, double *ajtot, ...)
-{
+void jPerturb(double *rvec, int num, double *ajtot, ...) {
     double mu;
     double req;
     double J2, J3, J4, J5, J6;
@@ -661,16 +632,16 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
     CelestialObject_t planetID;
     va_list args;
     va_start(args, ajtot);
-    planetID = (CelestialObject_t) va_arg(args, int);
+    planetID = (CelestialObject_t)va_arg(args, int);
     va_end(args);
 
     v3SetZero(ajtot);
 
-    switch(planetID) {
+    switch (planetID) {
         case CELESTIAL_MERCURY:
-            mu  = MU_MERCURY;
+            mu = MU_MERCURY;
             req = REQ_MERCURY;
-            J2  = J2_MERCURY;
+            J2 = J2_MERCURY;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -678,9 +649,9 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             break;
 
         case CELESTIAL_VENUS:
-            mu  = MU_VENUS;
+            mu = MU_VENUS;
             req = REQ_VENUS;
-            J2  = J2_VENUS;
+            J2 = J2_VENUS;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -688,9 +659,9 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             break;
 
         case CELESTIAL_MOON:
-            mu  = MU_MOON;
+            mu = MU_MOON;
             req = REQ_MOON;
-            J2  = J2_MOON;
+            J2 = J2_MOON;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -698,9 +669,9 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             break;
 
         case CELESTIAL_MARS:
-            mu  = MU_MARS;
+            mu = MU_MARS;
             req = REQ_MARS;
-            J2  = J2_MARS;
+            J2 = J2_MARS;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -708,9 +679,9 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             break;
 
         case CELESTIAL_JUPITER:
-            mu  = MU_JUPITER;
+            mu = MU_JUPITER;
             req = REQ_JUPITER;
-            J2  = J2_JUPITER;
+            J2 = J2_JUPITER;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -718,9 +689,9 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             break;
 
         case CELESTIAL_URANUS:
-            mu  = MU_URANUS;
+            mu = MU_URANUS;
             req = REQ_URANUS;
-            J2  = J2_URANUS;
+            J2 = J2_URANUS;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -728,9 +699,9 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             break;
 
         case CELESTIAL_NEPTUNE:
-            mu  = MU_NEPTUNE;
+            mu = MU_NEPTUNE;
             req = REQ_NEPTUNE;
-            J2  = J2_NEPTUNE;
+            J2 = J2_NEPTUNE;
             J3 = 0.0;
             J4 = 0.0;
             J5 = 0.0;
@@ -742,16 +713,15 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
             return;
 
         default:
-            mu  = MU_EARTH;
+            mu = MU_EARTH;
             req = REQ_EARTH;
-            J2  = J2_EARTH;
-            J3  = J3_EARTH;
-            J4  = J4_EARTH;
-            J5  = J5_EARTH;
-            J6  = J6_EARTH;
+            J2 = J2_EARTH;
+            J3 = J3_EARTH;
+            J4 = J4_EARTH;
+            J5 = J5_EARTH;
+            J6 = J6_EARTH;
             break;
     }
-
 
     /* Calculate the J perturbations */
     x = rvec[0];
@@ -763,38 +733,43 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
     assert(2 <= num && num <= 6);
 
     /* Calculating the total acceleration based on user input */
-    if(num >= 2) {
+    if (num >= 2) {
         v3Set((1.0 - 5.0 * pow(z / r, 2.0)) * (x / r),
               (1.0 - 5.0 * pow(z / r, 2.0)) * (y / r),
-              (3.0 - 5.0 * pow(z / r, 2.0)) * (z / r), ajtot);
-        v3Scale(-3.0 / 2.0 * J2 * (mu / pow(r, 2.0))*pow(req / r, 2.0), ajtot, ajtot);
+              (3.0 - 5.0 * pow(z / r, 2.0)) * (z / r),
+              ajtot);
+        v3Scale(-3.0 / 2.0 * J2 * (mu / pow(r, 2.0)) * pow(req / r, 2.0), ajtot, ajtot);
     }
-    if(num >= 3) {
+    if (num >= 3) {
         v3Set(5.0 * (7.0 * pow(z / r, 3.0) - 3.0 * (z / r)) * (x / r),
               5.0 * (7.0 * pow(z / r, 3.0) - 3.0 * (z / r)) * (y / r),
-              -3.0 * (10.0 * pow(z / r, 2.0) - (35.0 / 3.0)*pow(z / r, 4.0) - 1.0), temp);
-        v3Scale(1.0 / 2.0 * J3 * (mu / pow(r, 2.0))*pow(req / r, 3.0), temp, temp2);
+              -3.0 * (10.0 * pow(z / r, 2.0) - (35.0 / 3.0) * pow(z / r, 4.0) - 1.0),
+              temp);
+        v3Scale(1.0 / 2.0 * J3 * (mu / pow(r, 2.0)) * pow(req / r, 3.0), temp, temp2);
         v3Add(ajtot, temp2, ajtot);
     }
-    if(num >= 4) {
+    if (num >= 4) {
         v3Set((3.0 - 42.0 * pow(z / r, 2.0) + 63.0 * pow(z / r, 4.0)) * (x / r),
               (3.0 - 42.0 * pow(z / r, 2.0) + 63.0 * pow(z / r, 4.0)) * (y / r),
-              (15.0 - 70.0 * pow(z / r, 2) + 63.0 * pow(z / r, 4.0)) * (z / r), temp);
-        v3Scale(5.0 / 8.0 * J4 * (mu / pow(r, 2.0))*pow(req / r, 4.0), temp, temp2);
+              (15.0 - 70.0 * pow(z / r, 2) + 63.0 * pow(z / r, 4.0)) * (z / r),
+              temp);
+        v3Scale(5.0 / 8.0 * J4 * (mu / pow(r, 2.0)) * pow(req / r, 4.0), temp, temp2);
         v3Add(ajtot, temp2, ajtot);
     }
-    if(num >= 5) {
+    if (num >= 5) {
         v3Set(3.0 * (35.0 * (z / r) - 210.0 * pow(z / r, 3.0) + 231.0 * pow(z / r, 5.0)) * (x / r),
               3.0 * (35.0 * (z / r) - 210.0 * pow(z / r, 3.0) + 231.0 * pow(z / r, 5.0)) * (y / r),
-              -(15.0 - 315.0 * pow(z / r, 2.0) + 945.0 * pow(z / r, 4.0) - 693.0 * pow(z / r, 6.0)), temp);
-        v3Scale(1.0 / 8.0 * J5 * (mu / pow(r, 2.0))*pow(req / r, 5.0), temp, temp2);
+              -(15.0 - 315.0 * pow(z / r, 2.0) + 945.0 * pow(z / r, 4.0) - 693.0 * pow(z / r, 6.0)),
+              temp);
+        v3Scale(1.0 / 8.0 * J5 * (mu / pow(r, 2.0)) * pow(req / r, 5.0), temp, temp2);
         v3Add(ajtot, temp2, ajtot);
     }
-    if(num >= 6) {
+    if (num >= 6) {
         v3Set((35.0 - 945.0 * pow(z / r, 2) + 3465.0 * pow(z / r, 4.0) - 3003.0 * pow(z / r, 6.0)) * (x / r),
               (35.0 - 945.0 * pow(z / r, 2.0) + 3465.0 * pow(z / r, 4.0) - 3003.0 * pow(z / r, 6.0)) * (y / r),
-              -(3003.0 * pow(z / r, 6.0) - 4851.0 * pow(z / r, 4.0) + 2205.0 * pow(z / r, 2.0) - 245.0) * (z / r), temp);
-        v3Scale(-1.0 / 16.0 * J6 * (mu / pow(r, 2.0))*pow(req / r, 6.0), temp, temp2);
+              -(3003.0 * pow(z / r, 6.0) - 4851.0 * pow(z / r, 4.0) + 2205.0 * pow(z / r, 2.0) - 245.0) * (z / r),
+              temp);
+        v3Scale(-1.0 / 16.0 * J6 * (mu / pow(r, 2.0)) * pow(req / r, 6.0), temp, temp2);
         v3Add(ajtot, temp2, ajtot);
     }
 }
@@ -820,24 +795,23 @@ void jPerturb(double *rvec, int num, double *ajtot, ...)
  *       components of the output are the same as the vector
  *       components of the sunvec input vector.
  */
-void solarRad(double A, double m, double *sunvec, double *arvec)
-{
+void solarRad(double A, double m, double *sunvec, double *arvec) {
     double flux;
     double c;
     double Cr;
     double sundist;
 
     /* Solar Radiation Flux */
-    flux = 1372.5398;           /* Watts/m^2 */
+    flux = 1372.5398; /* Watts/m^2 */
 
     /* Speed of light */
-    c = 299792458.;             /* m/s */
+    c = 299792458.; /* m/s */
 
     /* Radiation pressure coefficient */
     Cr = 1.3;
 
     /* Magnitude of position vector */
-    sundist = v3Norm(sunvec);   /* AU */
+    sundist = v3Norm(sunvec); /* AU */
 
     /* Computing the acceleration vector */
     v3Scale((-Cr * A * flux) / (m * c * pow(sundist, 3)) / 1000., sunvec, arvec);
@@ -852,53 +826,81 @@ void clMeanOscMap(double req, double J2, ClassicElements *elements, ClassicEleme
     // Hanspeter Schaub, John L. Junkins, 4th edition.
     // [m] or [km] should be the same both for req and elements->a
 
-    double a     = elements->a;
-    double e     = elements->e;
-    double i     = elements->i;
+    double a = elements->a;
+    double e = elements->e;
+    double i = elements->i;
     double Omega = elements->Omega;
     double omega = elements->omega;
-    double f     = elements->f;
-    double E     = f2E(f, e);
-    double M     = E2M(E, e);
+    double f = elements->f;
+    double E = f2E(f, e);
+    double M = E2M(E, e);
 
     double gamma2 = sgn * J2 / 2.0 * pow((req / a), 2.0);  // (F.1),(F.2)
     double eta = sqrt(1.0 - pow(e, 2.0));
-    double gamma2p = gamma2 / pow(eta, 4.0);        // (F.3)
+    double gamma2p = gamma2 / pow(eta, 4.0);          // (F.3)
     double a_r = (1.0 + e * cos(f)) / pow(eta, 2.0);  // (F.6)
 
-    double ap = a + a * gamma2 * ((3.0 * pow(cos(i), 2.0) - 1.0) * (pow(a_r, 3.0) - 1.0 / pow(eta, 3.0))
-              + 3.0 * (1.0 - pow(cos(i), 2.0)) * pow(a_r, 3.0) * cos(2.0 * omega + 2.0 * f));  // (F.7)
+    double ap = a + a * gamma2 *
+                        ((3.0 * pow(cos(i), 2.0) - 1.0) * (pow(a_r, 3.0) - 1.0 / pow(eta, 3.0)) +
+                         3.0 * (1.0 - pow(cos(i), 2.0)) * pow(a_r, 3.0) * cos(2.0 * omega + 2.0 * f));  // (F.7)
 
-    double de1 = gamma2p / 8.0 * e * pow(eta, 2.0) * (1.0 - 11.0 * pow(cos(i), 2.0) - 40.0 * pow(cos(i), 4.0)
-               / (1.0 - 5.0 * pow(cos(i), 2.0))) * cos(2.0 * omega);  // (F.8)
+    double de1 = gamma2p / 8.0 * e * pow(eta, 2.0) *
+                 (1.0 - 11.0 * pow(cos(i), 2.0) - 40.0 * pow(cos(i), 4.0) / (1.0 - 5.0 * pow(cos(i), 2.0))) *
+                 cos(2.0 * omega);  // (F.8)
 
-    double de = de1 + pow(eta, 2.0) / 2.0 * (gamma2 * ((3.0 * pow(cos(i), 2.0) - 1.0) / pow(eta, 6.0) * (e * eta + e / (1.0 + eta) + 3.0 * cos(f)
-              + 3.0 * e * pow(cos(f), 2.0) + pow(e, 2.0) * pow(cos(f), 3.0)) + 3.0 * (1.0 - pow(cos(i), 2.0)) / pow(eta, 6.0) * (e + 3.0 * cos(f)
-              + 3 * e * pow(cos(f), 2) + pow(e, 2) * pow(cos(f), 3)) * cos(2 * omega + 2 * f))
-              - gamma2p * (1.0 - pow(cos(i), 2.0)) * (3.0 * cos(2.0 * omega + f) + cos(2.0 * omega + 3.0 * f)));  // (F.9)
+    double de = de1 + pow(eta, 2.0) / 2.0 *
+                          (gamma2 * ((3.0 * pow(cos(i), 2.0) - 1.0) / pow(eta, 6.0) *
+                                         (e * eta + e / (1.0 + eta) + 3.0 * cos(f) + 3.0 * e * pow(cos(f), 2.0) +
+                                          pow(e, 2.0) * pow(cos(f), 3.0)) +
+                                     3.0 * (1.0 - pow(cos(i), 2.0)) / pow(eta, 6.0) *
+                                         (e + 3.0 * cos(f) + 3 * e * pow(cos(f), 2) + pow(e, 2) * pow(cos(f), 3)) *
+                                         cos(2 * omega + 2 * f)) -
+                           gamma2p * (1.0 - pow(cos(i), 2.0)) *
+                               (3.0 * cos(2.0 * omega + f) + cos(2.0 * omega + 3.0 * f)));  // (F.9)
 
-    double di = -e * de1 / pow(eta, 2.0) / tan(i)
-              + gamma2p / 2.0 * cos(i) * sqrt(1.0 - pow(cos(i), 2.0)) * (3.0 * cos(2.0 * omega + 2.0 * f) + 3.0 * e * cos(2.0 * omega + f)
-              + e * cos(2.0 * omega + 3.0 * f));  // (F.10)
+    double di =
+        -e * de1 / pow(eta, 2.0) / tan(i) + gamma2p / 2.0 * cos(i) * sqrt(1.0 - pow(cos(i), 2.0)) *
+                                                (3.0 * cos(2.0 * omega + 2.0 * f) + 3.0 * e * cos(2.0 * omega + f) +
+                                                 e * cos(2.0 * omega + 3.0 * f));  // (F.10)
 
-    double MpopOp = M + omega + Omega + gamma2p / 8.0 * pow(eta, 3.0) * (1.0 - 11.0 * pow(cos(i), 2.0) - 40.0 * pow(cos(i), 4.0)
-                  / (1.0 - 5.0 * pow(cos(i), 2.0))) * sin(2.0 * omega) - gamma2p / 16.0 * (2.0 + pow(e, 2.0) - 11.0 * (2.0 + 3.0 * pow(e, 2.0))
-                  * pow(cos(i), 2.0) - 40.0 * (2.0 + 5.0 * pow(e, 2.0)) * pow(cos(i), 4.0) / (1.0 - 5.0 * pow(cos(i), 2.0)) - 400.0 * pow(e, 2.0)
-                  * pow(cos(i), 6.0) / pow(1.0 - 5.0 * pow(cos(i), 2.0), 2.0)) * sin(2.0 * omega) + gamma2p / 4.0 * (-6.0 * (1.0 - 5.0 * pow(cos(i), 2.0))
-                  * (f - M + e * sin(f)) + (3.0 - 5.0 * pow(cos(i), 2.0)) * (3.0 * sin(2.0 * omega + 2.0 * f) + 3.0 * e * sin(2.0 * omega + f) + e
-                  * sin(2.0 * omega + 3.0 * f))) - gamma2p / 8.0 * pow(e, 2.0) * cos(i) * (11.0 + 80.0 * pow(cos(i), 2.0) / (1.0 - 5.0 * pow(cos(i), 2.0))
-                  + 200.0 * pow(cos(i), 4.0) / pow(1.0 - 5.0 * pow(cos(i), 2.0), 2.0)) * sin(2.0 * omega) - gamma2p / 2.0 * cos(i)
-                  * (6.0 * (f - M + e * sin(f)) - 3.0 * sin(2.0 * omega + 2.0 * f) - 3.0 * e * sin(2.0 * omega + f) - e * sin(2.0 * omega + 3.0 * f));  // (F.11)
+    double MpopOp =
+        M + omega + Omega +
+        gamma2p / 8.0 * pow(eta, 3.0) *
+            (1.0 - 11.0 * pow(cos(i), 2.0) - 40.0 * pow(cos(i), 4.0) / (1.0 - 5.0 * pow(cos(i), 2.0))) *
+            sin(2.0 * omega) -
+        gamma2p / 16.0 *
+            (2.0 + pow(e, 2.0) - 11.0 * (2.0 + 3.0 * pow(e, 2.0)) * pow(cos(i), 2.0) -
+             40.0 * (2.0 + 5.0 * pow(e, 2.0)) * pow(cos(i), 4.0) / (1.0 - 5.0 * pow(cos(i), 2.0)) -
+             400.0 * pow(e, 2.0) * pow(cos(i), 6.0) / pow(1.0 - 5.0 * pow(cos(i), 2.0), 2.0)) *
+            sin(2.0 * omega) +
+        gamma2p / 4.0 *
+            (-6.0 * (1.0 - 5.0 * pow(cos(i), 2.0)) * (f - M + e * sin(f)) +
+             (3.0 - 5.0 * pow(cos(i), 2.0)) *
+                 (3.0 * sin(2.0 * omega + 2.0 * f) + 3.0 * e * sin(2.0 * omega + f) + e * sin(2.0 * omega + 3.0 * f))) -
+        gamma2p / 8.0 * pow(e, 2.0) * cos(i) *
+            (11.0 + 80.0 * pow(cos(i), 2.0) / (1.0 - 5.0 * pow(cos(i), 2.0)) +
+             200.0 * pow(cos(i), 4.0) / pow(1.0 - 5.0 * pow(cos(i), 2.0), 2.0)) *
+            sin(2.0 * omega) -
+        gamma2p / 2.0 * cos(i) *
+            (6.0 * (f - M + e * sin(f)) - 3.0 * sin(2.0 * omega + 2.0 * f) - 3.0 * e * sin(2.0 * omega + f) -
+             e * sin(2.0 * omega + 3.0 * f));  // (F.11)
 
-    double edM = gamma2p / 8.0 * e * pow(eta, 3.0) * (1.0 - 11.0 * pow(cos(i), 2.0)
-               - 40.0 * pow(cos(i), 4.0) / (1.0 - 5.0 * pow(cos(i), 2.0))) * sin(2.0 * omega)
-               - gamma2p / 4.0 * pow(eta, 3.0) * (2.0 * (3.0 * pow(cos(i), 2.0) - 1.0) * (pow(a_r * eta, 2.0) + a_r + 1.0) * sin(f)
-               + 3.0 * (1.0 - pow(cos(i), 2.0)) * ((-pow(a_r * eta, 2.0) - a_r + 1.0) * sin(2.0 * omega + f) + (pow(a_r * eta, 2.0) + a_r
-               + 1.0 / 3.0) * sin(2.0 * omega + 3.0 * f)));  // (F.12)
+    double edM = gamma2p / 8.0 * e * pow(eta, 3.0) *
+                     (1.0 - 11.0 * pow(cos(i), 2.0) - 40.0 * pow(cos(i), 4.0) / (1.0 - 5.0 * pow(cos(i), 2.0))) *
+                     sin(2.0 * omega) -
+                 gamma2p / 4.0 * pow(eta, 3.0) *
+                     (2.0 * (3.0 * pow(cos(i), 2.0) - 1.0) * (pow(a_r * eta, 2.0) + a_r + 1.0) * sin(f) +
+                      3.0 * (1.0 - pow(cos(i), 2.0)) *
+                          ((-pow(a_r * eta, 2.0) - a_r + 1.0) * sin(2.0 * omega + f) +
+                           (pow(a_r * eta, 2.0) + a_r + 1.0 / 3.0) * sin(2.0 * omega + 3.0 * f)));  // (F.12)
 
-    double dOmega = -gamma2p / 8.0 * pow(e, 2.0) * cos(i) * (11.0 + 80.0 * pow(cos(i), 2.0) / (1.0 - 5.0 * pow(cos(i), 2.0))
-                  + 200.0 * pow(cos(i), 4.0) / pow(1.0 - 5.0 * pow(cos(i), 2.0), 2.0)) * sin(2.0 * omega) - gamma2p / 2.0 * cos(i)
-                  * (6.0 * (f - M + e * sin(f)) - 3.0 * sin(2.0 * omega + 2.0 * f) - 3.0 * e * sin(2.0 * omega + f) - e * sin(2.0 * omega + 3.0 * f));  // (F.13)
+    double dOmega = -gamma2p / 8.0 * pow(e, 2.0) * cos(i) *
+                        (11.0 + 80.0 * pow(cos(i), 2.0) / (1.0 - 5.0 * pow(cos(i), 2.0)) +
+                         200.0 * pow(cos(i), 4.0) / pow(1.0 - 5.0 * pow(cos(i), 2.0), 2.0)) *
+                        sin(2.0 * omega) -
+                    gamma2p / 2.0 * cos(i) *
+                        (6.0 * (f - M + e * sin(f)) - 3.0 * sin(2.0 * omega + 2.0 * f) -
+                         3.0 * e * sin(2.0 * omega + f) - e * sin(2.0 * omega + 3.0 * f));  // (F.13)
 
     double d1 = (e + de) * sin(M) + edM * cos(M);  // (F.14)
     double d2 = (e + de) * cos(M) - edM * sin(M);  // (F.15)
@@ -909,9 +911,9 @@ void clMeanOscMap(double req, double J2, ClassicElements *elements, ClassicEleme
     double d3 = (sin(i / 2.0) + cos(i / 2.0) * di / 2.0) * sin(Omega) + sin(i / 2.0) * dOmega * cos(Omega);  // (F.18)
     double d4 = (sin(i / 2.0) + cos(i / 2.0) * di / 2.0) * cos(Omega) - sin(i / 2.0) * dOmega * sin(Omega);  // (F.19)
 
-    double Omegap = atan2(d3, d4);                  // (F.20)
+    double Omegap = atan2(d3, d4);                        // (F.20)
     double ip = 2.0 * safeAsin(sqrt(d3 * d3 + d4 * d4));  // (F.21)
-    double omegap = MpopOp - Mp - Omegap;           // (F.22)
+    double omegap = MpopOp - Mp - Omegap;                 // (F.22)
 
     double Ep = M2E(Mp, ep);
     double fp = E2f(Ep, ep);
@@ -929,13 +931,13 @@ void clElem2eqElem(ClassicElements *elements_cl, equinoctialElements *elements_e
     // conversion
     // from classical orbital elements (a,e,i,Omega,omega,f)
     // to equinoctial orbital elements (a,P1,P2,Q1,Q2,l,L)
-    elements_eq->a  = elements_cl->a;
+    elements_eq->a = elements_cl->a;
     elements_eq->P1 = elements_cl->e * sin(elements_cl->Omega + elements_cl->omega);
     elements_eq->P2 = elements_cl->e * cos(elements_cl->Omega + elements_cl->omega);
     elements_eq->Q1 = tan(elements_cl->i / 2.0) * sin(elements_cl->Omega);
     elements_eq->Q2 = tan(elements_cl->i / 2.0) * cos(elements_cl->Omega);
-    double E        = f2E(elements_cl->f, elements_cl->e);
-    double M        = E2M(E, elements_cl->e);
-    elements_eq->l  = elements_cl->Omega + elements_cl->omega + M;
-    elements_eq->L  = elements_cl->Omega + elements_cl->omega + elements_cl->f;
+    double E = f2E(elements_cl->f, elements_cl->e);
+    double M = E2M(E, elements_cl->e);
+    elements_eq->l = elements_cl->Omega + elements_cl->omega + M;
+    elements_eq->L = elements_cl->Omega + elements_cl->omega + elements_cl->f;
 }

--- a/src/architecture/utilities/rigidBodyKinematics.c
+++ b/src/architecture/utilities/rigidBodyKinematics.c
@@ -33,8 +33,7 @@
  * which corresponds to performing to successive
  * rotations B1 and B2.
  */
-void addEP(double *b1, double *b2, double *result)
-{
+void addEP(double *b1, double *b2, double *result) {
     result[0] = b2[0] * b1[0] - b2[1] * b1[1] - b2[2] * b1[2] - b2[3] * b1[3];
     result[1] = b2[1] * b1[0] + b2[0] * b1[1] + b2[3] * b1[2] - b2[2] * b1[3];
     result[2] = b2[2] * b1[0] - b2[3] * b1[1] + b2[0] * b1[2] + b2[1] * b1[3];
@@ -46,8 +45,7 @@ void addEP(double *b1, double *b2, double *result)
  * angle vector corresponding to two successive
  * (1-2-1) rotations E1 and E2.
  */
-void addEuler121(double *e1, double *e2, double *result)
-{
+void addEuler121(double *e1, double *e2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -72,8 +70,7 @@ void addEuler121(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (1-3-1) rotations E1 and E2.
  */
-void addEuler131(double *e1, double *e2, double *result)
-{
+void addEuler131(double *e1, double *e2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -98,8 +95,7 @@ void addEuler131(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (1-2-3) rotations E1 and E2.
  */
-void addEuler123(double *e1, double *e2, double *result)
-{
+void addEuler123(double *e1, double *e2, double *result) {
     double C1[3][3];
     double C2[3][3];
     double C[3][3];
@@ -115,8 +111,7 @@ void addEuler123(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (1-3-2) rotations E1 and E2.
  */
-void addEuler132(double *e1, double *e2, double *result)
-{
+void addEuler132(double *e1, double *e2, double *result) {
     double C1[3][3];
     double C2[3][3];
     double C[3][3];
@@ -132,8 +127,7 @@ void addEuler132(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (2-1-2) rotations E1 and E2.
  */
-void addEuler212(double *e1, double *e2, double *result)
-{
+void addEuler212(double *e1, double *e2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -158,8 +152,7 @@ void addEuler212(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (2-1-3) rotations E1 and E2.
  */
-void addEuler213(double *e1, double *e2, double *result)
-{
+void addEuler213(double *e1, double *e2, double *result) {
     double C1[3][3];
     double C2[3][3];
     double C[3][3];
@@ -175,8 +168,7 @@ void addEuler213(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (2-3-1) rotations E1 and E2.
  */
-void addEuler231(double *e1, double *e2, double *result)
-{
+void addEuler231(double *e1, double *e2, double *result) {
     double C1[3][3];
     double C2[3][3];
     double C[3][3];
@@ -192,8 +184,7 @@ void addEuler231(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (2-3-2) rotations E1 and E2.
  */
-void addEuler232(double *e1, double *e2, double *result)
-{
+void addEuler232(double *e1, double *e2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -218,8 +209,7 @@ void addEuler232(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (3-1-2) rotations E1 and E2.
  */
-void addEuler312(double *e1, double *e2, double *result)
-{
+void addEuler312(double *e1, double *e2, double *result) {
     double C1[3][3];
     double C2[3][3];
     double C[3][3];
@@ -235,8 +225,7 @@ void addEuler312(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (3-1-3) rotations E1 and E2.
  */
-void addEuler313(double *e1, double *e2, double *result)
-{
+void addEuler313(double *e1, double *e2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -261,8 +250,7 @@ void addEuler313(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (3-2-1) rotations E1 and E2.
  */
-void addEuler321(double *e1, double *e2, double *result)
-{
+void addEuler321(double *e1, double *e2, double *result) {
     double C1[3][3];
     double C2[3][3];
     double C[3][3];
@@ -278,8 +266,7 @@ void addEuler321(double *e1, double *e2, double *result)
  * angle vector corresponding to two successive
  * (3-2-3) rotations E1 and E2.
  */
-void addEuler323(double *e1, double *e2, double *result)
-{
+void addEuler323(double *e1, double *e2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -304,8 +291,7 @@ void addEuler323(double *e1, double *e2, double *result)
  * which corresponds to performing to successive
  * rotations Q1 and Q2.
  */
-void addGibbs(double *q1, double *q2, double *result)
-{
+void addGibbs(double *q1, double *q2, double *result) {
     double v1[3];
     double v2[3];
 
@@ -320,8 +306,7 @@ void addGibbs(double *q1, double *q2, double *result)
  * which corresponds to performing to successive
  * rotations Q1 and Q2.
  */
-void addMRP(double *q1, double *q2, double *result)
-{
+void addMRP(double *q1, double *q2, double *result) {
     double v1[3];
     double v2[3];
     double s1[3];
@@ -329,12 +314,12 @@ void addMRP(double *q1, double *q2, double *result)
     double mag;
 
     v3Copy(q1, s1);
-    det = (1 + v3Dot(s1, s1)*v3Dot(q2, q2) - 2 * v3Dot(s1, q2));
+    det = (1 + v3Dot(s1, s1) * v3Dot(q2, q2) - 2 * v3Dot(s1, q2));
 
     if (fabs(det) < 0.1) {
         mag = v3Dot(s1, s1);
-        v3Scale(-1./mag, s1, s1);
-        det = (1 + v3Dot(s1, s1)*v3Dot(q2, q2) - 2 * v3Dot(s1, q2));
+        v3Scale(-1. / mag, s1, s1);
+        det = (1 + v3Dot(s1, s1) * v3Dot(q2, q2) - 2 * v3Dot(s1, q2));
     }
 
     v3Cross(s1, q2, v1);
@@ -347,8 +332,8 @@ void addMRP(double *q1, double *q2, double *result)
 
     /* map MRP to inner set */
     mag = v3Dot(result, result);
-    if (mag > 1.0){
-        v3Scale(-1./mag, result, result);
+    if (mag > 1.0) {
+        v3Scale(-1. / mag, result, result);
     }
 }
 
@@ -357,8 +342,7 @@ void addMRP(double *q1, double *q2, double *result)
  * which corresponds to performing to successive
  * prinicipal rotations Q1 and Q2.
  */
-void addPRV(double *qq1, double *qq2, double *result)
-{
+void addPRV(double *qq1, double *qq2, double *result) {
     double cp1;
     double cp2;
     double sp1;
@@ -373,8 +357,7 @@ void addPRV(double *qq1, double *qq2, double *result)
 
     v3Add(qq1, qq2, compSum);
 
-    if((v3Norm(qq1) < 1.0E-7 || v3Norm(qq2) < 1.0E-7))
-    {
+    if ((v3Norm(qq1) < 1.0E-7 || v3Norm(qq2) < 1.0E-7)) {
         v3Add(qq1, qq2, result);
         return;
     }
@@ -389,8 +372,7 @@ void addPRV(double *qq1, double *qq2, double *result)
     v3Set(q2[1], q2[2], q2[3], e2);
 
     p = 2 * safeAcos(cp1 * cp2 - sp1 * sp2 * v3Dot(e1, e2));
-    if(fabs(p) < 1.0E-13)
-    {
+    if (fabs(p) < 1.0E-13) {
         v3SetZero(result);
         return;
     }
@@ -410,8 +392,7 @@ void addPRV(double *qq1, double *qq2, double *result)
  * body angular velocity vector w.
  * w = 2 [B(Q)]^(-1) dQ/dt
  */
-void BinvEP(double *q, double B[3][4])
-{
+void BinvEP(double *q, double B[3][4]) {
     B[0][0] = -q[1];
     B[0][1] = q[0];
     B[0][2] = q[3];
@@ -433,8 +414,7 @@ void BinvEP(double *q, double B[3][4])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler121(double *q, double B[3][3])
-{
+void BinvEuler121(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -463,8 +443,7 @@ void BinvEuler121(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler123(double *q, double B[3][3])
-{
+void BinvEuler123(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -493,8 +472,7 @@ void BinvEuler123(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler131(double *q, double B[3][3])
-{
+void BinvEuler131(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -523,8 +501,7 @@ void BinvEuler131(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler132(double *q, double B[3][3])
-{
+void BinvEuler132(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -553,8 +530,7 @@ void BinvEuler132(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler212(double *q, double B[3][3])
-{
+void BinvEuler212(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -583,8 +559,7 @@ void BinvEuler212(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler213(double *q, double B[3][3])
-{
+void BinvEuler213(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -613,8 +588,7 @@ void BinvEuler213(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler231(double *q, double B[3][3])
-{
+void BinvEuler231(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -643,8 +617,7 @@ void BinvEuler231(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler232(double *q, double B[3][3])
-{
+void BinvEuler232(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -673,8 +646,7 @@ void BinvEuler232(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler323(double *q, double B[3][3])
-{
+void BinvEuler323(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -703,8 +675,7 @@ void BinvEuler323(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler313(double *q, double B[3][3])
-{
+void BinvEuler313(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -733,8 +704,7 @@ void BinvEuler313(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler321(double *q, double B[3][3])
-{
+void BinvEuler321(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -763,8 +733,7 @@ void BinvEuler321(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvEuler312(double *q, double B[3][3])
-{
+void BinvEuler312(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -793,8 +762,7 @@ void BinvEuler312(double *q, double B[3][3])
  *
  * w = 2 [B(Q)]^(-1) dQ/dt
  */
-void BinvGibbs(double *q, double B[3][3])
-{
+void BinvGibbs(double *q, double B[3][3]) {
     B[0][0] = 1;
     B[0][1] = q[2];
     B[0][2] = -q[1];
@@ -808,14 +776,13 @@ void BinvGibbs(double *q, double B[3][3])
 }
 
 /*
-* BinvMRP(Q,B) returns the 3x3 matrix which relates
-* the derivative of MRP vector Q to the
-* body angular velocity vector w.
-*
-* w = 4 [B(Q)]^(-1) dQ/dt
-*/
-void BinvMRP(double *q, double B[3][3])
-{
+ * BinvMRP(Q,B) returns the 3x3 matrix which relates
+ * the derivative of MRP vector Q to the
+ * body angular velocity vector w.
+ *
+ * w = 4 [B(Q)]^(-1) dQ/dt
+ */
+void BinvMRP(double *q, double B[3][3]) {
     double s2;
 
     s2 = v3Dot(q, q);
@@ -838,8 +805,7 @@ void BinvMRP(double *q, double B[3][3])
  *
  * w = [B(Q)]^(-1) dQ/dt
  */
-void BinvPRV(double *q, double B[3][3])
-{
+void BinvPRV(double *q, double B[3][3]) {
     double p;
     double c1;
     double c2;
@@ -866,8 +832,7 @@ void BinvPRV(double *q, double B[3][3])
  *
  * dQ/dt = 1/2 [B(Q)] w
  */
-void BmatEP(double *q, double B[4][3])
-{
+void BmatEP(double *q, double B[4][3]) {
     B[0][0] = -q[1];
     B[0][1] = -q[2];
     B[0][2] = -q[3];
@@ -889,8 +854,7 @@ void BmatEP(double *q, double B[4][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler121(double *q, double B[3][3])
-{
+void BmatEuler121(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -920,8 +884,7 @@ void BmatEuler121(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler131(double *q, double B[3][3])
-{
+void BmatEuler131(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -951,8 +914,7 @@ void BmatEuler131(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler123(double *q, double B[3][3])
-{
+void BmatEuler123(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -982,8 +944,7 @@ void BmatEuler123(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler132(double *q, double B[3][3])
-{
+void BmatEuler132(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1013,8 +974,7 @@ void BmatEuler132(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler212(double *q, double B[3][3])
-{
+void BmatEuler212(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1044,8 +1004,7 @@ void BmatEuler212(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler213(double *q, double B[3][3])
-{
+void BmatEuler213(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1075,8 +1034,7 @@ void BmatEuler213(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler231(double *q, double B[3][3])
-{
+void BmatEuler231(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1106,8 +1064,7 @@ void BmatEuler231(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler232(double *q, double B[3][3])
-{
+void BmatEuler232(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1137,8 +1094,7 @@ void BmatEuler232(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler312(double *q, double B[3][3])
-{
+void BmatEuler312(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1168,8 +1124,7 @@ void BmatEuler312(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler313(double *q, double B[3][3])
-{
+void BmatEuler313(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1199,8 +1154,7 @@ void BmatEuler313(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler321(double *q, double B[3][3])
-{
+void BmatEuler321(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1230,8 +1184,7 @@ void BmatEuler321(double *q, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatEuler323(double *q, double B[3][3])
-{
+void BmatEuler323(double *q, double B[3][3]) {
     double s2;
     double c2;
     double s3;
@@ -1261,8 +1214,7 @@ void BmatEuler323(double *q, double B[3][3])
  *
  * dQ/dt = 1/2 [B(Q)] w
  */
-void BmatGibbs(double *q, double B[3][3])
-{
+void BmatGibbs(double *q, double B[3][3]) {
     B[0][0] = 1 + q[0] * q[0];
     B[0][1] = q[0] * q[1] - q[2];
     B[0][2] = q[0] * q[2] + q[1];
@@ -1281,8 +1233,7 @@ void BmatGibbs(double *q, double B[3][3])
  *
  * dQ/dt = 1/4 [B(Q)] w
  */
-void BmatMRP(double *q, double B[3][3])
-{
+void BmatMRP(double *q, double B[3][3]) {
     double s2;
 
     s2 = v3Dot(q, q);
@@ -1305,20 +1256,19 @@ void BmatMRP(double *q, double B[3][3])
  *
  * (d^2Q)/(dt^2) = 1/4 ( [B(Q)] dw + [Bdot(Q,dQ)] w )
  */
-void BdotmatMRP(double *q, double *dq, double B[3][3])
-{
+void BdotmatMRP(double *q, double *dq, double B[3][3]) {
     double s;
 
     s = -2 * v3Dot(q, dq);
-    B[0][0] = s + 4 * ( q[0] * dq[0] );
-    B[0][1] = 2 * (-dq[2] + q[0] * dq[1] + dq[0] * q[1] );
-    B[0][2] = 2 * ( dq[1] + q[0] * dq[2] + dq[0] * q[2] );
-    B[1][0] = 2 * ( dq[2] + q[0] * dq[1] + dq[0] * q[1] );
-    B[1][1] = s + 4 * ( q[1] * dq[1] );
-    B[1][2] = 2 * (-dq[0] + q[1] * dq[2] + dq[1] * q[2] );
-    B[2][0] = 2 * (-dq[1] + q[0] * dq[2] + dq[0] * q[2] );
-    B[2][1] = 2 * ( dq[0] + q[1] * dq[2] + dq[1] * q[2] );
-    B[2][2] = s + 4 * ( q[2] * dq[2] );
+    B[0][0] = s + 4 * (q[0] * dq[0]);
+    B[0][1] = 2 * (-dq[2] + q[0] * dq[1] + dq[0] * q[1]);
+    B[0][2] = 2 * (dq[1] + q[0] * dq[2] + dq[0] * q[2]);
+    B[1][0] = 2 * (dq[2] + q[0] * dq[1] + dq[0] * q[1]);
+    B[1][1] = s + 4 * (q[1] * dq[1]);
+    B[1][2] = 2 * (-dq[0] + q[1] * dq[2] + dq[1] * q[2]);
+    B[2][0] = 2 * (-dq[1] + q[0] * dq[2] + dq[0] * q[2]);
+    B[2][1] = 2 * (dq[0] + q[1] * dq[2] + dq[1] * q[2]);
+    B[2][2] = s + 4 * (q[2] * dq[2]);
 }
 
 /*
@@ -1328,8 +1278,7 @@ void BdotmatMRP(double *q, double *dq, double B[3][3])
  *
  * dQ/dt = [B(Q)] w
  */
-void BmatPRV(double *q, double B[3][3])
-{
+void BmatPRV(double *q, double B[3][3]) {
     double p;
     double c;
     p = v3Norm(q);
@@ -1353,8 +1302,7 @@ void BmatPRV(double *q, double B[3][3])
  * using the Stanley method.
  *
  */
-void C2EP(double C[3][3], double b[4])
-{
+void C2EP(double C[3][3], double b[4]) {
     double tr;
     double b2[4];
     double max;
@@ -1369,14 +1317,14 @@ void C2EP(double C[3][3], double b[4])
 
     i = 0;
     max = b2[0];
-    for(j = 1; j < 4; j++) {
-        if(b2[j] > max) {
+    for (j = 1; j < 4; j++) {
+        if (b2[j] > max) {
             i = j;
             max = b2[j];
         }
     }
 
-    switch(i) {
+    switch (i) {
         case 0:
             b[0] = sqrt(b2[0]);
             b[1] = (C[1][2] - C[2][1]) / 4 / b[0];
@@ -1386,7 +1334,7 @@ void C2EP(double C[3][3], double b[4])
         case 1:
             b[1] = sqrt(b2[1]);
             b[0] = (C[1][2] - C[2][1]) / 4 / b[1];
-            if(b[0] < 0) {
+            if (b[0] < 0) {
                 b[1] = -b[1];
                 b[0] = -b[0];
             }
@@ -1396,7 +1344,7 @@ void C2EP(double C[3][3], double b[4])
         case 2:
             b[2] = sqrt(b2[2]);
             b[0] = (C[2][0] - C[0][2]) / 4 / b[2];
-            if(b[0] < 0) {
+            if (b[0] < 0) {
                 b[2] = -b[2];
                 b[0] = -b[0];
             }
@@ -1406,7 +1354,7 @@ void C2EP(double C[3][3], double b[4])
         case 3:
             b[3] = sqrt(b2[3]);
             b[0] = (C[0][1] - C[1][0]) / 4 / b[3];
-            if(b[0] < 0) {
+            if (b[0] < 0) {
                 b[3] = -b[3];
                 b[0] = -b[0];
             }
@@ -1420,8 +1368,7 @@ void C2EP(double C[3][3], double b[4])
  * C2Euler121(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (1-2-1) Euler angle set.
  */
-void C2Euler121(double C[3][3], double *q)
-{
+void C2Euler121(double C[3][3], double *q) {
     q[0] = atan2(C[0][1], -C[0][2]);
     q[1] = safeAcos(C[0][0]);
     q[2] = atan2(C[1][0], C[2][0]);
@@ -1431,8 +1378,7 @@ void C2Euler121(double C[3][3], double *q)
  * C2Euler123(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (1-2-3) Euler angle set.
  */
-void C2Euler123(double C[3][3], double *q)
-{
+void C2Euler123(double C[3][3], double *q) {
     q[0] = atan2(-C[2][1], C[2][2]);
     q[1] = safeAsin(C[2][0]);
     q[2] = atan2(-C[1][0], C[0][0]);
@@ -1442,8 +1388,7 @@ void C2Euler123(double C[3][3], double *q)
  * C2Euler131(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (1-3-1) Euler angle set.
  */
-void C2Euler131(double C[3][3], double *q)
-{
+void C2Euler131(double C[3][3], double *q) {
     q[0] = atan2(C[0][2], C[0][1]);
     q[1] = safeAcos(C[0][0]);
     q[2] = atan2(C[2][0], -C[1][0]);
@@ -1453,8 +1398,7 @@ void C2Euler131(double C[3][3], double *q)
  * C2Euler132(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (1-3-2) Euler angle set.
  */
-void C2Euler132(double C[3][3], double *q)
-{
+void C2Euler132(double C[3][3], double *q) {
     q[0] = atan2(C[1][2], C[1][1]);
     q[1] = safeAsin(-C[1][0]);
     q[2] = atan2(C[2][0], C[0][0]);
@@ -1464,8 +1408,7 @@ void C2Euler132(double C[3][3], double *q)
  * C2Euler212(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (2-1-2) Euler angle set.
  */
-void C2Euler212(double C[3][3], double *q)
-{
+void C2Euler212(double C[3][3], double *q) {
     q[0] = atan2(C[1][0], C[1][2]);
     q[1] = safeAcos(C[1][1]);
     q[2] = atan2(C[0][1], -C[2][1]);
@@ -1475,8 +1418,7 @@ void C2Euler212(double C[3][3], double *q)
  * C2Euler213(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (2-1-3) Euler angle set.
  */
-void C2Euler213(double C[3][3], double *q)
-{
+void C2Euler213(double C[3][3], double *q) {
     q[0] = atan2(C[2][0], C[2][2]);
     q[1] = safeAsin(-C[2][1]);
     q[2] = atan2(C[0][1], C[1][1]);
@@ -1486,8 +1428,7 @@ void C2Euler213(double C[3][3], double *q)
  * C2Euler231(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (2-3-1) Euler angle set.
  */
-void C2Euler231(double C[3][3], double *q)
-{
+void C2Euler231(double C[3][3], double *q) {
     q[0] = atan2(-C[0][2], C[0][0]);
     q[1] = safeAsin(C[0][1]);
     q[2] = atan2(-C[2][1], C[1][1]);
@@ -1497,8 +1438,7 @@ void C2Euler231(double C[3][3], double *q)
  * C2Euler232(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (2-3-2) Euler angle set.
  */
-void C2Euler232(double C[3][3], double *q)
-{
+void C2Euler232(double C[3][3], double *q) {
     q[0] = atan2(C[1][2], -C[1][0]);
     q[1] = safeAcos(C[1][1]);
     q[2] = atan2(C[2][1], C[0][1]);
@@ -1508,8 +1448,7 @@ void C2Euler232(double C[3][3], double *q)
  * C2Euler312(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (3-1-2) Euler angle set.
  */
-void C2Euler312(double C[3][3], double *q)
-{
+void C2Euler312(double C[3][3], double *q) {
     q[0] = atan2(-C[1][0], C[1][1]);
     q[1] = safeAsin(C[1][2]);
     q[2] = atan2(-C[0][2], C[2][2]);
@@ -1519,8 +1458,7 @@ void C2Euler312(double C[3][3], double *q)
  * C2Euler313(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (3-1-3) Euler angle set.
  */
-void C2Euler313(double C[3][3], double *q)
-{
+void C2Euler313(double C[3][3], double *q) {
     q[0] = atan2(C[2][0], -C[2][1]);
     q[1] = safeAcos(C[2][2]);
     q[2] = atan2(C[0][2], C[1][2]);
@@ -1530,8 +1468,7 @@ void C2Euler313(double C[3][3], double *q)
  * C2Euler321(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (3-2-1) Euler angle set.
  */
-void C2Euler321(double C[3][3], double *q)
-{
+void C2Euler321(double C[3][3], double *q) {
     q[0] = atan2(C[0][1], C[0][0]);
     q[1] = safeAsin(-C[0][2]);
     q[2] = atan2(C[1][2], C[2][2]);
@@ -1541,8 +1478,7 @@ void C2Euler321(double C[3][3], double *q)
  * C2Euler323(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding (3-2-3) Euler angle set.
  */
-void C2Euler323(double C[3][3], double *q)
-{
+void C2Euler323(double C[3][3], double *q) {
     q[0] = atan2(C[2][1], C[2][0]);
     q[1] = safeAcos(C[2][2]);
     q[2] = atan2(C[1][2], -C[0][2]);
@@ -1552,8 +1488,7 @@ void C2Euler323(double C[3][3], double *q)
  * C2Gibbs(C,Q) translates the 3x3 direction cosine matrix
  * C into the corresponding 3x1 Gibbs vector Q.
  */
-void C2Gibbs(double C[3][3], double *q)
-{
+void C2Gibbs(double C[3][3], double *q) {
     double b[4];
 
     C2EP(C, b);
@@ -1568,8 +1503,7 @@ void C2Gibbs(double C[3][3], double *q)
  * C into the corresponding 3x1 MRP vector Q where the
  * MRP vector is chosen such that |Q| <= 1.
  */
-void C2MRP(double C[3][3], double *q)
-{
+void C2MRP(double C[3][3], double *q) {
     double b[4];
 
     v4SetZero(b);
@@ -1587,12 +1521,11 @@ void C2MRP(double C[3][3], double *q)
  * where the first component of Q is the principal rotation angle
  * phi (0<= phi <= Pi)
  */
-void C2PRV(double C[3][3], double *q)
-{
+void C2PRV(double C[3][3], double *q) {
     double beta[4];
 
-    C2EP(C,beta);
-    EP2PRV(beta,q);
+    C2EP(C, beta);
+    EP2PRV(beta, q);
 }
 
 /*
@@ -1602,17 +1535,16 @@ void C2PRV(double C[3][3], double *q)
  *
  * dQ/dt = 1/2 [B(Q)] w
  */
-void dEP(double *q, double *w, double *dq)
-{
+void dEP(double *q, double *w, double *dq) {
     double B[4][3];
     int i;
     int j;
 
     BmatEP(q, B);
     m33MultV3(B, w, dq);
-    for(i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++) {
         dq[i] = 0.;
-        for(j = 0; j < 3; j++) {
+        for (j = 0; j < 3; j++) {
             dq[i] += B[i][j] * w[j];
         }
     }
@@ -1627,8 +1559,7 @@ void dEP(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler121(double *q, double *w, double *dq)
-{
+void dEuler121(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler121(q, B);
@@ -1642,8 +1573,7 @@ void dEuler121(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler123(double *q, double *w, double *dq)
-{
+void dEuler123(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler123(q, B);
@@ -1657,8 +1587,7 @@ void dEuler123(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler131(double *q, double *w, double *dq)
-{
+void dEuler131(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler131(q, B);
@@ -1672,8 +1601,7 @@ void dEuler131(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler132(double *q, double *w, double *dq)
-{
+void dEuler132(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler132(q, B);
@@ -1687,8 +1615,7 @@ void dEuler132(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler212(double *q, double *w, double *dq)
-{
+void dEuler212(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler212(q, B);
@@ -1702,8 +1629,7 @@ void dEuler212(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler213(double *q, double *w, double *dq)
-{
+void dEuler213(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler213(q, B);
@@ -1717,8 +1643,7 @@ void dEuler213(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler231(double *q, double *w, double *dq)
-{
+void dEuler231(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler231(q, B);
@@ -1732,8 +1657,7 @@ void dEuler231(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler232(double *q, double *w, double *dq)
-{
+void dEuler232(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler232(q, B);
@@ -1747,8 +1671,7 @@ void dEuler232(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler312(double *q, double *w, double *dq)
-{
+void dEuler312(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler312(q, B);
@@ -1762,8 +1685,7 @@ void dEuler312(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler313(double *q, double *w, double *dq)
-{
+void dEuler313(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler313(q, B);
@@ -1777,8 +1699,7 @@ void dEuler313(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler321(double *q, double *w, double *dq)
-{
+void dEuler321(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler321(q, B);
@@ -1792,8 +1713,7 @@ void dEuler321(double *q, double *w, double *dq)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dEuler323(double *q, double *w, double *dq)
-{
+void dEuler323(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatEuler323(q, B);
@@ -1807,8 +1727,7 @@ void dEuler323(double *q, double *w, double *dq)
  *
  * dQ/dt = 1/2 [B(Q)] w
  */
-void dGibbs(double *q, double *w, double *dq)
-{
+void dGibbs(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatGibbs(q, B);
@@ -1823,8 +1742,7 @@ void dGibbs(double *q, double *w, double *dq)
  *
  * dQ/dt = 1/4 [B(Q)] w
  */
-void dMRP(double *q, double *w, double *dq)
-{
+void dMRP(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatMRP(q, B);
@@ -1839,8 +1757,7 @@ void dMRP(double *q, double *w, double *dq)
  *
  * w = 4 [B(Q)]^(-1) dQ/dt
  */
-void dMRP2Omega(double *q, double *dq, double *w)
-{
+void dMRP2Omega(double *q, double *dq, double *w) {
     double B[3][3];
 
     BinvMRP(q, B);
@@ -1855,8 +1772,7 @@ void dMRP2Omega(double *q, double *dq, double *w)
  *
  * (d^2Q)/(dt^2) = 1/4 ( [B(Q)] dw + [Bdot(Q,dQ)] w )
  */
-void ddMRP(double *q, double *dq, double *w, double *dw, double *ddq)
-{
+void ddMRP(double *q, double *dq, double *w, double *dw, double *ddq) {
     double B[3][3], Bdot[3][3];
     double s1[3], s2[3];
     int i;
@@ -1865,8 +1781,8 @@ void ddMRP(double *q, double *dq, double *w, double *dw, double *ddq)
     BdotmatMRP(q, dq, Bdot);
     m33MultV3(B, dw, s1);
     m33MultV3(Bdot, w, s2);
-    for(i = 0; i < 3; i++) {
-        ddq[i] = 0.25 * ( s1[i] + s2[i] );
+    for (i = 0; i < 3; i++) {
+        ddq[i] = 0.25 * (s1[i] + s2[i]);
     }
 }
 
@@ -1877,8 +1793,7 @@ void ddMRP(double *q, double *dq, double *w, double *dw, double *ddq)
  *
  * dW/dt = 4 [B(Q)]^(-1) ( ddQ - [Bdot(Q,dQ)] [B(Q)]^(-1) dQ )
  */
-void ddMRP2dOmega(double *q, double *dq, double *ddq, double *dw)
-{
+void ddMRP2dOmega(double *q, double *dq, double *ddq, double *dw) {
     double B[3][3], Bdot[3][3];
     double s1[3], s2[3], s3[3];
     int i;
@@ -1887,7 +1802,7 @@ void ddMRP2dOmega(double *q, double *dq, double *ddq, double *dw)
     BdotmatMRP(q, dq, Bdot);
     m33MultV3(B, dq, s1);
     m33MultV3(Bdot, s1, s2);
-    for(i = 0; i < 3; i++) {
+    for (i = 0; i < 3; i++) {
         s3[i] = ddq[i] - s2[i];
     }
     m33MultV3(B, s3, dw);
@@ -1901,8 +1816,7 @@ void ddMRP2dOmega(double *q, double *dq, double *ddq, double *dw)
  *
  * dQ/dt =  [B(Q)] w
  */
-void dPRV(double *q, double *w, double *dq)
-{
+void dPRV(double *q, double *w, double *dq) {
     double B[3][3];
 
     BmatPRV(q, B);
@@ -1914,8 +1828,7 @@ void dPRV(double *q, double *w, double *dq)
  * element set R into the corresponding principal
  * rotation vector Q.
  */
-void elem2PRV(double *r, double *q)
-{
+void elem2PRV(double *r, double *q) {
     q[0] = r[1] * r[0];
     q[1] = r[2] * r[0];
     q[2] = r[3] * r[0];
@@ -1928,8 +1841,7 @@ void elem2PRV(double *r, double *q)
  * parameter, while the remain three elements form
  * the Eulerparameter vector.
  */
-void EP2C(double *q, double C[3][3])
-{
+void EP2C(double *q, double C[3][3]) {
     double q0;
     double q1;
     double q2;
@@ -1956,8 +1868,7 @@ void EP2C(double *q, double C[3][3])
  * vector Q into the corresponding (1-2-1) Euler angle
  * vector E.
  */
-void EP2Euler121(double *q, double *e)
-{
+void EP2Euler121(double *q, double *e) {
     double t1;
     double t2;
 
@@ -1973,8 +1884,7 @@ void EP2Euler121(double *q, double *e)
  * EP2Euler123(Q,E) translates the Euler parameter vector
  * Q into the corresponding (1-2-3) Euler angle set.
  */
-void EP2Euler123(double *q, double *e)
-{
+void EP2Euler123(double *q, double *e) {
     double q0;
     double q1;
     double q2;
@@ -1995,8 +1905,7 @@ void EP2Euler123(double *q, double *e)
  * vector Q into the corresponding (1-3-1) Euler angle
  * vector E.
  */
-void EP2Euler131(double *q, double *e)
-{
+void EP2Euler131(double *q, double *e) {
     double t1;
     double t2;
 
@@ -2012,8 +1921,7 @@ void EP2Euler131(double *q, double *e)
  * EP2Euler132(Q,E) translates the Euler parameter vector
  * Q into the corresponding (1-3-2) Euler angle set.
  */
-void EP2Euler132(double *q, double *e)
-{
+void EP2Euler132(double *q, double *e) {
     double q0;
     double q1;
     double q2;
@@ -2034,8 +1942,7 @@ void EP2Euler132(double *q, double *e)
  * vector Q into the corresponding (2-1-2) Euler angle
  * vector E.
  */
-void EP2Euler212(double *q, double *e)
-{
+void EP2Euler212(double *q, double *e) {
     double t1;
     double t2;
 
@@ -2051,8 +1958,7 @@ void EP2Euler212(double *q, double *e)
  * EP2Euler213(Q,E) translates the Euler parameter vector
  * Q into the corresponding (2-1-3) Euler angle set.
  */
-void EP2Euler213(double *q, double *e)
-{
+void EP2Euler213(double *q, double *e) {
     double q0;
     double q1;
     double q2;
@@ -2072,8 +1978,7 @@ void EP2Euler213(double *q, double *e)
  * EP2Euler231(Q,E) translates the Euler parameter vector
  * Q into the corresponding (2-3-1) Euler angle set.
  */
-void EP2Euler231(double *q, double *e)
-{
+void EP2Euler231(double *q, double *e) {
     double q0;
     double q1;
     double q2;
@@ -2094,8 +1999,7 @@ void EP2Euler231(double *q, double *e)
  * vector Q into the corresponding (2-3-2) Euler angle
  * vector E.
  */
-void EP2Euler232(double *q, double *e)
-{
+void EP2Euler232(double *q, double *e) {
     double t1;
     double t2;
 
@@ -2111,8 +2015,7 @@ void EP2Euler232(double *q, double *e)
  * EP2Euler312(Q,E) translates the Euler parameter vector
  * Q into the corresponding (3-1-2) Euler angle set.
  */
-void EP2Euler312(double *q, double *e)
-{
+void EP2Euler312(double *q, double *e) {
     double q0;
     double q1;
     double q2;
@@ -2133,8 +2036,7 @@ void EP2Euler312(double *q, double *e)
  * vector Q into the corresponding (3-1-3) Euler angle
  * vector E.
  */
-void EP2Euler313(double *q, double *e)
-{
+void EP2Euler313(double *q, double *e) {
     double t1;
     double t2;
 
@@ -2150,8 +2052,7 @@ void EP2Euler313(double *q, double *e)
  * EP2Euler321(Q,E) translates the Euler parameter vector
  * Q into the corresponding (3-2-1) Euler angle set.
  */
-void EP2Euler321(double *q, double *e)
-{
+void EP2Euler321(double *q, double *e) {
     double q0;
     double q1;
     double q2;
@@ -2172,8 +2073,7 @@ void EP2Euler321(double *q, double *e)
  * vector Q into the corresponding (3-2-3) Euler angle
  * vector E.
  */
-void EP2Euler323(double *q, double *e)
-{
+void EP2Euler323(double *q, double *e) {
     double t1;
     double t2;
 
@@ -2189,8 +2089,7 @@ void EP2Euler323(double *q, double *e)
  * EP2Gibbs(Q1,Q) translates the Euler parameter vector Q1
  * into the Gibbs vector Q.
  */
-void EP2Gibbs(double *q1, double *q)
-{
+void EP2Gibbs(double *q1, double *q) {
     q[0] = q1[1] / q1[0];
     q[1] = q1[2] / q1[0];
     q[2] = q1[3] / q1[0];
@@ -2200,9 +2099,8 @@ void EP2Gibbs(double *q1, double *q)
  * EP2MRP(Q1,Q) translates the Euler parameter vector Q1
  * into the MRP vector Q.
  */
-void EP2MRP(double *q1, double *q)
-{
-    if (q1[0] >= 0){
+void EP2MRP(double *q1, double *q) {
+    if (q1[0] >= 0) {
         q[0] = q1[1] / (1 + q1[0]);
         q[1] = q1[2] / (1 + q1[0]);
         q[2] = q1[3] / (1 + q1[0]);
@@ -2217,8 +2115,7 @@ void EP2MRP(double *q1, double *q)
  * EP2PRV(Q1,Q) translates the Euler parameter vector Q1
  * into the principal rotation vector Q.
  */
-void EP2PRV(double *q1, double *q)
-{
+void EP2PRV(double *q1, double *q) {
     double p;
     double sp;
 
@@ -2240,8 +2137,7 @@ void EP2PRV(double *q1, double *q)
  * Returns the elementary rotation matrix about the
  * first body axis.
  */
-void Euler1(double x, double m[3][3])
-{
+void Euler1(double x, double m[3][3]) {
     m33SetIdentity(m);
     m[1][1] = cos(x);
     m[1][2] = sin(x);
@@ -2254,8 +2150,7 @@ void Euler1(double x, double m[3][3])
  * Returns the elementary rotation matrix about the
  * second body axis.
  */
-void Euler2(double x, double m[3][3])
-{
+void Euler2(double x, double m[3][3]) {
     m33SetIdentity(m);
     m[0][0] = cos(x);
     m[0][2] = -sin(x);
@@ -2268,8 +2163,7 @@ void Euler2(double x, double m[3][3])
  * Returns the elementary rotation matrix about the
  * third body axis.
  */
-void Euler3(double x, double m[3][3])
-{
+void Euler3(double x, double m[3][3]) {
     m33SetIdentity(m);
     m[0][0] = cos(x);
     m[0][1] = sin(x);
@@ -2282,8 +2176,7 @@ void Euler3(double x, double m[3][3])
  * matrix in terms of the 1-2-1 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler1212C(double *q, double C[3][3])
-{
+void Euler1212C(double *q, double C[3][3]) {
     double st1;
     double ct1;
     double st2;
@@ -2313,8 +2206,7 @@ void Euler1212C(double *q, double C[3][3])
  * Euler1212EP(E,Q) translates the 121 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler1212EP(double *e, double *q)
-{
+void Euler1212EP(double *e, double *q) {
     double e1;
     double e2;
     double e3;
@@ -2333,8 +2225,7 @@ void Euler1212EP(double *e, double *q)
  * Euler1212Gibbs(E,Q) translates the (1-2-1) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler1212Gibbs(double *e, double *q)
-{
+void Euler1212Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler1212EP(e, ep);
@@ -2345,8 +2236,7 @@ void Euler1212Gibbs(double *e, double *q)
  * Euler1212MRP(E,Q) translates the (1-2-1) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler1212MRP(double *e, double *q)
-{
+void Euler1212MRP(double *e, double *q) {
     double ep[4];
 
     Euler1212EP(e, ep);
@@ -2357,8 +2247,7 @@ void Euler1212MRP(double *e, double *q)
  * Euler1212PRV(E,Q) translates the (1-2-1) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler1212PRV(double *e, double *q)
-{
+void Euler1212PRV(double *e, double *q) {
     double ep[4];
 
     Euler1212EP(e, ep);
@@ -2370,8 +2259,7 @@ void Euler1212PRV(double *e, double *q)
  * matrix in terms of the 1-2-3 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler1232C(double *q, double C[3][3])
-{
+void Euler1232C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2401,8 +2289,7 @@ void Euler1232C(double *q, double C[3][3])
  * Euler1232EP(E,Q) translates the 123 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler1232EP(double *e, double *q)
-{
+void Euler1232EP(double *e, double *q) {
     double c1;
     double c2;
     double c3;
@@ -2427,8 +2314,7 @@ void Euler1232EP(double *e, double *q)
  * Euler1232Gibbs(E,Q) translates the (1-2-3) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler1232Gibbs(double *e, double *q)
-{
+void Euler1232Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler1232EP(e, ep);
@@ -2439,8 +2325,7 @@ void Euler1232Gibbs(double *e, double *q)
  * Euler1232MRP(E,Q) translates the (1-2-3) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler1232MRP(double *e, double *q)
-{
+void Euler1232MRP(double *e, double *q) {
     double ep[4];
 
     Euler1232EP(e, ep);
@@ -2451,8 +2336,7 @@ void Euler1232MRP(double *e, double *q)
  * Euler1232PRV(E,Q) translates the (1-2-3) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler1232PRV(double *e, double *q)
-{
+void Euler1232PRV(double *e, double *q) {
     double ep[4];
 
     Euler1232EP(e, ep);
@@ -2464,8 +2348,7 @@ void Euler1232PRV(double *e, double *q)
  * matrix in terms of the 1-3-1 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler1312C(double *q, double C[3][3])
-{
+void Euler1312C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2495,8 +2378,7 @@ void Euler1312C(double *q, double C[3][3])
  * Euler1312EP(E,Q) translates the 131 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler1312EP(double *e, double *q)
-{
+void Euler1312EP(double *e, double *q) {
     double e1;
     double e2;
     double e3;
@@ -2515,8 +2397,7 @@ void Euler1312EP(double *e, double *q)
  * Euler1312Gibbs(E,Q) translates the (1-3-1) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler1312Gibbs(double *e, double *q)
-{
+void Euler1312Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler1312EP(e, ep);
@@ -2527,8 +2408,7 @@ void Euler1312Gibbs(double *e, double *q)
  * Euler1312MRP(E,Q) translates the (1-3-1) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler1312MRP(double *e, double *q)
-{
+void Euler1312MRP(double *e, double *q) {
     double ep[4];
 
     Euler1312EP(e, ep);
@@ -2539,8 +2419,7 @@ void Euler1312MRP(double *e, double *q)
  * Euler1312PRV(E,Q) translates the (1-3-1) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler1312PRV(double *e, double *q)
-{
+void Euler1312PRV(double *e, double *q) {
     double ep[4];
 
     Euler1312EP(e, ep);
@@ -2552,8 +2431,7 @@ void Euler1312PRV(double *e, double *q)
  * matrix in terms of the 1-3-2 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler1322C(double *q, double C[3][3])
-{
+void Euler1322C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2583,8 +2461,7 @@ void Euler1322C(double *q, double C[3][3])
  * Euler1322EP(E,Q) translates the 132 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler1322EP(double *e, double *q)
-{
+void Euler1322EP(double *e, double *q) {
     double c1;
     double c2;
     double c3;
@@ -2609,8 +2486,7 @@ void Euler1322EP(double *e, double *q)
  * Euler1322Gibbs(E,Q) translates the (1-3-2) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler1322Gibbs(double *e, double *q)
-{
+void Euler1322Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler1322EP(e, ep);
@@ -2621,8 +2497,7 @@ void Euler1322Gibbs(double *e, double *q)
  * Euler1322MRP(E,Q) translates the (1-3-2) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler1322MRP(double *e, double *q)
-{
+void Euler1322MRP(double *e, double *q) {
     double ep[4];
 
     Euler1322EP(e, ep);
@@ -2633,8 +2508,7 @@ void Euler1322MRP(double *e, double *q)
  * Euler1322PRV(E,Q) translates the (1-3-2) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler1322PRV(double *e, double *q)
-{
+void Euler1322PRV(double *e, double *q) {
     double ep[4];
 
     Euler1322EP(e, ep);
@@ -2646,8 +2520,7 @@ void Euler1322PRV(double *e, double *q)
  * matrix in terms of the 2-1-2 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler2122C(double *q, double C[3][3])
-{
+void Euler2122C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2677,8 +2550,7 @@ void Euler2122C(double *q, double C[3][3])
  * Euler2122EP(E,Q) translates the 212 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler2122EP(double *e, double *q)
-{
+void Euler2122EP(double *e, double *q) {
     double e1;
     double e2;
     double e3;
@@ -2697,8 +2569,7 @@ void Euler2122EP(double *e, double *q)
  * Euler2122Gibbs(E,Q) translates the (2-1-2) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler2122Gibbs(double *e, double *q)
-{
+void Euler2122Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler2122EP(e, ep);
@@ -2709,8 +2580,7 @@ void Euler2122Gibbs(double *e, double *q)
  * Euler2122MRP(E,Q) translates the (2-1-2) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler2122MRP(double *e, double *q)
-{
+void Euler2122MRP(double *e, double *q) {
     double ep[4];
 
     Euler2122EP(e, ep);
@@ -2721,8 +2591,7 @@ void Euler2122MRP(double *e, double *q)
  * Euler2122PRV(E,Q) translates the (2-1-2) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler2122PRV(double *e, double *q)
-{
+void Euler2122PRV(double *e, double *q) {
     double ep[4];
 
     Euler2122EP(e, ep);
@@ -2734,8 +2603,7 @@ void Euler2122PRV(double *e, double *q)
  * matrix in terms of the 2-1-3 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler2132C(double *q, double C[3][3])
-{
+void Euler2132C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2765,8 +2633,7 @@ void Euler2132C(double *q, double C[3][3])
  * Euler2132EP(E,Q) translates the 213 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler2132EP(double *e, double *q)
-{
+void Euler2132EP(double *e, double *q) {
     double c1;
     double c2;
     double c3;
@@ -2791,8 +2658,7 @@ void Euler2132EP(double *e, double *q)
  * Euler2132Gibbs(E,Q) translates the (2-1-3) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler2132Gibbs(double *e, double *q)
-{
+void Euler2132Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler2132EP(e, ep);
@@ -2803,8 +2669,7 @@ void Euler2132Gibbs(double *e, double *q)
  * Euler2132MRP(E,Q) translates the (2-1-3) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler2132MRP(double *e, double *q)
-{
+void Euler2132MRP(double *e, double *q) {
     double ep[4];
 
     Euler2132EP(e, ep);
@@ -2815,8 +2680,7 @@ void Euler2132MRP(double *e, double *q)
  * Euler2132PRV(E,Q) translates the (2-1-3) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler2132PRV(double *e, double *q)
-{
+void Euler2132PRV(double *e, double *q) {
     double ep[4];
 
     Euler2132EP(e, ep);
@@ -2828,8 +2692,7 @@ void Euler2132PRV(double *e, double *q)
  * matrix in terms of the 2-3-1 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler2312C(double *q, double C[3][3])
-{
+void Euler2312C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2859,8 +2722,7 @@ void Euler2312C(double *q, double C[3][3])
  * Euler2312EP(E,Q) translates the 231 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler2312EP(double *e, double *q)
-{
+void Euler2312EP(double *e, double *q) {
     double c1;
     double c2;
     double c3;
@@ -2885,8 +2747,7 @@ void Euler2312EP(double *e, double *q)
  * Euler2312Gibbs(E,Q) translates the (2-3-1) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler2312Gibbs(double *e, double *q)
-{
+void Euler2312Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler2312EP(e, ep);
@@ -2897,8 +2758,7 @@ void Euler2312Gibbs(double *e, double *q)
  * Euler2312MRP(E,Q) translates the (2-3-1) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler2312MRP(double *e, double *q)
-{
+void Euler2312MRP(double *e, double *q) {
     double ep[4];
 
     Euler2312EP(e, ep);
@@ -2909,8 +2769,7 @@ void Euler2312MRP(double *e, double *q)
  * Euler2312PRV(E,Q) translates the (2-3-1) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler2312PRV(double *e, double *q)
-{
+void Euler2312PRV(double *e, double *q) {
     double ep[4];
 
     Euler2312EP(e, ep);
@@ -2922,8 +2781,7 @@ void Euler2312PRV(double *e, double *q)
  * matrix in terms of the 2-3-2 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler2322C(double *q, double C[3][3])
-{
+void Euler2322C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -2950,11 +2808,10 @@ void Euler2322C(double *q, double C[3][3])
 }
 
 /*
-* Euler2322EP(E,Q) translates the 232 Euler angle
-* vector E into the Euler parameter vector Q.
-*/
-void Euler2322EP(double *e, double *q)
-{
+ * Euler2322EP(E,Q) translates the 232 Euler angle
+ * vector E into the Euler parameter vector Q.
+ */
+void Euler2322EP(double *e, double *q) {
     double e1;
     double e2;
     double e3;
@@ -2973,8 +2830,7 @@ void Euler2322EP(double *e, double *q)
  * Euler2322Gibbs(E) translates the (2-3-2) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler2322Gibbs(double *e, double *q)
-{
+void Euler2322Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler2322EP(e, ep);
@@ -2985,8 +2841,7 @@ void Euler2322Gibbs(double *e, double *q)
  * Euler2322MRP(E,Q) translates the (2-3-2) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler2322MRP(double *e, double *q)
-{
+void Euler2322MRP(double *e, double *q) {
     double ep[4];
 
     Euler2322EP(e, ep);
@@ -2997,8 +2852,7 @@ void Euler2322MRP(double *e, double *q)
  * Euler2322PRV(E,Q) translates the (2-3-2) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler2322PRV(double *e, double *q)
-{
+void Euler2322PRV(double *e, double *q) {
     double ep[4];
 
     Euler2322EP(e, ep);
@@ -3010,8 +2864,7 @@ void Euler2322PRV(double *e, double *q)
  * matrix in terms of the 1-2-3 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler3122C(double *q, double C[3][3])
-{
+void Euler3122C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -3041,8 +2894,7 @@ void Euler3122C(double *q, double C[3][3])
  * Euler3122EP(E,Q) translates the 312 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler3122EP(double *e, double *q)
-{
+void Euler3122EP(double *e, double *q) {
     double c1;
     double c2;
     double c3;
@@ -3067,8 +2919,7 @@ void Euler3122EP(double *e, double *q)
  * Euler3122Gibbs(E,Q) translates the (3-1-2) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler3122Gibbs(double *e, double *q)
-{
+void Euler3122Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler3122EP(e, ep);
@@ -3079,8 +2930,7 @@ void Euler3122Gibbs(double *e, double *q)
  * Euler3122MRP(E,Q) translates the (3-1-2) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler3122MRP(double *e, double *q)
-{
+void Euler3122MRP(double *e, double *q) {
     double ep[4];
 
     Euler3122EP(e, ep);
@@ -3091,8 +2941,7 @@ void Euler3122MRP(double *e, double *q)
  * Euler3122PRV(E,Q) translates the (3-1-2) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler3122PRV(double *e, double *q)
-{
+void Euler3122PRV(double *e, double *q) {
     double ep[4];
 
     Euler3122EP(e, ep);
@@ -3104,8 +2953,7 @@ void Euler3122PRV(double *e, double *q)
  * matrix in terms of the 3-1-3 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler3132C(double *q, double C[3][3])
-{
+void Euler3132C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -3135,8 +2983,7 @@ void Euler3132C(double *q, double C[3][3])
  * Euler3132EP(E,Q) translates the 313 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler3132EP(double *e, double *q)
-{
+void Euler3132EP(double *e, double *q) {
     double e1;
     double e2;
     double e3;
@@ -3155,8 +3002,7 @@ void Euler3132EP(double *e, double *q)
  * Euler3132Gibbs(E,Q) translates the (3-1-3) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler3132Gibbs(double *e, double *q)
-{
+void Euler3132Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler3132EP(e, ep);
@@ -3167,8 +3013,7 @@ void Euler3132Gibbs(double *e, double *q)
  * Euler3132MRP(E,Q) translates the (3-1-3) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler3132MRP(double *e, double *q)
-{
+void Euler3132MRP(double *e, double *q) {
     double ep[4];
 
     Euler3132EP(e, ep);
@@ -3179,8 +3024,7 @@ void Euler3132MRP(double *e, double *q)
  * Euler3132PRV(E,Q) translates the (3-1-3) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler3132PRV(double *e, double *q)
-{
+void Euler3132PRV(double *e, double *q) {
     double ep[4];
 
     Euler3132EP(e, ep);
@@ -3192,8 +3036,7 @@ void Euler3132PRV(double *e, double *q)
  * matrix in terms of the 3-2-1 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler3212C(double *q, double C[3][3])
-{
+void Euler3212C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -3223,8 +3066,7 @@ void Euler3212C(double *q, double C[3][3])
  * Euler3212EPE,Q) translates the 321 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler3212EP(double *e, double *q)
-{
+void Euler3212EP(double *e, double *q) {
     double c1;
     double c2;
     double c3;
@@ -3249,8 +3091,7 @@ void Euler3212EP(double *e, double *q)
  * Euler3212Gibbs(E,Q) translates the (3-2-1) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler3212Gibbs(double *e, double *q)
-{
+void Euler3212Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler3212EP(e, ep);
@@ -3261,8 +3102,7 @@ void Euler3212Gibbs(double *e, double *q)
  * Euler3212MRP(E,Q) translates the (3-2-1) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler3212MRP(double *e, double *q)
-{
+void Euler3212MRP(double *e, double *q) {
     double ep[4];
 
     Euler3212EP(e, ep);
@@ -3273,8 +3113,7 @@ void Euler3212MRP(double *e, double *q)
  * Euler3212PRV(E,Q) translates the (3-2-1) Euler
  * angle vector E into the principal rotation vector Q.
  */
-void Euler3212PRV(double *e, double *q)
-{
+void Euler3212PRV(double *e, double *q) {
     double ep[4];
 
     Euler3212EP(e, ep);
@@ -3286,8 +3125,7 @@ void Euler3212PRV(double *e, double *q)
  * matrix in terms of the 3-2-3 Euler angles.
  * Input Q must be a 3x1 vector of Euler angles.
  */
-void Euler3232C(double *q, double C[3][3])
-{
+void Euler3232C(double *q, double C[3][3]) {
     double st1;
     double st2;
     double st3;
@@ -3317,8 +3155,7 @@ void Euler3232C(double *q, double C[3][3])
  * Euler3232EP(E,Q) translates the 323 Euler angle
  * vector E into the Euler parameter vector Q.
  */
-void Euler3232EP(double *e, double *q)
-{
+void Euler3232EP(double *e, double *q) {
     double e1;
     double e2;
     double e3;
@@ -3337,8 +3174,7 @@ void Euler3232EP(double *e, double *q)
  * Euler3232Gibbs(E,Q) translates the (3-2-3) Euler
  * angle vector E into the Gibbs vector Q.
  */
-void Euler3232Gibbs(double *e, double *q)
-{
+void Euler3232Gibbs(double *e, double *q) {
     double ep[4];
 
     Euler3232EP(e, ep);
@@ -3349,8 +3185,7 @@ void Euler3232Gibbs(double *e, double *q)
  * Euler3232MRP(E,Q) translates the (3-2-3) Euler
  * angle vector E into the MRP vector Q.
  */
-void Euler3232MRP(double *e, double *q)
-{
+void Euler3232MRP(double *e, double *q) {
     double ep[4];
 
     Euler3232EP(e, ep);
@@ -3361,8 +3196,7 @@ void Euler3232MRP(double *e, double *q)
  * Euler3232PRV(E,Q) translates the (3-2-3) Euler
  * angle vector Q1 into the principal rotation vector Q.
  */
-void Euler3232PRV(double *e, double *q)
-{
+void Euler3232PRV(double *e, double *q) {
     double ep[4];
 
     Euler3232EP(e, ep);
@@ -3373,8 +3207,7 @@ void Euler3232PRV(double *e, double *q)
  * Gibbs2C(Q,C) returns the direction cosine
  * matrix in terms of the 3x1 Gibbs vector Q.
  */
-void Gibbs2C(double *q, double C[3][3])
-{
+void Gibbs2C(double *q, double C[3][3]) {
     double q1;
     double q2;
     double q3;
@@ -3401,8 +3234,7 @@ void Gibbs2C(double *q, double C[3][3])
  * Gibbs2EP(Q1,Q) translates the Gibbs vector Q1
  * into the Euler parameter vector Q.
  */
-void Gibbs2EP(double *q1, double *q)
-{
+void Gibbs2EP(double *q1, double *q) {
     q[0] = 1 / sqrt(1 + v3Dot(q1, q1));
     q[1] = q1[0] * q[0];
     q[2] = q1[1] * q[0];
@@ -3413,8 +3245,7 @@ void Gibbs2EP(double *q1, double *q)
  * Gibbs2Euler121(Q,E) translates the Gibbs
  * vector Q into the (1-2-1) Euler angle vector E.
  */
-void Gibbs2Euler121(double *q, double *e)
-{
+void Gibbs2Euler121(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3425,8 +3256,7 @@ void Gibbs2Euler121(double *q, double *e)
  * Gibbs2Euler123(Q,E) translates the Gibbs
  * vector Q into the (1-2-3) Euler angle vector E.
  */
-void Gibbs2Euler123(double *q, double *e)
-{
+void Gibbs2Euler123(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3437,8 +3267,7 @@ void Gibbs2Euler123(double *q, double *e)
  * Gibbs2Euler131(Q,E) translates the Gibbs
  * vector Q into the (1-3-1) Euler angle vector E.
  */
-void Gibbs2Euler131(double *q, double *e)
-{
+void Gibbs2Euler131(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3449,8 +3278,7 @@ void Gibbs2Euler131(double *q, double *e)
  * Gibbs2Euler132(Q,E) translates the Gibbs
  * vector Q into the (1-3-2) Euler angle vector E.
  */
-void Gibbs2Euler132(double *q, double *e)
-{
+void Gibbs2Euler132(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3461,8 +3289,7 @@ void Gibbs2Euler132(double *q, double *e)
  * Gibbs2Euler212(Q,E) translates the Gibbs
  * vector Q into the (2-1-2) Euler angle vector E.
  */
-void Gibbs2Euler212(double *q, double *e)
-{
+void Gibbs2Euler212(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3473,8 +3300,7 @@ void Gibbs2Euler212(double *q, double *e)
  * Gibbs2Euler213(Q,E) translates the Gibbs
  * vector Q into the (2-1-3) Euler angle vector E.
  */
-void Gibbs2Euler213(double *q, double *e)
-{
+void Gibbs2Euler213(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3485,8 +3311,7 @@ void Gibbs2Euler213(double *q, double *e)
  * Gibbs2Euler231(Q,E) translates the Gibbs
  * vector Q into the (2-3-1) Euler angle vector E.
  */
-void Gibbs2Euler231(double *q, double *e)
-{
+void Gibbs2Euler231(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3497,8 +3322,7 @@ void Gibbs2Euler231(double *q, double *e)
  * Gibbs2Euler232(Q,E) translates the Gibbs
  * vector Q into the (2-3-2) Euler angle vector E.
  */
-void Gibbs2Euler232(double *q, double *e)
-{
+void Gibbs2Euler232(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3509,8 +3333,7 @@ void Gibbs2Euler232(double *q, double *e)
  * Gibbs2Euler312(Q,E) translates the Gibbs
  * vector Q into the (3-1-2) Euler angle vector E.
  */
-void Gibbs2Euler312(double *q, double *e)
-{
+void Gibbs2Euler312(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3521,8 +3344,7 @@ void Gibbs2Euler312(double *q, double *e)
  * Gibbs2Euler313(Q,E) translates the Gibbs
  * vector Q into the (3-1-3) Euler angle vector E.
  */
-void Gibbs2Euler313(double *q, double *e)
-{
+void Gibbs2Euler313(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3533,8 +3355,7 @@ void Gibbs2Euler313(double *q, double *e)
  * Gibbs2Euler321(Q,E) translates the Gibbs
  * vector Q into the (3-2-1) Euler angle vector E.
  */
-void Gibbs2Euler321(double *q, double *e)
-{
+void Gibbs2Euler321(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3545,8 +3366,7 @@ void Gibbs2Euler321(double *q, double *e)
  * Gibbs2Euler323(Q,E) translates the Gibbs
  * vector Q into the (3-2-3) Euler angle vector E.
  */
-void Gibbs2Euler323(double *q, double *e)
-{
+void Gibbs2Euler323(double *q, double *e) {
     double ep[4];
 
     Gibbs2EP(q, ep);
@@ -3557,17 +3377,13 @@ void Gibbs2Euler323(double *q, double *e)
  * Gibbs2MRP(Q1,Q) translates the Gibbs vector Q1
  * into the MRP vector Q.
  */
-void Gibbs2MRP(double *q1, double *q)
-{
-    v3Scale(1.0 / (1 + sqrt(1 + v3Dot(q1, q1))), q1, q);
-}
+void Gibbs2MRP(double *q1, double *q) { v3Scale(1.0 / (1 + sqrt(1 + v3Dot(q1, q1))), q1, q); }
 
 /*
  * Gibbs2PRV(Q1,Q) translates the Gibbs vector Q1
  * into the principal rotation vector Q.
  */
-void Gibbs2PRV(double *q1, double *q)
-{
+void Gibbs2PRV(double *q1, double *q) {
     double tp;
     double p;
 
@@ -3588,8 +3404,7 @@ void Gibbs2PRV(double *q1, double *q)
  * MRP2C(Q,C) returns the direction cosine
  * matrix in terms of the 3x1 MRP vector Q.
  */
-void MRP2C(double *q, double C[3][3])
-{
+void MRP2C(double *q, double C[3][3]) {
     double q1;
     double q2;
     double q3;
@@ -3620,8 +3435,7 @@ void MRP2C(double *q, double C[3][3])
  * MRP2EP(Q1,Q) translates the MRP vector Q1
  * into the Euler parameter vector Q.
  */
-void MRP2EP(double *q1, double *q)
-{
+void MRP2EP(double *q1, double *q) {
     double ps;
 
     ps = 1 + v3Dot(q1, q1);
@@ -3635,8 +3449,7 @@ void MRP2EP(double *q1, double *q)
  * MRP2Euler121(Q,E) translates the MRP
  * vector Q into the (1-2-1) Euler angle vector E.
  */
-void MRP2Euler121(double *q, double *e)
-{
+void MRP2Euler121(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3647,8 +3460,7 @@ void MRP2Euler121(double *q, double *e)
  * MRP2Euler123(Q,E) translates the MRP
  * vector Q into the (1-2-3) Euler angle vector E.
  */
-void MRP2Euler123(double *q, double *e)
-{
+void MRP2Euler123(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3659,8 +3471,7 @@ void MRP2Euler123(double *q, double *e)
  * MRP2Euler131(Q,E) translates the MRP
  * vector Q into the (1-3-1) Euler angle vector E.
  */
-void MRP2Euler131(double *q, double *e)
-{
+void MRP2Euler131(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3671,8 +3482,7 @@ void MRP2Euler131(double *q, double *e)
  * MRP2Euler132(Q,E) translates the MRP
  * vector Q into the (1-3-2) Euler angle vector E.
  */
-void MRP2Euler132(double *q, double *e)
-{
+void MRP2Euler132(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3683,8 +3493,7 @@ void MRP2Euler132(double *q, double *e)
  * E = MRP2Euler212(Q) translates the MRP
  * vector Q into the (2-1-2) Euler angle vector E.
  */
-void MRP2Euler212(double *q, double *e)
-{
+void MRP2Euler212(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3695,8 +3504,7 @@ void MRP2Euler212(double *q, double *e)
  * MRP2Euler213(Q,E) translates the MRP
  * vector Q into the (2-1-3) Euler angle vector E.
  */
-void MRP2Euler213(double *q, double *e)
-{
+void MRP2Euler213(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3707,8 +3515,7 @@ void MRP2Euler213(double *q, double *e)
  * MRP2Euler231(Q,E) translates the MRP
  * vector Q into the (2-3-1) Euler angle vector E.
  */
-void MRP2Euler231(double *q, double *e)
-{
+void MRP2Euler231(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3719,8 +3526,7 @@ void MRP2Euler231(double *q, double *e)
  * MRP2Euler232(Q,E) translates the MRP
  * vector Q into the (2-3-2) Euler angle vector E.
  */
-void MRP2Euler232(double *q, double *e)
-{
+void MRP2Euler232(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3731,8 +3537,7 @@ void MRP2Euler232(double *q, double *e)
  * MRP2Euler312(Q,E) translates the MRP
  * vector Q into the (3-1-2) Euler angle vector E.
  */
-void MRP2Euler312(double *q, double *e)
-{
+void MRP2Euler312(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3743,8 +3548,7 @@ void MRP2Euler312(double *q, double *e)
  * MRP2Euler313(Q,E) translates the MRP
  * vector Q into the (3-1-3) Euler angle vector E.
  */
-void MRP2Euler313(double *q, double *e)
-{
+void MRP2Euler313(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3755,8 +3559,7 @@ void MRP2Euler313(double *q, double *e)
  * MRP2Euler321(Q,E) translates the MRP
  * vector Q into the (3-2-1) Euler angle vector E.
  */
-void MRP2Euler321(double *q, double *e)
-{
+void MRP2Euler321(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3767,8 +3570,7 @@ void MRP2Euler321(double *q, double *e)
  * MRP2Euler323(Q,E) translates the MRP
  * vector Q into the (3-2-3) Euler angle vector E.
  */
-void MRP2Euler323(double *q, double *e)
-{
+void MRP2Euler323(double *q, double *e) {
     double ep[4];
 
     MRP2EP(q, ep);
@@ -3779,24 +3581,19 @@ void MRP2Euler323(double *q, double *e)
  * MRP2Gibbs(Q1,Q) translates the MRP vector Q1
  * into the Gibbs vector Q.
  */
-void MRP2Gibbs(double *q1, double *q)
-{
-    v3Scale(2. / (1. - v3Dot(q1, q1)), q1, q);
-}
+void MRP2Gibbs(double *q1, double *q) { v3Scale(2. / (1. - v3Dot(q1, q1)), q1, q); }
 
 /*
  * MRP2PRV(Q1,Q) translates the MRP vector Q1
  * into the principal rotation vector Q.
  */
-void MRP2PRV(double *q1, double *q)
-{
+void MRP2PRV(double *q1, double *q) {
     double tp;
     double p;
 
     tp = sqrt(v3Dot(q1, q1));
-    if(tp < nearZero)
-    {
-        memset(q, 0x0, 3*sizeof(double));
+    if (tp < nearZero) {
+        memset(q, 0x0, 3 * sizeof(double));
         return;
     }
     p = 4 * atan(tp);
@@ -3809,12 +3606,11 @@ void MRP2PRV(double *q1, double *q)
  * MRPswitch(Q,s2,s) checks to see if v3Norm(Q) is larger than s2.
  * If yes, then the MRP vector Q is mapped to its shadow set.
  */
-void MRPswitch(double *q, double s2, double *s)
-{
+void MRPswitch(double *q, double s2, double *s) {
     double q2;
 
     q2 = v3Dot(q, q);
-    if(q2 > s2 * s2) {
+    if (q2 > s2 * s2) {
         v3Scale(-1. / q2, q, s);
     } else {
         v3Copy(q, s);
@@ -3824,8 +3620,7 @@ void MRPswitch(double *q, double s2, double *s)
 /*
  * MRPshadow forces a switch from the current MRP to its shadow set
  */
-void MRPshadow(double *qIn, double *qOut)
-{
+void MRPshadow(double *qIn, double *qOut) {
     double q2;
 
     q2 = v3Dot(qIn, qIn);
@@ -3836,17 +3631,16 @@ void MRPshadow(double *qIn, double *qOut)
 /*
  * Makes sure that the angle x lies within +/- Pi.
  */
-double wrapToPi(double x)
-{
+double wrapToPi(double x) {
     double q;
 
     q = x;
 
-    if(x >  M_PI) {
+    if (x > M_PI) {
         q = x - 2 * M_PI;
     }
 
-    if(x < -M_PI) {
+    if (x < -M_PI) {
         q = x + 2 * M_PI;
     }
 
@@ -3858,8 +3652,7 @@ double wrapToPi(double x)
  * matrix in terms of the 3x1 principal rotation vector
  * Q.
  */
-void PRV2C(double *q, double C[3][3])
-{
+void PRV2C(double *q, double C[3][3]) {
     double q0;
     double q1;
     double q2;
@@ -3868,8 +3661,7 @@ void PRV2C(double *q, double C[3][3])
     double sp;
     double d1;
 
-    if(v3Norm(q) == 0.0)
-    {
+    if (v3Norm(q) == 0.0) {
         m33SetIdentity(C);
         return;
     }
@@ -3897,27 +3689,22 @@ void PRV2C(double *q, double C[3][3])
  * PRV2elem(R,Q) translates a prinicpal rotation vector R
  * into the corresponding principal rotation element set Q.
  */
-void PRV2elem(double *r, double *q)
-{
+void PRV2elem(double *r, double *q) {
     q[0] = sqrt(v3Dot(r, r));
-	if (q[0] < 1.0E-12)
-	{
-		q[1] = q[2] = q[3] = 0.0;
-	}
-	else
-	{
-		q[1] = r[0] / q[0];
-		q[2] = r[1] / q[0];
-		q[3] = r[2] / q[0];
-	}
+    if (q[0] < 1.0E-12) {
+        q[1] = q[2] = q[3] = 0.0;
+    } else {
+        q[1] = r[0] / q[0];
+        q[2] = r[1] / q[0];
+        q[3] = r[2] / q[0];
+    }
 }
 
 /*
  * PRV2EP(Q0,Q) translates the principal rotation vector Q1
  * into the Euler parameter vector Q.
  */
-void PRV2EP(double *q0, double *q)
-{
+void PRV2EP(double *q0, double *q) {
     double q1[4];
     double sp;
 
@@ -3933,8 +3720,7 @@ void PRV2EP(double *q0, double *q)
  * PRV2Euler121(Q,E) translates the principal rotation
  * vector Q into the (1-2-1) Euler angle vector E.
  */
-void PRV2Euler121(double *q, double *e)
-{
+void PRV2Euler121(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -3945,8 +3731,7 @@ void PRV2Euler121(double *q, double *e)
  * PRV2Euler123(Q,E) translates the principal rotation
  * vector Q into the (1-2-3) Euler angle vector E.
  */
-void PRV2Euler123(double *q, double *e)
-{
+void PRV2Euler123(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -3957,8 +3742,7 @@ void PRV2Euler123(double *q, double *e)
  * PRV2Euler131(Q,E) translates the principal rotation
  * vector Q into the (1-3-1) Euler angle vector E.
  */
-void PRV2Euler131(double *q, double *e)
-{
+void PRV2Euler131(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -3969,8 +3753,7 @@ void PRV2Euler131(double *q, double *e)
  * PRV2Euler132(Q,E) translates the principal rotation
  * vector Q into the (1-3-2) Euler angle vector E.
  */
-void PRV2Euler132(double *q, double *e)
-{
+void PRV2Euler132(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -3981,8 +3764,7 @@ void PRV2Euler132(double *q, double *e)
  * PRV2Euler212(Q,E) translates the principal rotation
  * vector Q into the (2-1-2) Euler angle vector E.
  */
-void PRV2Euler212(double *q, double *e)
-{
+void PRV2Euler212(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -3993,8 +3775,7 @@ void PRV2Euler212(double *q, double *e)
  * PRV2Euler213(Q,E) translates the principal rotation
  * vector Q into the (2-1-3) Euler angle vector E.
  */
-void PRV2Euler213(double *q, double *e)
-{
+void PRV2Euler213(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4005,8 +3786,7 @@ void PRV2Euler213(double *q, double *e)
  * PRV2Euler231(Q) translates the principal rotation
  * vector Q into the (2-3-1) Euler angle vector E.
  */
-void PRV2Euler231(double *q, double *e)
-{
+void PRV2Euler231(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4017,8 +3797,7 @@ void PRV2Euler231(double *q, double *e)
  * PRV2Euler232(Q,E) translates the principal rotation
  * vector Q into the (2-3-2) Euler angle vector E.
  */
-void PRV2Euler232(double *q, double *e)
-{
+void PRV2Euler232(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4029,8 +3808,7 @@ void PRV2Euler232(double *q, double *e)
  * PRV2Euler312(Q,E) translates the principal rotation
  * vector Q into the (3-1-2) Euler angle vector E.
  */
-void PRV2Euler312(double *q, double *e)
-{
+void PRV2Euler312(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4041,8 +3819,7 @@ void PRV2Euler312(double *q, double *e)
  * PRV2Euler313(Q,E) translates the principal rotation
  * vector Q into the (3-1-3) Euler angle vector E.
  */
-void PRV2Euler313(double *q, double *e)
-{
+void PRV2Euler313(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4053,8 +3830,7 @@ void PRV2Euler313(double *q, double *e)
  * PRV2Euler321(Q,E) translates the principal rotation
  * vector Q into the (3-2-1) Euler angle vector E.
  */
-void PRV2Euler321(double *q, double *e)
-{
+void PRV2Euler321(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4065,8 +3841,7 @@ void PRV2Euler321(double *q, double *e)
  * PRV2Euler323(Q,E) translates the principal rotation
  * vector Q into the (3-2-3) Euler angle vector E.
  */
-void PRV2Euler323(double *q, double *e)
-{
+void PRV2Euler323(double *q, double *e) {
     double ep[4];
 
     PRV2EP(q, ep);
@@ -4077,8 +3852,7 @@ void PRV2Euler323(double *q, double *e)
  * PRV2Gibbs(Q0,Q) translates the principal rotation vector Q1
  * into the Gibbs vector Q.
  */
-void PRV2Gibbs(double *q0, double *q)
-{
+void PRV2Gibbs(double *q0, double *q) {
     double q1[4];
     double tp;
 
@@ -4093,8 +3867,7 @@ void PRV2Gibbs(double *q0, double *q)
  * PRV2MRP(Q0,Q) translates the principal rotation vector Q1
  * into the MRP vector Q.
  */
-void PRV2MRP(double *q0, double *q)
-{
+void PRV2MRP(double *q0, double *q) {
     double q1[4];
     double tp;
 
@@ -4110,8 +3883,7 @@ void PRV2MRP(double *q0, double *q)
  * which corresponds to relative rotation from B2
  * to B1.
  */
-void subEP(double *b1, double *b2, double *q)
-{
+void subEP(double *b1, double *b2, double *q) {
     q[0] = b2[0] * b1[0] + b2[1] * b1[1] + b2[2] * b1[2] + b2[3] * b1[3];
     q[1] = -b2[1] * b1[0] + b2[0] * b1[1] + b2[3] * b1[2] - b2[2] * b1[3];
     q[2] = -b2[2] * b1[0] - b2[3] * b1[1] + b2[0] * b1[2] + b2[1] * b1[3];
@@ -4122,8 +3894,7 @@ void subEP(double *b1, double *b2, double *q)
  * subEuler121(E,E1,E2) computes the relative
  * (1-2-1) Euler angle vector from E1 to E.
  */
-void subEuler121(double *e, double *e1, double *e2)
-{
+void subEuler121(double *e, double *e1, double *e2) {
     double cp;
     double cp1;
     double sp;
@@ -4147,8 +3918,7 @@ void subEuler121(double *e, double *e1, double *e2)
  * subEuler123(E,E1,E2) computes the relative
  * (1-2-3) Euler angle vector from E1 to E.
  */
-void subEuler123(double *e, double *e1, double *e2)
-{
+void subEuler123(double *e, double *e1, double *e2) {
     double C[3][3];
     double C1[3][3];
     double C2[3][3];
@@ -4163,8 +3933,7 @@ void subEuler123(double *e, double *e1, double *e2)
  * subEuler131(E,E1,E2) computes the relative
  * (1-3-1) Euler angle vector from E1 to E.
  */
-void subEuler131(double *e, double *e1, double *e2)
-{
+void subEuler131(double *e, double *e1, double *e2) {
     double cp;
     double cp1;
     double sp;
@@ -4188,8 +3957,7 @@ void subEuler131(double *e, double *e1, double *e2)
  * subEuler132(E,E1,E2) computes the relative
  * (1-3-2) Euler angle vector from E1 to E.
  */
-void subEuler132(double *e, double *e1, double *e2)
-{
+void subEuler132(double *e, double *e1, double *e2) {
     double C[3][3];
     double C1[3][3];
     double C2[3][3];
@@ -4204,8 +3972,7 @@ void subEuler132(double *e, double *e1, double *e2)
  * subEuler212(E,E1,E2) computes the relative
  * (2-1-2) Euler angle vector from E1 to E.
  */
-void subEuler212(double *e, double *e1, double *e2)
-{
+void subEuler212(double *e, double *e1, double *e2) {
     double cp;
     double cp1;
     double sp;
@@ -4229,8 +3996,7 @@ void subEuler212(double *e, double *e1, double *e2)
  * subEuler213(E,E1,E2) computes the relative
  * (2-1-3) Euler angle vector from E1 to E.
  */
-void subEuler213(double *e, double *e1, double *e2)
-{
+void subEuler213(double *e, double *e1, double *e2) {
     double C[3][3];
     double C1[3][3];
     double C2[3][3];
@@ -4245,8 +4011,7 @@ void subEuler213(double *e, double *e1, double *e2)
  * subEuler231(E,E1,E2) computes the relative
  * (2-3-1) Euler angle vector from E1 to E.
  */
-void subEuler231(double *e, double *e1, double *e2)
-{
+void subEuler231(double *e, double *e1, double *e2) {
     double C[3][3];
     double C1[3][3];
     double C2[3][3];
@@ -4261,8 +4026,7 @@ void subEuler231(double *e, double *e1, double *e2)
  * subEuler232(E,E1,E2) computes the relative
  * (2-3-2) Euler angle vector from E1 to E.
  */
-void subEuler232(double *e, double *e1, double *e2)
-{
+void subEuler232(double *e, double *e1, double *e2) {
     double cp;
     double cp1;
     double sp;
@@ -4286,8 +4050,7 @@ void subEuler232(double *e, double *e1, double *e2)
  * subEuler312(E,E1,E2) computes the relative
  * (3-1-2) Euler angle vector from E1 to E.
  */
-void subEuler312(double *e, double *e1, double *e2)
-{
+void subEuler312(double *e, double *e1, double *e2) {
     double C[3][3];
     double C1[3][3];
     double C2[3][3];
@@ -4302,8 +4065,7 @@ void subEuler312(double *e, double *e1, double *e2)
  * subEuler313(E,E1,E2) computes the relative
  * (3-1-3) Euler angle vector from E1 to E.
  */
-void subEuler313(double *e, double *e1, double *e2)
-{
+void subEuler313(double *e, double *e1, double *e2) {
     double cp;
     double cp1;
     double sp;
@@ -4327,8 +4089,7 @@ void subEuler313(double *e, double *e1, double *e2)
  * subEuler321(E,E1,E2) computes the relative
  * (3-2-1) Euler angle vector from E1 to E.
  */
-void subEuler321(double *e, double *e1, double *e2)
-{
+void subEuler321(double *e, double *e1, double *e2) {
     double C[3][3];
     double C1[3][3];
     double C2[3][3];
@@ -4343,8 +4104,7 @@ void subEuler321(double *e, double *e1, double *e2)
  * subEuler323(E,E1,E2) computes the relative
  * (3-2-3) Euler angle vector from E1 to E.
  */
-void subEuler323(double *e, double *e1, double *e2)
-{
+void subEuler323(double *e, double *e1, double *e2) {
     double cp;
     double cp1;
     double sp;
@@ -4369,8 +4129,7 @@ void subEuler323(double *e, double *e1, double *e2)
  * which corresponds to relative rotation from Q2
  * to Q1.
  */
-void subGibbs(double *q1, double *q2, double *q)
-{
+void subGibbs(double *q1, double *q2, double *q) {
     double d1[3];
 
     v3Cross(q1, q2, d1);
@@ -4384,19 +4143,18 @@ void subGibbs(double *q1, double *q2, double *q)
  * which corresponds to relative rotation from Q2
  * to Q1.
  */
-void subMRP(double *q1, double *q2, double *q)
-{
+void subMRP(double *q1, double *q2, double *q) {
     double d1[3];
     double s1[3];
     double det;
     double mag;
 
     v3Copy(q1, s1);
-    det = (1. + v3Dot(s1, s1)*v3Dot(q2, q2) + 2.*v3Dot(s1, q2));
+    det = (1. + v3Dot(s1, s1) * v3Dot(q2, q2) + 2. * v3Dot(s1, q2));
     if (fabs(det) < 0.1) {
         mag = v3Dot(s1, s1);
-        v3Scale(-1.0/mag, s1, s1);
-        det = (1. + v3Dot(s1, s1)*v3Dot(q2, q2) + 2.*v3Dot(s1, q2));
+        v3Scale(-1.0 / mag, s1, s1);
+        det = (1. + v3Dot(s1, s1) * v3Dot(q2, q2) + 2. * v3Dot(s1, q2));
     }
 
     v3Cross(s1, q2, d1);
@@ -4409,10 +4167,9 @@ void subMRP(double *q1, double *q2, double *q)
 
     /* map MRP to inner set */
     mag = v3Dot(q, q);
-    if (mag > 1.0){
-        v3Scale(-1./mag, q, q);
+    if (mag > 1.0) {
+        v3Scale(-1. / mag, q, q);
     }
-
 }
 
 /*
@@ -4420,8 +4177,7 @@ void subMRP(double *q1, double *q2, double *q)
  * which corresponds to relative principal rotation from Q2
  * to Q1.
  */
-void subPRV(double *q10, double *q20, double *q)
-{
+void subPRV(double *q10, double *q20, double *q) {
     double q1[4];
     double q2[4];
     double cp1;
@@ -4442,7 +4198,7 @@ void subPRV(double *q10, double *q20, double *q)
     v3Copy(&(q1[1]), e1);
     v3Copy(&(q2[1]), e2);
 
-    p = 2.*safeAcos(cp1 * cp2 + sp1 * sp2 * v3Dot(e1, e2));
+    p = 2. * safeAcos(cp1 * cp2 + sp1 * sp2 * v3Dot(e1, e2));
     sp = sin(p / 2.);
 
     v3Cross(e1, e2, q1);
@@ -4458,45 +4214,44 @@ void subPRV(double *q10, double *q20, double *q)
  * Mi(theta, a, C) returns the rotation matrix corresponding
  * to a single axis rotation about axis a by the angle theta
  */
-void Mi(double theta, int a, double C[3][3])
-{
+void Mi(double theta, int a, double C[3][3]) {
     double c;
     double s;
 
     c = cos(theta);
     s = sin(theta);
 
-    switch(a) {
+    switch (a) {
         case 1:
             C[0][0] = 1.;
             C[0][1] = 0.;
             C[0][2] = 0.;
             C[1][0] = 0.;
-            C[1][1] =  c;
-            C[1][2] =  s;
+            C[1][1] = c;
+            C[1][2] = s;
             C[2][0] = 0.;
             C[2][1] = -s;
-            C[2][2] =  c;
+            C[2][2] = c;
             break;
 
         case 2:
-            C[0][0] =  c;
+            C[0][0] = c;
             C[0][1] = 0.;
             C[0][2] = -s;
             C[1][0] = 0.;
             C[1][1] = 1.;
             C[1][2] = 0.;
-            C[2][0] =  s;
+            C[2][0] = s;
             C[2][1] = 0.;
-            C[2][2] =  c;
+            C[2][2] = c;
             break;
 
         case 3:
-            C[0][0] =  c;
-            C[0][1] =  s;
+            C[0][0] = c;
+            C[0][1] = s;
             C[0][2] = 0.;
             C[1][0] = -s;
-            C[1][1] =  c;
+            C[1][1] = c;
             C[1][2] = 0.;
             C[2][0] = 0.;
             C[2][1] = 0.;
@@ -4511,8 +4266,7 @@ void Mi(double theta, int a, double C[3][3])
 /*
  * tilde(theta, mat) returns the the 3x3 cross product matrix
  */
-void   tilde(double *v, double mat[3][3])
-{
+void tilde(double *v, double mat[3][3]) {
     m33SetZero(mat);
     mat[0][1] = -v[2];
     mat[1][0] = v[2];

--- a/src/architecture/utilities/rigidBodyKinematics.c
+++ b/src/architecture/utilities/rigidBodyKinematics.c
@@ -19,9 +19,11 @@
 
 #include "rigidBodyKinematics.h"
 
-#include <assert.h>
-#include "linearAlgebra.h"
 #include "astroConstants.h"
+#include "linearAlgebra.h"
+#include "safeMath.h"
+
+#include <assert.h>
 #include <string.h>
 
 #define nearZero 0.0000000000001

--- a/src/architecture/utilities/safeMath.c
+++ b/src/architecture/utilities/safeMath.c
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "safeMath.h"
+
+#include <math.h>
+
+double safeAcos(double x) {
+    if (x < -1.0)
+        return acos(-1);
+    else if (x > 1.0)
+        return acos(1);
+    return acos(x);
+}
+
+double safeAsin(double x) {
+    if (x < -1.0)
+        return asin(-1);
+    else if (x > 1.0)
+        return asin(1);
+    return asin(x);
+}
+
+double safeSqrt(double x) {
+    if (x < 0.0) return 0.0;
+    return sqrt(x);
+}

--- a/src/architecture/utilities/safeMath.h
+++ b/src/architecture/utilities/safeMath.h
@@ -1,0 +1,35 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _SAFE_MATH_H_
+#define _SAFE_MATH_H_
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+double safeAcos(double x);
+double safeAsin(double x);
+double safeSqrt(double x);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.cpp
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.cpp
@@ -31,9 +31,7 @@ void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig, double
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void CssWlsEst::reset(uint64_t callTime)
-{
-
+void CssWlsEst::reset(uint64_t callTime) {
     // check that required messages have been included
     if (!this->cssConfigInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: cssWIsEst.cssConfigInMsg wasn't connected.");
@@ -44,8 +42,9 @@ void CssWlsEst::reset(uint64_t callTime)
 
     this->cssConfigInBuffer = this->cssConfigInMsg();
     if (this->cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
-        this->bskLogger.bskLog(BSK_ERROR, "cssWIsEst.cssDataInMsg.nCSS must not be greater than "
-                                                  "MAX_N_CSS_MEAS value.");
+        this->bskLogger.bskLog(BSK_ERROR,
+                               "cssWIsEst.cssDataInMsg.nCSS must not be greater than "
+                               "MAX_N_CSS_MEAS value.");
     }
 
     this->priorSignalAvailable = 0;
@@ -56,7 +55,6 @@ void CssWlsEst::reset(uint64_t callTime)
     v3SetZero(this->filtStatus.state);
     vSetZero(this->filtStatus.postFitRes, MAX_N_CSS_MEAS);
 
-
     /* Reset the prior time flag state.
      If zero, control time step not evaluated on the first function call */
     this->priorTime = 0;
@@ -64,24 +62,22 @@ void CssWlsEst::reset(uint64_t callTime)
     return;
 }
 
-
 /*! This method takes the parsed CSS sensor data and outputs an estimate of the
  sun vector in the ADCS body frame
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void CssWlsEst::updateState(uint64_t callTime)
-{
-    CSSArraySensorMsgPayload InputBuffer;        /* CSS measurements */
-    double H[MAX_NUM_CSS_SENSORS*3];             /* The predicted pointing vector for each measurement */
-    double y[MAX_NUM_CSS_SENSORS];               /* Measurements */
-    double W[MAX_NUM_CSS_SENSORS*MAX_NUM_CSS_SENSORS];  /* Matrix of measurement weights */
-    int status = 0;                              /* Quality of the module estimate */
-    double dOldDotNew;                           /* Intermediate value for dot product between new and old estimates for rate estimation */
-    double dHatNew[3];                           /* New normalized sun heading estimate */
-    double dHatOld[3];                           /* Prior normalized sun heading estimate */
-    double  dt;                                  /* [s] Control update period */
-    NavAttMsgPayload sunlineOutBuffer = {};               /* Output Nav message*/
+void CssWlsEst::updateState(uint64_t callTime) {
+    CSSArraySensorMsgPayload InputBuffer;                /* CSS measurements */
+    double H[MAX_NUM_CSS_SENSORS * 3];                   /* The predicted pointing vector for each measurement */
+    double y[MAX_NUM_CSS_SENSORS];                       /* Measurements */
+    double W[MAX_NUM_CSS_SENSORS * MAX_NUM_CSS_SENSORS]; /* Matrix of measurement weights */
+    int status = 0;                                      /* Quality of the module estimate */
+    double dOldDotNew; /* Intermediate value for dot product between new and old estimates for rate estimation */
+    double dHatNew[3]; /* New normalized sun heading estimate */
+    double dHatOld[3]; /* Prior normalized sun heading estimate */
+    double dt;         /* [s] Control update period */
+    NavAttMsgPayload sunlineOutBuffer = {}; /* Output Nav message*/
 
     /*! Message Read and Setup*/
     /*! - Read the input parsed CSS sensor data message*/
@@ -105,46 +101,40 @@ void CssWlsEst::updateState(uint64_t callTime)
     /*! -# Set inverse noise matrix */
     /*! -# increase the number of valid observations */
     /*! -# Otherwise just continue */
-    for(uint32_t i=0; i<this->cssConfigInBuffer.nCSS; i = i+1)
-    {
-        if(InputBuffer.CosValue[i] > this->sensorUseThresh)
-        {
+    for (uint32_t i = 0; i < this->cssConfigInBuffer.nCSS; i = i + 1) {
+        if (InputBuffer.CosValue[i] > this->sensorUseThresh) {
             v3Scale(this->cssConfigInBuffer.cssVals[i].CBias,
-                this->cssConfigInBuffer.cssVals[i].nHat_B, &H[this->numActiveCss*3]);
+                    this->cssConfigInBuffer.cssVals[i].nHat_B,
+                    &H[this->numActiveCss * 3]);
             y[this->numActiveCss] = InputBuffer.CosValue[i];
             this->numActiveCss = this->numActiveCss + 1;
-
         }
     }
 
     /*! Estimation Steps*/
     this->filtStatus = {};
 
-    if(this->numActiveCss == 0) /*! - If there is no sun, just quit*/
+    if (this->numActiveCss == 0) /*! - If there is no sun, just quit*/
     {
         /*! + If no CSS got a strong enough signal.  Sun estimation is not possible.  Return the zero vector instead */
-        v3SetZero(sunlineOutBuffer.vehSunPntBdy);       /* zero the sun heading to indicate now CSS info is available */
-        v3SetZero(sunlineOutBuffer.omega_BN_B);         /* zero the rate measure */
-        this->priorSignalAvailable = 0;                       /* reset the prior heading estimate flag */
-        computeWlsResiduals(InputBuffer.CosValue, &this->cssConfigInBuffer,
-                            sunlineOutBuffer.vehSunPntBdy, this->filtStatus.postFitRes);
+        v3SetZero(sunlineOutBuffer.vehSunPntBdy); /* zero the sun heading to indicate now CSS info is available */
+        v3SetZero(sunlineOutBuffer.omega_BN_B);   /* zero the rate measure */
+        this->priorSignalAvailable = 0;           /* reset the prior heading estimate flag */
+        computeWlsResiduals(
+            InputBuffer.CosValue, &this->cssConfigInBuffer, sunlineOutBuffer.vehSunPntBdy, this->filtStatus.postFitRes);
     } else {
         /*! - If at least one CSS got a strong enough signal.  Proceed with the sun heading estimation */
         /*! -# Configuration option to weight the measurements, otherwise set
          weighting matrix to identity*/
-        if(this->useWeights > 0)
-        {
+        if (this->useWeights > 0) {
             mDiag(y, this->numActiveCss, W);
-        }
-        else
-        {
+        } else {
             mSetIdentity(W, this->numActiveCss, this->numActiveCss);
         }
         /*! -# Get least squares fit for sun pointing vector*/
-        status = computeWlsmn((int) this->numActiveCss, H, W, y,
-                              sunlineOutBuffer.vehSunPntBdy);
-        computeWlsResiduals(InputBuffer.CosValue, &this->cssConfigInBuffer,
-                            sunlineOutBuffer.vehSunPntBdy, this->filtStatus.postFitRes);
+        status = computeWlsmn((int)this->numActiveCss, H, W, y, sunlineOutBuffer.vehSunPntBdy);
+        computeWlsResiduals(
+            InputBuffer.CosValue, &this->cssConfigInBuffer, sunlineOutBuffer.vehSunPntBdy, this->filtStatus.postFitRes);
 
         v3Normalize(sunlineOutBuffer.vehSunPntBdy, sunlineOutBuffer.vehSunPntBdy);
 
@@ -153,12 +143,12 @@ void CssWlsEst::updateState(uint64_t callTime)
             v3Normalize(sunlineOutBuffer.vehSunPntBdy, dHatNew);
             v3Normalize(this->dOld, dHatOld);
             v3Cross(dHatNew, dHatOld, sunlineOutBuffer.omega_BN_B);
-            v3Normalize(sunlineOutBuffer.omega_BN_B,sunlineOutBuffer.omega_BN_B);
+            v3Normalize(sunlineOutBuffer.omega_BN_B, sunlineOutBuffer.omega_BN_B);
             /* compute principal rotation angle between sun heading measurements */
-            dOldDotNew = v3Dot(dHatNew,dHatOld);
+            dOldDotNew = v3Dot(dHatNew, dHatOld);
             if (dOldDotNew > 1.0) dOldDotNew = 1.0;
             if (dOldDotNew < -1.0) dOldDotNew = -1.0;
-            v3Scale(safeAcos(dOldDotNew)/dt, sunlineOutBuffer.omega_BN_B, sunlineOutBuffer.omega_BN_B);
+            v3Scale(safeAcos(dOldDotNew) / dt, sunlineOutBuffer.omega_BN_B, sunlineOutBuffer.omega_BN_B);
         } else {
             this->priorSignalAvailable = 1;
         }
@@ -169,19 +159,18 @@ void CssWlsEst::updateState(uint64_t callTime)
     /*! Residual Computation */
     /*! - If the residual fit output message is set, then compute the residuals and stor them in the output message */
     if (this->cssWLSFiltResOutMsg.isLinked()) {
-        this->filtStatus.numObs = (int) this->numActiveCss;
-        this->filtStatus.timeTag = (double) (callTime*NANO2SEC);
+        this->filtStatus.numObs = (int)this->numActiveCss;
+        this->filtStatus.timeTag = (double)(callTime * NANO2SEC);
         v3Copy(sunlineOutBuffer.vehSunPntBdy, this->filtStatus.state);
         this->cssWLSFiltResOutMsg.write(&this->filtStatus, this->moduleID, callTime);
-
     }
     /*! Writing Outputs */
-    if(status > 0) /*! - If the status from the WLS computation is erroneous, populate the output messages with zeros*/
+    if (status > 0) /*! - If the status from the WLS computation is erroneous, populate the output messages with zeros*/
     {
         /* An error was detected while attempting to compute the sunline direction */
-        v3SetZero(sunlineOutBuffer.vehSunPntBdy);       /* zero the sun heading to indicate anomaly  */
-        v3SetZero(sunlineOutBuffer.omega_BN_B);         /* zero the rate measure */
-        this->priorSignalAvailable = 0;                       /* reset the prior heading estimate flag */
+        v3SetZero(sunlineOutBuffer.vehSunPntBdy); /* zero the sun heading to indicate anomaly  */
+        v3SetZero(sunlineOutBuffer.omega_BN_B);   /* zero the rate measure */
+        this->priorSignalAvailable = 0;           /* reset the prior heading estimate flag */
     }
     /*! - If the status from the WLS computation good, populate the output messages with the computed data*/
     this->navStateOutMsg.write(&sunlineOutBuffer, this->moduleID, callTime);
@@ -197,15 +186,12 @@ void CssWlsEst::updateState(uint64_t callTime)
     @param wlsEst The WLS estimate computed for the CSS measurements
     @param cssResiduals The measurement residuals output by this function
 */
-void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig,
-                         double *wlsEst, double *cssResiduals)
-{
+void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig, double *wlsEst, double *cssResiduals) {
     double cssDotProd;
 
-    memset(cssResiduals, 0x0, cssConfig->nCSS*sizeof(double));
+    memset(cssResiduals, 0x0, cssConfig->nCSS * sizeof(double));
     /*! The method loops through the sensors and performs: */
-    for(uint32_t i=0; i<cssConfig->nCSS; i++)
-    {
+    for (uint32_t i = 0; i < cssConfig->nCSS; i++) {
         /*! -# A dot product between the computed estimate with each sensor normal */
         cssDotProd = v3Dot(wlsEst, cssConfig->cssVals[i].nHat_B);
         cssDotProd = cssDotProd > 0.0 ? cssDotProd : 0.0; /*CSS values can't be negative!*/
@@ -213,7 +199,6 @@ void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig,
         cssResiduals[i] = cssMeas[i] - cssDotProd;
         /*! -# This populates the post-fit residuals*/
     }
-
 }
 
 /*! This method computes a least squares fit with the given parameters.  It
@@ -226,25 +211,23 @@ void computeWlsResiduals(double *cssMeas, CSSConfigMsgPayload *cssConfig,
  @param y the observation vector for the valid sensors
  @param x The output least squares fit for the observations
  */
-int computeWlsmn(int numActiveCss, double *H, double *W,
-                 double *y, double x[3])
-{
-    double m22[2*2];
-    double m32[3*2];
+int computeWlsmn(int numActiveCss, double *H, double *W, double *y, double x[3]) {
+    double m22[2 * 2];
+    double m32[3 * 2];
     int status = 0;
-    double  m33[3*3];
-    double  m33_2[3*3];
-    double  m3N[3*MAX_NUM_CSS_SENSORS];
-    double  m3N_2[3*MAX_NUM_CSS_SENSORS];
+    double m33[3 * 3];
+    double m33_2[3 * 3];
+    double m3N[3 * MAX_NUM_CSS_SENSORS];
+    double m3N_2[3 * MAX_NUM_CSS_SENSORS];
     uint32_t i;
 
     /*! - If we only have one sensor, output best guess (cone of possiblities)*/
-    if(numActiveCss == 1) {
+    if (numActiveCss == 1) {
         /* Here's a guess.  Do with it what you will. */
-        for(i = 0; i < 3; i=i+1) {
-            x[i] = H[0*MAX_NUM_CSS_SENSORS+i] * y[0];
+        for (i = 0; i < 3; i = i + 1) {
+            x[i] = H[0 * MAX_NUM_CSS_SENSORS + i] * y[0];
         }
-    } else if(numActiveCss == 2) { /*! - If we have two, then do a 2x2 fit */
+    } else if (numActiveCss == 2) { /*! - If we have two, then do a 2x2 fit */
 
         /*!   -# Find minimum norm solution */
         mMultMt(H, 2, 3, H, 2, 3, m22);
@@ -252,16 +235,16 @@ int computeWlsmn(int numActiveCss, double *H, double *W,
         mtMultM(H, 2, 3, m22, 2, 2, m32);
         /*!   -# Multiply the Ht(HHt)^-1 by the observation vector to get fit*/
         mMultV(m32, 3, 2, y, x);
-    } else if(numActiveCss > 2) {/*! - If we have more than 2, do true LSQ fit*/
+    } else if (numActiveCss > 2) { /*! - If we have more than 2, do true LSQ fit*/
         /*!    -# Use the weights to compute (HtWH)^-1HW*/
-        mtMultM(H, (size_t) numActiveCss, 3, W, (size_t) numActiveCss, (size_t) numActiveCss, m3N);
-        mMultM(m3N, 3, (size_t) numActiveCss, H, (size_t) numActiveCss, 3, m33);
+        mtMultM(H, (size_t)numActiveCss, 3, W, (size_t)numActiveCss, (size_t)numActiveCss, m3N);
+        mMultM(m3N, 3, (size_t)numActiveCss, H, (size_t)numActiveCss, 3, m33);
         status = m33Inverse(RECAST3X3 m33, RECAST3X3 m33_2);
-        mMultMt(m33_2, 3, 3, H, (size_t) numActiveCss, 3, m3N);
-        mMultM(m3N, 3, (size_t) numActiveCss, W, (size_t) numActiveCss, (size_t) numActiveCss, m3N_2);
+        mMultMt(m33_2, 3, 3, H, (size_t)numActiveCss, 3, m3N);
+        mMultM(m3N, 3, (size_t)numActiveCss, W, (size_t)numActiveCss, (size_t)numActiveCss, m3N_2);
         /*!    -# Multiply the LSQ matrix by the obs vector for best fit*/
-        mMultV(m3N_2, 3, (size_t) numActiveCss, y, x);
+        mMultV(m3N_2, 3, (size_t)numActiveCss, y, x);
     }
 
-    return(status);
+    return (status);
 }

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.cpp
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.cpp
@@ -20,6 +20,7 @@
 #include "fswAlgorithms/attDetermination/CSSEst/cssWlsEst.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/safeMath.h"
 #include <string.h>
 
 int computeWlsmn(int numActiveCss, double *H, double *W, double *y, double x[3]);

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.h
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.h
@@ -22,38 +22,38 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/CSSArraySensorMsgPayload.h"
 #include "architecture/msgPayloadDefC/CSSConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/CSSUnitConfigMsgPayload.h"
-#include "architecture/msgPayloadDefC/CSSArraySensorMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/msgPayloadDefC/SunlineFilterMsgPayload.h"
 
 #include "architecture/utilities/bskLogging.h"
 #include <stdint.h>
 
-
 /*! @brief Top level structure for the CSS weighted least squares estimator.
  Used to estimate the sun state in the vehicle body frame*/
 class CssWlsEst : public SysModel {
-public:
+   public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 
-    ReadFunctor<CSSArraySensorMsgPayload> cssDataInMsg;                   //!< The name of the CSS sensor input message
-    ReadFunctor<CSSConfigMsgPayload> cssConfigInMsg;                      //!< The name of the CSS configuration input message
-    Message<NavAttMsgPayload> navStateOutMsg;                         //!< The name of the navigation output message containing the estimated states
-    Message<SunlineFilterMsgPayload> cssWLSFiltResOutMsg;             //!< The name of the CSS filter data out message
+    ReadFunctor<CSSArraySensorMsgPayload> cssDataInMsg;  //!< The name of the CSS sensor input message
+    ReadFunctor<CSSConfigMsgPayload> cssConfigInMsg;     //!< The name of the CSS configuration input message
+    Message<NavAttMsgPayload>
+        navStateOutMsg;  //!< The name of the navigation output message containing the estimated states
+    Message<SunlineFilterMsgPayload> cssWLSFiltResOutMsg;  //!< The name of the CSS filter data out message
 
-    uint32_t numActiveCss;                              //!< [-] Number of currently active CSS sensors
-    uint32_t useWeights;                                //!< Flag indicating whether or not to use weights for least squares
-    uint32_t priorSignalAvailable;                      //!< Flag indicating if a recent prior heading estimate is available
-    double dOld[3];                                     //!< The prior sun heading estimate
-    double sensorUseThresh;                             //!< Threshold below which we discount sensors
-    uint64_t priorTime;                                 //!< [ns] Last time the attitude control is called
-    CSSConfigMsgPayload cssConfigInBuffer;              //!< CSS constellation configuration message buffer
-    SunlineFilterMsgPayload filtStatus;                 //!< Filter message
+    uint32_t numActiveCss;                  //!< [-] Number of currently active CSS sensors
+    uint32_t useWeights;                    //!< Flag indicating whether or not to use weights for least squares
+    uint32_t priorSignalAvailable;          //!< Flag indicating if a recent prior heading estimate is available
+    double dOld[3];                         //!< The prior sun heading estimate
+    double sensorUseThresh;                 //!< Threshold below which we discount sensors
+    uint64_t priorTime;                     //!< [ns] Last time the attitude control is called
+    CSSConfigMsgPayload cssConfigInBuffer;  //!< CSS constellation configuration message buffer
+    SunlineFilterMsgPayload filtStatus;     //!< Filter message
 
-    BSKLogger bskLogger={};                               //!< BSK Logging
+    BSKLogger bskLogger = {};  //!< BSK Logging
 };
 
 #endif

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.h
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.h
@@ -32,8 +32,6 @@
 #include <stdint.h>
 
 
-
-
 /*! @brief Top level structure for the CSS weighted least squares estimator.
  Used to estimate the sun state in the vehicle body frame*/
 class CssWlsEst : public SysModel {

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.cpp
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.cpp
@@ -19,8 +19,8 @@
 
 #include "fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/safeMath.h"
 #include <string.h>
 
 /*! This method resets the sunline attitude filter to an initial state and

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.cpp
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.cpp
@@ -28,9 +28,7 @@
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void OkeefeEKF::reset(uint64_t callTime)
-{
-
+void OkeefeEKF::reset(uint64_t callTime) {
     CSSConfigMsgPayload cssConfigInBuffer;
 
     /*! - Zero the local configuration data structures and outputs */
@@ -48,21 +46,21 @@ void OkeefeEKF::reset(uint64_t callTime)
     /*! - Read in coarse sun sensor configuration information.*/
     cssConfigInBuffer = this->cssConfigInMsg();
     if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
-        this->bskLogger.bskLog(BSK_ERROR, "okeefeEKF.cssConfigInMsg.nCSS must not be greater than "
-                                                  "MAX_N_CSS_MEAS value.");
+        this->bskLogger.bskLog(BSK_ERROR,
+                               "okeefeEKF.cssConfigInMsg.nCSS must not be greater than "
+                               "MAX_N_CSS_MEAS value.");
     }
 
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
-    for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i++)
-    {
-        v3Copy(cssConfigInBuffer.cssVals[i].nHat_B, &(this->cssNHat_B[i*3]));
+    for (uint32_t i = 0; i < cssConfigInBuffer.nCSS; i++) {
+        v3Copy(cssConfigInBuffer.cssVals[i].nHat_B, &(this->cssNHat_B[i * 3]));
         this->CBias[i] = cssConfigInBuffer.cssVals[i].CBias;
     }
     /*! - Save the count of sun sensors for later use */
     this->numCSSTotal = cssConfigInBuffer.nCSS;
 
     /*! - Initialize filter parameters to max values */
-    this->timeTag = callTime*NANO2SEC;
+    this->timeTag = callTime * NANO2SEC;
     this->dt = 0.0;
     this->numStates = SKF_N_STATES_HALF;
     this->numObs = MAX_N_CSS_MEAS;
@@ -71,7 +69,7 @@ void OkeefeEKF::reset(uint64_t callTime)
     vSetZero(this->obs, this->numObs);
     vSetZero(this->yMeas, this->numObs);
     vSetZero(this->xBar, this->numStates);
-//    vSetZero(this->omega, this->numStates);
+    //    vSetZero(this->omega, this->numStates);
     vSetZero(this->prev_states, this->numStates);
 
     mSetZero(this->covarBar, this->numStates, this->numStates);
@@ -81,7 +79,7 @@ void OkeefeEKF::reset(uint64_t callTime)
     mSetZero(this->measNoise, this->numObs, this->numObs);
 
     mSetIdentity(this->stateTransition, this->numStates, this->numStates);
-    mSetIdentity(this->procNoise,  this->numStates, this->numStates);
+    mSetIdentity(this->procNoise, this->numStates, this->numStates);
     mScale(this->qProcVal, this->procNoise, this->numStates, this->numStates, this->procNoise);
 
     return;
@@ -92,8 +90,7 @@ void OkeefeEKF::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void OkeefeEKF::updateState(uint64_t callTime)
-{
+void OkeefeEKF::updateState(uint64_t callTime) {
     double newTimeTag;
     double Hx[MAX_N_CSS_MEAS];
     uint64_t timeOfMsgWritten;
@@ -108,41 +105,37 @@ void OkeefeEKF::updateState(uint64_t callTime)
     /*! - If the time tag from the measured data is new compared to previous step,
           propagate and update the filter*/
     newTimeTag = timeOfMsgWritten * NANO2SEC;
-    if(newTimeTag >= this->timeTag && isWritten)
-    {
+    if (newTimeTag >= this->timeTag && isWritten) {
         this->sunlineTimeUpdate(newTimeTag);
         this->sunlineMeasUpdate(newTimeTag);
     }
 
     /*! - If current clock time is further ahead than the measured time, then
           propagate to this current time-step*/
-    newTimeTag = callTime*NANO2SEC;
-    if(newTimeTag > this->timeTag)
-    {
+    newTimeTag = callTime * NANO2SEC;
+    if (newTimeTag > this->timeTag) {
         this->sunlineTimeUpdate(newTimeTag);
         vCopy(this->xBar, SKF_N_STATES_HALF, this->x);
         mCopy(this->covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, this->covar);
     }
 
     /* Compute post fit residuals once that data has been processed */
-    mMultM(this->measMat, (size_t) this->numObs, SKF_N_STATES, this->x, SKF_N_STATES, 1, Hx);
-    mSubtract(this->yMeas, (size_t) this->numObs, 1, Hx, this->postFits);
+    mMultM(this->measMat, (size_t)this->numObs, SKF_N_STATES, this->x, SKF_N_STATES, 1, Hx);
+    mSubtract(this->yMeas, (size_t)this->numObs, 1, Hx, this->postFits);
 
     /*! - Write the sunline estimate into the copy of the navigation message structure*/
-	v3Copy(this->state, this->outputSunline.vehSunPntBdy);
-    v3Normalize(this->outputSunline.vehSunPntBdy,
-        this->outputSunline.vehSunPntBdy);
+    v3Copy(this->state, this->outputSunline.vehSunPntBdy);
+    v3Normalize(this->outputSunline.vehSunPntBdy, this->outputSunline.vehSunPntBdy);
     this->outputSunline.timeTag = this->timeTag;
     this->navStateOutMsg.write(&this->outputSunline, this->moduleID, callTime);
 
     /*! - Populate the filter states output buffer and write the output message*/
     sunlineDataOutBuffer.timeTag = this->timeTag;
-    sunlineDataOutBuffer.numObs = (int) this->numObs;
-    memmove(sunlineDataOutBuffer.covar, this->covar,
-            SKF_N_STATES_HALF*SKF_N_STATES_HALF*sizeof(double));
-    memmove(sunlineDataOutBuffer.state, this->state, SKF_N_STATES*sizeof(double));
-    memmove(sunlineDataOutBuffer.stateError, this->x, SKF_N_STATES*sizeof(double));
-    memmove(sunlineDataOutBuffer.postFitRes, this->postFits, MAX_N_CSS_MEAS*sizeof(double));
+    sunlineDataOutBuffer.numObs = (int)this->numObs;
+    memmove(sunlineDataOutBuffer.covar, this->covar, SKF_N_STATES_HALF * SKF_N_STATES_HALF * sizeof(double));
+    memmove(sunlineDataOutBuffer.state, this->state, SKF_N_STATES * sizeof(double));
+    memmove(sunlineDataOutBuffer.stateError, this->x, SKF_N_STATES * sizeof(double));
+    memmove(sunlineDataOutBuffer.postFitRes, this->postFits, MAX_N_CSS_MEAS * sizeof(double));
     this->filtDataOutMsg.write(&sunlineDataOutBuffer, this->moduleID, callTime);
 
     return;
@@ -151,22 +144,20 @@ void OkeefeEKF::updateState(uint64_t callTime)
 /*! This method performs the time update for the sunline kalman filter.
      It calls for the updated Dynamics Matrix, as well as the new states and STM.
      It then updates the covariance, with process noise.
-	 @return void
+     @return void
      @param updateTime The time that we need to fix the filter to (seconds)
 */
-void OkeefeEKF::sunlineTimeUpdate(double updateTime)
-{
-    double stmT[SKF_N_STATES_HALF*SKF_N_STATES_HALF], covPhiT[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double qGammaT[SKF_N_STATES_HALF*SKF_N_STATES_HALF], gammaQGammaT[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
+void OkeefeEKF::sunlineTimeUpdate(double updateTime) {
+    double stmT[SKF_N_STATES_HALF * SKF_N_STATES_HALF], covPhiT[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double qGammaT[SKF_N_STATES_HALF * SKF_N_STATES_HALF], gammaQGammaT[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
 
-	/*! Compute time step */
-	this->dt = updateTime - this->timeTag;
+    /*! Compute time step */
+    this->dt = updateTime - this->timeTag;
 
     /*! - Propagate the previous reference states and STM to the current time */
     sunlineDynMatrixOkeefe(this->omega, this->dt, this->dynMat);
     sunlineStateSTMProp(this->dynMat, this->dt, this->omega, this->state, this->prev_states, this->stateTransition);
     sunlineRateCompute(this->state, this->dt, this->prev_states, this->omega);
-
 
     /* xbar = Phi*x */
     mMultV(this->stateTransition, SKF_N_STATES_HALF, SKF_N_STATES_HALF, this->x, this->xBar);
@@ -175,16 +166,24 @@ void OkeefeEKF::sunlineTimeUpdate(double updateTime)
     /*Pbar = Phi*P*Phi^T + Gamma*Q*Gamma^T*/
     mTranspose(this->stateTransition, SKF_N_STATES_HALF, SKF_N_STATES_HALF, stmT);
     mMultM(this->covar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, stmT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covPhiT);
-    mMultM(this->stateTransition, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covPhiT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, this->covarBar);
+    mMultM(this->stateTransition,
+           SKF_N_STATES_HALF,
+           SKF_N_STATES_HALF,
+           covPhiT,
+           SKF_N_STATES_HALF,
+           SKF_N_STATES_HALF,
+           this->covarBar);
 
     /*Compute Gamma and add gammaQGamma^T to Pbar. This is the process noise addition*/
-    double Gamma[3][3]={{this->dt*this->dt/2,0,0},{0,this->dt*this->dt/2,0},{0,0,this->dt*this->dt/2}};
+    double Gamma[3][3] = {
+        {this->dt * this->dt / 2, 0, 0}, {0, this->dt * this->dt / 2, 0}, {0, 0, this->dt * this->dt / 2}};
 
-    mMultMt(this->procNoise, SKF_N_STATES_HALF, SKF_N_STATES_HALF, Gamma, SKF_N_STATES_HALF, SKF_N_STATES_HALF, qGammaT);
+    mMultMt(
+        this->procNoise, SKF_N_STATES_HALF, SKF_N_STATES_HALF, Gamma, SKF_N_STATES_HALF, SKF_N_STATES_HALF, qGammaT);
     mMultM(Gamma, SKF_N_STATES_HALF, SKF_N_STATES_HALF, qGammaT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, gammaQGammaT);
     mAdd(this->covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, gammaQGammaT, this->covarBar);
 
-	this->timeTag = updateTime;
+    this->timeTag = updateTime;
 }
 
 /*! This method performs the measurement update for the sunline kalman filter.
@@ -193,54 +192,78 @@ void OkeefeEKF::sunlineTimeUpdate(double updateTime)
  @return void
  @param updateTime The time that we need to fix the filter to (seconds)
  */
-void OkeefeEKF::sunlineMeasUpdate(double updateTime)
-{
+void OkeefeEKF::sunlineMeasUpdate(double updateTime) {
     /*! - Compute the valid observations and the measurement model for all observations*/
-    int numObsInt = (int) this->numObs;
-    sunlineHMatrixYMeas(this->state, this->numCSSTotal, this->cssSensorInBuffer.CosValue, this->sensorUseThresh, this->cssNHat_B,
-                        this->CBias, this->obs, this->yMeas, &(numObsInt), this->measMat);
-    this->numObs = (size_t) numObsInt;
+    int numObsInt = (int)this->numObs;
+    sunlineHMatrixYMeas(this->state,
+                        this->numCSSTotal,
+                        this->cssSensorInBuffer.CosValue,
+                        this->sensorUseThresh,
+                        this->cssNHat_B,
+                        this->CBias,
+                        this->obs,
+                        this->yMeas,
+                        &(numObsInt),
+                        this->measMat);
+    this->numObs = (size_t)numObsInt;
 
     /*! - Compute the Kalman Gain. */
-    sunlineKalmanGainOkeefe(this->covarBar, this->measMat, this->qObsVal, (int) this->numObs, this->kalmanGain);
+    sunlineKalmanGainOkeefe(this->covarBar, this->measMat, this->qObsVal, (int)this->numObs, this->kalmanGain);
 
-    /* Logic to switch from EKF to CKF. If the covariance is too large, switching references through an EKF could lead to filter divergence in extreme cases. In order to remedy this, past a certain infinite norm of the covariance, we update with a CKF in order to bring down the covariance. */
+    /* Logic to switch from EKF to CKF. If the covariance is too large, switching references through an EKF could lead
+     * to filter divergence in extreme cases. In order to remedy this, past a certain infinite norm of the covariance,
+     * we update with a CKF in order to bring down the covariance. */
 
-    if (vMaxAbs(this->covar, SKF_N_STATES_HALF*SKF_N_STATES_HALF) > this->eKFSwitch){
-    /*! - Compute the update with a CKF */
-    sunlineCKFUpdateOkeefe(this->xBar, this->kalmanGain, this->covarBar, this->qObsVal, (int) this->numObs, this->yMeas, this->measMat, this->x,this->covar);
-    }
-    else{
-    /*! - Compute the update with a EKF, notice the reference state is added as an argument because it is changed by the filter update */
-    okeefeEKFUpdate(this->kalmanGain, this->covarBar, this->qObsVal, (int) this->numObs, this->yMeas, this->measMat, this->state, this->x, this->covar);
+    if (vMaxAbs(this->covar, SKF_N_STATES_HALF * SKF_N_STATES_HALF) > this->eKFSwitch) {
+        /*! - Compute the update with a CKF */
+        sunlineCKFUpdateOkeefe(this->xBar,
+                               this->kalmanGain,
+                               this->covarBar,
+                               this->qObsVal,
+                               (int)this->numObs,
+                               this->yMeas,
+                               this->measMat,
+                               this->x,
+                               this->covar);
+    } else {
+        /*! - Compute the update with a EKF, notice the reference state is added as an argument because it is changed by
+         * the filter update */
+        okeefeEKFUpdate(this->kalmanGain,
+                        this->covarBar,
+                        this->qObsVal,
+                        (int)this->numObs,
+                        this->yMeas,
+                        this->measMat,
+                        this->state,
+                        this->x,
+                        this->covar);
     }
 }
 
 /*! This method computes the rotation rate of the spacecraft by using the two previous state estimates.
-	@return void
+    @return void
     @param states Updated states
     @param dt Time step
     @param prev_states The states saved from previous step for this purpose
     @param omega Pointer to the rotation rate
  */
-void sunlineRateCompute(double states[SKF_N_STATES_HALF], double dt, double prev_states[SKF_N_STATES_HALF], double *omega)
-{
-
+void sunlineRateCompute(double states[SKF_N_STATES_HALF],
+                        double dt,
+                        double prev_states[SKF_N_STATES_HALF],
+                        double *omega) {
     double dk_dot_dkmin1_normal, dk_cross_dkmin1_normal[SKF_N_STATES_HALF];
     double dk_hat[SKF_N_STATES_HALF], dkmin1_hat[SKF_N_STATES_HALF];
 
-    if (dt < 1E-10){
-    v3SetZero(omega);
+    if (dt < 1E-10) {
+        v3SetZero(omega);
     }
 
-    else{
-        if (v3IsZero(prev_states, 1E-10)){
-
+    else {
+        if (v3IsZero(prev_states, 1E-10)) {
             v3SetZero(omega);
-        }
-        else{
+        } else {
             /* Set local variables to zero */
-            dk_dot_dkmin1_normal=0;
+            dk_dot_dkmin1_normal = 0;
             vSetZero(dk_hat, SKF_N_STATES_HALF);
             vSetZero(dkmin1_hat, SKF_N_STATES_HALF);
 
@@ -255,23 +278,21 @@ void sunlineRateCompute(double states[SKF_N_STATES_HALF], double dt, double prev
             v3Cross(dk_hat, dkmin1_hat, dk_cross_dkmin1_normal);
 
             /* Scale direction by the acos and the 1/dt, and robustly compute arcos of angle*/
-            if(dk_dot_dkmin1_normal>1){
-                v3Scale(1/dt*safeAcos(1), dk_cross_dkmin1_normal, omega);
-            }
-            else if(dk_dot_dkmin1_normal<-1){
-                v3Scale(1/dt*safeAcos(-1), dk_cross_dkmin1_normal, omega);
-            }
-            else {
-                v3Scale(1/dt*safeAcos(dk_dot_dkmin1_normal), dk_cross_dkmin1_normal, omega);
+            if (dk_dot_dkmin1_normal > 1) {
+                v3Scale(1 / dt * safeAcos(1), dk_cross_dkmin1_normal, omega);
+            } else if (dk_dot_dkmin1_normal < -1) {
+                v3Scale(1 / dt * safeAcos(-1), dk_cross_dkmin1_normal, omega);
+            } else {
+                v3Scale(1 / dt * safeAcos(dk_dot_dkmin1_normal), dk_cross_dkmin1_normal, omega);
             }
         }
     }
     return;
 }
 
-
-/*! @brief This method propagates a sunline state vector forward in time.  Note that the calling parameter is updated in place to save on data copies. This also updates the STM using the dynamics matrix.
-	@return void
+/*! @brief This method propagates a sunline state vector forward in time.  Note that the calling parameter is updated in
+   place to save on data copies. This also updates the STM using the dynamics matrix.
+    @return void
     @param dynMat dynamic matrix
     @param dt time step
     @param omega angular velocity
@@ -279,17 +300,15 @@ void sunlineRateCompute(double states[SKF_N_STATES_HALF], double dt, double prev
     @param prevstates pointer to previous states
     @param stateTransition pointer to state transition matrix
  */
-void sunlineStateSTMProp(double dynMat[SKF_N_STATES_HALF*SKF_N_STATES_HALF],
+void sunlineStateSTMProp(double dynMat[SKF_N_STATES_HALF * SKF_N_STATES_HALF],
                          double dt,
                          double omega[SKF_N_STATES_HALF],
                          double *stateInOut,
                          double *prevstates,
-                         double *stateTransition)
-{
-
+                         double *stateTransition) {
     double propagatedVel[SKF_N_STATES_HALF];
     double omegaCrossd[SKF_N_STATES_HALF];
-    double deltatASTM[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
+    double deltatASTM[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
 
     /* Populate d_k-1 */
     vCopy(stateInOut, SKF_N_STATES_HALF, prevstates);
@@ -323,8 +342,7 @@ void sunlineStateSTMProp(double dynMat[SKF_N_STATES_HALF*SKF_N_STATES_HALF],
  @param dynMat Pointer to the Dynamic Matrix
  */
 
-void sunlineDynMatrixOkeefe(double omega[SKF_N_STATES_HALF], double dt, double *dynMat)
-{
+void sunlineDynMatrixOkeefe(double omega[SKF_N_STATES_HALF], double dt, double *dynMat) {
     double skewOmega[SKF_N_STATES_HALF][SKF_N_STATES_HALF];
     double negskewOmega[SKF_N_STATES_HALF][SKF_N_STATES_HALF];
 
@@ -349,22 +367,21 @@ void sunlineDynMatrixOkeefe(double omega[SKF_N_STATES_HALF], double dt, double *
  */
 
 void sunlineCKFUpdateOkeefe(double xBar[SKF_N_STATES_HALF],
-                            double kalmanGain[SKF_N_STATES_HALF*MAX_N_CSS_MEAS],
-                            double covarBar[SKF_N_STATES_HALF*SKF_N_STATES_HALF],
+                            double kalmanGain[SKF_N_STATES_HALF * MAX_N_CSS_MEAS],
+                            double covarBar[SKF_N_STATES_HALF * SKF_N_STATES_HALF],
                             double qObsVal,
                             int numObsInt,
                             double yObs[MAX_N_CSS_MEAS],
-                            double hObs[MAX_N_CSS_MEAS*SKF_N_STATES_HALF],
+                            double hObs[MAX_N_CSS_MEAS * SKF_N_STATES_HALF],
                             double *x,
-                            double *covar)
-{
+                            double *covar) {
     double measMatx[MAX_N_CSS_MEAS], innov[MAX_N_CSS_MEAS], kInnov[SKF_N_STATES_HALF];
-    double eye[SKF_N_STATES_HALF*SKF_N_STATES_HALF], kH[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double eyeKalH[SKF_N_STATES_HALF*SKF_N_STATES_HALF], eyeKalHT[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double eyeKalHCovarBar[SKF_N_STATES_HALF*SKF_N_STATES_HALF], kalR[SKF_N_STATES_HALF*MAX_N_CSS_MEAS];
-    double kalT[MAX_N_CSS_MEAS*SKF_N_STATES_HALF], kalRKalT[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double noiseMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    size_t numObs = (size_t) numObsInt;
+    double eye[SKF_N_STATES_HALF * SKF_N_STATES_HALF], kH[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double eyeKalH[SKF_N_STATES_HALF * SKF_N_STATES_HALF], eyeKalHT[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double eyeKalHCovarBar[SKF_N_STATES_HALF * SKF_N_STATES_HALF], kalR[SKF_N_STATES_HALF * MAX_N_CSS_MEAS];
+    double kalT[MAX_N_CSS_MEAS * SKF_N_STATES_HALF], kalRKalT[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double noiseMat[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
+    size_t numObs = (size_t)numObsInt;
 
     /* Set variables to zero */
     mSetZero(kH, SKF_N_STATES_HALF, SKF_N_STATES_HALF);
@@ -392,16 +409,16 @@ void sunlineCKFUpdateOkeefe(double xBar[SKF_N_STATES_HALF],
     mSetIdentity(eye, SKF_N_STATES_HALF, SKF_N_STATES_HALF);
     mSubtract(eye, SKF_N_STATES_HALF, SKF_N_STATES_HALF, kH, eyeKalH);
     mTranspose(eyeKalH, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHT);
-    mMultM(eyeKalH, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHCovarBar);
-    mMultM(eyeKalHCovarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covar);
+    mMultM(
+        eyeKalH, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHCovarBar);
+    mMultM(
+        eyeKalHCovarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covar);
 
     /* Add noise to the covariance*/
     mMultM(kalmanGain, SKF_N_STATES_HALF, numObs, noiseMat, numObs, numObs, kalR);
     mTranspose(kalmanGain, SKF_N_STATES_HALF, numObs, kalT);
     mMultM(kalR, SKF_N_STATES_HALF, numObs, kalT, numObs, SKF_N_STATES_HALF, kalRKalT);
     mAdd(covar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, kalRKalT, covar);
-
-
 }
 
 /*! This method computes the updated with a Extended Kalman Filter
@@ -416,23 +433,21 @@ void sunlineCKFUpdateOkeefe(double xBar[SKF_N_STATES_HALF],
  @param x Pointer to the state error for modification
  @param covar Pointer to the covariance after update
  */
-void okeefeEKFUpdate(double kalmanGain[SKF_N_STATES_HALF*MAX_N_CSS_MEAS],
-                     double covarBar[SKF_N_STATES_HALF*SKF_N_STATES_HALF],
+void okeefeEKFUpdate(double kalmanGain[SKF_N_STATES_HALF * MAX_N_CSS_MEAS],
+                     double covarBar[SKF_N_STATES_HALF * SKF_N_STATES_HALF],
                      double qObsVal,
                      int numObsInt,
                      double yObs[MAX_N_CSS_MEAS],
-                     double hObs[MAX_N_CSS_MEAS*SKF_N_STATES_HALF],
+                     double hObs[MAX_N_CSS_MEAS * SKF_N_STATES_HALF],
                      double *states,
                      double *x,
-                     double *covar)
-{
-
-    double eye[SKF_N_STATES_HALF*SKF_N_STATES_HALF], kH[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double eyeKalH[SKF_N_STATES_HALF*SKF_N_STATES_HALF], eyeKalHT[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double eyeKalHCovarBar[SKF_N_STATES_HALF*SKF_N_STATES_HALF], kalR[SKF_N_STATES_HALF*MAX_N_CSS_MEAS];
-    double kalT[MAX_N_CSS_MEAS*SKF_N_STATES_HALF], kalRKalT[SKF_N_STATES_HALF*SKF_N_STATES_HALF];
-    double noiseMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    size_t numObs = (size_t) numObsInt;
+                     double *covar) {
+    double eye[SKF_N_STATES_HALF * SKF_N_STATES_HALF], kH[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double eyeKalH[SKF_N_STATES_HALF * SKF_N_STATES_HALF], eyeKalHT[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double eyeKalHCovarBar[SKF_N_STATES_HALF * SKF_N_STATES_HALF], kalR[SKF_N_STATES_HALF * MAX_N_CSS_MEAS];
+    double kalT[MAX_N_CSS_MEAS * SKF_N_STATES_HALF], kalRKalT[SKF_N_STATES_HALF * SKF_N_STATES_HALF];
+    double noiseMat[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
+    size_t numObs = (size_t)numObsInt;
 
     /* Set variables to zero */
     mSetZero(kH, SKF_N_STATES_HALF, SKF_N_STATES_HALF);
@@ -460,15 +475,16 @@ void okeefeEKFUpdate(double kalmanGain[SKF_N_STATES_HALF*MAX_N_CSS_MEAS],
     mSetIdentity(eye, SKF_N_STATES_HALF, SKF_N_STATES_HALF);
     mSubtract(eye, SKF_N_STATES_HALF, SKF_N_STATES_HALF, kH, eyeKalH);
     mTranspose(eyeKalH, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHT);
-    mMultM(eyeKalH, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHCovarBar);
-    mMultM(eyeKalHCovarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covar);
+    mMultM(
+        eyeKalH, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHCovarBar);
+    mMultM(
+        eyeKalHCovarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, eyeKalHT, SKF_N_STATES_HALF, SKF_N_STATES_HALF, covar);
 
     /* Add noise to the covariance*/
-    mMultM(kalmanGain, SKF_N_STATES_HALF, numObs, noiseMat, (size_t) numObs, (size_t) numObs, kalR);
-    mTranspose(kalmanGain, SKF_N_STATES_HALF, (size_t) numObs, kalT);
-    mMultM(kalR, SKF_N_STATES_HALF, (size_t) numObs, kalT, (size_t) numObs, SKF_N_STATES_HALF, kalRKalT);
+    mMultM(kalmanGain, SKF_N_STATES_HALF, numObs, noiseMat, (size_t)numObs, (size_t)numObs, kalR);
+    mTranspose(kalmanGain, SKF_N_STATES_HALF, (size_t)numObs, kalT);
+    mMultM(kalR, SKF_N_STATES_HALF, (size_t)numObs, kalT, (size_t)numObs, SKF_N_STATES_HALF, kalRKalT);
     mAdd(covar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, kalRKalT, covar);
-
 }
 
 /*! This method computes the H matrix, defined by dGdX. As well as computing the
@@ -491,13 +507,12 @@ void sunlineHMatrixYMeas(double states[SKF_N_STATES_HALF],
                          size_t numCSS,
                          double cssSensorCos[MAX_N_CSS_MEAS],
                          double sensorUseThresh,
-                         double cssNHat_B[MAX_NUM_CSS_SENSORS*3],
+                         double cssNHat_B[MAX_NUM_CSS_SENSORS * 3],
                          double CBias[MAX_NUM_CSS_SENSORS],
                          double *obs,
                          double *yMeas,
                          int *numObs,
-                         double *measMat)
-{
+                         double *measMat) {
     uint32_t i, obsCounter;
     double sensorNormal[3];
 
@@ -505,23 +520,20 @@ void sunlineHMatrixYMeas(double states[SKF_N_STATES_HALF],
 
     obsCounter = 0;
     /*! - Loop over all available coarse sun sensors and only use ones that meet validity threshold*/
-    for(i=0; i<numCSS; i++)
-    {
-        if(cssSensorCos[i] > sensorUseThresh)
-        {
-            /*! - For each valid measurement, copy observation value and compute expected obs value and fill out H matrix.*/
-            v3Scale(CBias[i], &(cssNHat_B[i*3]), sensorNormal); /* scaled sensor normal */
+    for (i = 0; i < numCSS; i++) {
+        if (cssSensorCos[i] > sensorUseThresh) {
+            /*! - For each valid measurement, copy observation value and compute expected obs value and fill out H
+             * matrix.*/
+            v3Scale(CBias[i], &(cssNHat_B[i * 3]), sensorNormal); /* scaled sensor normal */
 
-            *(obs+obsCounter) = cssSensorCos[i];
-            *(yMeas+obsCounter) = cssSensorCos[i] - v3Dot(&(states[0]), sensorNormal);
+            *(obs + obsCounter) = cssSensorCos[i];
+            *(yMeas + obsCounter) = cssSensorCos[i] - v3Dot(&(states[0]), sensorNormal);
             mSetSubMatrix(sensorNormal, 1, 3, measMat, MAX_NUM_CSS_SENSORS, SKF_N_STATES_HALF, obsCounter, 0);
             obsCounter++;
         }
     }
-    *numObs = (int) obsCounter;
+    *numObs = (int)obsCounter;
 }
-
-
 
 /*! This method computes the Kalman gain given the measurements.
  @return void
@@ -532,18 +544,17 @@ void sunlineHMatrixYMeas(double states[SKF_N_STATES_HALF],
  @param kalmanGain Pointer to the Kalman Gain
  */
 
-void sunlineKalmanGainOkeefe(double covarBar[SKF_N_STATES_HALF*SKF_N_STATES_HALF],
-                             double hObs[MAX_N_CSS_MEAS*SKF_N_STATES_HALF],
+void sunlineKalmanGainOkeefe(double covarBar[SKF_N_STATES_HALF * SKF_N_STATES_HALF],
+                             double hObs[MAX_N_CSS_MEAS * SKF_N_STATES_HALF],
                              double qObsVal,
                              int numObsInt,
-                             double *kalmanGain)
-{
-    double hObsT[SKF_N_STATES_HALF*MAX_N_CSS_MEAS];
-    double covHT[SKF_N_STATES_HALF*MAX_N_CSS_MEAS];
-    double hCovar[MAX_N_CSS_MEAS*SKF_N_STATES_HALF], hCovarHT[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
-    double rMat[MAX_N_CSS_MEAS*MAX_N_CSS_MEAS];
+                             double *kalmanGain) {
+    double hObsT[SKF_N_STATES_HALF * MAX_N_CSS_MEAS];
+    double covHT[SKF_N_STATES_HALF * MAX_N_CSS_MEAS];
+    double hCovar[MAX_N_CSS_MEAS * SKF_N_STATES_HALF], hCovarHT[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
+    double rMat[MAX_N_CSS_MEAS * MAX_N_CSS_MEAS];
     size_t numObs;
-    numObs = (size_t) numObsInt;
+    numObs = (size_t)numObsInt;
 
     /* Setting all local variables to zero */
     mSetZero(hObsT, SKF_N_STATES_HALF, MAX_N_CSS_MEAS);
@@ -552,22 +563,21 @@ void sunlineKalmanGainOkeefe(double covarBar[SKF_N_STATES_HALF*SKF_N_STATES_HALF
     mSetZero(hCovarHT, MAX_N_CSS_MEAS, MAX_N_CSS_MEAS);
     mSetZero(rMat, MAX_N_CSS_MEAS, MAX_N_CSS_MEAS);
 
-    mTranspose(hObs, (size_t) numObs, SKF_N_STATES_HALF, hObsT);
+    mTranspose(hObs, (size_t)numObs, SKF_N_STATES_HALF, hObsT);
 
-    mMultM(covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, hObsT, SKF_N_STATES_HALF, (size_t) numObs, covHT);
-    mMultM(hObs, (size_t) numObs, SKF_N_STATES_HALF, covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, hCovar);
-    mMultM(hCovar, (size_t) numObs, SKF_N_STATES_HALF, hObsT, SKF_N_STATES_HALF, (size_t) numObs, hCovarHT);
+    mMultM(covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, hObsT, SKF_N_STATES_HALF, (size_t)numObs, covHT);
+    mMultM(hObs, (size_t)numObs, SKF_N_STATES_HALF, covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, hCovar);
+    mMultM(hCovar, (size_t)numObs, SKF_N_STATES_HALF, hObsT, SKF_N_STATES_HALF, (size_t)numObs, hCovarHT);
 
-    mSetIdentity(rMat, (size_t) numObs, (size_t) numObs);
-    mScale(qObsVal, rMat, (size_t) numObs, (size_t) numObs, rMat);
+    mSetIdentity(rMat, (size_t)numObs, (size_t)numObs);
+    mScale(qObsVal, rMat, (size_t)numObs, (size_t)numObs, rMat);
 
     /*! - Add measurement noise */
-    mAdd(hCovarHT, (size_t) numObs, (size_t) numObs, rMat, hCovarHT);
+    mAdd(hCovarHT, (size_t)numObs, (size_t)numObs, rMat, hCovarHT);
 
     /*! - Invert the previous matrix */
-    mInverse(hCovarHT, (size_t) numObs, hCovarHT);
+    mInverse(hCovarHT, (size_t)numObs, hCovarHT);
 
     /*! - Compute the Kalman Gain */
     mMultM(covHT, SKF_N_STATES_HALF, numObs, hCovarHT, numObs, numObs, kalmanGain);
-
 }

--- a/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.cpp
@@ -24,8 +24,7 @@
 
 #include <math.h>
 
-void CelestialTwoBodyPoint::reset(uint64_t callTime)
-{
+void CelestialTwoBodyPoint::reset(uint64_t callTime) {
     this->secCelBodyIsLinked = this->secCelBodyInMsg.isLinked();
 
     // check if required input messages have been included
@@ -46,8 +45,7 @@ void CelestialTwoBodyPoint::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void CelestialTwoBodyPoint::updateState(uint64_t callTime)
-{
+void CelestialTwoBodyPoint::updateState(uint64_t callTime) {
     /*! - Parse the input messages */
     this->parseInputMessages();
     /*! - Compute the pointing requirements */
@@ -61,22 +59,20 @@ void CelestialTwoBodyPoint::updateState(uint64_t callTime)
  necessary to create the restricted 2-body pointing reference frame.
  @return void
  */
-void CelestialTwoBodyPoint::parseInputMessages()
-{
+void CelestialTwoBodyPoint::parseInputMessages() {
     NavTransMsgPayload navData;
     EphemerisMsgPayload primPlanet;
     EphemerisMsgPayload secPlanet;
 
-    double R_P1B_N_hat[3];          /* Unit vector in the direction of r_P1 */
-    double R_P2B_N_hat[3];          /* Unit vector in the direction of r_P2 */
+    double R_P1B_N_hat[3]; /* Unit vector in the direction of r_P1 */
+    double R_P2B_N_hat[3]; /* Unit vector in the direction of r_P2 */
 
-    double platAngDiff{};             /* Angle between r_P1 and r_P2 */
-    double dotProduct;              /* Temporary scalar variable */
+    double platAngDiff{}; /* Angle between r_P1 and r_P2 */
+    double dotProduct;    /* Temporary scalar variable */
 
     // read input messages
     navData = this->transNavInMsg();
     primPlanet = this->celBodyInMsg();
-
 
     v3Subtract(primPlanet.r_BdyZero_N, navData.r_BN_N, this->R_P1B_N);
     v3Subtract(primPlanet.v_BdyZero_N, navData.v_BN_N, this->v_P1B_N);
@@ -84,9 +80,7 @@ void CelestialTwoBodyPoint::parseInputMessages()
     v3SetZero(this->a_P1B_N); /* accelerations of s/c relative to planets set to zero*/
     v3SetZero(this->a_P2B_N);
 
-    if(this->secCelBodyIsLinked)
-    {
-
+    if (this->secCelBodyIsLinked) {
         secPlanet = this->secCelBodyInMsg();
         /*! - Compute R_P2 and v_P2 */
         v3Subtract(secPlanet.r_BdyZero_N, navData.r_BN_N, this->R_P2B_N);
@@ -98,17 +92,13 @@ void CelestialTwoBodyPoint::parseInputMessages()
     }
 
     /*! - Cross the P1 states to get R_P2, v_p2 and a_P2 */
-    if(!this->secCelBodyIsLinked ||
-       fabs(platAngDiff) < this->singularityThresh ||
-       fabs(platAngDiff) > M_PI - this->singularityThresh)
-    {
+    if (!this->secCelBodyIsLinked || fabs(platAngDiff) < this->singularityThresh ||
+        fabs(platAngDiff) > M_PI - this->singularityThresh) {
         v3Cross(this->R_P1B_N, this->v_P1B_N, this->R_P2B_N);
         v3Cross(this->R_P1B_N, this->a_P1B_N, this->v_P2B_N);
         v3Cross(this->v_P1B_N, this->a_P1B_N, this->a_P2B_N);
     }
 }
-
-
 
 /*! This method takes the spacecraft and points a specified axis at a named
  celestial body specified in the configuration data.  It generates the
@@ -118,40 +108,39 @@ void CelestialTwoBodyPoint::parseInputMessages()
  @param this The configuration data associated with the celestial body guidance
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void CelestialTwoBodyPoint::computeCelestialTwoBodyPoint(uint64_t callTime)
-{
-    double temp3[3];        /* Temporary vector */
-    double temp3_1[3];      /* Temporary vector 1 */
-    double temp3_2[3];      /* Temporary vector 2 */
-    double temp3_3[3];      /* Temporary vector 3 */
-    double temp33[3][3];    /* Temporary 3x3 matrix */
-    double temp33_1[3][3];  /* Temporary 3x3 matrix 1 */
-    double temp33_2[3][3];  /* Temporary 3x3 matrix 2 */
+void CelestialTwoBodyPoint::computeCelestialTwoBodyPoint(uint64_t callTime) {
+    double temp3[3];       /* Temporary vector */
+    double temp3_1[3];     /* Temporary vector 1 */
+    double temp3_2[3];     /* Temporary vector 2 */
+    double temp3_3[3];     /* Temporary vector 3 */
+    double temp33[3][3];   /* Temporary 3x3 matrix */
+    double temp33_1[3][3]; /* Temporary 3x3 matrix 1 */
+    double temp33_2[3][3]; /* Temporary 3x3 matrix 2 */
 
-    double R_N[3];          /* Normal vector of the plane defined by R_P1 and R_P2 */
-    double v_N[3];          /* First time-derivative of R_n */
-    double a_N[3];          /* Second time-derivative of R_n */
+    double R_N[3]; /* Normal vector of the plane defined by R_P1 and R_P2 */
+    double v_N[3]; /* First time-derivative of R_n */
+    double a_N[3]; /* Second time-derivative of R_n */
 
-    double dcm_RN[3][3];    /* DCM that maps from Reference frame to the inertial */
-    double r1_hat[3];       /* 1st row vector of RN */
-    double r2_hat[3];       /* 2nd row vector of RN */
-    double r3_hat[3];       /* 3rd row vector of RN */
+    double dcm_RN[3][3]; /* DCM that maps from Reference frame to the inertial */
+    double r1_hat[3];    /* 1st row vector of RN */
+    double r2_hat[3];    /* 2nd row vector of RN */
+    double r3_hat[3];    /* 3rd row vector of RN */
 
-    double dr1_hat[3];      /* r1_hat first time-derivative */
-    double dr2_hat[3];      /* r2_hat first time-derivative */
-    double dr3_hat[3];      /* r3_hat first time-derivative */
-    double I_33[3][3];      /* Identity 3x3 matrix */
-    double C1[3][3];        /* DCM used in the computation of rates and acceleration */
-    double C3[3][3];        /* DCM used in the computation of rates and acceleration */
+    double dr1_hat[3]; /* r1_hat first time-derivative */
+    double dr2_hat[3]; /* r2_hat first time-derivative */
+    double dr3_hat[3]; /* r3_hat first time-derivative */
+    double I_33[3][3]; /* Identity 3x3 matrix */
+    double C1[3][3];   /* DCM used in the computation of rates and acceleration */
+    double C3[3][3];   /* DCM used in the computation of rates and acceleration */
 
-    double omega_RN_R[3];   /* Angular rate of the reference frame
-                             wrt the inertial in ref R-frame components */
-    double domega_RN_R[3];   /* Angular acceleration of the reference frame
-                              wrt the inertial in ref R-frame components */
+    double omega_RN_R[3];  /* Angular rate of the reference frame
+                            wrt the inertial in ref R-frame components */
+    double domega_RN_R[3]; /* Angular acceleration of the reference frame
+                            wrt the inertial in ref R-frame components */
 
-    double ddr1_hat[3];     /* r1_hat second time-derivative */
-    double ddr2_hat[3];     /* r2_hat second time-derivative */
-    double ddr3_hat[3];     /* r3_hat second time-derivative */
+    double ddr1_hat[3]; /* r1_hat second time-derivative */
+    double ddr2_hat[3]; /* r2_hat second time-derivative */
+    double ddr3_hat[3]; /* r3_hat second time-derivative */
 
     this->attRefOut = {};
 
@@ -165,12 +154,12 @@ void CelestialTwoBodyPoint::computeCelestialTwoBodyPoint(uint64_t callTime)
     v3Add(temp3_1, temp3_2, temp3_3);
     v3Cross(this->v_P1B_N, this->v_P2B_N, temp3);
     v3Scale(2.0, temp3, temp3);
-    v3Add(temp3, temp3_3, a_N);  /*Eq 5*/
+    v3Add(temp3, temp3_3, a_N); /*Eq 5*/
 
     /* - Reference Frame computation */
     v3Normalize(this->R_P1B_N, r1_hat); /* Eq 9a*/
-    v3Normalize(R_N, r3_hat); /* Eq 9c */
-    v3Cross(r3_hat, r1_hat, r2_hat); /* Eq 9b */
+    v3Normalize(R_N, r3_hat);           /* Eq 9c */
+    v3Cross(r3_hat, r1_hat, r2_hat);    /* Eq 9b */
     v3Normalize(r2_hat, r2_hat);
     v3Copy(r1_hat, dcm_RN[0]);
     v3Copy(r2_hat, dcm_RN[1]);
@@ -196,7 +185,7 @@ void CelestialTwoBodyPoint::computeCelestialTwoBodyPoint(uint64_t callTime)
 
     /* - Angular velocity computation */
     omega_RN_R[0] = v3Dot(r3_hat, dr2_hat);
-    omega_RN_R[1]= v3Dot(r1_hat, dr3_hat);
+    omega_RN_R[1] = v3Dot(r1_hat, dr3_hat);
     omega_RN_R[2] = v3Dot(r2_hat, dr1_hat);
     m33tMultV3(dcm_RN, omega_RN_R, this->attRefOut.omega_RN_N);
 

--- a/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.cpp
@@ -17,13 +17,12 @@
 
  */
 
-
-#include <math.h>
 #include "fswAlgorithms/attGuidance/celestialTwoBodyPoint/celestialTwoBodyPoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 
-
+#include <math.h>
 
 void CelestialTwoBodyPoint::reset(uint64_t callTime)
 {

--- a/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.cpp
+++ b/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.cpp
@@ -17,7 +17,6 @@
 
 */
 
-
 #include "fswAlgorithms/attGuidance/locationPointing/locationPointing.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
@@ -32,9 +31,7 @@
  @return void
  @param callTime [ns] time the method is called
 */
-void LocationPointing::reset(uint64_t callTime)
-{
-
+void LocationPointing::reset(uint64_t callTime) {
     // check if the required message has not been connected
     if (!this->scAttInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: locationPointing.scAttInMsg was not connected.");
@@ -42,15 +39,16 @@ void LocationPointing::reset(uint64_t callTime)
     if (!this->scTransInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: locationPointing.scTransInMsg was not connected.");
     }
-    int numInMsgs = this->locationInMsg.isLinked()
-                    + this->celBodyInMsg.isLinked()
-                    + this->scTargetInMsg.isLinked();
+    int numInMsgs = this->locationInMsg.isLinked() + this->celBodyInMsg.isLinked() + this->scTargetInMsg.isLinked();
 
     if (numInMsgs == 0) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error: In the locationPointing module no target messages were not connected.");
-    }
-    else if (numInMsgs > 1) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error: In the locationPointing module multiple target messages were connected. Defaulting to either ground location, planet location or spacecraft location, in that order.");
+        this->bskLogger.bskLog(BSK_ERROR,
+                               "Error: In the locationPointing module no target messages were not connected.");
+    } else if (numInMsgs > 1) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "Error: In the locationPointing module multiple target messages were connected. Defaulting to either "
+            "ground location, planet location or spacecraft location, in that order.");
     }
 
     this->init = 1;
@@ -59,15 +57,19 @@ void LocationPointing::reset(uint64_t callTime)
     this->time_old = callTime;
 
     /* compute an Eigen axis orthogonal to sHatBdyCmd */
-    if (v3Norm(this->pHat_B)  < 0.1) {
-      char info[MAX_LOGGING_LENGTH];
-      snprintf(info, sizeof(info), "locationPoint: vector pHat_B is not setup as a unit vector [%f, %f %f]",
-                this->pHat_B[0], this->pHat_B[1], this->pHat_B[2]);
-      this->bskLogger.bskLog(BSK_ERROR, info);
+    if (v3Norm(this->pHat_B) < 0.1) {
+        char info[MAX_LOGGING_LENGTH];
+        snprintf(info,
+                 sizeof(info),
+                 "locationPoint: vector pHat_B is not setup as a unit vector [%f, %f %f]",
+                 this->pHat_B[0],
+                 this->pHat_B[1],
+                 this->pHat_B[2]);
+        this->bskLogger.bskLog(BSK_ERROR, info);
     } else {
         double v1[3];
         v3Set(1., 0., 0., v1);
-        v3Normalize(this->pHat_B, this->pHat_B);    /* ensure that this vector is a unit vector */
+        v3Normalize(this->pHat_B, this->pHat_B); /* ensure that this vector is a unit vector */
         v3Cross(this->pHat_B, v1, this->eHat180_B);
         if (v3Norm(this->eHat180_B) < 0.1) {
             v3Set(0., 1., 0., v1);
@@ -77,39 +79,37 @@ void LocationPointing::reset(uint64_t callTime)
     }
 }
 
-
-/*! This method takes the estimated body states and position relative to the ground to compute the current attitude/attitude rate errors and pass them to control.
+/*! This method takes the estimated body states and position relative to the ground to compute the current
+ attitude/attitude rate errors and pass them to control.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */
-void LocationPointing::updateState(uint64_t callTime)
-{
+void LocationPointing::updateState(uint64_t callTime) {
     /* Local copies*/
-    NavAttMsgPayload scAttInMsgBuffer;  //!< local copy of input message buffer
-    NavTransMsgPayload scTransInMsgBuffer;  //!< local copy of input message buffer
-    GroundStateMsgPayload locationInMsgBuffer;  //!< local copy of location input message buffer
-    EphemerisMsgPayload celBodyInMsgBuffer; //!< local copy of celestial body input message buffer
-    NavTransMsgPayload scTargetInMsgBuffer;  //!< local copy of input message buffer of target spacecraft
+    NavAttMsgPayload scAttInMsgBuffer;           //!< local copy of input message buffer
+    NavTransMsgPayload scTransInMsgBuffer;       //!< local copy of input message buffer
+    GroundStateMsgPayload locationInMsgBuffer;   //!< local copy of location input message buffer
+    EphemerisMsgPayload celBodyInMsgBuffer;      //!< local copy of celestial body input message buffer
+    NavTransMsgPayload scTargetInMsgBuffer;      //!< local copy of input message buffer of target spacecraft
     AttGuidMsgPayload attGuidOutMsgBuffer = {};  //!< local copy of guidance output message buffer
-    AttRefMsgPayload attRefOutMsgBuffer = {};  //!< local copy of reference output message buffer
+    AttRefMsgPayload attRefOutMsgBuffer = {};    //!< local copy of reference output message buffer
 
-    double r_LS_N[3];                   /*!< Position vector of location w.r.t spacecraft CoM in inertial frame */
-    double r_LS_B[3];                   /*!< Position vector of location w.r.t spacecraft CoM in body frame */
-    double rHat_LS_B[3];                /*!< unit vector of location w.r.t spacecraft CoM in body frame */
-    double eHat_B[3];                   /*!< --- Eigen Axis */
-    double dcmBN[3][3];                 /*!< inertial spacecraft orientation DCM */
-    double phi;                         /*!< principal angle between pHat and heading to location */
-    double sigmaDot_BR[3];              /*!< time derivative of sigma_BR*/
-    double sigma_BR[3];                 /*!< MRP of B relative to R */
-    double sigma_RB[3];                 /*!< MRP of R relative to B */
-    double omega_RN_B[3];               /*!< angular velocity of the R frame w.r.t the B frame in B frame components */
+    double r_LS_N[3];      /*!< Position vector of location w.r.t spacecraft CoM in inertial frame */
+    double r_LS_B[3];      /*!< Position vector of location w.r.t spacecraft CoM in body frame */
+    double rHat_LS_B[3];   /*!< unit vector of location w.r.t spacecraft CoM in body frame */
+    double eHat_B[3];      /*!< --- Eigen Axis */
+    double dcmBN[3][3];    /*!< inertial spacecraft orientation DCM */
+    double phi;            /*!< principal angle between pHat and heading to location */
+    double sigmaDot_BR[3]; /*!< time derivative of sigma_BR*/
+    double sigma_BR[3];    /*!< MRP of B relative to R */
+    double sigma_RB[3];    /*!< MRP of R relative to B */
+    double omega_RN_B[3];  /*!< angular velocity of the R frame w.r.t the B frame in B frame components */
     double difference[3];
-    double time_diff;                   /*!< module update time */
-    double Binv[3][3];                  /*!< BinvMRP for dsigma_RB_R calculations*/
+    double time_diff;  /*!< module update time */
+    double Binv[3][3]; /*!< BinvMRP for dsigma_RB_R calculations*/
     double dum1;
-    double r_TN_N[3];                   /*!< [m] inertial target location */
-    double boreRate_B[3];               /*!< [rad/s] rotation rate about target direction */
-
+    double r_TN_N[3];     /*!< [m] inertial target location */
+    double boreRate_B[3]; /*!< [rad/s] rotation rate about target direction */
 
     // read in the input messages
     scAttInMsgBuffer = this->scAttInMsg();
@@ -117,8 +117,7 @@ void LocationPointing::updateState(uint64_t callTime)
     if (this->locationInMsg.isLinked()) {
         locationInMsgBuffer = this->locationInMsg();
         v3Copy(locationInMsgBuffer.r_LN_N, r_TN_N);
-    }
-    else if (this->celBodyInMsg.isLinked()) {
+    } else if (this->celBodyInMsg.isLinked()) {
         celBodyInMsgBuffer = this->celBodyInMsg();
         v3Copy(celBodyInMsgBuffer.r_BdyZero_N, r_TN_N);
     } else {
@@ -142,7 +141,7 @@ void LocationPointing::updateState(uint64_t callTime)
     /* calculate sigma_BR */
     if (phi < this->smallAngle) {
         /* body axis and desired inertial pointing direction are essentially aligned.  Set attitude error to zero. */
-         v3SetZero(sigma_BR);
+        v3SetZero(sigma_BR);
     } else {
         if (M_PI - phi < this->smallAngle) {
             /* the commanded body vector nearly is opposite the desired inertial heading */
@@ -163,11 +162,11 @@ void LocationPointing::updateState(uint64_t callTime)
     /* use sigma_BR to compute d(sigma_BR)/dt if at least two data points */
     if (this->init < 1) {
         // module update time
-        time_diff = (callTime - this->time_old)*NANO2SEC;
+        time_diff = (callTime - this->time_old) * NANO2SEC;
 
         // calculate d(sigma_BR)/dt
         v3Subtract(sigma_BR, this->sigma_BR_old, difference);
-        v3Scale(1.0/(time_diff), difference, sigmaDot_BR);
+        v3Scale(1.0 / (time_diff), difference, sigmaDot_BR);
 
         // calculate BinvMRP
         BinvMRP(sigma_BR, Binv);

--- a/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.cpp
+++ b/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.cpp
@@ -20,8 +20,10 @@
 
 #include "fswAlgorithms/attGuidance/locationPointing/locationPointing.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
+
 #include <math.h>
 
 /*! This method performs a complete reset of the module.  Local module variables that retain

--- a/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.cpp
@@ -17,11 +17,12 @@
 
  */
 
-#include <string.h>
-#include <math.h>
 #include "fswAlgorithms/attGuidance/opNavPoint/opNavPoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
+
+#include <math.h>
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.

--- a/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.cpp
+++ b/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.cpp
@@ -29,8 +29,7 @@
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void OpNavPoint::reset(uint64_t callTime)
-{
+void OpNavPoint::reset(uint64_t callTime) {
     double v1[3];
 
     // check if the required input messages are included
@@ -45,14 +44,18 @@ void OpNavPoint::reset(uint64_t callTime)
     }
 
     /* compute an Eigen axis orthogonal to alignAxis_C */
-    if (v3Norm(this->alignAxis_C)  < 0.1) {
+    if (v3Norm(this->alignAxis_C) < 0.1) {
         char info[MAX_LOGGING_LENGTH];
-        snprintf(info, sizeof(info), "The module vector alignAxis_C is not setup as a unit vector [%f, %f %f]",
-          this->alignAxis_C[0], this->alignAxis_C[1], this->alignAxis_C[2]);
+        snprintf(info,
+                 sizeof(info),
+                 "The module vector alignAxis_C is not setup as a unit vector [%f, %f %f]",
+                 this->alignAxis_C[0],
+                 this->alignAxis_C[1],
+                 this->alignAxis_C[2]);
         this->bskLogger.bskLog(BSK_ERROR, info);
     } else {
         v3Set(1., 0., 0., v1);
-        v3Normalize(this->alignAxis_C, this->alignAxis_C);    /* ensure that this vector is a unit vector */
+        v3Normalize(this->alignAxis_C, this->alignAxis_C); /* ensure that this vector is a unit vector */
         v3Cross(this->alignAxis_C, v1, this->eHat180_B);
         if (v3Norm(this->eHat180_B) < 0.1) {
             v3Set(0., 1., 0., v1);
@@ -72,16 +75,15 @@ void OpNavPoint::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void OpNavPoint::updateState(uint64_t callTime)
-{
+void OpNavPoint::updateState(uint64_t callTime) {
     OpNavMsgPayload opNavMsg;
     double cthNormalized;
     double timeWithoutMeas;
     double currentHeading_C[3], alignAxis_B[3];
-    double hNorm;                   /* Norm of measured direction vector */
-    double e_hat[3];                /* Principal rotation Axis */
-    double omega_BN_B[3];           /* r/s inertial body angular velocity vector in B frame components */
-    double omega_RN_B[3];           /* r/s local copy of the desired reference frame rate */
+    double hNorm;         /* Norm of measured direction vector */
+    double e_hat[3];      /* Principal rotation Axis */
+    double omega_BN_B[3]; /* r/s inertial body angular velocity vector in B frame components */
+    double omega_RN_B[3]; /* r/s local copy of the desired reference frame rate */
     double dcm_BN[3][3], dcm_CB[3][3], dcm_CN[3][3];
     NavAttMsgPayload localImuDataInBuffer;
     CameraConfigMsgPayload cameraSpecs;
@@ -91,37 +93,36 @@ void OpNavPoint::updateState(uint64_t callTime)
     localImuDataInBuffer = this->imuInMsg();
     cameraSpecs = this->cameraConfigInMsg();
 
-    if (this->lastTime==0){
-        this->lastTime=callTime*1E-9;
+    if (this->lastTime == 0) {
+        this->lastTime = callTime * 1E-9;
         v3SetZero(this->currentHeading_N);
     }
-    timeWithoutMeas = callTime*1E-9 - this->lastTime;
+    timeWithoutMeas = callTime * 1E-9 - this->lastTime;
 
     v3Copy(localImuDataInBuffer.omega_BN_B, omega_BN_B);
     MRP2C(localImuDataInBuffer.sigma_BN, dcm_BN);
     MRP2C(cameraSpecs.sigma_CB, dcm_CB);
     m33MultM33(dcm_CB, dcm_BN, dcm_CN);
-    /*! Compute the current error vector if it is valid. This checks for a valid, non-stale, previous message, or a new fresh measurement.*/
-    if((opNavMsg.valid == 1 || v3IsZero(this->currentHeading_N, 1E-10) == 0) && (timeWithoutMeas < this->timeOut)){
+    /*! Compute the current error vector if it is valid. This checks for a valid, non-stale, previous message, or a new
+     * fresh measurement.*/
+    if ((opNavMsg.valid == 1 || v3IsZero(this->currentHeading_N, 1E-10) == 0) && (timeWithoutMeas < this->timeOut)) {
         /*! - If a valid image is in save the heading direction for future use*/
-        if (opNavMsg.valid == 1){
-            this->lastTime = callTime*1E-9;
+        if (opNavMsg.valid == 1) {
+            this->lastTime = callTime * 1E-9;
             v3Copy(opNavMsg.r_BN_C, currentHeading_C);
             m33tMultV3(dcm_CN, opNavMsg.r_BN_C, this->currentHeading_N);
             v3Scale(-1, currentHeading_C, currentHeading_C);
             hNorm = v3Norm(currentHeading_C);
-            v3Scale(1/hNorm, currentHeading_C, currentHeading_C);
-        }
-        else{
+            v3Scale(1 / hNorm, currentHeading_C, currentHeading_C);
+        } else {
             /*! - Else use the previous direction in order to continue guidance */
             m33MultV3(dcm_CN, this->currentHeading_N, currentHeading_C);
             v3Scale(-1, currentHeading_C, currentHeading_C);
             hNorm = v3Norm(currentHeading_C);
-            v3Scale(1/hNorm, currentHeading_C, currentHeading_C);
+            v3Scale(1 / hNorm, currentHeading_C, currentHeading_C);
         }
         cthNormalized = v3Dot(this->alignAxis_C, currentHeading_C);
-        cthNormalized = fabs(cthNormalized) > 1.0 ?
-        cthNormalized/fabs(cthNormalized) : cthNormalized;
+        cthNormalized = fabs(cthNormalized) > 1.0 ? cthNormalized / fabs(cthNormalized) : cthNormalized;
         this->opNavAngleErr = safeAcos(cthNormalized);
 
         /*
@@ -129,7 +130,7 @@ void OpNavPoint::updateState(uint64_t callTime)
          */
         if (this->opNavAngleErr < this->smallAngle) {
             /* opNav heading and desired camera axis are essentially aligned.  Set attitude error to zero. */
-             v3SetZero(this->attGuidanceOutBuffer.sigma_BR);
+            v3SetZero(this->attGuidanceOutBuffer.sigma_BR);
         } else {
             if (M_PI - this->opNavAngleErr < this->smallAngle) {
                 /* the commanded camera vector nearly is opposite the opNav heading */
@@ -139,8 +140,7 @@ void OpNavPoint::updateState(uint64_t callTime)
                 v3Cross(currentHeading_C, this->alignAxis_C, e_hat);
             }
             v3Normalize(e_hat, this->opNavMnvrVec);
-            v3Scale(tan(this->opNavAngleErr*0.25), this->opNavMnvrVec,
-                    this->attGuidanceOutBuffer.sigma_BR);
+            v3Scale(tan(this->opNavAngleErr * 0.25), this->opNavMnvrVec, this->attGuidanceOutBuffer.sigma_BR);
             MRPswitch(this->attGuidanceOutBuffer.sigma_BR, 1.0, this->attGuidanceOutBuffer.sigma_BR);
         }
 
@@ -151,7 +151,7 @@ void OpNavPoint::updateState(uint64_t callTime)
         v3Copy(omega_RN_B, this->attGuidanceOutBuffer.omega_RN_B);
 
     } else {
-        this->lastTime=0;
+        this->lastTime = 0;
         /* no proper opNav direction vector is available */
         v3SetZero(this->attGuidanceOutBuffer.sigma_BR);
 

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.cpp
@@ -21,6 +21,7 @@
 #include "fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.cpp
@@ -17,19 +17,18 @@
 
  */
 
-#include <math.h>
 #include "fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/safeMath.h"
+#include <math.h>
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void SunSafePoint::reset(uint64_t callTime)
-{
+void SunSafePoint::reset(uint64_t callTime) {
     double v1[3];
 
     // check if the required input messages are included
@@ -41,14 +40,18 @@ void SunSafePoint::reset(uint64_t callTime)
     }
 
     /* compute an Eigen axis orthogonal to sHatBdyCmd */
-    if (v3Norm(this->sHatBdyCmd)  < 0.1) {
-      char info[MAX_LOGGING_LENGTH];
-      snprintf(info, sizeof(info), "The module vector sHatBdyCmd is not setup as a unit vector [%f, %f %f]",
-                this->sHatBdyCmd[0], this->sHatBdyCmd[1], this->sHatBdyCmd[2]);
-      this->bskLogger.bskLog(BSK_ERROR, info);
+    if (v3Norm(this->sHatBdyCmd) < 0.1) {
+        char info[MAX_LOGGING_LENGTH];
+        snprintf(info,
+                 sizeof(info),
+                 "The module vector sHatBdyCmd is not setup as a unit vector [%f, %f %f]",
+                 this->sHatBdyCmd[0],
+                 this->sHatBdyCmd[1],
+                 this->sHatBdyCmd[2]);
+        this->bskLogger.bskLog(BSK_ERROR, info);
     } else {
         v3Set(1., 0., 0., v1);
-        v3Normalize(this->sHatBdyCmd, this->sHatBdyCmd);    /* ensure that this vector is a unit vector */
+        v3Normalize(this->sHatBdyCmd, this->sHatBdyCmd); /* ensure that this vector is a unit vector */
         v3Cross(this->sHatBdyCmd, v1, this->eHat180_B);
         if (v3Norm(this->eHat180_B) < 0.1) {
             v3Set(0., 1., 0., v1);
@@ -67,14 +70,13 @@ void SunSafePoint::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */
-void SunSafePoint::updateState(uint64_t callTime)
-{
+void SunSafePoint::updateState(uint64_t callTime) {
     NavAttMsgPayload navMsg;
     double ctSNormalized;
-    double sNorm;                   /*!< --- Norm of measured direction vector */
-    double e_hat[3];                /*!< --- Eigen Axis */
-    double omega_BN_B[3];           /*!< r/s inertial body angular velocity vector in B frame components */
-    double omega_RN_B[3];           /*!< r/s local copy of the desired reference frame rate */
+    double sNorm;         /*!< --- Norm of measured direction vector */
+    double e_hat[3];      /*!< --- Eigen Axis */
+    double omega_BN_B[3]; /*!< r/s inertial body angular velocity vector in B frame components */
+    double omega_RN_B[3]; /*!< r/s local copy of the desired reference frame rate */
 
     NavAttMsgPayload localImuDataInBuffer;
     this->attGuidanceOutBuffer = {};
@@ -87,12 +89,10 @@ void SunSafePoint::updateState(uint64_t callTime)
 
     /*! - Compute the current error vector if it is valid*/
     sNorm = v3Norm(navMsg.vehSunPntBdy);
-    if(sNorm > this->minUnitMag)
-    {
+    if (sNorm > this->minUnitMag) {
         /* a good sun direction vector is available */
-        ctSNormalized = v3Dot(this->sHatBdyCmd, navMsg.vehSunPntBdy)/sNorm;
-        ctSNormalized = fabs(ctSNormalized) > 1.0 ?
-        ctSNormalized/fabs(ctSNormalized) : ctSNormalized;
+        ctSNormalized = v3Dot(this->sHatBdyCmd, navMsg.vehSunPntBdy) / sNorm;
+        ctSNormalized = fabs(ctSNormalized) > 1.0 ? ctSNormalized / fabs(ctSNormalized) : ctSNormalized;
         this->sunAngleErr = safeAcos(ctSNormalized);
 
         /*
@@ -100,7 +100,7 @@ void SunSafePoint::updateState(uint64_t callTime)
          */
         if (this->sunAngleErr < this->smallAngle) {
             /* sun heading and desired body axis are essentially aligned.  Set attitude error to zero. */
-             v3SetZero(this->attGuidanceOutBuffer.sigma_BR);
+            v3SetZero(this->attGuidanceOutBuffer.sigma_BR);
         } else {
             if (M_PI - this->sunAngleErr < this->smallAngle) {
                 /* the commanded body vector nearly is opposite the sun heading */
@@ -110,13 +110,12 @@ void SunSafePoint::updateState(uint64_t callTime)
                 v3Cross(navMsg.vehSunPntBdy, this->sHatBdyCmd, e_hat);
             }
             v3Normalize(e_hat, this->sunMnvrVec);
-            v3Scale(tan(this->sunAngleErr*0.25), this->sunMnvrVec,
-                    this->attGuidanceOutBuffer.sigma_BR);
+            v3Scale(tan(this->sunAngleErr * 0.25), this->sunMnvrVec, this->attGuidanceOutBuffer.sigma_BR);
             MRPswitch(this->attGuidanceOutBuffer.sigma_BR, 1.0, this->attGuidanceOutBuffer.sigma_BR);
         }
 
         /* rate tracking error are the body rates to bring spacecraft to rest */
-        v3Scale(this->sunAxisSpinRate/sNorm, navMsg.vehSunPntBdy, omega_RN_B);
+        v3Scale(this->sunAxisSpinRate / sNorm, navMsg.vehSunPntBdy, omega_RN_B);
         v3Subtract(omega_BN_B, omega_RN_B, this->attGuidanceOutBuffer.omega_BR_B);
         v3Copy(omega_RN_B, this->attGuidanceOutBuffer.omega_RN_B);
 

--- a/src/fswAlgorithms/attGuidance/sunSafePointCpp/sunSafePointCpp.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePointCpp/sunSafePointCpp.cpp
@@ -24,6 +24,7 @@
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
@@ -23,6 +23,7 @@
 
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/safeMath.h"
 
 int8_t asInt(ThrForceSign value) { return static_cast<int8_t>(value); }
 

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.cpp
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.cpp
@@ -16,24 +16,16 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-/*
-    FSW Electrostatic Tractor Control
 
- */
-
-/* modify the path to reflect the new module names */
 #include "etSphericalControl.h"
 
-#include <math.h>
-#include <string.h>
-
-/*
- Pull in support files from other modules.  Be sure to use the absolute path relative to Basilisk directory.
- */
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/orbitalMotion.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
+
+#include <math.h>
 
 
 /*! This method performs a complete reset of the module.  Local module variables that retain

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.cpp
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.cpp
@@ -27,14 +27,12 @@
 
 #include <math.h>
 
-
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void
  @param callTime [ns] time the method is called
 */
-void EtSphericalControl::reset(uint64_t callTime)
-{
+void EtSphericalControl::reset(uint64_t callTime) {
     // check if the required input messages are included
     if (!this->servicerTransInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: etSphericalControl.servicerTransInMsg wasn't connected.");
@@ -63,7 +61,8 @@ void EtSphericalControl::reset(uint64_t callTime)
 
     // m_T and m_D must be positive and non-zero
     if (this->servicerVehicleConfigInMsg().massSC <= 0.0) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error in etSphericalControl: servicer mass must be set to a positive value.");
+        this->bskLogger.bskLog(BSK_ERROR,
+                               "Error in etSphericalControl: servicer mass must be set to a positive value.");
     }
     if (this->debrisVehicleConfigInMsg().massSC <= 0.0) {
         this->bskLogger.bskLog(BSK_ERROR, "Error in etSphericalControl: debris mass must be set to a positive value.");
@@ -89,8 +88,7 @@ void EtSphericalControl::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */
-void EtSphericalControl::updateState(uint64_t callTime)
-{
+void EtSphericalControl::updateState(uint64_t callTime) {
     // in
     NavTransMsgPayload servicerTransInMsgBuffer;
     NavTransMsgPayload debrisTransInMsgBuffer;
@@ -111,7 +109,14 @@ void EtSphericalControl::updateState(uint64_t callTime)
     eForceInMsgBuffer = this->eForceInMsg();
 
     // - calculate control force
-    this->calcRelativeMotionControl(servicerTransInMsgBuffer, debrisTransInMsgBuffer, servicerAttInMsgBuffer, servicerVehicleConfigInMsgBuffer, debrisVehicleConfigInMsgBuffer, eForceInMsgBuffer, &forceInertialOutMsgBuffer, &forceBodyOutMsgBuffer);
+    this->calcRelativeMotionControl(servicerTransInMsgBuffer,
+                                    debrisTransInMsgBuffer,
+                                    servicerAttInMsgBuffer,
+                                    servicerVehicleConfigInMsgBuffer,
+                                    debrisVehicleConfigInMsgBuffer,
+                                    eForceInMsgBuffer,
+                                    &forceInertialOutMsgBuffer,
+                                    &forceBodyOutMsgBuffer);
 
     // - write the module output messages
     this->forceInertialOutMsg.write(&forceInertialOutMsgBuffer, this->moduleID, callTime);
@@ -133,36 +138,36 @@ void EtSphericalControl::updateState(uint64_t callTime)
  @param forceBodyOutMsgBuffer body force output (3-axis)
  */
 void EtSphericalControl::calcRelativeMotionControl(NavTransMsgPayload servicerTransInMsgBuffer,
-                                                    NavTransMsgPayload debrisTransInMsgBuffer,
-                                                    NavAttMsgPayload servicerAttInMsgBuffer,
-                                                    VehicleConfigMsgPayload servicerVehicleConfigInMsgBuffer,
-                                                    VehicleConfigMsgPayload debrisVehicleConfigInMsgBuffer,
-                                                    CmdForceInertialMsgPayload eForceInMsgBuffer,
-                                                    CmdForceInertialMsgPayload *forceInertialOutMsgBuffer,
-                                                    CmdForceBodyMsgPayload *forceBodyOutMsgBuffer)
-{
-    // relative motion control according to "Relative Motion Control For Two-Spacecraft Electrostatic Orbit Corrections" https://doi.org/10.2514/1.56118
+                                                   NavTransMsgPayload debrisTransInMsgBuffer,
+                                                   NavAttMsgPayload servicerAttInMsgBuffer,
+                                                   VehicleConfigMsgPayload servicerVehicleConfigInMsgBuffer,
+                                                   VehicleConfigMsgPayload debrisVehicleConfigInMsgBuffer,
+                                                   CmdForceInertialMsgPayload eForceInMsgBuffer,
+                                                   CmdForceInertialMsgPayload *forceInertialOutMsgBuffer,
+                                                   CmdForceBodyMsgPayload *forceBodyOutMsgBuffer) {
+    // relative motion control according to "Relative Motion Control For Two-Spacecraft Electrostatic Orbit Corrections"
+    // https://doi.org/10.2514/1.56118
 
     // DCMs
-    double dcm_HN[3][3]; // [HN] from inertial frame to Hill frame
-    double dcm_NH[3][3]; // [NH] from Hill frame to inertial frame
+    double dcm_HN[3][3];  // [HN] from inertial frame to Hill frame
+    double dcm_NH[3][3];  // [NH] from Hill frame to inertial frame
     hillFrame(servicerTransInMsgBuffer.r_BN_N, servicerTransInMsgBuffer.v_BN_N, dcm_HN);
     m33Transpose(dcm_HN, dcm_NH);
     // relative position and velocity vector
-    double rho_N[3]; // position
-    double rho_H[3]; // in Hill frame components
-    double rhoDot_N[3]; // inertial (absolute) relative velocity
-    double rhoPrime_H[3]; // Hill relative velocity in Hill frame
-    double r_TN_mag = v3Norm(servicerTransInMsgBuffer.r_BN_N); // magnitude of servicer position vector
-    double omega_HN[3]; // angular velocity vector of Hill frame with respect to inertial frame
+    double rho_N[3];                                            // position
+    double rho_H[3];                                            // in Hill frame components
+    double rhoDot_N[3];                                         // inertial (absolute) relative velocity
+    double rhoPrime_H[3];                                       // Hill relative velocity in Hill frame
+    double r_TN_mag = v3Norm(servicerTransInMsgBuffer.r_BN_N);  // magnitude of servicer position vector
+    double omega_HN[3];  // angular velocity vector of Hill frame with respect to inertial frame
     v3Subtract(debrisTransInMsgBuffer.r_BN_N, servicerTransInMsgBuffer.r_BN_N, rho_N);
     m33MultV3(dcm_HN, rho_N, rho_H);
     v3Subtract(debrisTransInMsgBuffer.v_BN_N, servicerTransInMsgBuffer.v_BN_N, rhoDot_N);
-    double rTN_cross_vTN[3]; // temporary vector
-    double omega_cross_rho_N[3]; // temporary vector
-    double rhoDot_m_rel[3]; // temporary vector
+    double rTN_cross_vTN[3];      // temporary vector
+    double omega_cross_rho_N[3];  // temporary vector
+    double rhoDot_m_rel[3];       // temporary vector
     v3Cross(servicerTransInMsgBuffer.r_BN_N, servicerTransInMsgBuffer.v_BN_N, rTN_cross_vTN);
-    v3Scale(1./r_TN_mag/r_TN_mag, rTN_cross_vTN, omega_HN);
+    v3Scale(1. / r_TN_mag / r_TN_mag, rTN_cross_vTN, omega_HN);
     v3Cross(omega_HN, rho_N, omega_cross_rho_N);
     v3Subtract(rhoDot_N, omega_cross_rho_N, rhoDot_m_rel);
     m33MultV3(dcm_HN, rhoDot_m_rel, rhoPrime_H);
@@ -171,18 +176,24 @@ void EtSphericalControl::calcRelativeMotionControl(NavTransMsgPayload servicerTr
     double y = rho_H[1];
     double z = rho_H[2];
     // spherical coordinates
-    double L = v3Norm(rho_H); // separation distance
-    double theta = atan2(x,-y); // in-plane rotation angle
-    double phi = safeAsin(-z/L); // out-of-plane rotation angle
+    double L = v3Norm(rho_H);       // separation distance
+    double theta = atan2(x, -y);    // in-plane rotation angle
+    double phi = safeAsin(-z / L);  // out-of-plane rotation angle
     // more DCMs
-    double dcm_SH[3][3]; // [SH] from Hill frame to spherical frame
-    m33Set(cos(phi)*sin(theta), -cos(theta)*cos(phi), -sin(phi),
-           cos(theta), sin(theta), 0.,
-           sin(theta)*sin(phi), -cos(theta)*sin(phi), cos(phi),
+    double dcm_SH[3][3];  // [SH] from Hill frame to spherical frame
+    m33Set(cos(phi) * sin(theta),
+           -cos(theta) * cos(phi),
+           -sin(phi),
+           cos(theta),
+           sin(theta),
+           0.,
+           sin(theta) * sin(phi),
+           -cos(theta) * sin(phi),
+           cos(phi),
            dcm_SH);
-    double dcm_SN[3][3]; // [SN] from inertial frame to spherical frame
-    double dcm_NS[3][3]; // [NS] from spherical frame to inertial frame
-    double dcm_TN[3][3]; // [TN] from inertial frame to body frame of servicer
+    double dcm_SN[3][3];  // [SN] from inertial frame to spherical frame
+    double dcm_NS[3][3];  // [NS] from spherical frame to inertial frame
+    double dcm_TN[3][3];  // [TN] from inertial frame to body frame of servicer
     m33MultM33(dcm_SH, dcm_HN, dcm_SN);
     m33Transpose(dcm_SN, dcm_NS);
     MRP2C(servicerAttInMsgBuffer.sigma_BN, dcm_TN);
@@ -190,47 +201,52 @@ void EtSphericalControl::calcRelativeMotionControl(NavTransMsgPayload servicerTr
     double X[3];
     v3Set(L, theta, phi, X);
     // state vector derivative
-    double TransfMatrix[3][3]; // transformation matrix to map state vector derivative from Hill components to spherical components
-    m33Set(cos(phi)*sin(theta), -cos(theta)*cos(phi), -sin(phi),
-           cos(theta)/cos(phi)/L, 1./cos(phi)*sin(theta)/L, 0.,
-           -sin(theta)*sin(phi)/L, cos(theta)*sin(phi)/L, -cos(phi)/L,
+    double TransfMatrix[3][3];  // transformation matrix to map state vector derivative from Hill components to
+                                // spherical components
+    m33Set(cos(phi) * sin(theta),
+           -cos(theta) * cos(phi),
+           -sin(phi),
+           cos(theta) / cos(phi) / L,
+           1. / cos(phi) * sin(theta) / L,
+           0.,
+           -sin(theta) * sin(phi) / L,
+           cos(theta) * sin(phi) / L,
+           -cos(phi) / L,
            TransfMatrix);
-    double XDot[3]; // state vector derivative
+    double XDot[3];  // state vector derivative
     m33MultV3(TransfMatrix, rhoPrime_H, XDot);
     double LDot = XDot[0];
     double thetaDot = XDot[1];
     double phiDot = XDot[2];
     // control matrices [F] and [G]
-    double mu = this->mu; // [m^3/s^2] Earth's gravitational parameter
+    double mu = this->mu;  // [m^3/s^2] Earth's gravitational parameter
     ClassicElements elements;
     rv2elem(mu, servicerTransInMsgBuffer.r_BN_N, servicerTransInMsgBuffer.v_BN_N, &elements);
     double a = elements.a;
-    double n = sqrt(mu/a/a/a); // mean motion
+    double n = sqrt(mu / a / a / a);  // mean motion
 
     double Fvector[3];
-    v3Set(1./4.*L*(n*n*(-6.*cos(2.*theta)*cos(phi)*cos(phi)+5.*cos(2.*phi)+1.)+4.*thetaDot*cos(phi)*cos(phi)*(2.*n+thetaDot)+4.*phiDot*phiDot),
-          (3.*n*n*sin(theta)*cos(theta)+2.*phiDot*tan(phi)*(n+thetaDot))-2.*LDot/L*(n+thetaDot),
-          1./4.*sin(2.*phi)*(n*n*(3.*cos(2.*theta)-5.)-2.*thetaDot*(2.*n+thetaDot))-2.*LDot/L*phiDot,
+    v3Set(1. / 4. * L *
+              (n * n * (-6. * cos(2. * theta) * cos(phi) * cos(phi) + 5. * cos(2. * phi) + 1.) +
+               4. * thetaDot * cos(phi) * cos(phi) * (2. * n + thetaDot) + 4. * phiDot * phiDot),
+          (3. * n * n * sin(theta) * cos(theta) + 2. * phiDot * tan(phi) * (n + thetaDot)) -
+              2. * LDot / L * (n + thetaDot),
+          1. / 4. * sin(2. * phi) * (n * n * (3. * cos(2. * theta) - 5.) - 2. * thetaDot * (2. * n + thetaDot)) -
+              2. * LDot / L * phiDot,
           Fvector);
-    double GmatrixInv[3][3]; // inverse of [G]
-    m33Set(1., 0., 0.,
-           0., L*cos(phi), 0.,
-           0., 0., -L,
-           GmatrixInv);
+    double GmatrixInv[3][3];  // inverse of [G]
+    m33Set(1., 0., 0., 0., L * cos(phi), 0., 0., 0., -L, GmatrixInv);
     // desired state vector
     double X_r[3];
-    v3Set(this->L_r,
-          this->theta_r,
-          this->phi_r,
-          X_r);
+    v3Set(this->L_r, this->theta_r, this->phi_r, X_r);
     // feedback control acceleration
-    double P_XDot[3]; // temporary vector
-    double K_X[3]; // temporary vector
-    double XmX_r[3]; // temporary vector
-    double mP[3]; // temporary vector
-    double PK[3]; // temporary vector
-    double zeros[3]; // temporary vector
-    double PKF[3]; // temporary vector
+    double P_XDot[3];  // temporary vector
+    double K_X[3];     // temporary vector
+    double XmX_r[3];   // temporary vector
+    double mP[3];      // temporary vector
+    double PK[3];      // temporary vector
+    double zeros[3];   // temporary vector
+    double PKF[3];     // temporary vector
     v3SetZero(zeros);
     v3Subtract(X, X_r, XmX_r);
     m33MultV3(RECAST3X3 this->P, XDot, P_XDot);
@@ -238,21 +254,21 @@ void EtSphericalControl::calcRelativeMotionControl(NavTransMsgPayload servicerTr
     v3Subtract(zeros, P_XDot, mP);
     v3Subtract(mP, K_X, PK);
     v3Subtract(PK, Fvector, PKF);
-    double u_S[3]; // feedback control acceleration
-    m33MultV3( GmatrixInv, PKF, u_S);   // u_S = [G]^-1*(-[P]*XDot-[K]*(X-X_r)-[F])
+    double u_S[3];                    // feedback control acceleration
+    m33MultV3(GmatrixInv, PKF, u_S);  // u_S = [G]^-1*(-[P]*XDot-[K]*(X-X_r)-[F])
 
     // control thrust force
-    double m_T; // mass of servicer
-    double m_D; // mass of debris
-    double FcmuTD[3]; // temporary vector
-    double Fc_S[3]; // electrostatic force in spherical frame
-    double uFc[3]; // temporary vector
-    double T_S[3]; // control thrust force in spherical frame
-    double T_N[3]; // control thrust force in inertial frame
-    double T_T[3]; // control thrust force in servicer body frame
+    double m_T;        // mass of servicer
+    double m_D;        // mass of debris
+    double FcmuTD[3];  // temporary vector
+    double Fc_S[3];    // electrostatic force in spherical frame
+    double uFc[3];     // temporary vector
+    double T_S[3];     // control thrust force in spherical frame
+    double T_N[3];     // control thrust force in inertial frame
+    double T_T[3];     // control thrust force in servicer body frame
     m_T = servicerVehicleConfigInMsgBuffer.massSC;
     m_D = debrisVehicleConfigInMsgBuffer.massSC;
-    double muTD = 1./m_T+1./m_D;
+    double muTD = 1. / m_T + 1. / m_D;
     m33MultV3(dcm_SN, eForceInMsgBuffer.forceRequestInertial, Fc_S);
     v3Scale(muTD, Fc_S, FcmuTD);
     v3Add(u_S, FcmuTD, uFc);

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.cpp
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.cpp
@@ -18,11 +18,13 @@
 */
 
 #include "spacecraftReconfig.h"
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
+
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
+
+#include <stdlib.h>
+#include <math.h>
 
 static double AdjustRange(double lower, double upper, double angle);
 static int CompareTime(const void * n1, const void * n2);

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.cpp
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.cpp
@@ -23,11 +23,11 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/safeMath.h"
 
-#include <stdlib.h>
 #include <math.h>
+#include <stdlib.h>
 
 static double AdjustRange(double lower, double upper, double angle);
-static int CompareTime(const void * n1, const void * n2);
+static int CompareTime(const void *n1, const void *n2);
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.  The local copy of the
@@ -35,8 +35,7 @@ static int CompareTime(const void * n1, const void * n2);
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void SpacecraftReconfig::reset(uint64_t callTime)
-{
+void SpacecraftReconfig::reset(uint64_t callTime) {
     // check if the required input messages are included
     if (!this->chiefTransInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: spacecraftReconfig.chiefTransInMsg wasn't connected.");
@@ -54,9 +53,9 @@ void SpacecraftReconfig::reset(uint64_t callTime)
     // zero the burn info buffer
     this->burnArrayInfoOutMsgBuffer = {};
 
-    this->prevCallTime    = 0;
-    this->tCurrent        = 0.0;
-    this->thrustOnFlag    = 0;
+    this->prevCallTime = 0;
+    this->tCurrent = 0.0;
+    this->thrustOnFlag = 0;
 
     this->attRefInIsLinked = this->attRefInMsg.isLinked();
 
@@ -67,8 +66,7 @@ void SpacecraftReconfig::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void SpacecraftReconfig::updateState(uint64_t callTime)
-{
+void SpacecraftReconfig::updateState(uint64_t callTime) {
     // in
     NavTransMsgPayload chiefTransMsgBuffer;
     NavTransMsgPayload deputyTransMsgBuffer;
@@ -89,21 +87,27 @@ void SpacecraftReconfig::updateState(uint64_t callTime)
         attRefInMsgBuffer = this->attRefInMsg();
     }
 
-    if(this->prevCallTime == 0) {
-		this->prevCallTime = callTime; // initialize
-	}
+    if (this->prevCallTime == 0) {
+        this->prevCallTime = callTime;  // initialize
+    }
     // calculate elapsed time from last module updated time
     double elapsed_time = ((double)(callTime - this->prevCallTime)) * NANO2SEC;
     this->tCurrent = this->tCurrent + elapsed_time;
-	this->prevCallTime = callTime;
+    this->prevCallTime = callTime;
 
-    this->UpdateManeuver(chiefTransMsgBuffer, deputyTransMsgBuffer, attRefInMsgBuffer,
-                     thrustConfigMsgBuffer, vehicleConfigMsgBuffer, &attRefOutMsgBuffer, &thrustOnMsgBuffer, callTime);
+    this->UpdateManeuver(chiefTransMsgBuffer,
+                         deputyTransMsgBuffer,
+                         attRefInMsgBuffer,
+                         thrustConfigMsgBuffer,
+                         vehicleConfigMsgBuffer,
+                         &attRefOutMsgBuffer,
+                         &thrustOnMsgBuffer,
+                         callTime);
 
     /*! - write the module output messages */
     this->attRefOutMsg.write(&attRefOutMsgBuffer, this->moduleID, callTime);
     this->burnArrayInfoOutMsg.write(&this->burnArrayInfoOutMsgBuffer, this->moduleID, callTime);
-    if(this->thrustOnFlag == 1){
+    if (this->thrustOnFlag == 1) {
         // only when thrustOnFlag is 1, thrustOnMessage is output
         this->onTimeOutMsg.write(&thrustOnMsgBuffer, this->moduleID, callTime);
     }
@@ -130,129 +134,153 @@ void SpacecraftReconfig::UpdateManeuver(NavTransMsgPayload chiefTransMsgBuffer,
                                         VehicleConfigMsgPayload vehicleConfigMsgBuffer,
                                         AttRefMsgPayload *attRefOutMsgBuffer,
                                         THRArrayOnTimeCmdMsgPayload *thrustOnMsgBuffer,
-                                        uint64_t callTime)
-{
+                                        uint64_t callTime) {
     /* conversion from r,v to classical orbital elements */
     ClassicElements oe_c, oe_d;
-    rv2elem(this->mu,chiefTransMsgBuffer.r_BN_N,chiefTransMsgBuffer.v_BN_N,&oe_c);
-    rv2elem(this->mu,deputyTransMsgBuffer.r_BN_N,deputyTransMsgBuffer.v_BN_N,&oe_d);
+    rv2elem(this->mu, chiefTransMsgBuffer.r_BN_N, chiefTransMsgBuffer.v_BN_N, &oe_c);
+    rv2elem(this->mu, deputyTransMsgBuffer.r_BN_N, deputyTransMsgBuffer.v_BN_N, &oe_d);
 
     /* schedule dv manuever at the initiation timing of this module */
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 0){
-        this->resetPeriod = 2*M_PI/sqrt(this->mu/pow(oe_c.a,3)); // one orbital period
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 0) {
+        this->resetPeriod = 2 * M_PI / sqrt(this->mu / pow(oe_c.a, 3));  // one orbital period
         this->ScheduleDV(oe_c, oe_d, thrustConfigMsgBuffer, vehicleConfigMsgBuffer);
         // sort three burns (dvArray structures) in ascending order
-        qsort(this->burnArrayInfoOutMsgBuffer.burnArray, sizeof(this->burnArrayInfoOutMsgBuffer) / sizeof(this->burnArrayInfoOutMsgBuffer.burnArray[0]),
-              sizeof(ReconfigBurnInfoMsgPayload), CompareTime);
+        qsort(this->burnArrayInfoOutMsgBuffer.burnArray,
+              sizeof(this->burnArrayInfoOutMsgBuffer) / sizeof(this->burnArrayInfoOutMsgBuffer.burnArray[0]),
+              sizeof(ReconfigBurnInfoMsgPayload),
+              CompareTime);
     }
 
     /* After burn scheduling, the routine below is executed at every time step */
     /* Overall, this->burnArrayInfoOutMsgBuffer.burnArray[i].flag is checked sequentially (i=0,1,2)  */
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 1){
-        double t_left = this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->tCurrent; // remaining time until first burn
-        if(t_left > this->attControlTime && this->attRefInIsLinked){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 1) {
+        double t_left =
+            this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->tCurrent;  // remaining time until first burn
+        if (t_left > this->attControlTime && this->attRefInIsLinked) {
             // in this case, there is enough time until first burn, so reference input attitude is set as target
             *attRefOutMsgBuffer = attRefInMsgBuffer;
-        }else{
+        } else {
             // in this case, first burn attitude is set at target
             v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN, attRefOutMsgBuffer->sigma_RN);
         }
         // middle of thruster burn duration time is located at the expected exact timing of impulsive control
-        if(t_left < (int)this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters) &&
-            this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 1){
-            this->thrustOnFlag     = 1; // thrustOnFlag is ON
-            this->burnArrayInfoOutMsgBuffer.burnArray[0].flag  = 2; // first burn is regarded as finished by setting this to 2
+        if (t_left < (int)this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime /
+                         (2 * thrustConfigMsgBuffer.numThrusters) &&
+            this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 1) {
+            this->thrustOnFlag = 1;  // thrustOnFlag is ON
+            this->burnArrayInfoOutMsgBuffer.burnArray[0].flag =
+                2;  // first burn is regarded as finished by setting this to 2
             int i = 0;
-            for(i = 0;i < thrustConfigMsgBuffer.numThrusters;++i){
-                thrustOnMsgBuffer->OnTimeRequest[i] = this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/thrustConfigMsgBuffer.numThrusters;
+            for (i = 0; i < thrustConfigMsgBuffer.numThrusters; ++i) {
+                thrustOnMsgBuffer->OnTimeRequest[i] =
+                    this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime / thrustConfigMsgBuffer.numThrusters;
             }
-        }else{
-            this->thrustOnFlag = 0; // thrustOnFlag is OFF
+        } else {
+            this->thrustOnFlag = 0;  // thrustOnFlag is OFF
         }
-    }else if(this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 1) {
-        double t_left = this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->tCurrent; // remaining time until second burn
-        if(this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 &&
-           this->tCurrent < (this->burnArrayInfoOutMsgBuffer.burnArray[0].t+this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters))){
+    } else if (this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 1) {
+        double t_left =
+            this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->tCurrent;  // remaining time until second burn
+        if (this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 &&
+            this->tCurrent < (this->burnArrayInfoOutMsgBuffer.burnArray[0].t +
+                              this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime /
+                                  (2 * thrustConfigMsgBuffer.numThrusters))) {
             // in this case, first burn is still executed, so first burn attitude is set as target
             v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN, attRefOutMsgBuffer->sigma_RN);
-        }else if(t_left > this->attControlTime && this->attRefInIsLinked){
+        } else if (t_left > this->attControlTime && this->attRefInIsLinked) {
             // in this case, there is enough time until second burn, so reference input attitude is set as target
             *attRefOutMsgBuffer = attRefInMsgBuffer;
-        }else{
+        } else {
             // in this case, second burn attitude is set at target
             v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN, attRefOutMsgBuffer->sigma_RN);
         }
-        if(t_left < (int)this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters) &&
-           this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 1){
+        if (t_left < (int)this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime /
+                         (2 * thrustConfigMsgBuffer.numThrusters) &&
+            this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 1) {
             this->thrustOnFlag = 1;
             this->burnArrayInfoOutMsgBuffer.burnArray[1].flag = 2;
             int i = 0;
-            for(i = 0;i < thrustConfigMsgBuffer.numThrusters;++i){
-                thrustOnMsgBuffer->OnTimeRequest[i] = this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime/thrustConfigMsgBuffer.numThrusters;
+            for (i = 0; i < thrustConfigMsgBuffer.numThrusters; ++i) {
+                thrustOnMsgBuffer->OnTimeRequest[i] =
+                    this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime / thrustConfigMsgBuffer.numThrusters;
             }
-        }else{
+        } else {
             this->thrustOnFlag = 0;
         }
-    }else if(this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 1){
-        double t_left = this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->tCurrent; // remaining time until third burn
-        if(this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 2 &&
-           this->tCurrent < (this->burnArrayInfoOutMsgBuffer.burnArray[1].t+this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters))){
+    } else if (this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 1) {
+        double t_left =
+            this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->tCurrent;  // remaining time until third burn
+        if (this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 2 &&
+            this->tCurrent < (this->burnArrayInfoOutMsgBuffer.burnArray[1].t +
+                              this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime /
+                                  (2 * thrustConfigMsgBuffer.numThrusters))) {
             // in this case, second burn is still executed, so second burn attitude is set as target
             v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN, attRefOutMsgBuffer->sigma_RN);
-        }else if(this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 &&
-           this->tCurrent < (this->burnArrayInfoOutMsgBuffer.burnArray[0].t+this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters))){
+        } else if (this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2 &&
+                   this->tCurrent < (this->burnArrayInfoOutMsgBuffer.burnArray[0].t +
+                                     this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime /
+                                         (2 * thrustConfigMsgBuffer.numThrusters))) {
             // in this case, first burn is still executed, so first burn attitude is set as target
             v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN, attRefOutMsgBuffer->sigma_RN);
-        }else if(t_left > this->attControlTime && this->attRefInIsLinked){
+        } else if (t_left > this->attControlTime && this->attRefInIsLinked) {
             // in this case, there is enough time until second burn, so reference input attitude is set as target
             *attRefOutMsgBuffer = attRefInMsgBuffer;
-        }else{
+        } else {
             // in this case, third burn attitude is set at target
             v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[2].sigma_RN, attRefOutMsgBuffer->sigma_RN);
         }
-        if(t_left < (int)this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters) &&
-           this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 1){
+        if (t_left < (int)this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime /
+                         (2 * thrustConfigMsgBuffer.numThrusters) &&
+            this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 1) {
             this->thrustOnFlag = 1;
             this->burnArrayInfoOutMsgBuffer.burnArray[2].flag = 2;
             int i = 0;
-            for(i = 0;i < thrustConfigMsgBuffer.numThrusters;++i){
-                thrustOnMsgBuffer->OnTimeRequest[i] = this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime/thrustConfigMsgBuffer.numThrusters;
+            for (i = 0; i < thrustConfigMsgBuffer.numThrusters; ++i) {
+                thrustOnMsgBuffer->OnTimeRequest[i] =
+                    this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime / thrustConfigMsgBuffer.numThrusters;
             }
-        }else{
+        } else {
             this->thrustOnFlag = 0;
         }
-    }else{
+    } else {
         // this section is valid when all the impulses are finished
-        // we have to consider a case when one dvArray[].flag is set to 3, which means that the burn is combined with another
-        if(this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 2){
-            if(this->tCurrent > (this->burnArrayInfoOutMsgBuffer.burnArray[2].t+this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters)) &&
-               this->attRefInIsLinked){
+        // we have to consider a case when one dvArray[].flag is set to 3, which means that the burn is combined with
+        // another
+        if (this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 2) {
+            if (this->tCurrent > (this->burnArrayInfoOutMsgBuffer.burnArray[2].t +
+                                  this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime /
+                                      (2 * thrustConfigMsgBuffer.numThrusters)) &&
+                this->attRefInIsLinked) {
                 *attRefOutMsgBuffer = attRefInMsgBuffer;
-            }else{
+            } else {
                 v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[2].sigma_RN, attRefOutMsgBuffer->sigma_RN);
             }
-        }else if(this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 2){
-            if(this->tCurrent > (this->burnArrayInfoOutMsgBuffer.burnArray[1].t+this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters)) &&
-               this->attRefInIsLinked){
+        } else if (this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 2) {
+            if (this->tCurrent > (this->burnArrayInfoOutMsgBuffer.burnArray[1].t +
+                                  this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime /
+                                      (2 * thrustConfigMsgBuffer.numThrusters)) &&
+                this->attRefInIsLinked) {
                 *attRefOutMsgBuffer = attRefInMsgBuffer;
-            }else{
+            } else {
                 v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN, attRefOutMsgBuffer->sigma_RN);
             }
-        }else if(this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2){
-            if(this->tCurrent > (this->burnArrayInfoOutMsgBuffer.burnArray[0].t+this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/(2*thrustConfigMsgBuffer.numThrusters)) &&
-               this->attRefInIsLinked){
+        } else if (this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 2) {
+            if (this->tCurrent > (this->burnArrayInfoOutMsgBuffer.burnArray[0].t +
+                                  this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime /
+                                      (2 * thrustConfigMsgBuffer.numThrusters)) &&
+                this->attRefInIsLinked) {
                 *attRefOutMsgBuffer = attRefInMsgBuffer;
-            }else{
+            } else {
                 v3Copy(this->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN, attRefOutMsgBuffer->sigma_RN);
             }
-        }else{
+        } else {
             *attRefOutMsgBuffer = attRefInMsgBuffer;
         }
         this->thrustOnFlag = 0;
     }
 
     // at the end of one orbital period, reset this module
-    if(this->tCurrent > this->resetPeriod){
+    if (this->tCurrent > this->resetPeriod) {
         this->reset(callTime);
     }
 
@@ -260,24 +288,24 @@ void SpacecraftReconfig::UpdateManeuver(NavTransMsgPayload chiefTransMsgBuffer,
 }
 
 /*! This function is used to adjust a certain value in a certain range between lower threshold and upper threshold.
- This function is particularily used to adjsut angles used in orbital motions such as True Anomaly, Mean Anomaly, and so on.
+ This function is particularily used to adjsut angles used in orbital motions such as True Anomaly, Mean Anomaly, and so
+ on.
  @return double
  @param lower lower threshold
  @param upper upper threshold
  @param angle an angle which you want to be between lower and upper
 */
-static double AdjustRange(double lower, double upper, double angle)
-{
-    if(upper < lower){
+static double AdjustRange(double lower, double upper, double angle) {
+    if (upper < lower) {
         printf("illegal parameters\n");
         return -1;
     }
     double width = upper - lower;
     double adjusted_angle = angle;
-    while (adjusted_angle > upper){
+    while (adjusted_angle > upper) {
         adjusted_angle = adjusted_angle - width;
     }
-    while (adjusted_angle < lower){
+    while (adjusted_angle < lower) {
         adjusted_angle = adjusted_angle + width;
     }
     return adjusted_angle;
@@ -289,20 +317,14 @@ static double AdjustRange(double lower, double upper, double angle)
  @param n1
  @param n2
  */
-static int CompareTime(const void * n1, const void * n2)
-{
-	if (((ReconfigBurnInfoMsgPayload*)n1)->t > ((ReconfigBurnInfoMsgPayload*)n2)->t)
-	{
-		return 1;
-	}
-	else if (((ReconfigBurnInfoMsgPayload*)n1)->t < ((ReconfigBurnInfoMsgPayload*)n2)->t)
-	{
-		return -1;
-	}
-	else
-	{
-		return 0;
-	}
+static int CompareTime(const void *n1, const void *n2) {
+    if (((ReconfigBurnInfoMsgPayload *)n1)->t > ((ReconfigBurnInfoMsgPayload *)n2)->t) {
+        return 1;
+    } else if (((ReconfigBurnInfoMsgPayload *)n1)->t < ((ReconfigBurnInfoMsgPayload *)n2)->t) {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 /*! This function is used to sort an array of
@@ -316,38 +338,37 @@ static int CompareTime(const void * n1, const void * n2)
 void SpacecraftReconfig::ScheduleDV(ClassicElements oe_c,
                                     ClassicElements oe_d,
                                     THRArrayConfigMsgPayload thrustConfigMsgBuffer,
-                                    VehicleConfigMsgPayload vehicleConfigMsgBuffer)
-{
+                                    VehicleConfigMsgPayload vehicleConfigMsgBuffer) {
     // calculation necessary variables
-    double da     = oe_d.a - oe_c.a;
-    double de     = oe_d.e - oe_c.e;
-    double di     = oe_d.i - oe_c.i;
-    di            = AdjustRange(-M_PI, M_PI, di);
+    double da = oe_d.a - oe_c.a;
+    double de = oe_d.e - oe_c.e;
+    double di = oe_d.i - oe_c.i;
+    di = AdjustRange(-M_PI, M_PI, di);
     double domega = oe_d.omega - oe_c.omega;
     double dOmega = oe_d.Omega - oe_c.Omega;
-    dOmega        = AdjustRange(-M_PI, M_PI, dOmega);
-    domega        = AdjustRange(-M_PI, M_PI, domega);
-    double E_c    = f2E(oe_c.f, oe_c.e);
-    double M_c    = E2M(E_c, oe_c.e);
-    M_c           = AdjustRange(0, 2*M_PI, M_c);
-    double E_d    = f2E(oe_d.f, oe_d.e);
-    double M_d    = E2M(E_d, oe_d.e);
-    M_d           = AdjustRange(0, 2*M_PI, M_d);
-    double dM     = M_d - M_c;
-    dM            = AdjustRange(-M_PI, M_PI, dM);
-    double n      = sqrt(this->mu/(oe_c.a*oe_c.a*oe_c.a));
-    double eta    = sqrt(1.0-oe_c.e*oe_c.e);
-    double p      = oe_c.a*(1.0-oe_c.e*oe_c.e);
-    double h      = n*oe_c.a*oe_c.a*eta;
-    double rp     = oe_c.a*(1.0-oe_c.e);
-    double ra     = oe_c.a*(1.0+oe_c.e);
+    dOmega = AdjustRange(-M_PI, M_PI, dOmega);
+    domega = AdjustRange(-M_PI, M_PI, domega);
+    double E_c = f2E(oe_c.f, oe_c.e);
+    double M_c = E2M(E_c, oe_c.e);
+    M_c = AdjustRange(0, 2 * M_PI, M_c);
+    double E_d = f2E(oe_d.f, oe_d.e);
+    double M_d = E2M(E_d, oe_d.e);
+    M_d = AdjustRange(0, 2 * M_PI, M_d);
+    double dM = M_d - M_c;
+    dM = AdjustRange(-M_PI, M_PI, dM);
+    double n = sqrt(this->mu / (oe_c.a * oe_c.a * oe_c.a));
+    double eta = sqrt(1.0 - oe_c.e * oe_c.e);
+    double p = oe_c.a * (1.0 - oe_c.e * oe_c.e);
+    double h = n * oe_c.a * oe_c.a * eta;
+    double rp = oe_c.a * (1.0 - oe_c.e);
+    double ra = oe_c.a * (1.0 + oe_c.e);
 
-    da     = da     - this->targetClassicOED[0];
-    di     = di     - this->targetClassicOED[2];
-    de     = de     - this->targetClassicOED[1];
+    da = da - this->targetClassicOED[0];
+    di = di - this->targetClassicOED[2];
+    de = de - this->targetClassicOED[1];
     dOmega = dOmega - this->targetClassicOED[3];
     domega = domega - this->targetClassicOED[4];
-    dM     = dM     - this->targetClassicOED[5];
+    dM = dM - this->targetClassicOED[5];
 
     /* calculation below is divided into two parts */
     /* 1. calculate dV maneuver timing in tangential and radial direction at perigee */
@@ -357,88 +378,105 @@ void SpacecraftReconfig::ScheduleDV(ClassicElements oe_c,
     /* 5. calculate thrustOnTime */
 
     // 1. calculate t_dvrtp
-    double f_c_dvrtp = 0.0; // f = 0 @ perigee
+    double f_c_dvrtp = 0.0;  // f = 0 @ perigee
     double E_c_dvrtp = f2E(f_c_dvrtp, oe_c.e);
     double M_c_dvrtp = E2M(E_c_dvrtp, oe_c.e);
-    M_c_dvrtp        = AdjustRange(0, 2*M_PI, M_c_dvrtp);
-    if(M_c_dvrtp > M_c){
-        this->burnArrayInfoOutMsgBuffer.burnArray[0].t = (M_c_dvrtp - M_c)/n;
-    }else{
-        this->burnArrayInfoOutMsgBuffer.burnArray[0].t = (2*M_PI + M_c_dvrtp - M_c)/n;
+    M_c_dvrtp = AdjustRange(0, 2 * M_PI, M_c_dvrtp);
+    if (M_c_dvrtp > M_c) {
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].t = (M_c_dvrtp - M_c) / n;
+    } else {
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].t = (2 * M_PI + M_c_dvrtp - M_c) / n;
     }
     // 2. calculate t_dvrta
-    double f_c_dvrta = M_PI; // f = pi @ apogee
+    double f_c_dvrta = M_PI;  // f = pi @ apogee
     double E_c_dvrta = f2E(f_c_dvrta, oe_c.e);
     double M_c_dvrta = E2M(E_c_dvrta, oe_c.e);
-    M_c_dvrta        = AdjustRange(0, 2*M_PI, M_c_dvrta);
-    if(M_c_dvrta > M_c){
-        this->burnArrayInfoOutMsgBuffer.burnArray[1].t = (M_c_dvrta - M_c)/n;
-    }else{
-        this->burnArrayInfoOutMsgBuffer.burnArray[1].t = (2*M_PI + M_c_dvrta - M_c)/n;
+    M_c_dvrta = AdjustRange(0, 2 * M_PI, M_c_dvrta);
+    if (M_c_dvrta > M_c) {
+        this->burnArrayInfoOutMsgBuffer.burnArray[1].t = (M_c_dvrta - M_c) / n;
+    } else {
+        this->burnArrayInfoOutMsgBuffer.burnArray[1].t = (2 * M_PI + M_c_dvrta - M_c) / n;
     }
     // 3. calculate t_dvn
-    double theta_c     = oe_c.omega + oe_c.f;
-    theta_c            = AdjustRange(0, 2*M_PI, theta_c);
-    double theta_c_dvn = atan2((-dOmega)*sin(oe_c.i), (-di));
+    double theta_c = oe_c.omega + oe_c.f;
+    theta_c = AdjustRange(0, 2 * M_PI, theta_c);
+    double theta_c_dvn = atan2((-dOmega) * sin(oe_c.i), (-di));
     // choose burn lattitude angle so that dV is +z direction in LVLH
-    if((-di)*cos(theta_c_dvn)<0 && (-dOmega)*sin(oe_c.i)*sin(theta_c_dvn) <0){
+    if ((-di) * cos(theta_c_dvn) < 0 && (-dOmega) * sin(oe_c.i) * sin(theta_c_dvn) < 0) {
         theta_c_dvn = theta_c_dvn + M_PI;
     }
-    theta_c_dvn    = AdjustRange(0, 2*M_PI, theta_c_dvn);
+    theta_c_dvn = AdjustRange(0, 2 * M_PI, theta_c_dvn);
     double f_c_dvn = theta_c_dvn - oe_c.omega;
     double E_c_dvn = f2E(f_c_dvn, oe_c.e);
     double M_c_dvn = E2M(E_c_dvn, oe_c.e);
-    M_c_dvn        = AdjustRange(0, 2*M_PI, M_c_dvn);
-    if(M_c_dvn > M_c){
-        this->burnArrayInfoOutMsgBuffer.burnArray[2].t = (M_c_dvn - M_c)/n;
-    }else{
-        this->burnArrayInfoOutMsgBuffer.burnArray[2].t = (2*M_PI + M_c_dvn - M_c)/n;
+    M_c_dvn = AdjustRange(0, 2 * M_PI, M_c_dvn);
+    if (M_c_dvn > M_c) {
+        this->burnArrayInfoOutMsgBuffer.burnArray[2].t = (M_c_dvn - M_c) / n;
+    } else {
+        this->burnArrayInfoOutMsgBuffer.burnArray[2].t = (2 * M_PI + M_c_dvn - M_c) / n;
     }
     // 4. calculate dvrp_mag, dvtp_mag, dvra_mag, dvta_mag, dvn_mag
-    double dvtp_mag = n*oe_c.a*eta/4.0*((-da)/oe_c.a + (-de)/(1.0+oe_c.e));
-    double dvta_mag = n*oe_c.a*eta/4.0*((-da)/oe_c.a - (-de)/(1.0-oe_c.e));
+    double dvtp_mag = n * oe_c.a * eta / 4.0 * ((-da) / oe_c.a + (-de) / (1.0 + oe_c.e));
+    double dvta_mag = n * oe_c.a * eta / 4.0 * ((-da) / oe_c.a - (-de) / (1.0 - oe_c.e));
     // compensate drift of dM caused by initial da
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[0].t < this->burnArrayInfoOutMsgBuffer.burnArray[1].t){
-        dM = dM
-           - 3.0/2.0*n/oe_c.a*da*this->burnArrayInfoOutMsgBuffer.burnArray[0].t
-           - 3.0/2.0*n/oe_c.a*(da+2.0*oe_c.a*oe_c.a/h*p/rp*dvtp_mag)*(this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t);
-    }else{
-        dM = dM
-           - 3.0/2.0*n/oe_c.a*da*this->burnArrayInfoOutMsgBuffer.burnArray[1].t
-           - 3.0/2.0*n/oe_c.a*(da+2.0*oe_c.a*oe_c.a/h*p/ra*dvta_mag)*(this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t);
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[0].t < this->burnArrayInfoOutMsgBuffer.burnArray[1].t) {
+        dM = dM - 3.0 / 2.0 * n / oe_c.a * da * this->burnArrayInfoOutMsgBuffer.burnArray[0].t -
+             3.0 / 2.0 * n / oe_c.a * (da + 2.0 * oe_c.a * oe_c.a / h * p / rp * dvtp_mag) *
+                 (this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t);
+    } else {
+        dM = dM - 3.0 / 2.0 * n / oe_c.a * da * this->burnArrayInfoOutMsgBuffer.burnArray[1].t -
+             3.0 / 2.0 * n / oe_c.a * (da + 2.0 * oe_c.a * oe_c.a / h * p / ra * dvta_mag) *
+                 (this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t);
     }
-    double dvrp_mag = -n*oe_c.a/4*(pow(1+oe_c.e,2)/eta*((-domega)+(-dOmega)*cos(oe_c.i)) + (-dM));
-    double dvra_mag = -n*oe_c.a/4*(pow(1-oe_c.e,2)/eta*((-domega)+(-dOmega)*cos(oe_c.i)) + (-dM));
-    double r_dvn = p/(1+oe_c.e*cos(f_c_dvn));
-    double dvn_mag = h/r_dvn*sqrt(pow((-di),2) + pow((-dOmega)*sin(oe_c.i),2));
+    double dvrp_mag = -n * oe_c.a / 4 * (pow(1 + oe_c.e, 2) / eta * ((-domega) + (-dOmega) * cos(oe_c.i)) + (-dM));
+    double dvra_mag = -n * oe_c.a / 4 * (pow(1 - oe_c.e, 2) / eta * ((-domega) + (-dOmega) * cos(oe_c.i)) + (-dM));
+    double r_dvn = p / (1 + oe_c.e * cos(f_c_dvn));
+    double dvn_mag = h / r_dvn * sqrt(pow((-di), 2) + pow((-dOmega) * sin(oe_c.i), 2));
     // 5. calculate thrustOnTime
     // if timings of any two burns are close to each other, they are combined into one burn
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t < this->attControlTime &&
-       this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t < this->attControlTime){
-        this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime = sqrt(dvrp_mag*dvrp_mag+dvtp_mag*dvtp_mag+dvn_mag*dvn_mag)* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
-        this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime = sqrt(dvra_mag*dvra_mag+dvta_mag*dvta_mag)* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t <
+            this->attControlTime &&
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t <
+            this->attControlTime) {
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime =
+            sqrt(dvrp_mag * dvrp_mag + dvtp_mag * dvtp_mag + dvn_mag * dvn_mag) * vehicleConfigMsgBuffer.massSC /
+            thrustConfigMsgBuffer.thrusters[0].maxThrust;
+        this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime = sqrt(dvra_mag * dvra_mag + dvta_mag * dvta_mag) *
+                                                                    vehicleConfigMsgBuffer.massSC /
+                                                                    thrustConfigMsgBuffer.thrusters[0].maxThrust;
         this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime = 0.0;
         this->burnArrayInfoOutMsgBuffer.burnArray[2].flag = 3;
-    }else if(this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t < this->attControlTime &&
-             this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t < this->attControlTime){
-        this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime = sqrt(dvrp_mag*dvrp_mag+dvtp_mag*dvtp_mag)* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
-        this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime = sqrt(dvra_mag*dvra_mag+dvta_mag*dvta_mag+dvn_mag*dvn_mag)* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
+    } else if (this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t <
+                   this->attControlTime &&
+               this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t <
+                   this->attControlTime) {
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime = sqrt(dvrp_mag * dvrp_mag + dvtp_mag * dvtp_mag) *
+                                                                    vehicleConfigMsgBuffer.massSC /
+                                                                    thrustConfigMsgBuffer.thrusters[0].maxThrust;
+        this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime =
+            sqrt(dvra_mag * dvra_mag + dvta_mag * dvta_mag + dvn_mag * dvn_mag) * vehicleConfigMsgBuffer.massSC /
+            thrustConfigMsgBuffer.thrusters[0].maxThrust;
         this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime = 0.0;
         this->burnArrayInfoOutMsgBuffer.burnArray[2].flag = 3;
-    }else{
-        this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime = sqrt(dvrp_mag*dvrp_mag+dvtp_mag*dvtp_mag)* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
-        this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime = sqrt(dvra_mag*dvra_mag+dvta_mag*dvta_mag)* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
-        this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime = dvn_mag* vehicleConfigMsgBuffer.massSC/thrustConfigMsgBuffer.thrusters[0].maxThrust;
+    } else {
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime = sqrt(dvrp_mag * dvrp_mag + dvtp_mag * dvtp_mag) *
+                                                                    vehicleConfigMsgBuffer.massSC /
+                                                                    thrustConfigMsgBuffer.thrusters[0].maxThrust;
+        this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime = sqrt(dvra_mag * dvra_mag + dvta_mag * dvta_mag) *
+                                                                    vehicleConfigMsgBuffer.massSC /
+                                                                    thrustConfigMsgBuffer.thrusters[0].maxThrust;
+        this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime =
+            dvn_mag * vehicleConfigMsgBuffer.massSC / thrustConfigMsgBuffer.thrusters[0].maxThrust;
     }
     // if thrustOnTime is smaller than a cerain threshold, the impulse is neglected
     // 1.0 second is temporarily set as threshold regarding whether small impulse is neglected or not
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime/thrustConfigMsgBuffer.numThrusters < 1.0){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[0].thrustOnTime / thrustConfigMsgBuffer.numThrusters < 1.0) {
         this->burnArrayInfoOutMsgBuffer.burnArray[0].flag = 3;
     }
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime/thrustConfigMsgBuffer.numThrusters < 1.0){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[1].thrustOnTime / thrustConfigMsgBuffer.numThrusters < 1.0) {
         this->burnArrayInfoOutMsgBuffer.burnArray[1].flag = 3;
     }
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime/thrustConfigMsgBuffer.numThrusters < 1.0){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[2].thrustOnTime / thrustConfigMsgBuffer.numThrusters < 1.0) {
         this->burnArrayInfoOutMsgBuffer.burnArray[2].flag = 3;
     }
 
@@ -450,49 +488,54 @@ void SpacecraftReconfig::ScheduleDV(ClassicElements oe_c,
     /* calculate dcm_TR (this is common in three burns) */
     double thruster_dir[3];
     double ep_vec[3];
-    double ez[3] = {0.0,0.0,1.0};
-    v3Normalize(thrustConfigMsgBuffer.thrusters[0].tHatThrust_B,thruster_dir);
-    if(thruster_dir[0] == 0.0 && thruster_dir[1] == 0.0){
+    double ez[3] = {0.0, 0.0, 1.0};
+    v3Normalize(thrustConfigMsgBuffer.thrusters[0].tHatThrust_B, thruster_dir);
+    if (thruster_dir[0] == 0.0 && thruster_dir[1] == 0.0) {
         // can be any vector in XY-plane
         ep_vec[0] = 1.0;
         ep_vec[1] = 0.0;
         ep_vec[2] = 0.0;
-    }else{
-        v3Cross(thruster_dir,ez,ep_vec);
+    } else {
+        v3Cross(thruster_dir, ez, ep_vec);
     }
-    v3Normalize(ep_vec,ep_vec);
-    double cos_dv = v3Dot(thruster_dir,ez);
+    v3Normalize(ep_vec, ep_vec);
+    double cos_dv = v3Dot(thruster_dir, ez);
     double acos_dv = safeAcos(cos_dv);
-    double ep_TR[4] = {cos(acos_dv/2.0),ep_vec[0]*sin(acos_dv/2.0),ep_vec[1]*sin(acos_dv/2.0),ep_vec[2]*sin(acos_dv/2.0)};
+    double ep_TR[4] = {cos(acos_dv / 2.0),
+                       ep_vec[0] * sin(acos_dv / 2.0),
+                       ep_vec[1] * sin(acos_dv / 2.0),
+                       ep_vec[2] * sin(acos_dv / 2.0)};
     double dcm_TR[3][3];
-    EP2C(ep_TR,dcm_TR);
+    EP2C(ep_TR, dcm_TR);
 
     /* calculate sigma_dvrtp_RN */
     // calculate dcm_RN
-    double M_d_dvrtp = M_d + this->burnArrayInfoOutMsgBuffer.burnArray[0].t*n;
+    double M_d_dvrtp = M_d + this->burnArrayInfoOutMsgBuffer.burnArray[0].t * n;
     double E_d_dvrtp = M2E(M_d_dvrtp, oe_d.e);
     double f_d_dvrtp = E2f(E_d_dvrtp, oe_d.e);
     ClassicElements oe_d_dvrtp;
-    oe_d_dvrtp   = oe_d;
+    oe_d_dvrtp = oe_d;
     oe_d_dvrtp.f = f_d_dvrtp;
-    double rVec_d_dvrtp[3], vVec_d_dvrtp[3], hVec_d_dvrtp[3],tVec_d_dvrtp[3];
+    double rVec_d_dvrtp[3], vVec_d_dvrtp[3], hVec_d_dvrtp[3], tVec_d_dvrtp[3];
     elem2rv(this->mu, &oe_d_dvrtp, rVec_d_dvrtp, vVec_d_dvrtp);
     v3Cross(rVec_d_dvrtp, vVec_d_dvrtp, hVec_d_dvrtp);
     v3Cross(hVec_d_dvrtp, rVec_d_dvrtp, tVec_d_dvrtp);
-    v3Normalize(rVec_d_dvrtp,rVec_d_dvrtp);
-    v3Scale(dvrp_mag,rVec_d_dvrtp,rVec_d_dvrtp);
-    v3Normalize(tVec_d_dvrtp,tVec_d_dvrtp);
-    v3Scale(dvtp_mag,tVec_d_dvrtp,tVec_d_dvrtp);
+    v3Normalize(rVec_d_dvrtp, rVec_d_dvrtp);
+    v3Scale(dvrp_mag, rVec_d_dvrtp, rVec_d_dvrtp);
+    v3Normalize(tVec_d_dvrtp, tVec_d_dvrtp);
+    v3Scale(dvtp_mag, tVec_d_dvrtp, tVec_d_dvrtp);
     double thrustVec_dvrtp[3];
     // sum of scalalized two vectors in tangential and radial directions
-    v3Add(rVec_d_dvrtp,tVec_d_dvrtp,thrustVec_dvrtp);
+    v3Add(rVec_d_dvrtp, tVec_d_dvrtp, thrustVec_dvrtp);
     // in case two burns are combined, target attitude also has to be adjusted
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t < this->attControlTime &&
-       this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t < this->attControlTime){
-        v3Normalize(hVec_d_dvrtp,hVec_d_dvrtp);
-        v3Scale(dvn_mag,hVec_d_dvrtp,hVec_d_dvrtp);
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t <
+            this->attControlTime &&
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t <
+            this->attControlTime) {
+        v3Normalize(hVec_d_dvrtp, hVec_d_dvrtp);
+        v3Scale(dvn_mag, hVec_d_dvrtp, hVec_d_dvrtp);
         // add normal direction vector
-        v3Add(thrustVec_dvrtp,hVec_d_dvrtp,thrustVec_dvrtp);
+        v3Add(thrustVec_dvrtp, hVec_d_dvrtp, thrustVec_dvrtp);
         v3Cross(thrustVec_dvrtp, hVec_d_dvrtp, hVec_d_dvrtp);
     }
     double dcm_RN_dvrtp[3][3];
@@ -501,34 +544,36 @@ void SpacecraftReconfig::ScheduleDV(ClassicElements oe_c,
     v3Cross(dcm_RN_dvrtp[1], dcm_RN_dvrtp[2], dcm_RN_dvrtp[0]);
     // calculate dcm_TN = dcm_TR * dcm_RN
     double dcm_TN_dvrtp[3][3];
-    m33MultM33(dcm_TR,dcm_RN_dvrtp,dcm_TN_dvrtp);
+    m33MultM33(dcm_TR, dcm_RN_dvrtp, dcm_TN_dvrtp);
     C2MRP(dcm_TN_dvrtp, this->burnArrayInfoOutMsgBuffer.burnArray[0].sigma_RN);
 
     /* calculate sigma_dvrta_RN */
-    double M_d_dvrta = M_d + this->burnArrayInfoOutMsgBuffer.burnArray[1].t*n;
+    double M_d_dvrta = M_d + this->burnArrayInfoOutMsgBuffer.burnArray[1].t * n;
     double E_d_dvrta = M2E(M_d_dvrta, oe_d.e);
     double f_d_dvrta = E2f(E_d_dvrta, oe_d.e);
     ClassicElements oe_d_dvrta;
-    oe_d_dvrta   = oe_d;
+    oe_d_dvrta = oe_d;
     oe_d_dvrta.f = f_d_dvrta;
-    double rVec_d_dvrta[3], vVec_d_dvrta[3], hVec_d_dvrta[3],tVec_d_dvrta[3];
+    double rVec_d_dvrta[3], vVec_d_dvrta[3], hVec_d_dvrta[3], tVec_d_dvrta[3];
     elem2rv(this->mu, &oe_d_dvrta, rVec_d_dvrta, vVec_d_dvrta);
     v3Cross(rVec_d_dvrta, vVec_d_dvrta, hVec_d_dvrta);
     v3Cross(hVec_d_dvrta, rVec_d_dvrta, tVec_d_dvrta);
-    v3Normalize(rVec_d_dvrta,rVec_d_dvrta);
-    v3Scale(dvra_mag,rVec_d_dvrta,rVec_d_dvrta);
-    v3Normalize(tVec_d_dvrta,tVec_d_dvrta);
-    v3Scale(dvta_mag,tVec_d_dvrta,tVec_d_dvrta);
+    v3Normalize(rVec_d_dvrta, rVec_d_dvrta);
+    v3Scale(dvra_mag, rVec_d_dvrta, rVec_d_dvrta);
+    v3Normalize(tVec_d_dvrta, tVec_d_dvrta);
+    v3Scale(dvta_mag, tVec_d_dvrta, tVec_d_dvrta);
     double thrustVec_dvrta[3];
     // sum of scalalized two vectors in tangential and radial directions
-    v3Add(rVec_d_dvrta,tVec_d_dvrta,thrustVec_dvrta);
+    v3Add(rVec_d_dvrta, tVec_d_dvrta, thrustVec_dvrta);
     // in case two burns are combined, target attitude also has to be adjusted
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t < this->attControlTime &&
-       this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t < this->attControlTime){
-        v3Normalize(hVec_d_dvrta,hVec_d_dvrta);
-        v3Scale(dvn_mag,hVec_d_dvrta,hVec_d_dvrta);
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t <
+            this->attControlTime &&
+        this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t <
+            this->attControlTime) {
+        v3Normalize(hVec_d_dvrta, hVec_d_dvrta);
+        v3Scale(dvn_mag, hVec_d_dvrta, hVec_d_dvrta);
         // add normal direction vector
-        v3Add(thrustVec_dvrta,hVec_d_dvrta,thrustVec_dvrta);
+        v3Add(thrustVec_dvrta, hVec_d_dvrta, thrustVec_dvrta);
         v3Cross(thrustVec_dvrta, hVec_d_dvrta, hVec_d_dvrta);
     }
     double dcm_RN_dvrta[3][3];
@@ -537,11 +582,11 @@ void SpacecraftReconfig::ScheduleDV(ClassicElements oe_c,
     v3Cross(dcm_RN_dvrta[1], dcm_RN_dvrta[2], dcm_RN_dvrta[0]);
     // calculate dcm_TN = dcm_TR * dcm_RN
     double dcm_TN_dvrta[3][3];
-    m33MultM33(dcm_TR,dcm_RN_dvrta,dcm_TN_dvrta);
+    m33MultM33(dcm_TR, dcm_RN_dvrta, dcm_TN_dvrta);
     C2MRP(dcm_TN_dvrta, this->burnArrayInfoOutMsgBuffer.burnArray[1].sigma_RN);
 
     /* calculate sigma_dvn_RN */
-    double M_d_dvn = M_d + this->burnArrayInfoOutMsgBuffer.burnArray[2].t*n;
+    double M_d_dvn = M_d + this->burnArrayInfoOutMsgBuffer.burnArray[2].t * n;
     double E_d_dvn = M2E(M_d_dvn, oe_d.e);
     double f_d_dvn = E2f(E_d_dvn, oe_d.e);
     ClassicElements oe_d_dvn;
@@ -555,27 +600,31 @@ void SpacecraftReconfig::ScheduleDV(ClassicElements oe_c,
     // normal direction is thrust direction
     v3Normalize(hVec_d_dvn, dcm_RN[2]);
     v3Cross(dcm_RN[2], dcm_RN[0], dcm_RN[1]);
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t < this->attControlTime &&
-       this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t < this->attControlTime){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[0].t <
+            this->attControlTime &&
+        this->burnArrayInfoOutMsgBuffer.burnArray[0].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t <
+            this->attControlTime) {
         C2MRP(dcm_TN_dvrtp, this->burnArrayInfoOutMsgBuffer.burnArray[2].sigma_RN);
-    }else if(this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t < this->attControlTime &&
-             this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t < this->attControlTime){
+    } else if (this->burnArrayInfoOutMsgBuffer.burnArray[2].t - this->burnArrayInfoOutMsgBuffer.burnArray[1].t <
+                   this->attControlTime &&
+               this->burnArrayInfoOutMsgBuffer.burnArray[1].t - this->burnArrayInfoOutMsgBuffer.burnArray[2].t <
+                   this->attControlTime) {
         C2MRP(dcm_TN_dvrta, this->burnArrayInfoOutMsgBuffer.burnArray[2].sigma_RN);
-    }else{
+    } else {
         // calculate dcm_TN = dcm_TR * dcm_RN
         double dcm_TN_dvn[3][3];
-        m33MultM33(dcm_TR,dcm_RN,dcm_TN_dvn);
+        m33MultM33(dcm_TR, dcm_RN, dcm_TN_dvn);
         C2MRP(dcm_TN_dvn, this->burnArrayInfoOutMsgBuffer.burnArray[2].sigma_RN);
     }
 
     // if each dV is scheduled (and not skipped), then set flag to 1
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 0){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[0].flag == 0) {
         this->burnArrayInfoOutMsgBuffer.burnArray[0].flag = 1;
     }
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 0){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[1].flag == 0) {
         this->burnArrayInfoOutMsgBuffer.burnArray[1].flag = 1;
     }
-    if(this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 0){
+    if (this->burnArrayInfoOutMsgBuffer.burnArray[2].flag == 0) {
         this->burnArrayInfoOutMsgBuffer.burnArray[2].flag = 1;
     }
 }

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.cpp
@@ -26,35 +26,33 @@
 #include "architecture/utilities/safeMath.h"
 #include "architecture/utilities/ukfUtilities.h"
 
-#include <string.h>
 #include <math.h>
+#include <string.h>
 
-/*! Function for two body dynamics solvers in order to use in the RK4. Only two body dynamics is used currently, but SRP, Solar Gravity, spherical harmonics can be added here.
+/*! Function for two body dynamics solvers in order to use in the RK4. Only two body dynamics is used currently, but
+ SRP, Solar Gravity, spherical harmonics can be added here.
  @return double Next state
  @param state The starting state
  @param muPlanet planet gravity constant
  @param stateDeriv derivative of state set
  */
-static void pixelLineBiasUKFTwoBodyDyn(double state[PIXLINE_DYN_STATES], double muPlanet, double *stateDeriv)
-{
+static void pixelLineBiasUKFTwoBodyDyn(double state[PIXLINE_DYN_STATES], double muPlanet, double *stateDeriv) {
     double rNorm;
     double dvdt[3];
 
     rNorm = v3Norm(state);
     v3Copy(&state[3], stateDeriv);
     v3Copy(state, dvdt);
-    v3Scale(-muPlanet/pow(rNorm, 3), dvdt, &stateDeriv[3]);
+    v3Scale(-muPlanet / pow(rNorm, 3), dvdt, &stateDeriv[3]);
     return;
 }
-
 
 /*! This method resets the relative OD filter to an initial state and
  initializes the internal estimation matrices.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void PixelLineBiasUKF::reset(uint64_t callTime)
-{
+void PixelLineBiasUKF::reset(uint64_t callTime) {
     // check if the required message has not been connected
     if (!this->circlesInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: pixelLineBiasUKF.circlesInMsg wasn't connected.");
@@ -67,11 +65,11 @@ void PixelLineBiasUKF::reset(uint64_t callTime)
     }
 
     size_t i;
-    int32_t badUpdate=0; /* Negative badUpdate is faulty, */
-    double tempMatrix[PIXLINE_N_STATES*PIXLINE_N_STATES];
+    int32_t badUpdate = 0; /* Negative badUpdate is faulty, */
+    double tempMatrix[PIXLINE_N_STATES * PIXLINE_N_STATES];
 
     /*! - Initialize filter parameters to max values */
-    this->timeTag = callTime*NANO2SEC;
+    this->timeTag = callTime * NANO2SEC;
     this->dt = 0.0;
     this->numStates = PIXLINE_N_STATES;
     this->countHalfSPs = PIXLINE_N_STATES;
@@ -84,53 +82,42 @@ void PixelLineBiasUKF::reset(uint64_t callTime)
     vSetZero(this->wM, this->countHalfSPs * 2 + 1);
     vSetZero(this->wC, this->countHalfSPs * 2 + 1);
     mSetZero(this->sBar, this->numStates, this->numStates);
-    mSetZero(this->SP, this->countHalfSPs * 2 + 1,
-             this->numStates);
+    mSetZero(this->SP, this->countHalfSPs * 2 + 1, this->numStates);
     mSetZero(this->sQnoise, this->numStates, this->numStates);
     mSetZero(this->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS);
 
     /*! - Set lambda/gamma to standard value for unscented kalman filters */
-    this->lambdaVal = this->alpha*this->alpha*
-    (this->numStates + this->kappa) - this->numStates;
+    this->lambdaVal = this->alpha * this->alpha * (this->numStates + this->kappa) - this->numStates;
     this->gamma = sqrt(this->numStates + this->lambdaVal);
 
-
     /*! - Set the wM/wC vectors to standard values for unscented kalman filters*/
-    this->wM[0] = this->lambdaVal / (this->numStates +
-                                                 this->lambdaVal);
-    this->wC[0] = this->lambdaVal / (this->numStates +
-                                                 this->lambdaVal) + (1 - this->alpha*this->alpha + this->beta);
-    for (i = 1; i<this->countHalfSPs * 2 + 1; i++)
-    {
-        this->wM[i] = 1.0 / 2.0*1.0 / (this->numStates + this->lambdaVal);
+    this->wM[0] = this->lambdaVal / (this->numStates + this->lambdaVal);
+    this->wC[0] = this->lambdaVal / (this->numStates + this->lambdaVal) + (1 - this->alpha * this->alpha + this->beta);
+    for (i = 1; i < this->countHalfSPs * 2 + 1; i++) {
+        this->wM[i] = 1.0 / 2.0 * 1.0 / (this->numStates + this->lambdaVal);
         this->wC[i] = this->wM[i];
     }
 
     vCopy(this->stateInit, this->numStates, this->state);
-    v6Scale(1E-3, this->state, this->state); // Convert to km
+    v6Scale(1E-3, this->state, this->state);  // Convert to km
     /*! - User a cholesky decomposition to obtain the sBar and sQnoise matrices for use in filter at runtime*/
-    mCopy(this->covarInit, this->numStates, this->numStates,
-          this->sBar);
-    vScale(1E-6, this->sBar, PIXLINE_DYN_STATES*PIXLINE_N_STATES + PIXLINE_DYN_STATES, this->sBar); // Convert to km
-    mCopy(this->covarInit, this->numStates, this->numStates,
-          this->covar);
-    vScale(1E-6, this->covar, PIXLINE_DYN_STATES*PIXLINE_N_STATES + PIXLINE_DYN_STATES, this->covar); // Convert to km
+    mCopy(this->covarInit, this->numStates, this->numStates, this->sBar);
+    vScale(1E-6, this->sBar, PIXLINE_DYN_STATES * PIXLINE_N_STATES + PIXLINE_DYN_STATES, this->sBar);  // Convert to km
+    mCopy(this->covarInit, this->numStates, this->numStates, this->covar);
+    vScale(
+        1E-6, this->covar, PIXLINE_DYN_STATES * PIXLINE_N_STATES + PIXLINE_DYN_STATES, this->covar);  // Convert to km
 
     mSetZero(tempMatrix, this->numStates, this->numStates);
-    badUpdate += ukfCholDecomp(this->sBar, (int) this->numStates,
-                               (int) this->numStates, tempMatrix);
+    badUpdate += ukfCholDecomp(this->sBar, (int)this->numStates, (int)this->numStates, tempMatrix);
 
-    badUpdate += ukfCholDecomp(this->qNoise, (int) this->numStates,
-                               (int) this->numStates, this->sQnoise);
+    badUpdate += ukfCholDecomp(this->qNoise, (int)this->numStates, (int)this->numStates, this->sQnoise);
 
-    mCopy(tempMatrix, this->numStates, this->numStates,
-          this->sBar);
-    mTranspose(this->sQnoise, this->numStates,
-               this->numStates, this->sQnoise);
+    mCopy(tempMatrix, this->numStates, this->numStates, this->sBar);
+    mTranspose(this->sQnoise, this->numStates, this->numStates, this->sQnoise);
 
     this->timeTagOut = this->timeTag;
 
-    if (badUpdate <0){
+    if (badUpdate < 0) {
         this->bskLogger.bskLog(BSK_WARNING, "Reset method contained bad update");
     }
     return;
@@ -141,20 +128,18 @@ void PixelLineBiasUKF::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void PixelLineBiasUKF::updateState(uint64_t callTime)
-{
-    double newTimeTag = 0.0;  /* [s] Local Time-tag variable*/
+void PixelLineBiasUKF::updateState(uint64_t callTime) {
+    double newTimeTag = 0.0; /* [s] Local Time-tag variable*/
     double yBar[PIXLINE_N_MEAS], tempYVec[PIXLINE_N_MEAS];
     uint64_t i;
     int computePostFits;
     PixelLineFilterMsgPayload opNavOutBuffer = {}; /* [-] Output filter info*/
     NavTransMsgPayload outputRelOD = {};
     OpNavCirclesMsgPayload inputCircles;
-    this->moduleId = (int) moduleId;
+    this->moduleId = (int)moduleId;
 
     computePostFits = 0;
     v3SetZero(this->postFits);
-
 
     /*! - read input messages */
     inputCircles = this->circlesInMsg();
@@ -165,58 +150,55 @@ void PixelLineBiasUKF::updateState(uint64_t callTime)
     /*! - If the time tag from the measured data is new compared to previous step,
      propagate and update the filter*/
     newTimeTag = this->attInMsg.timeWritten() * NANO2SEC;
-    if(newTimeTag >= this->timeTag && this->attInMsg.isWritten() && inputCircles.valid ==1)
-    {
+    if (newTimeTag >= this->timeTag && this->attInMsg.isWritten() && inputCircles.valid == 1) {
         this->circlesInBuffer = inputCircles;
-        this->planetId = (int) inputCircles.planetIds[0];
+        this->planetId = (int)inputCircles.planetIds[0];
         pixelLineBiasUKFTimeUpdate(newTimeTag);
         pixelLineBiasUKFMeasUpdate();
         computePostFits = 1;
     }
     /*! - If current clock time is further ahead than the measured time, then
      propagate to this current time-step*/
-    newTimeTag = callTime*NANO2SEC;
-    if(newTimeTag > this->timeTag)
-    {
+    newTimeTag = callTime * NANO2SEC;
+    if (newTimeTag > this->timeTag) {
         pixelLineBiasUKFTimeUpdate(newTimeTag);
     }
 
-
-    /*! - The post fits are y - ybar if a measurement was read, if observations are zero, do not compute post fit residuals*/
-    if(computePostFits == 1){
+    /*! - The post fits are y - ybar if a measurement was read, if observations are zero, do not compute post fit
+     * residuals*/
+    if (computePostFits == 1) {
         /*! - Compute Post Fit Residuals, first get Y (eq 22) using the states post fit*/
         pixelLineBiasUKFMeasModel();
 
         /*! - Compute the value for the yBar parameter (equation 23)*/
         vSetZero(yBar, this->numObs);
-        for(i=0; i<this->countHalfSPs*2+1; i++)
-        {
-            vCopy(&(this->yMeas[i*this->numObs]), this->numObs,
-                  tempYVec);
+        for (i = 0; i < this->countHalfSPs * 2 + 1; i++) {
+            vCopy(&(this->yMeas[i * this->numObs]), this->numObs, tempYVec);
             vScale(this->wM[i], tempYVec, this->numObs, tempYVec);
             vAdd(yBar, this->numObs, tempYVec, yBar);
         }
         mSubtract(this->obs, PIXLINE_N_MEAS, 1, yBar, this->postFits);
     }
 
-
     /*! - Write the relative OD estimate into the copy of the navigation message structure*/
     v3Copy(this->state, outputRelOD.r_BN_N);
     outputRelOD.timeTag = this->timeTag;
-    v3Scale(1E3, outputRelOD.r_BN_N, outputRelOD.r_BN_N); // Convert to m
+    v3Scale(1E3, outputRelOD.r_BN_N, outputRelOD.r_BN_N);  // Convert to m
     v3Copy(&this->state[3], outputRelOD.v_BN_N);
-    v3Scale(1E3, outputRelOD.v_BN_N, outputRelOD.v_BN_N); // Convert to m
+    v3Scale(1E3, outputRelOD.v_BN_N, outputRelOD.v_BN_N);  // Convert to m
     outputRelOD.timeTag = this->timeTagOut;
     this->navStateOutMsg.write(&outputRelOD, this->moduleId, callTime);
 
     /*! - Populate the filter states output buffer and write the output message*/
     opNavOutBuffer.timeTag = this->timeTag;
-    memmove(opNavOutBuffer.covar, this->covar,
-            PIXLINE_N_STATES*PIXLINE_N_STATES*sizeof(double));
-    memmove(opNavOutBuffer.state, this->state, PIXLINE_N_STATES*sizeof(double));
-    memmove(opNavOutBuffer.postFitRes, this->postFits, PIXLINE_N_MEAS*sizeof(double));
-    v6Scale(1E3, opNavOutBuffer.state, opNavOutBuffer.state); // Convert to m
-    vScale(1E6, opNavOutBuffer.covar, PIXLINE_DYN_STATES*PIXLINE_N_STATES+PIXLINE_DYN_STATES, opNavOutBuffer.covar); // Convert to m
+    memmove(opNavOutBuffer.covar, this->covar, PIXLINE_N_STATES * PIXLINE_N_STATES * sizeof(double));
+    memmove(opNavOutBuffer.state, this->state, PIXLINE_N_STATES * sizeof(double));
+    memmove(opNavOutBuffer.postFitRes, this->postFits, PIXLINE_N_MEAS * sizeof(double));
+    v6Scale(1E3, opNavOutBuffer.state, opNavOutBuffer.state);  // Convert to m
+    vScale(1E6,
+           opNavOutBuffer.covar,
+           PIXLINE_DYN_STATES * PIXLINE_N_STATES + PIXLINE_DYN_STATES,
+           opNavOutBuffer.covar);  // Convert to m
     this->filtDataOutMsg.write(&opNavOutBuffer, this->moduleId, callTime);
 
     return;
@@ -228,24 +210,28 @@ void PixelLineBiasUKF::updateState(uint64_t callTime)
  @param stateInOut The state that is propagated
  @param dt Time step (s)
  */
-void PixelLineBiasUKF::relODStateProp(double *stateInOut, double dt)
-{
-
+void PixelLineBiasUKF::relODStateProp(double *stateInOut, double dt) {
     double muPlanet;
     double k1[PIXLINE_DYN_STATES], k2[PIXLINE_DYN_STATES], k3[PIXLINE_DYN_STATES], k4[PIXLINE_DYN_STATES];
     double states1[PIXLINE_DYN_STATES], states2[PIXLINE_DYN_STATES], states3[PIXLINE_DYN_STATES];
-    if(this->planetId ==1){muPlanet = MU_EARTH;} //in km
-    if(this->planetId ==2){muPlanet = MU_MARS;} //in km
-    if(this->planetId ==3){muPlanet = MU_JUPITER;} //in km
+    if (this->planetId == 1) {
+        muPlanet = MU_EARTH;
+    }  // in km
+    if (this->planetId == 2) {
+        muPlanet = MU_MARS;
+    }  // in km
+    if (this->planetId == 3) {
+        muPlanet = MU_JUPITER;
+    }  // in km
 
     /*! Start RK4 */
     /*! - Compute k1 */
     pixelLineBiasUKFTwoBodyDyn(stateInOut, muPlanet, &k1[0]);
-    vScale(dt/2, k1, PIXLINE_DYN_STATES, k1); // k1 is now k1/2
+    vScale(dt / 2, k1, PIXLINE_DYN_STATES, k1);  // k1 is now k1/2
     /*! - Compute k2 */
     vAdd(stateInOut, PIXLINE_DYN_STATES, k1, states1);
     pixelLineBiasUKFTwoBodyDyn(states1, muPlanet, &k2[0]);
-    vScale(dt/2, k2, PIXLINE_DYN_STATES, k2); // k2 is now k2/2
+    vScale(dt / 2, k2, PIXLINE_DYN_STATES, k2);  // k2 is now k2/2
     /*! - Compute k3 */
     vAdd(stateInOut, PIXLINE_DYN_STATES, k2, states2);
     pixelLineBiasUKFTwoBodyDyn(states2, muPlanet, &k3[0]);
@@ -255,10 +241,10 @@ void PixelLineBiasUKF::relODStateProp(double *stateInOut, double dt)
     pixelLineBiasUKFTwoBodyDyn(states3, muPlanet, &k4[0]);
     vScale(dt, k4, PIXLINE_DYN_STATES, k4);
     /*! - Gather all terms with proper scales */
-    vScale(1./3., k1, PIXLINE_DYN_STATES, k1); // k1 is now k1/6
-    vScale(2./3., k2, PIXLINE_DYN_STATES, k2); // k2 is now k2/3
-    vScale(1./3., k3, PIXLINE_DYN_STATES, k3); // k3 is now k2/3
-    vScale(1./6., k4, PIXLINE_DYN_STATES, k4); // k4 is now k2/6
+    vScale(1. / 3., k1, PIXLINE_DYN_STATES, k1);  // k1 is now k1/6
+    vScale(2. / 3., k2, PIXLINE_DYN_STATES, k2);  // k2 is now k2/3
+    vScale(1. / 3., k3, PIXLINE_DYN_STATES, k3);  // k3 is now k2/3
+    vScale(1. / 6., k4, PIXLINE_DYN_STATES, k4);  // k4 is now k2/6
 
     vAdd(stateInOut, PIXLINE_DYN_STATES, k1, stateInOut);
     vAdd(stateInOut, PIXLINE_DYN_STATES, k2, stateInOut);
@@ -274,16 +260,17 @@ void PixelLineBiasUKF::relODStateProp(double *stateInOut, double dt)
  @return void
  @param updateTime The time that we need to fix the filter to (seconds)
  */
-int PixelLineBiasUKF::pixelLineBiasUKFTimeUpdate(double updateTime)
-{
+int PixelLineBiasUKF::pixelLineBiasUKFTimeUpdate(double updateTime) {
     uint64_t i, Index;
-    double sBarT[PIXLINE_N_STATES*PIXLINE_N_STATES]; // Sbar transpose (chol decomp of covar)
-    double xComp[PIXLINE_N_STATES], AT[(2 * PIXLINE_N_STATES + PIXLINE_N_STATES)*PIXLINE_N_STATES]; // Intermediate state, process noise chol decomp
-    double aRow[PIXLINE_N_STATES], rAT[PIXLINE_N_STATES*PIXLINE_N_STATES], xErr[PIXLINE_N_STATES]; //Row of A mat, R of QR decomp of A, state error
-    double sBarUp[PIXLINE_N_STATES*PIXLINE_N_STATES]; // S bar cholupdate
-    double *spPtr; //sigma point intermediate varaible
-    double procNoise[PIXLINE_N_STATES*PIXLINE_N_STATES]; //process noise
-    int32_t badUpdate=0;
+    double sBarT[PIXLINE_N_STATES * PIXLINE_N_STATES];  // Sbar transpose (chol decomp of covar)
+    double xComp[PIXLINE_N_STATES], AT[(2 * PIXLINE_N_STATES + PIXLINE_N_STATES) *
+                                       PIXLINE_N_STATES];  // Intermediate state, process noise chol decomp
+    double aRow[PIXLINE_N_STATES], rAT[PIXLINE_N_STATES * PIXLINE_N_STATES],
+        xErr[PIXLINE_N_STATES];                             // Row of A mat, R of QR decomp of A, state error
+    double sBarUp[PIXLINE_N_STATES * PIXLINE_N_STATES];     // S bar cholupdate
+    double *spPtr;                                          // sigma point intermediate varaible
+    double procNoise[PIXLINE_N_STATES * PIXLINE_N_STATES];  // process noise
+    int32_t badUpdate = 0;
 
     this->dt = updateTime - this->timeTag;
     vCopy(this->state, this->numStates, this->statePrev);
@@ -291,30 +278,25 @@ int PixelLineBiasUKF::pixelLineBiasUKFTimeUpdate(double updateTime)
     mCopy(this->covar, this->numStates, this->numStates, this->covarPrev);
 
     /*! - Read the planet ID from the message*/
-    if(this->planetId == 0)
-    {
-      this->bskLogger.bskLog(BSK_ERROR, "Need a planet to navigate");
+    if (this->planetId == 0) {
+        this->bskLogger.bskLog(BSK_ERROR, "Need a planet to navigate");
     }
 
     mCopy(this->sQnoise, PIXLINE_N_STATES, PIXLINE_N_STATES, procNoise);
     /*! - Copy over the current state estimate into the 0th Sigma point and propagate by dt*/
-    vCopy(this->state, this->numStates,
-          &(this->SP[0 * this->numStates + 0]));
-    this->relODStateProp(&(this->SP[0]),this->dt);
+    vCopy(this->state, this->numStates, &(this->SP[0 * this->numStates + 0]));
+    this->relODStateProp(&(this->SP[0]), this->dt);
     /*! - Scale that Sigma point by the appopriate scaling factor (Wm[0])*/
-    vScale(this->wM[0], &(this->SP[0]),
-           this->numStates, this->xBar);
+    vScale(this->wM[0], &(this->SP[0]), this->numStates, this->xBar);
     /*! - Get the transpose of the sBar matrix because it is easier to extract Rows vs columns*/
-    mTranspose(this->sBar, this->numStates, this->numStates,
-               sBarT);
+    mTranspose(this->sBar, this->numStates, this->numStates, sBarT);
     /*! - For each Sigma point, apply sBar-based error, propagate forward, and scale by Wm just like 0th.
      Note that we perform +/- sigma points simultaneously in loop to save loop values.*/
-    for (i = 0; i<this->countHalfSPs; i++)
-    {
+    for (i = 0; i < this->countHalfSPs; i++) {
         /*! - Adding covariance columns from sigma points*/
         Index = i + 1;
-        spPtr = &(this->SP[Index*this->numStates]);
-        vCopy(&sBarT[i*this->numStates], this->numStates, spPtr);
+        spPtr = &(this->SP[Index * this->numStates]);
+        vCopy(&sBarT[i * this->numStates], this->numStates, spPtr);
         vScale(this->gamma, spPtr, this->numStates, spPtr);
         vAdd(spPtr, this->numStates, this->state, spPtr);
         this->relODStateProp(spPtr, this->dt);
@@ -322,8 +304,8 @@ int PixelLineBiasUKF::pixelLineBiasUKFTimeUpdate(double updateTime)
         vAdd(xComp, this->numStates, this->xBar, this->xBar);
         /*! - Subtracting covariance columns from sigma points*/
         Index = i + 1 + this->countHalfSPs;
-        spPtr = &(this->SP[Index*this->numStates]);
-        vCopy(&sBarT[i*this->numStates], this->numStates, spPtr);
+        spPtr = &(this->SP[Index * this->numStates]);
+        vCopy(&sBarT[i * this->numStates], this->numStates, spPtr);
         vScale(-this->gamma, spPtr, this->numStates, spPtr);
         vAdd(spPtr, this->numStates, this->state, spPtr);
         this->relODStateProp(spPtr, this->dt);
@@ -331,61 +313,49 @@ int PixelLineBiasUKF::pixelLineBiasUKFTimeUpdate(double updateTime)
         vAdd(xComp, this->numStates, this->xBar, this->xBar);
     }
     /*! - Zero the AT matrix prior to assembly*/
-    mSetZero(AT, (2 * this->countHalfSPs + this->numStates),
-             this->countHalfSPs);
+    mSetZero(AT, (2 * this->countHalfSPs + this->numStates), this->countHalfSPs);
     /*! - Assemble the AT matrix.  Note that this matrix is the internals of
      the qr decomposition call in the source design documentation.  It is
      the inside of equation 20 in that document*/
-    for (i = 0; i<2 * this->countHalfSPs; i++)
-    {
+    for (i = 0; i < 2 * this->countHalfSPs; i++) {
         vScale(-1.0, this->xBar, this->numStates, aRow);
-        vAdd(aRow, this->numStates,
-             &(this->SP[(i+1)*this->numStates]), aRow);
+        vAdd(aRow, this->numStates, &(this->SP[(i + 1) * this->numStates]), aRow);
         /*Check sign of wC to know if the sqrt will fail*/
-        if (this->wC[i+1]<=0){
+        if (this->wC[i + 1] <= 0) {
             pixelLineBiasUKFCleanUpdate();
-            return -1;}
-        vScale(sqrt(this->wC[i+1]), aRow, this->numStates, aRow);
-        memcpy((void *)&AT[i*this->numStates], (void *)aRow,
-               this->numStates*sizeof(double));
-
+            return -1;
+        }
+        vScale(sqrt(this->wC[i + 1]), aRow, this->numStates, aRow);
+        memcpy((void *)&AT[i * this->numStates], (void *)aRow, this->numStates * sizeof(double));
     }
     /*! - Pop the sQNoise matrix on to the end of AT prior to getting QR decomposition*/
-    memcpy(&AT[2 * this->countHalfSPs*this->numStates],
-           procNoise, this->numStates*this->numStates
-           *sizeof(double));
+    memcpy(
+        &AT[2 * this->countHalfSPs * this->numStates], procNoise, this->numStates * this->numStates * sizeof(double));
     /*! - QR decomposition (only R computed!) of the AT matrix provides the new sBar matrix*/
-    ukfQRDJustR(AT, (int) (2 * this->countHalfSPs + this->numStates),
-                (int) this->countHalfSPs, rAT);
+    ukfQRDJustR(AT, (int)(2 * this->countHalfSPs + this->numStates), (int)this->countHalfSPs, rAT);
 
     mCopy(rAT, this->numStates, this->numStates, sBarT);
-    mTranspose(sBarT, this->numStates, this->numStates,
-               this->sBar);
+    mTranspose(sBarT, this->numStates, this->numStates, this->sBar);
 
     /*! - Shift the sBar matrix over by the xBar vector using the appropriate weight
      like in equation 21 in design document.*/
     vScale(-1.0, this->xBar, this->numStates, xErr);
     vAdd(xErr, this->numStates, &this->SP[0], xErr);
-    badUpdate += ukfCholDownDate(this->sBar, xErr, this->wC[0],
-                                 (int) this->numStates, sBarUp);
-
+    badUpdate += ukfCholDownDate(this->sBar, xErr, this->wC[0], (int)this->numStates, sBarUp);
 
     /*! - Save current sBar matrix, covariance, and state estimate off for further use*/
     mCopy(sBarUp, this->numStates, this->numStates, this->sBar);
-    mTranspose(this->sBar, this->numStates, this->numStates,
-               this->covar);
-    mMultM(this->sBar, this->numStates, this->numStates,
-           this->covar, this->numStates, this->numStates,
-           this->covar);
+    mTranspose(this->sBar, this->numStates, this->numStates, this->covar);
+    mMultM(this->sBar, this->numStates, this->numStates, this->covar, this->numStates, this->numStates, this->covar);
     vCopy(&(this->SP[0]), this->numStates, this->state);
 
-    if (badUpdate<0){
+    if (badUpdate < 0) {
         pixelLineBiasUKFCleanUpdate();
-        return(-1);}
-    else{
+        return (-1);
+    } else {
         this->timeTag = updateTime;
     }
-    return(0);
+    return (0);
 }
 
 /*! This method computes the measurement model.  Given that the data is coming from
@@ -393,14 +363,16 @@ int PixelLineBiasUKF::pixelLineBiasUKFTimeUpdate(double updateTime)
  @return void
  @param this The configuration data associated with the OD filter
  */
-void PixelLineBiasUKF::pixelLineBiasUKFMeasModel()
-{
+void PixelLineBiasUKF::pixelLineBiasUKFMeasModel() {
     size_t i, j;
     double dcm_CN[3][3], dcm_CB[3][3], dcm_BN[3][3];
     double reCentered[2], rNorm, denom, planetRad;
     double r_C[3];
 
-    v3Set(this->circlesInBuffer.circlesCenters[0], this->circlesInBuffer.circlesCenters[1], this->circlesInBuffer.circlesRadii[0], this->obs);
+    v3Set(this->circlesInBuffer.circlesCenters[0],
+          this->circlesInBuffer.circlesCenters[1],
+          this->circlesInBuffer.circlesRadii[0],
+          this->obs);
 
     MRP2C(this->cameraSpecs.sigma_CB, dcm_CB);
     MRP2C(this->attInfo.sigma_BN, dcm_BN);
@@ -408,63 +380,64 @@ void PixelLineBiasUKF::pixelLineBiasUKFMeasModel()
     double X, Y;
     double pX, pY;
     /* compute sensorSize/focalLength = 2*tan(FOV/2) */
-    pX = 2.*tan(this->cameraSpecs.fieldOfView*this->cameraSpecs.resolution[0]/this->cameraSpecs.resolution[1]/2.0);
-    pY = 2.*tan(this->cameraSpecs.fieldOfView/2.0);
-    X = pX/this->cameraSpecs.resolution[0];
-    Y = pY/this->cameraSpecs.resolution[1];
+    pX = 2. *
+         tan(this->cameraSpecs.fieldOfView * this->cameraSpecs.resolution[0] / this->cameraSpecs.resolution[1] / 2.0);
+    pY = 2. * tan(this->cameraSpecs.fieldOfView / 2.0);
+    X = pX / this->cameraSpecs.resolution[0];
+    Y = pY / this->cameraSpecs.resolution[1];
 
-    if(this->circlesInBuffer.planetIds[0] > 0){
-        if(this->circlesInBuffer.planetIds[0] ==1){
-            planetRad = REQ_EARTH;//in km
+    if (this->circlesInBuffer.planetIds[0] > 0) {
+        if (this->circlesInBuffer.planetIds[0] == 1) {
+            planetRad = REQ_EARTH;  // in km
         }
-        if(this->circlesInBuffer.planetIds[0] ==2){
-            planetRad = REQ_MARS;//in km
+        if (this->circlesInBuffer.planetIds[0] == 2) {
+            planetRad = REQ_MARS;  // in km
         }
-        if(this->circlesInBuffer.planetIds[0] ==3){
-            planetRad = REQ_JUPITER;//in km
+        if (this->circlesInBuffer.planetIds[0] == 3) {
+            planetRad = REQ_JUPITER;  // in km
         }
     }
 
-    for(j=0; j<this->countHalfSPs*2+1; j++)
-    {
-        double centers[2], r_N_bar[3], radius=0;
+    for (j = 0; j < this->countHalfSPs * 2 + 1; j++) {
+        double centers[2], r_N_bar[3], radius = 0;
         v2SetZero(centers);
         v3SetZero(r_N_bar);
 
-        v3Copy(&this->SP[j*this->numStates], r_N_bar);
+        v3Copy(&this->SP[j * this->numStates], r_N_bar);
         rNorm = v3Norm(r_N_bar);
 
         m33MultV3(dcm_CN, r_N_bar, r_C);
-        v3Scale(-1./r_C[2], r_C, r_C);
+        v3Scale(-1. / r_C[2], r_C, r_C);
 
         /*! - Find pixel size using camera specs */
-        reCentered[0] = r_C[0]/X;
-        reCentered[1] = r_C[1]/Y;
+        reCentered[0] = r_C[0] / X;
+        reCentered[1] = r_C[1] / Y;
 
-        centers[0] = reCentered[0] + this->cameraSpecs.resolution[0]/2 - 0.5;
-        centers[1] = reCentered[1] + this->cameraSpecs.resolution[1]/2 - 0.5;
+        centers[0] = reCentered[0] + this->cameraSpecs.resolution[0] / 2 - 0.5;
+        centers[1] = reCentered[1] + this->cameraSpecs.resolution[1] / 2 - 0.5;
 
-        denom = planetRad/rNorm;
+        denom = planetRad / rNorm;
         radius = tan(safeAsin(denom)) / X;
-        if (j==0){
+        if (j == 0) {
             v2Subtract(centers, this->obs, &this->obs[3]);
             this->obs[5] = radius - this->obs[2];
         }
-        for(i=0; i<3; i++){
-            this->obs[i+3] = round(this->obs[i+3]);
-            if (i<2){
-                this->yMeas[i*(this->countHalfSPs*2+1) + j] = centers[i] - this->SP[j*this->numStates+PIXLINE_DYN_STATES + i];
+        for (i = 0; i < 3; i++) {
+            this->obs[i + 3] = round(this->obs[i + 3]);
+            if (i < 2) {
+                this->yMeas[i * (this->countHalfSPs * 2 + 1) + j] =
+                    centers[i] - this->SP[j * this->numStates + PIXLINE_DYN_STATES + i];
             }
-            if (i==2){
-                this->yMeas[i*(this->countHalfSPs*2+1) + j] = radius - this->SP[j*this->numStates+PIXLINE_DYN_STATES + i];
+            if (i == 2) {
+                this->yMeas[i * (this->countHalfSPs * 2 + 1) + j] =
+                    radius - this->SP[j * this->numStates + PIXLINE_DYN_STATES + i];
             }
-            this->yMeas[(i+PIXLINE_N_MEAS/2)*(this->countHalfSPs*2+1) + j] = this->SP[j*this->numStates+ PIXLINE_DYN_STATES + i];
+            this->yMeas[(i + PIXLINE_N_MEAS / 2) * (this->countHalfSPs * 2 + 1) + j] =
+                this->SP[j * this->numStates + PIXLINE_DYN_STATES + i];
         }
     }
     /*! - yMeas matrix was set backwards deliberately so we need to transpose it through*/
-    mTranspose(this->yMeas, PIXLINE_N_MEAS, this->countHalfSPs*2+1,
-               this->yMeas);
-
+    mTranspose(this->yMeas, PIXLINE_N_MEAS, this->countHalfSPs * 2 + 1, this->yMeas);
 }
 
 /*! This method performs the measurement update for the kalman filter.
@@ -473,17 +446,19 @@ void PixelLineBiasUKF::pixelLineBiasUKFMeasModel()
  @return void
  @param this The configuration data associated with the OD filter
  */
-int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
-{
+int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate() {
     uint32_t i;
-    double yBar[PIXLINE_N_MEAS], syInv[PIXLINE_N_MEAS*PIXLINE_N_MEAS]; //measurement, Sy inv
-    double kMat[PIXLINE_N_STATES*PIXLINE_N_MEAS], cholNoise[PIXLINE_N_MEAS*PIXLINE_N_MEAS];//Kalman Gain, chol decomp of noise
-    double xHat[PIXLINE_N_STATES], Ucol[PIXLINE_N_STATES], sBarT[PIXLINE_N_STATES*PIXLINE_N_STATES], tempYVec[PIXLINE_N_MEAS];// state error, U column eq 28, intermediate variables
-    double AT[(2 * PIXLINE_N_STATES + PIXLINE_N_MEAS)*PIXLINE_N_MEAS]; //Process noise matrix
-    double rAT[PIXLINE_N_MEAS*PIXLINE_N_MEAS], syT[PIXLINE_N_MEAS*PIXLINE_N_MEAS]; //QR R decomp, Sy transpose
-    double sy[PIXLINE_N_MEAS*PIXLINE_N_MEAS]; // Chol of covariance
-    double updMat[PIXLINE_N_MEAS*PIXLINE_N_MEAS], pXY[PIXLINE_N_STATES*PIXLINE_N_MEAS], Umat[PIXLINE_N_STATES*PIXLINE_N_MEAS]; // Intermediate variable, covariance eq 26, U eq 28
-    int32_t badUpdate=0;
+    double yBar[PIXLINE_N_MEAS], syInv[PIXLINE_N_MEAS * PIXLINE_N_MEAS];  // measurement, Sy inv
+    double kMat[PIXLINE_N_STATES * PIXLINE_N_MEAS],
+        cholNoise[PIXLINE_N_MEAS * PIXLINE_N_MEAS];  // Kalman Gain, chol decomp of noise
+    double xHat[PIXLINE_N_STATES], Ucol[PIXLINE_N_STATES], sBarT[PIXLINE_N_STATES * PIXLINE_N_STATES],
+        tempYVec[PIXLINE_N_MEAS];  // state error, U column eq 28, intermediate variables
+    double AT[(2 * PIXLINE_N_STATES + PIXLINE_N_MEAS) * PIXLINE_N_MEAS];                // Process noise matrix
+    double rAT[PIXLINE_N_MEAS * PIXLINE_N_MEAS], syT[PIXLINE_N_MEAS * PIXLINE_N_MEAS];  // QR R decomp, Sy transpose
+    double sy[PIXLINE_N_MEAS * PIXLINE_N_MEAS];                                         // Chol of covariance
+    double updMat[PIXLINE_N_MEAS * PIXLINE_N_MEAS], pXY[PIXLINE_N_STATES * PIXLINE_N_MEAS],
+        Umat[PIXLINE_N_STATES * PIXLINE_N_MEAS];  // Intermediate variable, covariance eq 26, U eq 28
+    int32_t badUpdate = 0;
 
     vCopy(this->state, this->numStates, this->statePrev);
     mCopy(this->sBar, this->numStates, this->numStates, this->sBarPrev);
@@ -494,10 +469,8 @@ int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
     /*! - Compute the value for the yBar parameter (note that this is equation 23 in the
      time update section of the reference document*/
     vSetZero(yBar, this->numObs);
-    for(i=0; i<this->countHalfSPs*2+1; i++)
-    {
-        vCopy(&(this->yMeas[i*this->numObs]), this->numObs,
-              tempYVec);
+    for (i = 0; i < this->countHalfSPs * 2 + 1; i++) {
+        vCopy(&(this->yMeas[i * this->numObs]), this->numObs, tempYVec);
         vScale(this->wM[i], tempYVec, this->numObs, tempYVec);
         vAdd(yBar, this->numObs, tempYVec, yBar);
     }
@@ -505,32 +478,28 @@ int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
     /*! - Populate the matrix that we perform the QR decomposition on in the measurement
      update section of the code.  This is based on the differenence between the yBar
      parameter and the calculated measurement models.  Equation 24 in driving doc. */
-    mSetZero(AT, this->countHalfSPs*2+this->numObs,
-             this->numObs);
-    for(i=0; i<this->countHalfSPs*2; i++)
-    {
+    mSetZero(AT, this->countHalfSPs * 2 + this->numObs, this->numObs);
+    for (i = 0; i < this->countHalfSPs * 2; i++) {
         vScale(-1.0, yBar, this->numObs, tempYVec);
-        vAdd(tempYVec, this->numObs,
-             &(this->yMeas[(i+1)*this->numObs]), tempYVec);
-        if (this->wC[i+1]<0){return -1;}
-        vScale(sqrt(this->wC[i+1]), tempYVec, this->numObs, tempYVec);
-        memcpy(&(AT[i*this->numObs]), tempYVec,
-               this->numObs*sizeof(double));
+        vAdd(tempYVec, this->numObs, &(this->yMeas[(i + 1) * this->numObs]), tempYVec);
+        if (this->wC[i + 1] < 0) {
+            return -1;
+        }
+        vScale(sqrt(this->wC[i + 1]), tempYVec, this->numObs, tempYVec);
+        memcpy(&(AT[i * this->numObs]), tempYVec, this->numObs * sizeof(double));
     }
 
     /*! - This is the square-root of the Rk matrix which we treat as the Cholesky
      decomposition of the observation variance matrix constructed for our number
      of observations*/
     mSetZero(this->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS);
-    mSetSubMatrix(this->circlesInBuffer.uncertainty, 3, 3, this->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS, 3,3);
+    mSetSubMatrix(this->circlesInBuffer.uncertainty, 3, 3, this->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS, 3, 3);
     mSetSubMatrix(this->circlesInBuffer.uncertainty, 3, 3, this->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS, 0, 0);
     badUpdate += ukfCholDecomp(this->measNoise, PIXLINE_N_MEAS, PIXLINE_N_MEAS, cholNoise);
-    memcpy(&(AT[2*this->countHalfSPs*this->numObs]),
-           cholNoise, this->numObs*this->numObs*sizeof(double));
+    memcpy(&(AT[2 * this->countHalfSPs * this->numObs]), cholNoise, this->numObs * this->numObs * sizeof(double));
     /*! - Perform QR decomposition (only R again) of the above matrix to obtain the
      current Sy matrix*/
-    ukfQRDJustR(AT, (int) (2*this->countHalfSPs+this->numObs),
-                (int) this->numObs, rAT);
+    ukfQRDJustR(AT, (int)(2 * this->countHalfSPs + this->numObs), (int)this->numObs, rAT);
 
     mCopy(rAT, this->numObs, this->numObs, syT);
     mTranspose(syT, this->numObs, this->numObs, sy);
@@ -538,8 +507,7 @@ int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
      model and the yBar matrix (cholesky down-date again)*/
     vScale(-1.0, yBar, this->numObs, tempYVec);
     vAdd(tempYVec, this->numObs, &(this->yMeas[0]), tempYVec);
-    badUpdate += ukfCholDownDate(sy, tempYVec, this->wC[0],
-                                 (int) this->numObs, updMat);
+    badUpdate += ukfCholDownDate(sy, tempYVec, this->wC[0], (int)this->numObs, updMat);
 
     /*! - Shifted matrix represents the Sy matrix */
     mCopy(updMat, this->numObs, this->numObs, sy);
@@ -548,16 +516,12 @@ int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
     /*! - Construct the Pxy matrix (equation 26) which multiplies the Sigma-point cloud
      by the measurement model cloud (weighted) to get the total Pxy matrix*/
     mSetZero(pXY, this->numStates, this->numObs);
-    for(i=0; i<2*this->countHalfSPs+1; i++)
-    {
+    for (i = 0; i < 2 * this->countHalfSPs + 1; i++) {
         vScale(-1.0, yBar, this->numObs, tempYVec);
-        vAdd(tempYVec, this->numObs,
-             &(this->yMeas[i*this->numObs]), tempYVec);
-        vSubtract(&(this->SP[i*this->numStates]), this->numStates,
-                  this->xBar, xHat);
+        vAdd(tempYVec, this->numObs, &(this->yMeas[i * this->numObs]), tempYVec);
+        vSubtract(&(this->SP[i * this->numStates]), this->numStates, this->xBar, xHat);
         vScale(this->wC[i], xHat, this->numStates, xHat);
-        mMultM(xHat, this->numStates, 1, tempYVec, 1, this->numObs,
-               kMat);
+        mMultM(xHat, this->numStates, 1, tempYVec, 1, this->numObs, kMat);
         mAdd(pXY, this->numStates, this->numObs, kMat, pXY);
     }
 
@@ -565,51 +529,42 @@ int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
      The Sy matrix is lower triangular, we can do a back-sub inversion instead of
      a full matrix inversion.  That is the ukfUInv and ukfLInv calls below.  Once that
      multiplication is done (equation 27), we have the Kalman Gain.*/
-    ukfUInv(syT, (int) this->numObs, (int) this->numObs, syInv);
+    ukfUInv(syT, (int)this->numObs, (int)this->numObs, syInv);
 
-    mMultM(pXY, this->numStates, this->numObs, syInv,
-           this->numObs, this->numObs, kMat);
-    ukfLInv(sy, (int) this->numObs, (int) this->numObs, syInv);
-    mMultM(kMat, this->numStates, this->numObs, syInv,
-           this->numObs, this->numObs, kMat);
-
+    mMultM(pXY, this->numStates, this->numObs, syInv, this->numObs, this->numObs, kMat);
+    ukfLInv(sy, (int)this->numObs, (int)this->numObs, syInv);
+    mMultM(kMat, this->numStates, this->numObs, syInv, this->numObs, this->numObs, kMat);
 
     /*! - Difference the yBar and the observations to get the observed error and
      multiply by the Kalman Gain to get the state update.  Add the state update
      to the state to get the updated state value (equation 27).*/
     vSubtract(this->obs, this->numObs, yBar, tempYVec);
-    mMultM(kMat, this->numStates, this->numObs, tempYVec,
-           this->numObs, 1, xHat);
+    mMultM(kMat, this->numStates, this->numObs, tempYVec, this->numObs, 1, xHat);
     vAdd(this->state, this->numStates, xHat, this->state);
-    for (i=6;i<9;i++){
+    for (i = 6; i < 9; i++) {
         this->state[i] = round(this->state[i]);
     }
     /*! - Compute the updated matrix U from equation 28.  Note that I then transpose it
      so that I can extract "columns" from adjacent memory*/
-    mMultM(kMat, this->numStates, this->numObs, sy,
-           this->numObs, this->numObs, Umat);
+    mMultM(kMat, this->numStates, this->numObs, sy, this->numObs, this->numObs, Umat);
     mTranspose(Umat, this->numStates, this->numObs, Umat);
     /*! - For each column in the update matrix, perform a cholesky down-date on it to
      get the total shifted S matrix (called sBar in internal parameters*/
-    for(i=0; i<this->numObs; i++)
-    {
-        vCopy(&(Umat[i*this->numStates]), this->numStates, Ucol);
-        badUpdate += ukfCholDownDate(this->sBar, Ucol, -1.0, (int) this->numStates, sBarT);
-        mCopy(sBarT, this->numStates, this->numStates,
-              this->sBar);
+    for (i = 0; i < this->numObs; i++) {
+        vCopy(&(Umat[i * this->numStates]), this->numStates, Ucol);
+        badUpdate += ukfCholDownDate(this->sBar, Ucol, -1.0, (int)this->numStates, sBarT);
+        mCopy(sBarT, this->numStates, this->numStates, this->sBar);
     }
 
     /*! - Compute equivalent covariance based on updated sBar matrix*/
-    mTranspose(this->sBar, this->numStates, this->numStates,
-               this->covar);
-    mMultM(this->sBar, this->numStates, this->numStates,
-           this->covar, this->numStates, this->numStates,
-           this->covar);
+    mTranspose(this->sBar, this->numStates, this->numStates, this->covar);
+    mMultM(this->sBar, this->numStates, this->numStates, this->covar, this->numStates, this->numStates, this->covar);
 
-    if (badUpdate<0){
+    if (badUpdate < 0) {
         pixelLineBiasUKFCleanUpdate();
-        return(-1);}
-    return(0);
+        return (-1);
+    }
+    return (0);
 }
 
 /*! This method cleans the filter states after a bad upadate on the fly.
@@ -618,7 +573,7 @@ int PixelLineBiasUKF::pixelLineBiasUKFMeasUpdate()
  @return void
  @param this The configuration data associated with the OD filter
  */
-void PixelLineBiasUKF::pixelLineBiasUKFCleanUpdate(){
+void PixelLineBiasUKF::pixelLineBiasUKFCleanUpdate() {
     size_t i;
     /*! - Reset the observations, state, and covariannces to a previous safe value*/
     vSetZero(this->obs, this->numObs);
@@ -627,14 +582,10 @@ void PixelLineBiasUKF::pixelLineBiasUKFCleanUpdate(){
     mCopy(this->covarPrev, this->numStates, this->numStates, this->covar);
 
     /*! - Reset the wM/wC vectors to standard values for unscented kalman filters*/
-    this->wM[0] = this->lambdaVal / (this->numStates +
-                                                 this->lambdaVal);
-    this->wC[0] = this->lambdaVal / (this->numStates +
-                                                 this->lambdaVal) + (1 - this->alpha*this->alpha + this->beta);
-    for (i = 1; i<this->countHalfSPs * 2 + 1; i++)
-    {
-        this->wM[i] = 1.0 / 2.0*1.0 / (this->numStates +
-                                             this->lambdaVal);
+    this->wM[0] = this->lambdaVal / (this->numStates + this->lambdaVal);
+    this->wC[0] = this->lambdaVal / (this->numStates + this->lambdaVal) + (1 - this->alpha * this->alpha + this->beta);
+    for (i = 1; i < this->countHalfSPs * 2 + 1; i++) {
+        this->wM[i] = 1.0 / 2.0 * 1.0 / (this->numStates + this->lambdaVal);
         this->wC[i] = this->wM[i];
     }
 

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.cpp
@@ -17,11 +17,17 @@
 
  */
 
-#include <string.h>
-#include <math.h>
 #include "pixelLineBiasUKF.h"
+
+#include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 #include "architecture/utilities/ukfUtilities.h"
 
+#include <string.h>
+#include <math.h>
 
 /*! Function for two body dynamics solvers in order to use in the RK4. Only two body dynamics is used currently, but SRP, Solar Gravity, spherical harmonics can be added here.
  @return double Next state

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.h
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.h
@@ -24,20 +24,19 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
 #include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
 #include "architecture/msgPayloadDefC/OpNavCirclesMsgPayload.h"
 #include "architecture/msgPayloadDefC/PixelLineFilterMsgPayload.h"
 
 #include "architecture/utilities/bskLogging.h"
 
-
 /*! @brief Top level structure for the relative OD unscented kalman filter.
  Used to estimate the spacecraft's inertial position relative to a body.
  */
 class PixelLineBiasUKF : public SysModel {
-public:
+   public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 
@@ -47,64 +46,63 @@ public:
     void relODStateProp(double *stateInOut, double dt);
     void pixelLineBiasUKFMeasModel();
 
-    Message<NavTransMsgPayload> navStateOutMsg; //!< navigation translation output message
-    Message<PixelLineFilterMsgPayload> filtDataOutMsg; //!< output filter data message
-    ReadFunctor<OpNavCirclesMsgPayload> circlesInMsg;  //!< [-] input messages with circles information
-    ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg; //!< camera config input message
-    ReadFunctor<NavAttMsgPayload> attInMsg; //!< attitude input message
+    Message<NavTransMsgPayload> navStateOutMsg;             //!< navigation translation output message
+    Message<PixelLineFilterMsgPayload> filtDataOutMsg;      //!< output filter data message
+    ReadFunctor<OpNavCirclesMsgPayload> circlesInMsg;       //!< [-] input messages with circles information
+    ReadFunctor<CameraConfigMsgPayload> cameraConfigInMsg;  //!< camera config input message
+    ReadFunctor<NavAttMsgPayload> attInMsg;                 //!< attitude input message
 
-    int moduleId; //!< module ID
+    int moduleId;  //!< module ID
 
-    size_t numStates;             //!< [-] Number of states for this filter
-    size_t countHalfSPs;          //!< [-] Number of sigma points over 2
-    size_t numObs;                //!< [-] Number of measurements this cycle
-    double beta;                  //!< [-] Beta parameter for filter
-    double alpha;                 //!< [-] Alpha parameter for filter
-    double kappa;                 //!< [-] Kappa parameter for filter
-    double lambdaVal;             //!< [-] Lambda parameter for filter
-    double gamma;                 //!< [-] Gamma parameter for filter
-    double switchMag;             //!< [-] Threshold for where we switch MRP set
+    size_t numStates;     //!< [-] Number of states for this filter
+    size_t countHalfSPs;  //!< [-] Number of sigma points over 2
+    size_t numObs;        //!< [-] Number of measurements this cycle
+    double beta;          //!< [-] Beta parameter for filter
+    double alpha;         //!< [-] Alpha parameter for filter
+    double kappa;         //!< [-] Kappa parameter for filter
+    double lambdaVal;     //!< [-] Lambda parameter for filter
+    double gamma;         //!< [-] Gamma parameter for filter
+    double switchMag;     //!< [-] Threshold for where we switch MRP set
 
-    double dt;                     //!< [s] seconds since last data epoch
-    double timeTag;                //!< [s]  Time tag for statecovar/etc
-    double gyrAggTimeTag;          //!< [s] Time-tag for aggregated gyro data
-    double aggSigma_b2b1[3];       //!< [-] Aggregated attitude motion from gyros
-    double dcm_BdyGyrpltf[3][3];   //!< [-] DCM for converting gyro data to body frame
-    double wM[2 * PIXLINE_N_STATES + 1]; //!< [-] Weighting vector for sigma points
-    double wC[2 * PIXLINE_N_STATES + 1]; //!< [-] Weighting vector for sigma points
+    double dt;                            //!< [s] seconds since last data epoch
+    double timeTag;                       //!< [s]  Time tag for statecovar/etc
+    double gyrAggTimeTag;                 //!< [s] Time-tag for aggregated gyro data
+    double aggSigma_b2b1[3];              //!< [-] Aggregated attitude motion from gyros
+    double dcm_BdyGyrpltf[3][3];          //!< [-] DCM for converting gyro data to body frame
+    double wM[2 * PIXLINE_N_STATES + 1];  //!< [-] Weighting vector for sigma points
+    double wC[2 * PIXLINE_N_STATES + 1];  //!< [-] Weighting vector for sigma points
 
-    double stateInit[PIXLINE_N_STATES];    //!< [-] State estimate to initialize filter to
-    double state[PIXLINE_N_STATES];        //!< [-] State estimate for time TimeTag
-    double statePrev[PIXLINE_N_STATES];        //!< [-] State estimate for time TimeTag at previous time
-    double sBar[PIXLINE_N_STATES*PIXLINE_N_STATES];         //!< [-] Time updated covariance
-    double sBarPrev[PIXLINE_N_STATES*PIXLINE_N_STATES];     //!< [-] Time updated covariance at previous time
-    double covar[PIXLINE_N_STATES*PIXLINE_N_STATES];        //!< [-] covariance
-    double covarPrev[PIXLINE_N_STATES*PIXLINE_N_STATES];    //!< [-] covariance at previous time
-    double covarInit[PIXLINE_N_STATES*PIXLINE_N_STATES];    //!< [-] Covariance to init filter with
-    double xBar[PIXLINE_N_STATES];            //!< [-] Current mean state estimate
+    double stateInit[PIXLINE_N_STATES];                     //!< [-] State estimate to initialize filter to
+    double state[PIXLINE_N_STATES];                         //!< [-] State estimate for time TimeTag
+    double statePrev[PIXLINE_N_STATES];                     //!< [-] State estimate for time TimeTag at previous time
+    double sBar[PIXLINE_N_STATES * PIXLINE_N_STATES];       //!< [-] Time updated covariance
+    double sBarPrev[PIXLINE_N_STATES * PIXLINE_N_STATES];   //!< [-] Time updated covariance at previous time
+    double covar[PIXLINE_N_STATES * PIXLINE_N_STATES];      //!< [-] covariance
+    double covarPrev[PIXLINE_N_STATES * PIXLINE_N_STATES];  //!< [-] covariance at previous time
+    double covarInit[PIXLINE_N_STATES * PIXLINE_N_STATES];  //!< [-] Covariance to init filter with
+    double xBar[PIXLINE_N_STATES];                          //!< [-] Current mean state estimate
 
-    double obs[PIXLINE_N_MEAS];                               //!< [-] Observation vector for frame
-    double yMeas[PIXLINE_N_MEAS*(2*PIXLINE_N_STATES+1)];        //!< [-] Measurement model data
+    double obs[PIXLINE_N_MEAS];                                 //!< [-] Observation vector for frame
+    double yMeas[PIXLINE_N_MEAS * (2 * PIXLINE_N_STATES + 1)];  //!< [-] Measurement model data
 
-    double SP[(2*PIXLINE_N_STATES+1)*PIXLINE_N_STATES];          //!< [-]    sigma point matrix
+    double SP[(2 * PIXLINE_N_STATES + 1) * PIXLINE_N_STATES];  //!< [-]    sigma point matrix
 
-    double qNoise[PIXLINE_N_STATES*PIXLINE_N_STATES];       //!< [-] process noise matrix
-    double sQnoise[PIXLINE_N_STATES*PIXLINE_N_STATES];      //!< [-] cholesky of Qnoise
-    double measNoise[PIXLINE_N_MEAS*PIXLINE_N_MEAS];      //!< [-] Measurement Noise
+    double qNoise[PIXLINE_N_STATES * PIXLINE_N_STATES];   //!< [-] process noise matrix
+    double sQnoise[PIXLINE_N_STATES * PIXLINE_N_STATES];  //!< [-] cholesky of Qnoise
+    double measNoise[PIXLINE_N_MEAS * PIXLINE_N_MEAS];    //!< [-] Measurement Noise
 
-    int planetIdInit;                    //!< [-] Planet being navigated inital value
-    int planetId;                   //!< [-] Planet being navigated as per measurement
-    uint32_t firstPassComplete;         //!< [-] Flag to know if first filter update
-    double postFits[3];      //!< [-] PostFit residuals
-    double timeTagOut;       //!< [s] Output time-tag information
-    double maxTimeJump;      //!< [s] Maximum time jump to allow in propagation
+    int planetIdInit;            //!< [-] Planet being navigated inital value
+    int planetId;                //!< [-] Planet being navigated as per measurement
+    uint32_t firstPassComplete;  //!< [-] Flag to know if first filter update
+    double postFits[3];          //!< [-] PostFit residuals
+    double timeTagOut;           //!< [s] Output time-tag information
+    double maxTimeJump;          //!< [s] Maximum time jump to allow in propagation
 
-    OpNavCirclesMsgPayload circlesInBuffer; //!< [-] ST sensor data read in from message bus
-    CameraConfigMsgPayload cameraSpecs;  //!< [-] Camera specs for nav
-    NavAttMsgPayload attInfo;         //!< [-] Att info for frame transformation
+    OpNavCirclesMsgPayload circlesInBuffer;  //!< [-] ST sensor data read in from message bus
+    CameraConfigMsgPayload cameraSpecs;      //!< [-] Camera specs for nav
+    NavAttMsgPayload attInfo;                //!< [-] Att info for frame transformation
 
-    BSKLogger bskLogger={};  //!< BSK Logging
-
+    BSKLogger bskLogger = {};  //!< BSK Logging
 };
 
 #endif

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.h
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/pixelLineBiasUKF.h
@@ -30,13 +30,7 @@
 #include "architecture/msgPayloadDefC/OpNavCirclesMsgPayload.h"
 #include "architecture/msgPayloadDefC/PixelLineFilterMsgPayload.h"
 
-#include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/bskLogging.h"
-#include "architecture/utilities/astroConstants.h"
-
-
 
 
 /*! @brief Top level structure for the relative OD unscented kalman filter.

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
@@ -19,6 +19,7 @@
 
 #include "simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.h"
 #include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/safeMath.h"
 
 //! The constructor.  Note that you have to overwrite the message names.
 BoreAngCalc::BoreAngCalc()

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
@@ -22,8 +22,7 @@
 #include "architecture/utilities/safeMath.h"
 
 //! The constructor.  Note that you have to overwrite the message names.
-BoreAngCalc::BoreAngCalc()
-{
+BoreAngCalc::BoreAngCalc() {
     CallCounts = 0;
 
     // Initialize the pointing vectors
@@ -38,12 +37,10 @@ BoreAngCalc::BoreAngCalc()
 //! The destructor.
 BoreAngCalc::~BoreAngCalc() = default;
 
-
 /*! This method is used to reset the module.
  @return void
  */
-void BoreAngCalc::reset(uint64_t currentSimNanos)
-{
+void BoreAngCalc::reset(uint64_t currentSimNanos) {
     // check if required input messages have not been included
     if (!this->scStateInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "boreAngCalc.scStateInMsg was not linked.");
@@ -51,22 +48,20 @@ void BoreAngCalc::reset(uint64_t currentSimNanos)
 
     if (this->celBodyInMsg.isLinked()) {
         this->useCelestialHeading = true;
-    }
-    else if (this->inertialHeadingVec_N.norm() > 1e-8) {
+    } else if (this->inertialHeadingVec_N.norm() > 1e-8) {
         this->useInertialHeading = true;
+    } else {
+        bskLogger.bskLog(
+            BSK_ERROR,
+            "Either boreAngCalc.celBodyInMsg was not linked or boreAngCalc.inertialHeadingVec_N was not set.");
     }
-    else {
-        bskLogger.bskLog(BSK_ERROR, "Either boreAngCalc.celBodyInMsg was not linked or boreAngCalc.inertialHeadingVec_N was not set.");
-    }
-
 }
 
 /*! This method writes the output data out into the messaging system.
  @return void
  @param CurrentClock The current time in the system for output stamping
  */
-void BoreAngCalc::WriteOutputMessages(uint64_t CurrentClock)
-{
+void BoreAngCalc::WriteOutputMessages(uint64_t CurrentClock) {
     this->angOutMsg.write(&this->boresightAng, this->moduleID, CurrentClock);
 }
 
@@ -74,8 +69,7 @@ void BoreAngCalc::WriteOutputMessages(uint64_t CurrentClock)
  appropriate parameters
  @return void
  */
-void BoreAngCalc::ReadInputs()
-{
+void BoreAngCalc::ReadInputs() {
     //! - Read the input message into the correct pointer
     this->localState = this->scStateInMsg();
     bool celBodyMsgGood = false;
@@ -92,19 +86,18 @@ void BoreAngCalc::ReadInputs()
     is used later to compute how far off that vector is in an angular sense.
     @return void
 */
-void BoreAngCalc::computeCelestialAxisPoint()
-{
+void BoreAngCalc::computeCelestialAxisPoint() {
     // Convert planet and body data to Eigen variables
-    Eigen::Vector3d r_BN_N = cArray2EigenVector3d(this->localState.r_BN_N); // spacecraft's inertial position
-    Eigen::Vector3d v_BN_N = cArray2EigenVector3d(this->localState.v_BN_N); // spacecraft''s inertial velocity
-    Eigen::Vector3d r_PN_N = cArray2EigenVector3d(this->localPlanet.PositionVector);    // planet's inertial position
-    Eigen::Vector3d v_PN_N = cArray2EigenVector3d(this->localPlanet.VelocityVector);    // planet's inertial velocity
+    Eigen::Vector3d r_BN_N = cArray2EigenVector3d(this->localState.r_BN_N);           // spacecraft's inertial position
+    Eigen::Vector3d v_BN_N = cArray2EigenVector3d(this->localState.v_BN_N);           // spacecraft''s inertial velocity
+    Eigen::Vector3d r_PN_N = cArray2EigenVector3d(this->localPlanet.PositionVector);  // planet's inertial position
+    Eigen::Vector3d v_PN_N = cArray2EigenVector3d(this->localPlanet.VelocityVector);  // planet's inertial velocity
 
     // Compute the relative vectors
-    Eigen::Vector3d r_PB_N = r_PN_N - r_BN_N;   // relative position vector
-    Eigen::Vector3d rHat_PB_N = r_PB_N.normalized();    // unit vector for relative position
-    Eigen::Vector3d v_PB_N = v_PN_N - v_BN_N;   // relative velocity vector
-    Eigen::Vector3d secHat_N = r_PB_N.cross(v_PB_N).normalized();   // perpendicular unit vector
+    Eigen::Vector3d r_PB_N = r_PN_N - r_BN_N;                      // relative position vector
+    Eigen::Vector3d rHat_PB_N = r_PB_N.normalized();               // unit vector for relative position
+    Eigen::Vector3d v_PB_N = v_PN_N - v_BN_N;                      // relative velocity vector
+    Eigen::Vector3d secHat_N = r_PB_N.cross(v_PB_N).normalized();  // perpendicular unit vector
 
     // Calculate the inertial to point DCM
     Eigen::Matrix3d dcm_PoN;  // dcm, inertial to point frame
@@ -113,9 +106,9 @@ void BoreAngCalc::computeCelestialAxisPoint()
     dcm_PoN.row(1) = dcm_PoN.row(2).cross(dcm_PoN.row(0));
 
     // Compute the point to body frame DCM and convert the boresight vector to the Po frame
-    Eigen::MRPd sigma_BN = cArray2EigenMRPd(this->localState.sigma_BN); // mrp, inertial to body frame
-    Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();   // dcm, inertial to body frame
-    Eigen::Matrix3d dcm_BPo = dcm_BN * dcm_PoN.transpose(); // dcm, point to body frame
+    Eigen::MRPd sigma_BN = cArray2EigenMRPd(this->localState.sigma_BN);  // mrp, inertial to body frame
+    Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();    // dcm, inertial to body frame
+    Eigen::Matrix3d dcm_BPo = dcm_BN * dcm_PoN.transpose();              // dcm, point to body frame
     this->boreVec_Po = dcm_BPo.transpose() * this->boreVec_B;
 }
 
@@ -125,8 +118,7 @@ void BoreAngCalc::computeCelestialAxisPoint()
     desired pointing vector projected into the y/z plane.
     @return void
 */
-void BoreAngCalc::computeCelestialOutputData()
-{
+void BoreAngCalc::computeCelestialOutputData() {
     // Define epsilon that will avoid atan2 giving a NaN.
     double eps = 1e-10;
 
@@ -135,8 +127,7 @@ void BoreAngCalc::computeCelestialOutputData()
     this->boresightAng.missAngle = fabs(safeAcos(dotValue));
     if (fabs(this->boreVec_Po(1)) < eps) {
         this->boresightAng.azimuth = 0.0;
-    }
-    else {
+    } else {
         this->boresightAng.azimuth = atan2(this->boreVec_Po(2), this->boreVec_Po(1));
     }
 }
@@ -145,14 +136,14 @@ void BoreAngCalc::computeCelestialOutputData()
     computed using the body heading and the provided inertial heading
     @return void
 */
-void BoreAngCalc::computeInertialOutputData()
-{
+void BoreAngCalc::computeInertialOutputData() {
     // Compute the DCM from inertial do body frame
-    Eigen::MRPd sigma_BN = cArray2EigenMRPd(this->localState.sigma_BN); // mrp, inertial to body frame
-    Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();   // dcm, inertial to body frame
+    Eigen::MRPd sigma_BN = cArray2EigenMRPd(this->localState.sigma_BN);  // mrp, inertial to body frame
+    Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();    // dcm, inertial to body frame
 
     // Calculate the inertial heading vector
-    Eigen::Vector3d inertialHeadingVec_B = dcm_BN * this->inertialHeadingVec_N; // inertial heading written in the body frame
+    Eigen::Vector3d inertialHeadingVec_B =
+        dcm_BN * this->inertialHeadingVec_N;  // inertial heading written in the body frame
     double dotValue = this->boreVec_B.dot(inertialHeadingVec_B);
     this->boresightAng.missAngle = fabs(safeAcos(dotValue));
 
@@ -166,19 +157,15 @@ void BoreAngCalc::computeInertialOutputData()
  @return void
  @param currentSimNanos The current simulation time for system
  */
-void BoreAngCalc::updateState(uint64_t currentSimNanos)
-{
+void BoreAngCalc::updateState(uint64_t currentSimNanos) {
     //! - Read the input message and convert it over appropriately depending on switch
     ReadInputs();
 
-    if(this->inputsGood)
-    {
-        if (this->useCelestialHeading)
-        {
+    if (this->inputsGood) {
+        if (this->useCelestialHeading) {
             this->computeCelestialAxisPoint();
             this->computeCelestialOutputData();
-        }
-        else {
+        } else {
             this->computeInertialOutputData();
         }
     }

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -20,42 +20,40 @@
 #define FUEL_TANK_H
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"
 #include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"
 #include "simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h"
+#include "simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h"
 #include "simulation/dynamics/_GeneralModuleFiles/fuelSlosh.h"
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-#include "simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h"
 
-#include <math.h>
-#include <vector>
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/avsEigenSupport.h"
-
+#include <math.h>
+#include <vector>
 
 /*! Tank model class */
 class FuelTankModel {
-public:
-    double propMassInit{};                              //!< [kg] Initial propellant mass in tank
-    double maxFuelMass = 1.0;                          //!< [kg] maximum tank mass
-    Eigen::Vector3d r_TcT_TInit;                          //!< [m] Initial position vector from B to tank point in B frame comp.
-    Eigen::Matrix3d ITankPntT_T;                            //!< [kg m^2] Inertia of tank about pnt T in B frame comp.
-    Eigen::Matrix3d IPrimeTankPntT_T;                   //!< [kg m^2/s] Derivative of inertia of tank about pnt T in B frame comp.
-    Eigen::Vector3d r_TcT_T;                           //!< [m] position vector from B to tank point in B frame comp.
-    Eigen::Vector3d rPrime_TcT_T;                      //!< [m/s] Derivative of position vector from B to tank point in B frame comp.
-    Eigen::Vector3d rPPrime_TcT_T;                     //!< [m/s^2] Second derivative of position vector from B to tank point in B frame comp.
-    virtual void computeTankProps(double mFuel) = 0;    //!< class method
-    virtual void computeTankPropDerivs(double mFuel, double mDotFuel) = 0; //!< class method
-    FuelTankModel() {
-        this->r_TcT_TInit.setZero();
-    }
+   public:
+    double propMassInit{};             //!< [kg] Initial propellant mass in tank
+    double maxFuelMass = 1.0;          //!< [kg] maximum tank mass
+    Eigen::Vector3d r_TcT_TInit;       //!< [m] Initial position vector from B to tank point in B frame comp.
+    Eigen::Matrix3d ITankPntT_T;       //!< [kg m^2] Inertia of tank about pnt T in B frame comp.
+    Eigen::Matrix3d IPrimeTankPntT_T;  //!< [kg m^2/s] Derivative of inertia of tank about pnt T in B frame comp.
+    Eigen::Vector3d r_TcT_T;           //!< [m] position vector from B to tank point in B frame comp.
+    Eigen::Vector3d rPrime_TcT_T;      //!< [m/s] Derivative of position vector from B to tank point in B frame comp.
+    Eigen::Vector3d
+        rPPrime_TcT_T;  //!< [m/s^2] Second derivative of position vector from B to tank point in B frame comp.
+    virtual void computeTankProps(double mFuel) = 0;                        //!< class method
+    virtual void computeTankPropDerivs(double mFuel, double mDotFuel) = 0;  //!< class method
+    FuelTankModel() { this->r_TcT_TInit.setZero(); }
     virtual ~FuelTankModel() = default;
 };
 
 /*! Tank constant volume class */
 class FuelTankModelConstantVolume : public FuelTankModel {
-public:
-    double radiusTankInit{};                             //!< [m] Initial radius of the spherical tank
+   public:
+    double radiusTankInit{};  //!< [m] Initial radius of the spherical tank
 
     FuelTankModelConstantVolume() = default;
 
@@ -63,11 +61,13 @@ public:
 
     void computeTankProps(double mFuel) override {
         this->r_TcT_T = this->r_TcT_TInit;
-        this->ITankPntT_T = 2.0 / 5.0 * mFuel * this->radiusTankInit * this->radiusTankInit * Eigen::Matrix3d::Identity();
+        this->ITankPntT_T =
+            2.0 / 5.0 * mFuel * this->radiusTankInit * this->radiusTankInit * Eigen::Matrix3d::Identity();
     }
 
     void computeTankPropDerivs(double mFuel, double mDotFuel) override {
-        this->IPrimeTankPntT_T = 2.0 / 5.0 * mDotFuel * this->radiusTankInit * this->radiusTankInit * Eigen::Matrix3d::Identity();
+        this->IPrimeTankPntT_T =
+            2.0 / 5.0 * mDotFuel * this->radiusTankInit * this->radiusTankInit * Eigen::Matrix3d::Identity();
         this->rPrime_TcT_T.setZero();
         this->rPPrime_TcT_T.setZero();
     }
@@ -75,9 +75,9 @@ public:
 
 /*! Tank constant density class */
 class FuelTankModelConstantDensity : public FuelTankModel {
-public:
-    double radiusTankInit{};                             //!< [m] Initial radius of the spherical tank
-    double radiusTank{};                                   //!< [m] Current radius of the spherical tank
+   public:
+    double radiusTankInit{};  //!< [m] Initial radius of the spherical tank
+    double radiusTank{};      //!< [m] Current radius of the spherical tank
 
     FuelTankModelConstantDensity() = default;
 
@@ -90,7 +90,8 @@ public:
     }
 
     void computeTankPropDerivs(double mFuel, double mDotFuel) override {
-        this->IPrimeTankPntT_T = 2.0 / 3.0 * mDotFuel * this->radiusTank * this->radiusTank * Eigen::Matrix3d::Identity();
+        this->IPrimeTankPntT_T =
+            2.0 / 3.0 * mDotFuel * this->radiusTank * this->radiusTank * Eigen::Matrix3d::Identity();
         this->rPrime_TcT_T.setZero();
         this->rPPrime_TcT_T.setZero();
     }
@@ -98,13 +99,13 @@ public:
 
 /*! Tank model emptying class */
 class FuelTankModelEmptying : public FuelTankModel {
-public:
-    double radiusTankInit{};                             //!< [m] Initial radius of the spherical tank
-    double rhoFuel{};                                    //!< [kg/m^3] density of the fuel
-    double thetaStar{};                                   //!< [rad] angle from vertical to top of fuel
-    double thetaDotStar{};                               //!< [rad/s] derivative of angle from vertical to top of fuel
-    double thetaDDotStar{};                               //!< [rad/s^2] second derivative of angle from vertical to top of fuel
-    Eigen::Vector3d k3;                                   //!< -- Direction of fuel depletion
+   public:
+    double radiusTankInit{};  //!< [m] Initial radius of the spherical tank
+    double rhoFuel{};         //!< [kg/m^3] density of the fuel
+    double thetaStar{};       //!< [rad] angle from vertical to top of fuel
+    double thetaDotStar{};    //!< [rad/s] derivative of angle from vertical to top of fuel
+    double thetaDDotStar{};   //!< [rad/s^2] second derivative of angle from vertical to top of fuel
+    Eigen::Vector3d k3;       //!< -- Direction of fuel depletion
 
     FuelTankModelEmptying() = default;
 
@@ -133,17 +134,19 @@ public:
     }
 
     void computeTankProps(double mFuel) override {
-        this->rhoFuel = this->propMassInit / (4.0 / 3.0 * M_PI * this->radiusTankInit * this->radiusTankInit * this->radiusTankInit);
+        this->rhoFuel = this->propMassInit /
+                        (4.0 / 3.0 * M_PI * this->radiusTankInit * this->radiusTankInit * this->radiusTankInit);
         double rtank = this->radiusTankInit;
         double volume;
         double deltaRadiusK3;
-        this->k3 << 0, 0, 1; //k3 is zhat
+        this->k3 << 0, 0, 1;  // k3 is zhat
 
         if (mFuel != this->propMassInit) {
             double rhoFuel = this->rhoFuel;
             std::function<double(double)> f = [rhoFuel, rtank, mFuel](double thetaStar) -> double {
                 return 2.0 / 3.0 * M_PI * rhoFuel * rtank * rtank * rtank *
-                       (1 + 3.0 / 2.0 * cos(thetaStar) - 1.0 / 2.0 * pow(cos(thetaStar), 3)) - mFuel;
+                           (1 + 3.0 / 2.0 * cos(thetaStar) - 1.0 / 2.0 * pow(cos(thetaStar), 3)) -
+                       mFuel;
             };
             std::function<double(double)> fPrime = [rhoFuel, rtank](double thetaStar) -> double {
                 return 2.0 / 3.0 * M_PI * rhoFuel * rtank * rtank * rtank *
@@ -166,49 +169,55 @@ public:
         this->r_TcT_T = this->r_TcT_TInit + deltaRadiusK3 * this->k3;
         this->ITankPntT_T.setZero();
         this->IPrimeTankPntT_T.setZero();
-        this->ITankPntT_T(2, 2) = 2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) *
-                            (2.0 / 3.0 + 1.0 / 4.0 * std::cos(this->thetaStar) * std::pow(std::sin(this->thetaStar), 4) -
-                             1 / 12.0 * (std::cos(3 * this->thetaStar) - 9 * std::cos(this->thetaStar)));
-        this->ITankPntT_T(0, 0) = this->ITankPntT_T(1, 1) = 2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) *
-                                                (2.0 / 3.0 - 1.0 / 4.0 * std::pow(std::cos(this->thetaStar), 5) +
-                                                 1 / 24.0 * (std::cos(3 * this->thetaStar) - 9 * std::cos(this->thetaStar)) +
-                                                 5.0 / 4.0 * cos(this->thetaStar) +
-                                                 1 / 8.0 * std::cos(this->thetaStar) * std::pow(std::sin(this->thetaStar), 4));
+        this->ITankPntT_T(2, 2) =
+            2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) *
+            (2.0 / 3.0 + 1.0 / 4.0 * std::cos(this->thetaStar) * std::pow(std::sin(this->thetaStar), 4) -
+             1 / 12.0 * (std::cos(3 * this->thetaStar) - 9 * std::cos(this->thetaStar)));
+        this->ITankPntT_T(0, 0) = this->ITankPntT_T(1, 1) =
+            2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) *
+            (2.0 / 3.0 - 1.0 / 4.0 * std::pow(std::cos(this->thetaStar), 5) +
+             1 / 24.0 * (std::cos(3 * this->thetaStar) - 9 * std::cos(this->thetaStar)) +
+             5.0 / 4.0 * cos(this->thetaStar) +
+             1 / 8.0 * std::cos(this->thetaStar) * std::pow(std::sin(this->thetaStar), 4));
     }
 
     void computeTankPropDerivs(double mFuel, double mDotFuel) override {
         if (mFuel != this->propMassInit) {
-            this->thetaDotStar = -mDotFuel / (M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 3) * std::sin(this->thetaStar));
+            this->thetaDotStar =
+                -mDotFuel / (M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 3) * std::sin(this->thetaStar));
             this->thetaDDotStar = -3 * this->thetaDotStar * this->thetaDotStar * std::cos(this->thetaStar) /
-                            std::sin(this->thetaStar); //This assumes that mddot = 0
+                                  std::sin(this->thetaStar);  // This assumes that mddot = 0
         } else {
             this->thetaDotStar = 0.0;
             this->thetaDDotStar = 0.0;
         }
-        this->IPrimeTankPntT_T(2, 2) = 2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) * this->thetaDotStar *
-                                 (std::pow(std::cos(this->thetaStar), 2) * std::pow(std::sin(this->thetaStar), 3) -
-                                  1.0 / 4.0 * std::pow(std::sin(this->thetaStar), 5) +
-                                  1 / 4.0 * std::sin(3 * this->thetaStar) - 3.0 / 4.0 * std::sin(this->thetaStar));
+        this->IPrimeTankPntT_T(2, 2) =
+            2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) * this->thetaDotStar *
+            (std::pow(std::cos(this->thetaStar), 2) * std::pow(std::sin(this->thetaStar), 3) -
+             1.0 / 4.0 * std::pow(std::sin(this->thetaStar), 5) + 1 / 4.0 * std::sin(3 * this->thetaStar) -
+             3.0 / 4.0 * std::sin(this->thetaStar));
         this->IPrimeTankPntT_T(0, 0) = this->IPrimeTankPntT_T(1, 1) =
-                2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) * this->thetaDotStar *
-                (5.0 / 4.0 * std::sin(this->thetaStar) * std::cos(this->thetaStar) - 5.0 / 4.0 * std::sin(this->thetaStar) -
-                 1 / 8.0 * std::sin(3 * this->thetaStar) +
-                 3.0 / 8.0 * sin(this->thetaStar) +
-                 1 / 2.0 * std::pow(std::cos(this->thetaStar), 2) * std::pow(std::sin(this->thetaStar), 3) -
-                 1 / 8.0 * std::pow(std::sin(this->thetaStar), 5));
+            2.0 / 5.0 * M_PI * this->rhoFuel * std::pow(this->radiusTankInit, 5) * this->thetaDotStar *
+            (5.0 / 4.0 * std::sin(this->thetaStar) * std::cos(this->thetaStar) - 5.0 / 4.0 * std::sin(this->thetaStar) -
+             1 / 8.0 * std::sin(3 * this->thetaStar) + 3.0 / 8.0 * sin(this->thetaStar) +
+             1 / 2.0 * std::pow(std::cos(this->thetaStar), 2) * std::pow(std::sin(this->thetaStar), 3) -
+             1 / 8.0 * std::pow(std::sin(this->thetaStar), 5));
         if (mFuel != 0) {
-            this->rPrime_TcT_T = -M_PI * std::pow(this->radiusTankInit, 4) * this->rhoFuel / (4 * mFuel * mFuel) *
-                           (4 * mFuel * this->thetaDotStar * std::pow(std::sin(this->thetaStar), 3) * std::cos(this->thetaStar) +
-                            mDotFuel * (2 * std::pow(std::cos(this->thetaStar), 2) - std::pow(std::cos(this->thetaStar), 4) - 1)) *
-                           this->k3;
+            this->rPrime_TcT_T =
+                -M_PI * std::pow(this->radiusTankInit, 4) * this->rhoFuel / (4 * mFuel * mFuel) *
+                (4 * mFuel * this->thetaDotStar * std::pow(std::sin(this->thetaStar), 3) * std::cos(this->thetaStar) +
+                 mDotFuel * (2 * std::pow(std::cos(this->thetaStar), 2) - std::pow(std::cos(this->thetaStar), 4) - 1)) *
+                this->k3;
 
-            this->rPPrime_TcT_T = -M_PI * std::pow(this->radiusTankInit, 4) * this->rhoFuel / (2 * mFuel * mFuel * mFuel) *
-                            (4 * mFuel * std::pow(std::sin(this->thetaStar), 3) * std::cos(this->thetaStar) *
-                             (this->thetaDDotStar * mFuel - 2 * this->thetaDotStar * mDotFuel) -
-                             4 * mFuel * mFuel * this->thetaDotStar * this->thetaDotStar * std::pow(std::sin(this->thetaStar), 2) *
-                             (3 * std::pow(std::cos(this->thetaStar), 2) - std::pow(std::sin(this->thetaStar), 2)) +
-                             (2 * std::pow(std::cos(this->thetaStar), 2) - std::pow(std::cos(this->thetaStar), 4) - 1) *
-                             (-2 * mDotFuel * mDotFuel)) * this->k3;
+            this->rPPrime_TcT_T =
+                -M_PI * std::pow(this->radiusTankInit, 4) * this->rhoFuel / (2 * mFuel * mFuel * mFuel) *
+                (4 * mFuel * std::pow(std::sin(this->thetaStar), 3) * std::cos(this->thetaStar) *
+                     (this->thetaDDotStar * mFuel - 2 * this->thetaDotStar * mDotFuel) -
+                 4 * mFuel * mFuel * this->thetaDotStar * this->thetaDotStar * std::pow(std::sin(this->thetaStar), 2) *
+                     (3 * std::pow(std::cos(this->thetaStar), 2) - std::pow(std::sin(this->thetaStar), 2)) +
+                 (2 * std::pow(std::cos(this->thetaStar), 2) - std::pow(std::cos(this->thetaStar), 4) - 1) *
+                     (-2 * mDotFuel * mDotFuel)) *
+                this->k3;
 
         } else {
             this->rPrime_TcT_T.setZero();
@@ -219,9 +228,9 @@ public:
 
 /*! Tank model class for a uniform burn */
 class FuelTankModelUniformBurn : public FuelTankModel {
-public:
-    double radiusTankInit{};                             //!< [m] Initial radius of the cylindrical tank
-    double lengthTank{};                                   //!< [m] Length of the tank
+   public:
+    double radiusTankInit{};  //!< [m] Initial radius of the cylindrical tank
+    double lengthTank{};      //!< [m] Length of the tank
 
     FuelTankModelUniformBurn() = default;
 
@@ -231,14 +240,14 @@ public:
         this->r_TcT_T = this->r_TcT_TInit;
         this->ITankPntT_T.setZero();
         this->ITankPntT_T(0, 0) = this->ITankPntT_T(1, 1) =
-                mFuel * (this->radiusTankInit * this->radiusTankInit / 4.0 + this->lengthTank * this->lengthTank / 12.0);
+            mFuel * (this->radiusTankInit * this->radiusTankInit / 4.0 + this->lengthTank * this->lengthTank / 12.0);
         this->ITankPntT_T(2, 2) = mFuel * this->radiusTankInit * this->radiusTankInit / 2;
     }
 
     void computeTankPropDerivs(double mFuel, double mDotFuel) override {
         this->IPrimeTankPntT_T.setZero();
         this->IPrimeTankPntT_T(0, 0) = this->IPrimeTankPntT_T(1, 1) =
-                mDotFuel * (this->radiusTankInit * this->radiusTankInit / 4.0 + this->lengthTank * this->lengthTank / 12.0);
+            mDotFuel * (this->radiusTankInit * this->radiusTankInit / 4.0 + this->lengthTank * this->lengthTank / 12.0);
         this->IPrimeTankPntT_T(2, 2) = mDotFuel * this->radiusTankInit * this->radiusTankInit / 2;
         this->rPrime_TcT_T.setZero();
         this->rPPrime_TcT_T.setZero();
@@ -247,10 +256,10 @@ public:
 
 /*! Tank model class for a centrifugal burn */
 class FuelTankModelCentrifugalBurn : public FuelTankModel {
-public:
-    double radiusTankInit{};                             //!< [m] Initial radius of the cylindrical tank
-    double lengthTank{};                                   //!< [m] Length of the tank
-    double radiusInner{};                                   //!< [m] Inner radius of the cylindrical tank
+   public:
+    double radiusTankInit{};  //!< [m] Initial radius of the cylindrical tank
+    double lengthTank{};      //!< [m] Length of the tank
+    double radiusInner{};     //!< [m] Inner radius of the cylindrical tank
 
     FuelTankModelCentrifugalBurn() = default;
 
@@ -258,21 +267,21 @@ public:
 
     void computeTankProps(double mFuel) override {
         double rhoFuel = this->propMassInit / (M_PI * this->radiusTankInit * this->radiusTankInit * this->lengthTank);
-        this->radiusInner = std::sqrt(std::max(this->radiusTankInit * this->radiusTankInit - mFuel / (M_PI * this->lengthTank * rhoFuel), 0.0));
+        this->radiusInner = std::sqrt(
+            std::max(this->radiusTankInit * this->radiusTankInit - mFuel / (M_PI * this->lengthTank * rhoFuel), 0.0));
         this->r_TcT_T = this->r_TcT_TInit;
         this->ITankPntT_T.setZero();
-        this->ITankPntT_T(0, 0) = this->ITankPntT_T(1, 1) = mFuel *
-                                                ((this->radiusTankInit * this->radiusTankInit +
-                                                this->radiusInner * this->radiusInner) / 4.0 +
-                                                 this->lengthTank * this->lengthTank / 12.0);
-        this->ITankPntT_T(2, 2) = mFuel * (this->radiusTankInit * this->radiusTankInit +
-                this->radiusInner * this->radiusInner) / 2;
+        this->ITankPntT_T(0, 0) = this->ITankPntT_T(1, 1) =
+            mFuel * ((this->radiusTankInit * this->radiusTankInit + this->radiusInner * this->radiusInner) / 4.0 +
+                     this->lengthTank * this->lengthTank / 12.0);
+        this->ITankPntT_T(2, 2) =
+            mFuel * (this->radiusTankInit * this->radiusTankInit + this->radiusInner * this->radiusInner) / 2;
     }
 
     void computeTankPropDerivs(double mFuel, double mDotFuel) override {
         this->IPrimeTankPntT_T.setZero();
         this->IPrimeTankPntT_T(0, 0) = this->IPrimeTankPntT_T(1, 1) =
-                mDotFuel * (this->radiusInner * this->radiusInner / 2.0 + this->lengthTank * this->lengthTank / 12.0);
+            mDotFuel * (this->radiusInner * this->radiusInner / 2.0 + this->lengthTank * this->lengthTank / 12.0);
         this->IPrimeTankPntT_T(2, 2) = mDotFuel * this->radiusInner * this->radiusInner;
         this->rPrime_TcT_T.setZero();
         this->rPPrime_TcT_T.setZero();
@@ -280,42 +289,41 @@ public:
 };
 
 /*! Fuel tank effector model class */
-class FuelTank :
-        public StateEffector, public SysModel {
-public:
-    std::string nameOfMassState{};                       //!< -- name of mass state
-    std::vector<FuelSlosh *> fuelSloshParticles;        //!< -- vector of fuel slosh particles
-    std::vector<ThrusterDynamicEffector *> thrDynEffectors;        //!< -- Vector of dynamic effectors for thrusters
-    std::vector<ThrusterStateEffector *> thrStateEffectors;        //!< -- Vector of state effectors for thrusters
-    Eigen::Matrix3d dcm_TB;                               //!< -- DCM from body frame to tank frame
-    Eigen::Vector3d r_TB_B;                               //!< [m] position of tank in B frame
-    bool updateOnly = true;                                   //!< -- Sets whether to use update only mass depletion
-    Message<FuelTankMsgPayload> fuelTankOutMsg{};        //!< -- fuel tank output message name
-    FuelTankMsgPayload fuelTankMassPropMsg{};            //!< instance of messaging system message struct
+class FuelTank : public StateEffector, public SysModel {
+   public:
+    std::string nameOfMassState{};                           //!< -- name of mass state
+    std::vector<FuelSlosh *> fuelSloshParticles;             //!< -- vector of fuel slosh particles
+    std::vector<ThrusterDynamicEffector *> thrDynEffectors;  //!< -- Vector of dynamic effectors for thrusters
+    std::vector<ThrusterStateEffector *> thrStateEffectors;  //!< -- Vector of state effectors for thrusters
+    Eigen::Matrix3d dcm_TB;                                  //!< -- DCM from body frame to tank frame
+    Eigen::Vector3d r_TB_B;                                  //!< [m] position of tank in B frame
+    bool updateOnly = true;                                  //!< -- Sets whether to use update only mass depletion
+    Message<FuelTankMsgPayload> fuelTankOutMsg{};            //!< -- fuel tank output message name
+    FuelTankMsgPayload fuelTankMassPropMsg{};                //!< instance of messaging system message struct
 
-private:
-    StateData *omegaState{};                             //!< -- state data for omega_BN of the hub
-    StateData *massState{};                              //!< -- state data for mass state
-    double fuelConsumption{};                               //!< [kg/s] rate of fuel being consumed
-    double tankFuelConsumption{};                           //!< [kg/s] rate of fuel being consumed from tank
-    FuelTankModel *fuelTankModel{};                       //!< -- style of tank to simulate
+   private:
+    StateData *omegaState{};         //!< -- state data for omega_BN of the hub
+    StateData *massState{};          //!< -- state data for mass state
+    double fuelConsumption{};        //!< [kg/s] rate of fuel being consumed
+    double tankFuelConsumption{};    //!< [kg/s] rate of fuel being consumed from tank
+    FuelTankModel *fuelTankModel{};  //!< -- style of tank to simulate
     Eigen::Matrix3d ITankPntT_B;
     Eigen::Vector3d r_TcB_B;
-    static uint64_t effectorID;                        //!< [] ID number of this fuel tank effector
+    static uint64_t effectorID;  //!< [] ID number of this fuel tank effector
 
-public:
+   public:
     FuelTank();
     ~FuelTank();
     void writeOutputMessages(uint64_t currentClock);
     void updateState(uint64_t currentSimNanos) override;
     void setTankModel(FuelTankModel *model);
-    void pushFuelSloshParticle(FuelSlosh *particle);  //!< -- Attach fuel slosh particle
-    void registerStates(DynParamManager &states) override;  //!< -- Register mass state with state manager
-    void linkInStates(DynParamManager &states) override;  //!< -- Give the tank access to other states
-    void updateEffectorMassProps(double integTime) override;  //!< -- Add contribution mass props from the tank
+    void pushFuelSloshParticle(FuelSlosh *particle);             //!< -- Attach fuel slosh particle
+    void registerStates(DynParamManager &states) override;       //!< -- Register mass state with state manager
+    void linkInStates(DynParamManager &states) override;         //!< -- Give the tank access to other states
+    void updateEffectorMassProps(double integTime) override;     //!< -- Add contribution mass props from the tank
     void setNameOfMassState(const std::string nameOfMassState);  //!< -- Setter for fuel tank mass state name
-    void addThrusterSet(ThrusterDynamicEffector *dynEff);  //!< -- Add DynamicEffector thruster
-    void addThrusterSet(ThrusterStateEffector *stateEff);  //!< -- Add StateEffector thruster
+    void addThrusterSet(ThrusterDynamicEffector *dynEff);        //!< -- Add DynamicEffector thruster
+    void addThrusterSet(ThrusterStateEffector *stateEff);        //!< -- Add StateEffector thruster
     void updateContributions(double integTime,
                              BackSubMatrices &backSubContr,
                              Eigen::Vector3d sigma_BN,
@@ -330,6 +338,5 @@ public:
                             Eigen::Vector3d omegaDot_BN_B,
                             Eigen::Vector3d sigma_BN) override;  //!< -- Calculate stateEffector's derivatives
 };
-
 
 #endif /* FUEL_TANK_H */

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -110,6 +110,28 @@ public:
 
     ~FuelTankModelEmptying() override = default;
 
+    /*! This function solves for the zero of the passed function using the Newton Raphson Method
+    @return double
+    @param initialEstimate The initial value to use for newton-raphson
+    @param accuracy The desired upper bound for the error
+    @param f Function to find the zero of
+    @param fPrime First derivative of the function
+    */
+    double newtonRaphsonSolve(const double &initialEstimate,
+                              const double &accuracy,
+                              const std::function<double(double)> &f,
+                              const std::function<double(double)> &fPrime) const {
+        double currentEstimate = initialEstimate;
+        for (int i = 0; i < 100; i++) {
+            if (std::abs(f(currentEstimate)) < accuracy) break;
+
+            double functionVal = f(currentEstimate);
+            double functionDeriv = fPrime(currentEstimate);
+            currentEstimate = currentEstimate - functionVal / functionDeriv;
+        }
+        return currentEstimate;
+    }
+
     void computeTankProps(double mFuel) override {
         this->rhoFuel = this->propMassInit / (4.0 / 3.0 * M_PI * this->radiusTankInit * this->radiusTankInit * this->radiusTankInit);
         double rtank = this->radiusTankInit;

--- a/src/simulation/environment/albedo/albedo.cpp
+++ b/src/simulation/environment/albedo/albedo.cpp
@@ -19,6 +19,14 @@
 
 #include "albedo.h"
 
+#include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/geodeticConversion.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/safeMath.h"
+
+#include <fstream>
+#include <sstream>
+
 /*! Albedo module constructor
  @return void
  */

--- a/src/simulation/environment/albedo/albedo.cpp
+++ b/src/simulation/environment/albedo/albedo.cpp
@@ -30,8 +30,7 @@
 /*! Albedo module constructor
  @return void
  */
-Albedo::Albedo()
-{
+Albedo::Albedo() {
     this->albOutMsgs.clear();
     this->planetInMsgs.clear();
     this->planetMsgData.clear();
@@ -60,7 +59,7 @@ Albedo::Albedo()
     this->albedoAtInstrument = -1.0;
     this->defaultNumLon = 360;
     this->defaultNumLat = 180;
-    this->nHat_B_default = { 1.0, 0.0, 0.0 };
+    this->nHat_B_default = {1.0, 0.0, 0.0};
     this->fov_default = 90. * D2R;
     this->eclipseCase = false;
     this->shadowFactorAtdA = 1.0;
@@ -71,9 +70,8 @@ Albedo::Albedo()
 /*! Albedo module destructor
  @return void
  */
-Albedo::~Albedo()
-{
-    for (long unsigned int c=0; c<this->albOutMsgs.size(); c++) {
+Albedo::~Albedo() {
+    for (long unsigned int c = 0; c < this->albOutMsgs.size(); c++) {
         delete this->albOutMsgs.at(c);
     }
     return;
@@ -86,9 +84,7 @@ Config::Config() {
     return;
 }
 
-Config::~Config() {
-    return;
-}
+Config::~Config() { return; }
 
 /*! Adds the instrument configuration and automatically creates an output message name (overloaded function)
  @return void
@@ -102,9 +98,11 @@ void Albedo::addInstrumentConfig(instConfig_t configMsg) {
     // Do a sanity check and push fov back to the vector (if not defined, use the default value.)
     if (configMsg.fov < 0.0) {
         this->fovs.push_back(this->fov_default);
-        bskLogger.bskLog(BSK_WARNING, "Albedo Module (addInstrumentConfig): For the instrument (%lu)'s half field of view angle (fov), the default value is used.", (int) this->albOutMsgs.size()-1);
-    }
-    else {
+        bskLogger.bskLog(BSK_WARNING,
+                         "Albedo Module (addInstrumentConfig): For the instrument (%lu)'s half field of view angle "
+                         "(fov), the default value is used.",
+                         (int)this->albOutMsgs.size() - 1);
+    } else {
         this->fovs.push_back(configMsg.fov);
     }
 
@@ -114,10 +112,12 @@ void Albedo::addInstrumentConfig(instConfig_t configMsg) {
     // Do a sanity check and push nHat_B back to the vector (if not defined, use the default value.)
     if (!configMsg.nHat_B.isZero()) {
         this->nHat_Bs.push_back(configMsg.nHat_B / configMsg.nHat_B.norm());
-    }
-    else {
+    } else {
         this->nHat_Bs.push_back(nHat_B_default);
-        bskLogger.bskLog(BSK_WARNING, "Albedo Module (addInstrumentConfig): For the instrument (%lu)'s unit normal vector (nHat_B), the default vector is used.", this->albOutMsgs.size()-1);
+        bskLogger.bskLog(BSK_WARNING,
+                         "Albedo Module (addInstrumentConfig): For the instrument (%lu)'s unit normal vector (nHat_B), "
+                         "the default vector is used.",
+                         this->albOutMsgs.size() - 1);
     }
     return;
 }
@@ -134,9 +134,11 @@ void Albedo::addInstrumentConfig(double fov, Eigen::Vector3d nHat_B, Eigen::Vect
     // Do a sanity check and push fov back to the vector (if not defined, use the default value.)
     if (fov < 0.0) {
         this->fovs.push_back(this->fov_default);
-        bskLogger.bskLog(BSK_WARNING, "Albedo Module (addInstrumentConfig): Instrument (%lu)'s half field of view angle (fov) cannot be negative, the default value is used instead.", this->albOutMsgs.size()-1);
-    }
-    else {
+        bskLogger.bskLog(BSK_WARNING,
+                         "Albedo Module (addInstrumentConfig): Instrument (%lu)'s half field of view angle (fov) "
+                         "cannot be negative, the default value is used instead.",
+                         this->albOutMsgs.size() - 1);
+    } else {
         this->fovs.push_back(fov);
     }
 
@@ -146,10 +148,12 @@ void Albedo::addInstrumentConfig(double fov, Eigen::Vector3d nHat_B, Eigen::Vect
     // Do a sanity check and push nHat_B back to the vector (if not defined, use the default value.)
     if (!nHat_B.isZero()) {
         this->nHat_Bs.push_back(nHat_B / nHat_B.norm());
-    }
-    else {
+    } else {
         this->nHat_Bs.push_back(nHat_B_default);
-        bskLogger.bskLog(BSK_WARNING, "Albedo Module (addInstrumentConfig): Instrument (%lu)'s unit normal vector (nHat_B) cannot be composed of all zeros, the default vector is used instead.", this->albOutMsgs.size()-1);
+        bskLogger.bskLog(BSK_WARNING,
+                         "Albedo Module (addInstrumentConfig): Instrument (%lu)'s unit normal vector (nHat_B) cannot "
+                         "be composed of all zeros, the default vector is used instead.",
+                         this->albOutMsgs.size() - 1);
     }
 
     return;
@@ -158,15 +162,14 @@ void Albedo::addInstrumentConfig(double fov, Eigen::Vector3d nHat_B, Eigen::Vect
 /*! This method subscribes to the planet msg and sets the albedo average model (overloaded function)
  @return void
  */
-void Albedo::addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> *planetSpiceMsg)
-{
+void Albedo::addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> *planetSpiceMsg) {
     std::string modelName = "ALBEDO_AVG";
     this->modelNames.push_back(modelName);
     this->fileNames.push_back("");
     this->dataPaths.push_back("");
     this->numLats.push_back(-1);
     this->numLons.push_back(-1);
-    double ALB_avg = -1;    // value will be set in reset() when we can determine the planet name
+    double ALB_avg = -1;  // value will be set in reset() when we can determine the planet name
     this->ALB_avgs.push_back(ALB_avg);
     this->albArray.push_back(false);
 
@@ -180,8 +183,10 @@ void Albedo::addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> 
 /*! This method subscribes to the  planet msg and sets the albedo average model (overloaded function)
  @return void
  */
-void Albedo::addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> *planetSpiceMsg, double ALB_avg, int numLat, int numLon)
-{
+void Albedo::addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> *planetSpiceMsg,
+                                            double ALB_avg,
+                                            int numLat,
+                                            int numLon) {
     std::string modelName = "ALBEDO_AVG";
     this->modelNames.push_back(modelName);
     this->fileNames.push_back("");
@@ -200,9 +205,9 @@ void Albedo::addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> 
 /*! This method subscribes to the planet msg and sets the albedo data model
  @return void
  */
-void Albedo::addPlanetandAlbedoDataModel(Message<SpicePlanetStateMsgPayload> *planetSpiceMsg, std::string dataPath, std::string fileName)
-{
-
+void Albedo::addPlanetandAlbedoDataModel(Message<SpicePlanetStateMsgPayload> *planetSpiceMsg,
+                                         std::string dataPath,
+                                         std::string fileName) {
     std::string modelName = "ALBEDO_DATA";
     this->modelNames.push_back(modelName);
     this->fileNames.push_back(fileName);
@@ -219,27 +224,24 @@ void Albedo::addPlanetandAlbedoDataModel(Message<SpicePlanetStateMsgPayload> *pl
     this->planetMsgData.push_back(plMsg);
 }
 
-
-
 /*! Read Messages, calculate albedo then write it out
  @return void
  */
-void Albedo::updateState(uint64_t currentSimNanos)
-{
+void Albedo::updateState(uint64_t currentSimNanos) {
     this->readMessages();
     this->albOutData.clear();
     std::vector<SpicePlanetStateMsgPayload>::iterator planetIt;
     int idx;
-    for (int instIdx = 0; instIdx < this->albOutMsgs.size(); instIdx++)
-    {
+    for (int instIdx = 0; instIdx < this->albOutMsgs.size(); instIdx++) {
         idx = 0;
         double tmpTot[4] = {};
         double outData[4] = {};
-        for (planetIt = this->planetMsgData.begin(); planetIt != this->planetMsgData.end(); planetIt++)
-        {
+        for (planetIt = this->planetMsgData.begin(); planetIt != this->planetMsgData.end(); planetIt++) {
             this->computeAlbedo(idx, instIdx, *planetIt, albArray.at(idx), outData);
-            tmpTot[0] += outData[0]; tmpTot[1] += outData[1];
-            tmpTot[2] += outData[2]; tmpTot[3] += outData[3];
+            tmpTot[0] += outData[0];
+            tmpTot[1] += outData[1];
+            tmpTot[2] += outData[2];
+            tmpTot[3] += outData[3];
             idx++;
         }
         this->albOutData.push_back(cArray2EigenMatrixXd(tmpTot, 4, 1));
@@ -250,8 +252,7 @@ void Albedo::updateState(uint64_t currentSimNanos)
 /*! This method resets the module
  @return void
  */
-void Albedo::reset(uint64_t currentSimNanos)
-{
+void Albedo::reset(uint64_t currentSimNanos) {
     if (this->modelNames.empty()) {
         bskLogger.bskLog(BSK_ERROR, "Albedo Module (Reset): Albedo model was not set.");
         return;
@@ -268,12 +269,14 @@ void Albedo::reset(uint64_t currentSimNanos)
 
     int idx = 0;
     this->ALB.clear();
-    this->gdlat.clear(); this->gdlon.clear();
-    this->latDiff.clear(); this->lonDiff.clear();
-    this->REQ_planets.clear();  this->RP_planets.clear();
+    this->gdlat.clear();
+    this->gdlon.clear();
+    this->latDiff.clear();
+    this->lonDiff.clear();
+    this->REQ_planets.clear();
+    this->RP_planets.clear();
     std::vector<SpicePlanetStateMsgPayload>::iterator planetIt;
-    for (planetIt = this->planetMsgData.begin(); planetIt != this->planetMsgData.end(); planetIt++)
-    {
+    for (planetIt = this->planetMsgData.begin(); planetIt != this->planetMsgData.end(); planetIt++) {
         /* read in planet information */
         *planetIt = this->planetInMsgs.at(idx)();
         std::string plName(planetIt->PlanetName);
@@ -288,7 +291,7 @@ void Albedo::reset(uint64_t currentSimNanos)
  */
 void Albedo::readMessages() {
     //! - Read in planet state message (required)
-    for (long unsigned int c=0; c<this->planetInMsgs.size(); c++) {
+    for (long unsigned int c = 0; c < this->planetInMsgs.size(); c++) {
         this->planetMsgData.at(c) = this->planetInMsgs.at(c)();
         if (m33Determinant(this->planetMsgData.at(c).J20002Pfix) == 0.0) {
             m33SetIdentity(this->planetMsgData.at(c).J20002Pfix);
@@ -310,7 +313,7 @@ void Albedo::writeMessages(uint64_t currentSimNanos) {
     memset(&localMessage, 0x0, sizeof(localMessage));
 
     //! - Write albedo output messages for each instrument
-    for (long unsigned int idx=0; idx<this->albOutMsgs.size(); idx++) {
+    for (long unsigned int idx = 0; idx < this->albOutMsgs.size(); idx++) {
         localMessage.albedoAtInstrumentMax = this->albOutData.at(idx)[0];
         localMessage.albedoAtInstrument = this->albOutData.at(idx)[1];
         localMessage.AfluxAtInstrumentMax = this->albOutData.at(idx)[2];
@@ -322,46 +325,39 @@ void Albedo::writeMessages(uint64_t currentSimNanos) {
 /*! Planet's equatorial radii and polar radii (if exists) in meters
  @return void
  */
-void Albedo::getPlanetRadius(std::string planetSpiceName)
-{
+void Albedo::getPlanetRadius(std::string planetSpiceName) {
     if (planetSpiceName == "mercury") {
-        this->REQ_planets.push_back(REQ_MERCURY * 1000.0); // [m]
-        this->RP_planets.push_back(-1.0);                  // [m]
-    }
-    else if (planetSpiceName == "venus") {
-        this->REQ_planets.push_back(REQ_VENUS * 1000.0);   // [m]
-        this->RP_planets.push_back(-1.0);                  // [m]
-    }
-    else if (planetSpiceName == "earth") {
-        this->REQ_planets.push_back(REQ_EARTH * 1000.0); // [m]
-        this->RP_planets.push_back(RP_EARTH * 1000.0);   // [m]
-    }
-    else if (planetSpiceName == "moon") {
-        this->REQ_planets.push_back(REQ_MOON * 1000.0); // [m]
-        this->RP_planets.push_back(-1.0);               // [m]
-    }
-    else if (planetSpiceName == "mars" || planetSpiceName == "mars barycenter") {
-        this->REQ_planets.push_back(REQ_MARS * 1000.0); // [m]
-        this->RP_planets.push_back(RP_MARS * 1000.0);   // [m]
-    }
-    else if (planetSpiceName == "jupiter") {
-        this->REQ_planets.push_back(REQ_JUPITER * 1000.0); // [m]
-        this->RP_planets.push_back(-1.0);                  // [m]
-    }
-    else if (planetSpiceName == "saturn") {
-        this->REQ_planets.push_back(REQ_SATURN * 1000.0); // [m]
+        this->REQ_planets.push_back(REQ_MERCURY * 1000.0);  // [m]
+        this->RP_planets.push_back(-1.0);                   // [m]
+    } else if (planetSpiceName == "venus") {
+        this->REQ_planets.push_back(REQ_VENUS * 1000.0);  // [m]
         this->RP_planets.push_back(-1.0);                 // [m]
-    }
-    else if (planetSpiceName == "uranus") {
-        this->REQ_planets.push_back(REQ_URANUS * 1000.0); // [m]
-        this->RP_planets.push_back(-1.0);                 // [m]
-    }
-    else if (planetSpiceName == "neptune") {
-        this->REQ_planets.push_back(REQ_NEPTUNE * 1000.0); // [m]
+    } else if (planetSpiceName == "earth") {
+        this->REQ_planets.push_back(REQ_EARTH * 1000.0);  // [m]
+        this->RP_planets.push_back(RP_EARTH * 1000.0);    // [m]
+    } else if (planetSpiceName == "moon") {
+        this->REQ_planets.push_back(REQ_MOON * 1000.0);  // [m]
+        this->RP_planets.push_back(-1.0);                // [m]
+    } else if (planetSpiceName == "mars" || planetSpiceName == "mars barycenter") {
+        this->REQ_planets.push_back(REQ_MARS * 1000.0);  // [m]
+        this->RP_planets.push_back(RP_MARS * 1000.0);    // [m]
+    } else if (planetSpiceName == "jupiter") {
+        this->REQ_planets.push_back(REQ_JUPITER * 1000.0);  // [m]
+        this->RP_planets.push_back(-1.0);                   // [m]
+    } else if (planetSpiceName == "saturn") {
+        this->REQ_planets.push_back(REQ_SATURN * 1000.0);  // [m]
         this->RP_planets.push_back(-1.0);                  // [m]
-    }
-    else {
-        bskLogger.bskLog(BSK_ERROR, "Albedo Module (getPlanetRadius): The planet's radius cannot be obtained. The planet (%s) is not found.", planetSpiceName.c_str());
+    } else if (planetSpiceName == "uranus") {
+        this->REQ_planets.push_back(REQ_URANUS * 1000.0);  // [m]
+        this->RP_planets.push_back(-1.0);                  // [m]
+    } else if (planetSpiceName == "neptune") {
+        this->REQ_planets.push_back(REQ_NEPTUNE * 1000.0);  // [m]
+        this->RP_planets.push_back(-1.0);                   // [m]
+    } else {
+        bskLogger.bskLog(
+            BSK_ERROR,
+            "Albedo Module (getPlanetRadius): The planet's radius cannot be obtained. The planet (%s) is not found.",
+            planetSpiceName.c_str());
     }
     return;
 }
@@ -369,46 +365,48 @@ void Albedo::getPlanetRadius(std::string planetSpiceName)
 /*! This method gets the average albedo value of the planet
  @return double
  */
-double Albedo::getAlbedoAverage(std::string planetSpiceName)
-{
+double Albedo::getAlbedoAverage(std::string planetSpiceName) {
     double ALB_avg;
     if (planetSpiceName == "mercury") {
-        ALB_avg = 0.119; return ALB_avg;
-    }
-    else if (planetSpiceName == "venus") {
-        ALB_avg = 0.75; return ALB_avg;
-    }
-    else if (planetSpiceName == "earth") {
-        ALB_avg = 0.29; return ALB_avg;
-    }
-    else if (planetSpiceName == "moon") {
-        ALB_avg = 0.123; return ALB_avg;
-    }
-    else if (planetSpiceName == "mars" || planetSpiceName == "mars barycenter") {
-        ALB_avg = 0.16; return ALB_avg;
-    }
-    else if (planetSpiceName == "jupiter") {
-        ALB_avg = 0.34; return ALB_avg;
-    }
-    else if (planetSpiceName == "saturn") {
-        ALB_avg = 0.34; return ALB_avg;
-    }
-    else if (planetSpiceName == "uranus") {
-        ALB_avg = 0.29; return ALB_avg;
-    }
-    else if (planetSpiceName == "neptune") {
-        ALB_avg = 0.31; return ALB_avg;
-    }
-    else {
-        bskLogger.bskLog(BSK_ERROR, "Albedo Module (getAlbedoAverage): The average albedo value is not defined for the specified planet (%s).", planetSpiceName.c_str()); return 0.;
+        ALB_avg = 0.119;
+        return ALB_avg;
+    } else if (planetSpiceName == "venus") {
+        ALB_avg = 0.75;
+        return ALB_avg;
+    } else if (planetSpiceName == "earth") {
+        ALB_avg = 0.29;
+        return ALB_avg;
+    } else if (planetSpiceName == "moon") {
+        ALB_avg = 0.123;
+        return ALB_avg;
+    } else if (planetSpiceName == "mars" || planetSpiceName == "mars barycenter") {
+        ALB_avg = 0.16;
+        return ALB_avg;
+    } else if (planetSpiceName == "jupiter") {
+        ALB_avg = 0.34;
+        return ALB_avg;
+    } else if (planetSpiceName == "saturn") {
+        ALB_avg = 0.34;
+        return ALB_avg;
+    } else if (planetSpiceName == "uranus") {
+        ALB_avg = 0.29;
+        return ALB_avg;
+    } else if (planetSpiceName == "neptune") {
+        ALB_avg = 0.31;
+        return ALB_avg;
+    } else {
+        bskLogger.bskLog(
+            BSK_ERROR,
+            "Albedo Module (getAlbedoAverage): The average albedo value is not defined for the specified planet (%s).",
+            planetSpiceName.c_str());
+        return 0.;
     }
 }
 
 /*! This method evaluates the albedo model
  @return void
  */
-void Albedo::evaluateAlbedoModel(int idx)
-{
+void Albedo::evaluateAlbedoModel(int idx) {
     this->readFile = false;
     auto modelName = this->modelNames.at(idx);
     auto fileName = this->fileNames.at(idx);
@@ -418,8 +416,12 @@ void Albedo::evaluateAlbedoModel(int idx)
     //! - Obtain the parameters of the specified model
     if (modelName == "ALBEDO_AVG") {
         //! - Albedo model based on an average value
-        if (numLat < 0.0) { numLat = this->defaultNumLat; }
-        if (numLon < 0.0) { numLon = this->defaultNumLon; }
+        if (numLat < 0.0) {
+            numLat = this->defaultNumLat;
+        }
+        if (numLon < 0.0) {
+            numLon = this->defaultNumLon;
+        }
         auto albAvg = this->ALB_avgs.at(idx);
         if (albAvg < 0.0) {
             // set the albedo average automatically based on the planet's name
@@ -428,20 +430,18 @@ void Albedo::evaluateAlbedoModel(int idx)
             std::string plName(planetInfo.PlanetName);
             this->ALB_avgs.at(idx) = getAlbedoAverage(plName);
         }
-    }
-    else if (modelName == "ALBEDO_DATA") {
+    } else if (modelName == "ALBEDO_DATA") {
         //! - Albedo model based on data
         //! - Check that required module variables are set
         if (fileName == "") {
             bskLogger.bskLog(BSK_ERROR, "Albedo Module (evaluateAlbedoModel): Albedo fileName was not set.");
-        }
-        else {
+        } else {
             this->readFile = true;
         }
         fileName = dataPath + "/" + fileName;
-    }
-    else {
-        bskLogger.bskLog(BSK_ERROR, "Albedo Module (evaluateAlbedoModel): Check the model name (%s).", modelName.c_str());
+    } else {
+        bskLogger.bskLog(
+            BSK_ERROR, "Albedo Module (evaluateAlbedoModel): Check the model name (%s).", modelName.c_str());
     }
     //! - Read the albedo coefficient file if the model requires
     if (this->readFile) {
@@ -451,16 +451,17 @@ void Albedo::evaluateAlbedoModel(int idx)
         }
         std::ifstream input(fileName);
         if (!input) {
-            bskLogger.bskLog(BSK_ERROR, "Albedo Module (evaluateAlbedoModel): Albedo module is unable to load file %s", fileName.c_str());
+            bskLogger.bskLog(BSK_ERROR,
+                             "Albedo Module (evaluateAlbedoModel): Albedo module is unable to load file %s",
+                             fileName.c_str());
             // return to avoid reading/attempting to process the invalid file below
             return;
         }
         //! - Read the albedo coefficients
         std::string line, field;
-        std::vector< std::vector<std::string> > array;  // the 2D array
-        std::vector<std::string> v;                     // array of values for one line only
-        while (getline(input, line))
-        {
+        std::vector<std::vector<std::string> > array;  // the 2D array
+        std::vector<std::string> v;                    // array of values for one line only
+        while (getline(input, line)) {
             v.clear();
             std::stringstream ss(line);
             while (std::getline(ss, field, ','))  // break line into comma delimitted fields
@@ -469,35 +470,39 @@ void Albedo::evaluateAlbedoModel(int idx)
             }
             array.push_back(v);
         }
-        numLat = (int) array.size();
-        numLon = (int) array[0].size();
+        numLat = (int)array.size();
+        numLon = (int)array[0].size();
         //! - Compare if the numLat/numLon are not zero
         if (!numLat || !numLon) {
-            bskLogger.bskLog(BSK_ERROR, "Albedo Module (evaluateAlbedoModel): There has been an error in reading albedo data from (%s).", fileName.c_str());
+            bskLogger.bskLog(
+                BSK_ERROR,
+                "Albedo Module (evaluateAlbedoModel): There has been an error in reading albedo data from (%s).",
+                fileName.c_str());
         }
         //! - Define the albedo array based on the number of grid points
-        this->ALB[idx] = std::vector < std::vector < double > >(numLat, std::vector < double >(numLon, 0.0));
+        this->ALB[idx] = std::vector<std::vector<double> >(numLat, std::vector<double>(numLon, 0.0));
 
         //! - Albedo coefficients (2d array) from string array to double
-        for (auto i = 0; i < numLat; ++i)
-        {
-            for (auto j = 0; j < numLon; ++j)
-            {
-                this->ALB[idx][i][j] = atof(array[i][j].c_str()); // Lat: -90 to +90 deg, Lon: -180 to +180 deg
+        for (auto i = 0; i < numLat; ++i) {
+            for (auto j = 0; j < numLon; ++j) {
+                this->ALB[idx][i][j] = atof(array[i][j].c_str());  // Lat: -90 to +90 deg, Lon: -180 to +180 deg
             }
         }
+    } else {
+        this->ALB[idx] = std::vector<std::vector<double> >(1, std::vector<double>(1, 0.0));
     }
-    else { this->ALB[idx] = std::vector < std::vector < double > >(1, std::vector < double >(1, 0.0)); }
     //! - Construct the latitude and longitude points
     //! - Geodetic latitude and longitude grid points in radian for albedo calculations
-    double ilat = 0.0; double ilon = 0.0;
-    double halfLat = numLat / 2; double halfLon = numLon / 2;
-    this->gdlat[idx] = std::vector < double >(numLat, 0.0);
-    this->gdlon[idx] = std::vector < double >(numLon, 0.0);
+    double ilat = 0.0;
+    double ilon = 0.0;
+    double halfLat = numLat / 2;
+    double halfLon = numLon / 2;
+    this->gdlat[idx] = std::vector<double>(numLat, 0.0);
+    this->gdlon[idx] = std::vector<double>(numLon, 0.0);
     this->latDiff[idx] = (180.0 / numLat) * M_PI / 180.0;
     this->lonDiff[idx] = (360.0 / numLon) * M_PI / 180.0;
     for (ilat = -halfLat; ilat < halfLat; ilat++) {
-        this->gdlat[idx][(int64_t) (ilat + halfLat)] = (ilat + 0.5) * this->latDiff[idx];
+        this->gdlat[idx][(int64_t)(ilat + halfLat)] = (ilat + 0.5) * this->latDiff[idx];
     }
     for (ilon = -halfLon; ilon < halfLon; ilon++) {
         this->gdlon[idx][(int64_t)(ilon + halfLon)] = (ilon + 0.5) * this->lonDiff[idx];
@@ -509,31 +514,35 @@ void Albedo::evaluateAlbedoModel(int idx)
 /*! This method calculates the albedo at instrument
  @return void
  */
-void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload planetMsg, bool albArray, double outData[]) {
+void Albedo::computeAlbedo(int idx,
+                           int instIdx,
+                           SpicePlanetStateMsgPayload planetMsg,
+                           bool albArray,
+                           double outData[]) {
     //! - Letters denoting the frames:
     //! - P: planet frame
     //! - B: spacecraft body frame
     //! - N: inertial frame
     //! - S: sun (helio) frame
     //! - I: instrument body frame
-    auto fov = this->fovs[instIdx];                                         //! - [rad] instrument's field of view half angle
-    auto nHat_B = this->nHat_Bs[instIdx];                                   //! - [-] unit normal vector of the instrument (spacecraft body)
-    auto r_IB_B = this->r_IB_Bs[instIdx];                                   //! - [m] instrument's misalignment vector wrt spacecraft's body frame
-    this->r_PN_N = Eigen::Vector3d(planetMsg.PositionVector);               //! - [m] Planet's position vector (inertial)
-    this->r_SN_N = Eigen::Vector3d(this->sunMsgData.PositionVector);        //! - [m] Sun's position vector (inertial)
-    this->r_BN_N = Eigen::Vector3d(this->scStatesMsgData.r_BN_N);           //! - [m] Spacecraft's position vector (inertial)
-    this->sigma_BN = Eigen::Vector3d(this->scStatesMsgData.sigma_BN);       //! - [m] Spacecraft's MRPs (inertial)
-    Eigen::Matrix3d dcm_BN = this->sigma_BN.toRotationMatrix().transpose(); //! - inertial to sc body transformation
-    this->nHat_N = dcm_BN.transpose() * nHat_B;                             //! - instrument's normal vector (inertial)
+    auto fov = this->fovs[instIdx];        //! - [rad] instrument's field of view half angle
+    auto nHat_B = this->nHat_Bs[instIdx];  //! - [-] unit normal vector of the instrument (spacecraft body)
+    auto r_IB_B = this->r_IB_Bs[instIdx];  //! - [m] instrument's misalignment vector wrt spacecraft's body frame
+    this->r_PN_N = Eigen::Vector3d(planetMsg.PositionVector);          //! - [m] Planet's position vector (inertial)
+    this->r_SN_N = Eigen::Vector3d(this->sunMsgData.PositionVector);   //! - [m] Sun's position vector (inertial)
+    this->r_BN_N = Eigen::Vector3d(this->scStatesMsgData.r_BN_N);      //! - [m] Spacecraft's position vector (inertial)
+    this->sigma_BN = Eigen::Vector3d(this->scStatesMsgData.sigma_BN);  //! - [m] Spacecraft's MRPs (inertial)
+    Eigen::Matrix3d dcm_BN = this->sigma_BN.toRotationMatrix().transpose();  //! - inertial to sc body transformation
+    this->nHat_N = dcm_BN.transpose() * nHat_B;                              //! - instrument's normal vector (inertial)
     //! - [m] sun's position wrt planet (inertial)
     auto r_SP_N = this->r_SN_N - this->r_PN_N;
     //! - Vectors related to spacecraft
-    auto r_BP_N = this->r_BN_N - this->r_PN_N;        //! - [m] spacecraft's position wrt planet (inertial)
+    auto r_BP_N = this->r_BN_N - this->r_PN_N;  //! - [m] spacecraft's position wrt planet (inertial)
     //! - Vectors related to instrument
-    auto r_IB_N = dcm_BN.transpose() * r_IB_B;        //! - [m] instrument's position vector wrt spacecraft (inertial)
-    auto r_IP_N = r_IB_N + r_BP_N;                    //! - [m] instrument's position vector wrt planet (inertial)
-    this->rHat_PI_N = -r_IP_N / r_IP_N.norm();        //! - [-] direction vector from instrument to planet (inertial)
-    auto r_SI_N = r_SP_N - r_IP_N;                    //! - [m] sun's position wrt instrument (inertial)
+    auto r_IB_N = dcm_BN.transpose() * r_IB_B;  //! - [m] instrument's position vector wrt spacecraft (inertial)
+    auto r_IP_N = r_IB_N + r_BP_N;              //! - [m] instrument's position vector wrt planet (inertial)
+    this->rHat_PI_N = -r_IP_N / r_IP_N.norm();  //! - [-] direction vector from instrument to planet (inertial)
+    auto r_SI_N = r_SP_N - r_IP_N;              //! - [m] sun's position wrt instrument (inertial)
     //! - Calculate the authalic radius, if the polar radius available
     double t[3], t_aut[3], e, RA_planet, shadowFactorAtdA;
     if (this->RP_planets.at(idx) > 0.0) {
@@ -546,8 +555,7 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
         t_aut[0] = pow(e, 2) / 3.0 + 31.0 * pow(e, 4) / 180.0 + 59.0 * pow(e, 6) / 560.0;
         t_aut[1] = 17.0 * pow(e, 4) / 360.0 + 61.0 * pow(e, 6) / 1260.0;
         t_aut[2] = 383.0 * pow(e, 6) / 45360.0;
-    }
-    else {
+    } else {
         RA_planet = this->REQ_planets.at(idx);
         v3SetZero(t_aut);
     }
@@ -559,14 +567,16 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
     auto alti_I = r_IP_N.norm() - RA_planet;
     /* Return zeross if the rate of the instrument's altitude
     to the planet's radius exceeds the specified limit */
-    if (this->altitudeRateLimit >=0 && alti_I / RA_planet > this->altitudeRateLimit) {
-        bskLogger.bskLog(BSK_WARNING, "Albedo Module (computeAlbedo): The rate (altitude to planet's radii) limit is exceeded for the planet (%s) and albedo set to zero.", planetMsg.PlanetName);
+    if (this->altitudeRateLimit >= 0 && alti_I / RA_planet > this->altitudeRateLimit) {
+        bskLogger.bskLog(BSK_WARNING,
+                         "Albedo Module (computeAlbedo): The rate (altitude to planet's radii) limit is exceeded for "
+                         "the planet (%s) and albedo set to zero.",
+                         planetMsg.PlanetName);
         outData[0] = 0.0;
         outData[1] = 0.0;
         outData[2] = 0.0;
         outData[3] = 0.0;
-    }
-    else {
+    } else {
         //! - Variable definitions needed for the albedo calculations
         Eigen::Vector3d gdlla;
         Eigen::Vector3d r_dAP_N, r_SdA_N, r_IdA_N;
@@ -575,7 +585,7 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
         double lon1 = 0.0, lon2 = 0.0, lat1 = 0.0, lat2 = 0.0, tempmax = 0.0, tempfov = 0.0;
         double f1 = 0.0, f2 = 0.0, f3 = 0.0;
         double dArea = 0.0, alb_I = 0.0, alb_Imax = 0.0;
-        std::vector< double > albLon1, albLat1;
+        std::vector<double> albLon1, albLat1;
         for (ilon = 0; ilon < this->numLons.at(idx); ilon++) {
             lon1 = this->gdlon[idx][ilon] + 0.5 * this->lonDiff[idx];
             lon2 = this->gdlon[idx][ilon] - 0.5 * this->lonDiff[idx];
@@ -587,34 +597,37 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
                     lat1 -= t_aut[0] * sin(2.0 * lat1) - t_aut[1] * sin(4.0 * lat1) + t_aut[2] * sin(6.0 * lat1);
                     lat2 -= t_aut[0] * sin(2.0 * lat2) - t_aut[1] * sin(4.0 * lat2) + t_aut[2] * sin(6.0 * lat2);
                 }
-                gdlla[0] = this->gdlat[idx][ilat]; gdlla[1] = this->gdlon[idx][ilon]; gdlla[2] = 0.0;
+                gdlla[0] = this->gdlat[idx][ilat];
+                gdlla[1] = this->gdlon[idx][ilon];
+                gdlla[2] = 0.0;
                 //! - Vectors related to incremental area
                 //! - [m] position of the incremental area (inertial)
-                r_dAP_N = LLA2PCI(gdlla, planetMsg.J20002Pfix, RA_planet); //! - Assumes that the planet is a sphere.
-                r_SdA_N = r_SP_N - r_dAP_N;            //! - [m] position vector from dA to Sun (inertial)
-                r_IdA_N = r_IP_N - r_dAP_N;            //! - [m] position vector from dA to instrument (inertial)
-                rHat_dAP_N = r_dAP_N / r_dAP_N.norm(); //! - [-] -assuming- dA normal vector (inertial)
-                sHat_SdA_N = r_SdA_N / r_SdA_N.norm(); //! - [-] sun direction vector from dA (inertial)
-                rHat_IdA_N = r_IdA_N / r_IdA_N.norm(); //! - [-] dA to instrument direction vector (inertial)
+                r_dAP_N = LLA2PCI(gdlla, planetMsg.J20002Pfix, RA_planet);  //! - Assumes that the planet is a sphere.
+                r_SdA_N = r_SP_N - r_dAP_N;             //! - [m] position vector from dA to Sun (inertial)
+                r_IdA_N = r_IP_N - r_dAP_N;             //! - [m] position vector from dA to instrument (inertial)
+                rHat_dAP_N = r_dAP_N / r_dAP_N.norm();  //! - [-] -assuming- dA normal vector (inertial)
+                sHat_SdA_N = r_SdA_N / r_SdA_N.norm();  //! - [-] sun direction vector from dA (inertial)
+                rHat_IdA_N = r_IdA_N / r_IdA_N.norm();  //! - [-] dA to instrument direction vector (inertial)
                 //! - Portions of the planet
-                f1 = rHat_dAP_N.dot(sHat_SdA_N);       //! - for sunlit
-                f2 = rHat_dAP_N.dot(rHat_IdA_N);       //! - for instrument's max fov
-                f3 = this->nHat_N.dot(-rHat_IdA_N);    //! - for instrument's config fov
+                f1 = rHat_dAP_N.dot(sHat_SdA_N);     //! - for sunlit
+                f2 = rHat_dAP_N.dot(rHat_IdA_N);     //! - for instrument's max fov
+                f3 = this->nHat_N.dot(-rHat_IdA_N);  //! - for instrument's config fov
                 //! - Detect the sunlit region of the planet seen by the instrument
                 if (f1 > 0 && f2 > 0) {
                     //! - Sunlit portion of the planet seen by the instrument's position (max)
                     //! - Shadow factor at dA (optional)
                     shadowFactorAtdA = this->shadowFactorAtdA;
-                    if (this->eclipseCase) { shadowFactorAtdA = computeEclipseAtdA(RA_planet, r_dAP_N, r_SP_N); }
+                    if (this->eclipseCase) {
+                        shadowFactorAtdA = computeEclipseAtdA(RA_planet, r_dAP_N, r_SP_N);
+                    }
                     //! - Area of the incremental area
                     dArea = (fabs(lon1 - lon2) * fabs(sin(lat1) - sin(lat2)) * pow(r_dAP_N.norm(), 2));
                     //! - Maximum albedo flux ratio at instrument's position [-]
                     tempmax = f1 * f2 * dArea / (pow(r_IdA_N.norm(), 2) * M_PI);
-                    //if (this->ALB_data >= 0.0) { tempmax = this->ALB_data * tempmax; }
+                    // if (this->ALB_data >= 0.0) { tempmax = this->ALB_data * tempmax; }
                     if (albArray == false) {
                         tempmax = this->ALB_avgs.at(idx) * tempmax;
-                    }
-                    else {
+                    } else {
                         tempmax = this->ALB[idx][ilat][ilon] * tempmax;
                     }
                     alb_Imax = alb_Imax + tempmax * shadowFactorAtdA;
@@ -625,8 +638,7 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
                         tempfov = f1 * f2 * f3 * dArea / (pow(r_IdA_N.norm(), 2) * M_PI);
                         if (albArray == false) {
                             tempfov = this->ALB_avgs.at(idx) * tempfov;
-                        }
-                        else {
+                        } else {
                             tempfov = this->ALB[idx][ilat][ilon] * tempfov;
                         }
                         alb_I = alb_I + tempfov * shadowFactorAtdA;
@@ -665,11 +677,10 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
 /*! This method computes eclipse at the incremental area if eclipseCase is defined true
  @return double
  */
-double Albedo::computeEclipseAtdA(double Rplanet, Eigen::Vector3d r_dAP_N, Eigen::Vector3d r_SP_N)
-{
+double Albedo::computeEclipseAtdA(double Rplanet, Eigen::Vector3d r_dAP_N, Eigen::Vector3d r_SP_N) {
     //! - Compute the shadow factor at incremental area
     //! - Note that the eclipse module computes the shadow factor at the spacecraft position
-    auto r_SdA_N = r_SP_N - r_dAP_N; //! - [m] position vector from dA to Sun (inertial)
+    auto r_SdA_N = r_SP_N - r_dAP_N;  //! - [m] position vector from dA to Sun (inertial)
     auto s = r_dAP_N.norm();
     auto f_1 = safeAsin((REQ_SUN * 1000 + Rplanet) / r_SP_N.norm());
     auto f_2 = safeAsin((REQ_SUN * 1000 - Rplanet) / r_SP_N.norm());
@@ -680,25 +691,22 @@ double Albedo::computeEclipseAtdA(double Rplanet, Eigen::Vector3d r_dAP_N, Eigen
     auto l_1 = c_1 * tan(f_1);
     auto l_2 = c_2 * tan(f_2);
     double area = 0.0;
-    double shadowFactorAtdA = 1.0; //! - Initialise the value for no eclipse
-    double a = safeAsin(REQ_SUN * 1000 / r_SdA_N.norm());   //! - Apparent radius of sun
-    double b = safeAsin(Rplanet / r_dAP_N.norm()); //! - Apparent radius of occulting body
+    double shadowFactorAtdA = 1.0;                         //! - Initialise the value for no eclipse
+    double a = safeAsin(REQ_SUN * 1000 / r_SdA_N.norm());  //! - Apparent radius of sun
+    double b = safeAsin(Rplanet / r_dAP_N.norm());         //! - Apparent radius of occulting body
     double c = safeAcos((-r_dAP_N.dot(r_SdA_N)) / (r_dAP_N.norm() * r_SdA_N.norm()));
-    if (fabs(l) < fabs(l_2) || fabs(l) < fabs(l_1))
-    {
+    if (fabs(l) < fabs(l_2) || fabs(l) < fabs(l_1)) {
         // The order of the conditionals is important.
         // In particular (c < a + b) must check last to avoid testing
         // with implausible a, b and c values
-        if (c < b - a) { // total eclipse, implying a < b
+        if (c < b - a) {  // total eclipse, implying a < b
             shadowFactorAtdA = 0.0;
-        }
-        else if (c < a - b) { // partial maximum eclipse, implying a > b
+        } else if (c < a - b) {  // partial maximum eclipse, implying a > b
             double areaSun = M_PI * a * a;
             double areaBody = M_PI * b * b;
             area = areaSun - areaBody;
             shadowFactorAtdA = 1 - area / (M_PI * a * a);
-        }
-        else if (c < a + b) { // partial eclipse
+        } else if (c < a + b) {  // partial eclipse
             double x = (c * c + a * a - b * b) / (2 * c);
             double y = sqrt(a * a - x * x);
             area = a * a * safeAcos(x / a) + b * b * safeAcos((c - x) / b) - c * y;
@@ -707,8 +715,7 @@ double Albedo::computeEclipseAtdA(double Rplanet, Eigen::Vector3d r_dAP_N, Eigen
     }
     if (shadowFactorAtdA < 0.0) {
         shadowFactorAtdA = 0.0;
-    }
-    else if (shadowFactorAtdA > 1.0) {
+    } else if (shadowFactorAtdA > 1.0) {
         shadowFactorAtdA = 1.0;
     }
     return shadowFactorAtdA;

--- a/src/simulation/environment/albedo/albedo.h
+++ b/src/simulation/environment/albedo/albedo.h
@@ -21,22 +21,21 @@
 #define ALBEDO_H
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/avsEigenMRP.h"
+#include "architecture/utilities/avsEigenSupport.h"
 
 #include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/AlbedoMsgPayload.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
-#include "architecture/msgPayloadDefC/AlbedoMsgPayload.h"
 
 #include <Eigen/Core>
-#include <vector>
 #include <string>
-
+#include <vector>
 
 /*! albedo instrument configuration class */
 typedef class Config {
-public:
+   public:
     Config();
     ~Config();
     double fov;              //!< [rad] instrument's field of view half angle
@@ -46,78 +45,97 @@ public:
 
 /*! @brief albedo class */
 class Albedo : public SysModel {
-public:
+   public:
     Albedo();
     ~Albedo();
 
-    void updateState(uint64_t currentSimNanos);               //!< @brief updates the state
-    void reset(uint64_t currentSimNanos);                     //!< @brief resets the module
+    void updateState(uint64_t currentSimNanos);  //!< @brief updates the state
+    void reset(uint64_t currentSimNanos);        //!< @brief resets the module
 
     void addInstrumentConfig(instConfig_t configMsg);  //!< @brief adds instrument configuration (overloaded function)
-    void addInstrumentConfig(double fov, Eigen::Vector3d nHat_B, Eigen::Vector3d r_IB_B);  //!< @brief adds instrument configuration (overloaded function)
-    void addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> *msg); //!< @brief This method adds planet msg and albedo average model name (overloaded function)
-    void addPlanetandAlbedoAverageModel(Message<SpicePlanetStateMsgPayload> *msg, double ALB_avg, int numLat, int numLon);  //!< @brief This method adds planet name and albedo average model name (overloaded function)
-    void addPlanetandAlbedoDataModel(Message<SpicePlanetStateMsgPayload> *msg, std::string dataPath, std::string fileName); //!< @brief This method adds planet name and albedo data model
-    double getAlbedoAverage(std::string planetSpiceName);     //!< @brief gets the average albedo value of the specified planet
+    void addInstrumentConfig(double fov,
+                             Eigen::Vector3d nHat_B,
+                             Eigen::Vector3d r_IB_B);  //!< @brief adds instrument configuration (overloaded function)
+    void addPlanetandAlbedoAverageModel(
+        Message<SpicePlanetStateMsgPayload>
+            *msg);  //!< @brief This method adds planet msg and albedo average model name (overloaded function)
+    void addPlanetandAlbedoAverageModel(
+        Message<SpicePlanetStateMsgPayload> *msg,
+        double ALB_avg,
+        int numLat,
+        int numLon);  //!< @brief This method adds planet name and albedo average model name (overloaded function)
+    void addPlanetandAlbedoDataModel(
+        Message<SpicePlanetStateMsgPayload> *msg,
+        std::string dataPath,
+        std::string fileName);  //!< @brief This method adds planet name and albedo data model
+    double getAlbedoAverage(
+        std::string planetSpiceName);  //!< @brief gets the average albedo value of the specified planet
 
-private:
-    void readMessages();                                      //!< reads the inpt messages
-    void writeMessages(uint64_t currentSimNanos);             //!< writes the outpus messages
-    void getPlanetRadius(std::string planetSpiceName);        //!< gets the planet's radius
-    void evaluateAlbedoModel(int idx);                        //!< evaluates the ALB model
-    void computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload planetMsg, bool AlbArray, double outData[]); //!< computes the albedo at instrument's location
-    double computeEclipseAtdA(double Rplanet, Eigen::Vector3d r_dAP_N, Eigen::Vector3d r_SP_N); //!< computes the shadow factor at dA
+   private:
+    void readMessages();                                //!< reads the inpt messages
+    void writeMessages(uint64_t currentSimNanos);       //!< writes the outpus messages
+    void getPlanetRadius(std::string planetSpiceName);  //!< gets the planet's radius
+    void evaluateAlbedoModel(int idx);                  //!< evaluates the ALB model
+    void computeAlbedo(int idx,
+                       int instIdx,
+                       SpicePlanetStateMsgPayload planetMsg,
+                       bool AlbArray,
+                       double outData[]);  //!< computes the albedo at instrument's location
+    double computeEclipseAtdA(double Rplanet,
+                              Eigen::Vector3d r_dAP_N,
+                              Eigen::Vector3d r_SP_N);  //!< computes the shadow factor at dA
 
-public:
-    std::vector<Message<AlbedoMsgPayload>*> albOutMsgs;         //!< vector of output messages for albedo data
-    ReadFunctor<SpicePlanetStateMsgPayload> sunPositionInMsg;   //!< input message name for sun data
-    ReadFunctor<SCStatesMsgPayload> spacecraftStateInMsg;   //!< input message name for spacecraft data
-    std::vector<ReadFunctor<SpicePlanetStateMsgPayload>> planetInMsgs; //!< vector of planet data input data
+   public:
+    std::vector<Message<AlbedoMsgPayload> *> albOutMsgs;                //!< vector of output messages for albedo data
+    ReadFunctor<SpicePlanetStateMsgPayload> sunPositionInMsg;           //!< input message name for sun data
+    ReadFunctor<SCStatesMsgPayload> spacecraftStateInMsg;               //!< input message name for spacecraft data
+    std::vector<ReadFunctor<SpicePlanetStateMsgPayload>> planetInMsgs;  //!< vector of planet data input data
 
-    BSKLogger bskLogger;                        //!< BSK Logging
-    int defaultNumLat;                                 //!< [-] default number of latitude grid points
-    int defaultNumLon;                                 //!< [-] default number of longitude grid points
-    Eigen::Vector3d nHat_B_default;             //!< [-] default value for unit normal of the instrument (spacecraft body)
-    double fov_default;                         //!< [rad] default value for instrument's field of view half angle
-    bool eclipseCase;                           //!< consider eclipse at dA, if true
-    double shadowFactorAtdA;                    //!< [-] shadow factor at incremental area
-    double altitudeRateLimit;                   //!< [-] rate limit of the instrument's altitude to the planet's radius for albedo calculations
+    BSKLogger bskLogger;             //!< BSK Logging
+    int defaultNumLat;               //!< [-] default number of latitude grid points
+    int defaultNumLon;               //!< [-] default number of longitude grid points
+    Eigen::Vector3d nHat_B_default;  //!< [-] default value for unit normal of the instrument (spacecraft body)
+    double fov_default;              //!< [rad] default value for instrument's field of view half angle
+    bool eclipseCase;                //!< consider eclipse at dA, if true
+    double shadowFactorAtdA;         //!< [-] shadow factor at incremental area
+    double altitudeRateLimit;        //!< [-] rate limit of the instrument's altitude to the planet's radius for albedo
+                                     //!< calculations
 
-private:
+   private:
     std::vector<std::string> dataPaths;           //!< string with the path to the ALB coefficient folder
     std::vector<std::string> fileNames;           //!< file names containing the ALB coefficients
     std::vector<std::string> modelNames;          //!< albedo model names
     std::vector<double> ALB_avgs;                 //!< [-] albedo average value vector for each planet defined
     std::vector<double> REQ_planets, RP_planets;  //!< [m] equatorial and polar radius of the planets
-    Eigen::MatrixXd albLon, albLat;          //!< sunlit area seen by the instroment fov
-    double scLon, scLat;                     //!< [deg, deg] spaceccraft footprint
-    std::vector<int> numLats, numLons;       //!< [-] vector of latitude and longitude number
-    double albedoAtInstrument;               //!< [-] total albedo at instrument location
-    double albedoAtInstrumentMax;            //!< [-] max total albedo at instrument location
-    double SfluxAtInstrument;                //!< [W/m2] solar flux at instrument's position
-    double AfluxAtInstrumentMax;             //!< [W/m2] max albedo flux at instrument's position
-    double AfluxAtInstrument;                //!< [W/m2] albedo flux at instrument's position
-    std::vector < Eigen::Vector3d > r_IB_Bs; //!< [m] instrument's misalignment vector wrt spacecraft's body frame
-    std::vector < Eigen::Vector3d > nHat_Bs; //!< [-] unit normal vector of the instrument (spacecraft body)
-    std::vector < double > fovs;             //!< [rad] vector containing instrument's field of view half angle
-    std::vector < Eigen::Vector4d > albOutData;     //!< the vector that keeps the albedo output data
-    std::map < int, std::vector < double > > gdlat; //!< [rad] geodetic latitude
-    std::map < int, std::vector < double > > gdlon; //!< [rad] geodetic longitude
-    std::map < int, double > latDiff;               //!< [rad] latitude difference between grid points
-    std::map < int, double > lonDiff;               //!< [rad] longitude difference between grid points
-    std::map < int, std::vector < std::vector < double > > > ALB; //!< [-] ALB coefficients
-    bool readFile;                          //!< defines if there is a need for reading an albedo model file or not
-    std::vector<bool> albArray;             //!< defines if the albedo data is formatted as array or not
-    Eigen::Vector3d r_PN_N;                 //!< [m] planet position (inertial)
-    Eigen::Vector3d r_SN_N;                 //!< [m] sun position (inertial)
-    Eigen::MRPd sigma_BN;                   //!< [-] Current spaceraft MRPs (inertial)
-    Eigen::Vector3d r_BN_N;                 //!< [m] s/c position (inertial)
-    Eigen::Vector3d nHat_N;                 //!< [-] Unit normal vector of the instrument (inertial)
-    Eigen::Vector3d rHat_PI_N;              //!< [-] direction vector from instrument to planet
+    Eigen::MatrixXd albLon, albLat;               //!< sunlit area seen by the instroment fov
+    double scLon, scLat;                          //!< [deg, deg] spaceccraft footprint
+    std::vector<int> numLats, numLons;            //!< [-] vector of latitude and longitude number
+    double albedoAtInstrument;                    //!< [-] total albedo at instrument location
+    double albedoAtInstrumentMax;                 //!< [-] max total albedo at instrument location
+    double SfluxAtInstrument;                     //!< [W/m2] solar flux at instrument's position
+    double AfluxAtInstrumentMax;                  //!< [W/m2] max albedo flux at instrument's position
+    double AfluxAtInstrument;                     //!< [W/m2] albedo flux at instrument's position
+    std::vector<Eigen::Vector3d> r_IB_Bs;         //!< [m] instrument's misalignment vector wrt spacecraft's body frame
+    std::vector<Eigen::Vector3d> nHat_Bs;         //!< [-] unit normal vector of the instrument (spacecraft body)
+    std::vector<double> fovs;                     //!< [rad] vector containing instrument's field of view half angle
+    std::vector<Eigen::Vector4d> albOutData;      //!< the vector that keeps the albedo output data
+    std::map<int, std::vector<double>> gdlat;     //!< [rad] geodetic latitude
+    std::map<int, std::vector<double>> gdlon;     //!< [rad] geodetic longitude
+    std::map<int, double> latDiff;                //!< [rad] latitude difference between grid points
+    std::map<int, double> lonDiff;                //!< [rad] longitude difference between grid points
+    std::map<int, std::vector<std::vector<double>>> ALB;  //!< [-] ALB coefficients
+    bool readFile;               //!< defines if there is a need for reading an albedo model file or not
+    std::vector<bool> albArray;  //!< defines if the albedo data is formatted as array or not
+    Eigen::Vector3d r_PN_N;      //!< [m] planet position (inertial)
+    Eigen::Vector3d r_SN_N;      //!< [m] sun position (inertial)
+    Eigen::MRPd sigma_BN;        //!< [-] Current spaceraft MRPs (inertial)
+    Eigen::Vector3d r_BN_N;      //!< [m] s/c position (inertial)
+    Eigen::Vector3d nHat_N;      //!< [-] Unit normal vector of the instrument (inertial)
+    Eigen::Vector3d rHat_PI_N;   //!< [-] direction vector from instrument to planet
 
-    std::vector<SpicePlanetStateMsgPayload> planetMsgData; //!< vector of incoming planet message states
-    SpicePlanetStateMsgPayload sunMsgData;      //!< sun message data
-    SCStatesMsgPayload scStatesMsgData;     //!< spacecraft message data
+    std::vector<SpicePlanetStateMsgPayload> planetMsgData;  //!< vector of incoming planet message states
+    SpicePlanetStateMsgPayload sunMsgData;                  //!< sun message data
+    SCStatesMsgPayload scStatesMsgData;                     //!< spacecraft message data
 };
 
 #endif /* ALBEDO_BASE_H */

--- a/src/simulation/environment/albedo/albedo.h
+++ b/src/simulation/environment/albedo/albedo.h
@@ -20,29 +20,19 @@
 #ifndef ALBEDO_H
 #define ALBEDO_H
 
-// General
-#include <Eigen/Dense>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <inttypes.h>
-#include <vector>
-#include <string>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-// Utilities
-#include "architecture/utilities/astroConstants.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/avsEigenMRP.h"
-#include "architecture/utilities/geodeticConversion.h"
-#include "architecture/utilities/linearAlgebra.h"
-// Sim Messages
+
+#include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 #include "architecture/msgPayloadDefC/AlbedoMsgPayload.h"
-#include "architecture/messaging/messaging.h"
 
-#include "architecture/utilities/macroDefinitions.h"
+#include <Eigen/Core>
+#include <vector>
+#include <string>
+
 
 /*! albedo instrument configuration class */
 typedef class Config {

--- a/src/simulation/environment/eclipse/eclipse.cpp
+++ b/src/simulation/environment/eclipse/eclipse.cpp
@@ -24,54 +24,49 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/safeMath.h"
 
-
-Eclipse::Eclipse()
-{
+Eclipse::Eclipse() {
     rEqCustom = -1.0;
     return;
 }
 
-Eclipse::~Eclipse()
-{
-    for (long unsigned int c=0; c<this->eclipseOutMsgs.size(); c++) {
+Eclipse::~Eclipse() {
+    for (long unsigned int c = 0; c < this->eclipseOutMsgs.size(); c++) {
         delete this->eclipseOutMsgs.at(c);
     }
     return;
 }
 
-
-
 /*! Reset the module to origina configuration values.
  @return void
  */
-void Eclipse::reset(uint64_t CurrenSimNanos)
-{
+void Eclipse::reset(uint64_t CurrenSimNanos) {
     if (!this->sunInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "Eclipse: sunInMsg must be linked to sun Spice state message.");
     }
 
     if (this->positionInMsgs.size() == 0) {
-        bskLogger.bskLog(BSK_ERROR, "Eclipse: positionInMsgs is empty.  Must use addSpacecraftToModel() to add at least one spacecraft.");
+        bskLogger.bskLog(
+            BSK_ERROR,
+            "Eclipse: positionInMsgs is empty.  Must use addSpacecraftToModel() to add at least one spacecraft.");
     }
 
     if (this->planetInMsgs.size() == 0) {
-        bskLogger.bskLog(BSK_ERROR, "Eclipse: planetInMsgs is empty.  Must use addPlanetToModel() to add at least one planet.");
+        bskLogger.bskLog(BSK_ERROR,
+                         "Eclipse: planetInMsgs is empty.  Must use addPlanetToModel() to add at least one planet.");
     }
-
 }
 
 /*! This method reads the spacecraft state, spice planet states and the sun position from the messaging system.
  @return void
  */
-void Eclipse::readInputMessages()
-{
-    for (long unsigned int c = 0; c<this->positionInMsgs.size(); c++){
+void Eclipse::readInputMessages() {
+    for (long unsigned int c = 0; c < this->positionInMsgs.size(); c++) {
         this->scStateBuffer.at(c) = this->positionInMsgs.at(c)();
     }
 
     this->sunInMsgState = this->sunInMsg();
 
-    for (long unsigned int c = 0; c<this->planetInMsgs.size(); c++){
+    for (long unsigned int c = 0; c < this->planetInMsgs.size(); c++) {
         this->planetBuffer[c] = this->planetInMsgs[c]();
     }
 }
@@ -81,8 +76,7 @@ void Eclipse::readInputMessages()
  @param CurrentClock The current simulation time (used for time stamping)
  @return void
  */
-void Eclipse::writeOutputMessages(uint64_t CurrentClock)
-{
+void Eclipse::writeOutputMessages(uint64_t CurrentClock) {
     for (long unsigned int c = 0; c < this->eclipseOutMsgs.size(); c++) {
         EclipseMsgPayload tmpEclipseMsg = {};
         tmpEclipseMsg.shadowFactor = this->eclipseShadowFactors.at(c);
@@ -95,8 +89,7 @@ void Eclipse::writeOutputMessages(uint64_t CurrentClock)
  @param currentSimNanos The current clock time for the simulation
  @return void
  */
-void Eclipse::updateState(uint64_t currentSimNanos)
-{
+void Eclipse::updateState(uint64_t currentSimNanos) {
     this->readInputMessages();
 
     // A lot of different vectors here. The below letters denote frames
@@ -104,31 +97,28 @@ void Eclipse::updateState(uint64_t currentSimNanos)
     // B: spacecraft body frame
     // N: inertial frame
     // H: sun (helio) frame
-    Eigen::Vector3d r_PN_N(0.0, 0.0, 0.0); // r_planet
-    Eigen::Vector3d r_HN_N(this->sunInMsgState.PositionVector); // r_sun
-    Eigen::Vector3d r_BN_N(0.0, 0.0, 0.0); // r_sc
-    Eigen::Vector3d s_BP_N(0.0, 0.0, 0.0); // s_sc wrt planet
-    Eigen::Vector3d s_HP_N(0.0, 0.0, 0.0); // s_sun wrt planet
-    Eigen::Vector3d r_HB_N(0.0, 0.0, 0.0); // r_sun wrt sc
+    Eigen::Vector3d r_PN_N(0.0, 0.0, 0.0);                       // r_planet
+    Eigen::Vector3d r_HN_N(this->sunInMsgState.PositionVector);  // r_sun
+    Eigen::Vector3d r_BN_N(0.0, 0.0, 0.0);                       // r_sc
+    Eigen::Vector3d s_BP_N(0.0, 0.0, 0.0);                       // s_sc wrt planet
+    Eigen::Vector3d s_HP_N(0.0, 0.0, 0.0);                       // s_sun wrt planet
+    Eigen::Vector3d r_HB_N(0.0, 0.0, 0.0);                       // r_sun wrt sc
     std::vector<SCStatesMsgPayload>::iterator scIt;
     std::vector<SpicePlanetStateMsgPayload>::iterator planetIt;
-
 
     // Index to assign the shadowFactor for each body position (S/C)
     // being tracked
     int scIdx = 0;
 
-    for(scIt = this->scStateBuffer.begin(); scIt != this->scStateBuffer.end(); scIt++)
-    {
-        double tmpShadowFactor = 1.0; // 1.0 means 100% illumination (no eclipse)
+    for (scIt = this->scStateBuffer.begin(); scIt != this->scStateBuffer.end(); scIt++) {
+        double tmpShadowFactor = 1.0;  // 1.0 means 100% illumination (no eclipse)
         double eclipsePlanetDistance = 0.0;
         int64_t eclipsePlanetKey = -1;
         r_BN_N = cArray2EigenVector3d(scIt->r_BN_N);
 
         // Find the closest planet if there is one
         int idx = 0;
-        for(planetIt = this->planetBuffer.begin(); planetIt != this->planetBuffer.end(); planetIt++)
-        {
+        for (planetIt = this->planetBuffer.begin(); planetIt != this->planetBuffer.end(); planetIt++) {
             r_PN_N = cArray2EigenVector3d(planetIt->PositionVector);
             s_HP_N = r_HN_N - r_PN_N;
             r_HB_N = r_HN_N - r_BN_N;
@@ -139,8 +129,7 @@ void Eclipse::updateState(uint64_t currentSimNanos)
             if (r_HB_N.norm() < s_HP_N.norm()) {
                 idx++;
                 continue;
-            }
-            else{
+            } else {
                 // Find the closest planet and save its distance and vector index slot
                 if (s_BP_N.norm() < eclipsePlanetDistance || eclipsePlanetKey < 0) {
                     eclipsePlanetDistance = s_BP_N.norm();
@@ -161,22 +150,22 @@ void Eclipse::updateState(uint64_t currentSimNanos)
             double s = s_BP_N.norm();
             std::string plName(this->planetBuffer[eclipsePlanetKey].PlanetName);
             double planetRadius = this->getPlanetEquatorialRadius(plName);
-            double f_1 = safeAsin((REQ_SUN*1000 + planetRadius)/s_HP_N.norm());
-            double f_2 = safeAsin((REQ_SUN*1000 - planetRadius)/s_HP_N.norm());
-            double s_0 = (-s_BP_N.dot(s_HP_N))/s_HP_N.norm();
-            double c_1 = s_0 + planetRadius/sin(f_1);
-            double c_2 = s_0 - planetRadius/sin(f_2);
-            double l = safeSqrt(s*s - s_0*s_0);
-            double l_1 = c_1*tan(f_1);
-            double l_2 = c_2*tan(f_2);
+            double f_1 = safeAsin((REQ_SUN * 1000 + planetRadius) / s_HP_N.norm());
+            double f_2 = safeAsin((REQ_SUN * 1000 - planetRadius) / s_HP_N.norm());
+            double s_0 = (-s_BP_N.dot(s_HP_N)) / s_HP_N.norm();
+            double c_1 = s_0 + planetRadius / sin(f_1);
+            double c_2 = s_0 - planetRadius / sin(f_2);
+            double l = safeSqrt(s * s - s_0 * s_0);
+            double l_1 = c_1 * tan(f_1);
+            double l_2 = c_2 * tan(f_2);
 
             if (fabs(l) < fabs(l_2)) {
-                if (c_2 < 0) { // total eclipse
+                if (c_2 < 0) {  // total eclipse
                     tmpShadowFactor = this->computePercentShadow(planetRadius, r_HB_N, s_BP_N);
-                } else { //c_2 > 0 // annular
+                } else {  // c_2 > 0 // annular
                     tmpShadowFactor = this->computePercentShadow(planetRadius, r_HB_N, s_BP_N);
                 }
-            } else if (fabs(l) < fabs(l_1)) { // partial
+            } else if (fabs(l) < fabs(l_1)) {  // partial
                 tmpShadowFactor = this->computePercentShadow(planetRadius, r_HB_N, s_BP_N);
             }
         }
@@ -192,31 +181,30 @@ void Eclipse::updateState(uint64_t currentSimNanos)
  @param s_BP_N
  @return double fractionShadow The eclipse shadow fraction.
  */
-double Eclipse::computePercentShadow(double planetRadius, Eigen::Vector3d r_HB_N, Eigen::Vector3d s_BP_N)
-{
+double Eclipse::computePercentShadow(double planetRadius, Eigen::Vector3d r_HB_N, Eigen::Vector3d s_BP_N) {
     double area = 0.0;
-    double shadowFraction = 1.0; // Initialise to value for no eclipse
+    double shadowFraction = 1.0;  // Initialise to value for no eclipse
     double normR_HB_N = r_HB_N.norm();
     double normS_BP_N = s_BP_N.norm();
-    double a = safeAsin(REQ_SUN*1000/normR_HB_N); // apparent radius of sun
-    double b = safeAsin(planetRadius/normS_BP_N); // apparent radius of occulting body
-    double c = safeAcos((-s_BP_N.dot(r_HB_N))/(normS_BP_N*normR_HB_N));
+    double a = safeAsin(REQ_SUN * 1000 / normR_HB_N);  // apparent radius of sun
+    double b = safeAsin(planetRadius / normS_BP_N);    // apparent radius of occulting body
+    double c = safeAcos((-s_BP_N.dot(r_HB_N)) / (normS_BP_N * normR_HB_N));
 
     // The order of these conditionals is important.
     // In particular (c < a + b) must check last to avoid testing
     // with implausible a, b and c values
-    if (c < b - a) { // total eclipse, implying a < b
+    if (c < b - a) {  // total eclipse, implying a < b
         shadowFraction = 0.0;
-    } else if (c < a - b) { // partial maximum eclipse, implying a > b
-        double areaSun = M_PI*a*a;
-        double areaBody = M_PI*b*b;
+    } else if (c < a - b) {  // partial maximum eclipse, implying a > b
+        double areaSun = M_PI * a * a;
+        double areaBody = M_PI * b * b;
         area = areaSun - areaBody;
-        shadowFraction = 1 - area/(M_PI*a*a);
-    } else if (c < a + b) { // partial eclipse
-        double x = (c*c + a*a - b*b)/(2*c);
-        double y = sqrt(a*a - x*x);
-        area = a*a*safeAcos(x/a) + b*b*safeAcos((c-x)/b) - c*y;
-        shadowFraction = 1 - area/(M_PI*a*a);
+        shadowFraction = 1 - area / (M_PI * a * a);
+    } else if (c < a + b) {  // partial eclipse
+        double x = (c * c + a * a - b * b) / (2 * c);
+        double y = sqrt(a * a - x * x);
+        area = a * a * safeAcos(x / a) + b * b * safeAcos((c - x) / b) - c * y;
+        shadowFraction = 1 - area / (M_PI * a * a);
     }
     return shadowFraction;
 }
@@ -227,8 +215,7 @@ double Eclipse::computePercentShadow(double planetRadius, Eigen::Vector3d r_HB_N
     @param tmpScMsg The state output message for the spacecraft for which to compute the eclipse data.
     @return void
  */
-void Eclipse::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg)
-{
+void Eclipse::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg) {
     this->positionInMsgs.push_back(tmpScMsg->addSubscriber());
 
     /* create output message */
@@ -243,15 +230,13 @@ void Eclipse::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg)
     // Now that we know the number of output messages we can size and zero
     // the eclipse data vector
     this->eclipseShadowFactors.resize(this->eclipseOutMsgs.size());
-
 }
 
 /*! This method adds planet state data message names to a vector.
  @param tmpSpMsg The planet name
  @return void
  */
-void Eclipse::addPlanetToModel(Message<SpicePlanetStateMsgPayload> *tmpSpMsg)
-{
+void Eclipse::addPlanetToModel(Message<SpicePlanetStateMsgPayload> *tmpSpMsg) {
     this->planetInMsgs.push_back(tmpSpMsg->addSubscriber());
 
     SpicePlanetStateMsgPayload tmpMsg;
@@ -263,28 +248,27 @@ void Eclipse::addPlanetToModel(Message<SpicePlanetStateMsgPayload> *tmpSpMsg)
  @param  planetSpiceName The planet name according to the spice NAIF Integer ID codes.
  @return double  The equatorial radius in metres associated with the given planet name.
  */
-double Eclipse::getPlanetEquatorialRadius(std::string planetSpiceName)
-{
+double Eclipse::getPlanetEquatorialRadius(std::string planetSpiceName) {
     if (planetSpiceName == "mercury") {
-        return REQ_MERCURY*1000.0; // [meters]
+        return REQ_MERCURY * 1000.0;  // [meters]
     } else if (planetSpiceName == "venus") {
-        return REQ_VENUS*1000.0;
+        return REQ_VENUS * 1000.0;
     } else if (planetSpiceName == "earth") {
-        return REQ_EARTH*1000.0;
+        return REQ_EARTH * 1000.0;
     } else if (planetSpiceName == "moon") {
-        return REQ_MOON*1000.0;
+        return REQ_MOON * 1000.0;
     } else if (planetSpiceName == "mars barycenter") {
-        return REQ_MARS*1000.0;
+        return REQ_MARS * 1000.0;
     } else if (planetSpiceName == "mars") {
-        return REQ_MARS*1000.0;
+        return REQ_MARS * 1000.0;
     } else if (planetSpiceName == "jupiter barycenter") {
-        return REQ_JUPITER*1000.0;
+        return REQ_JUPITER * 1000.0;
     } else if (planetSpiceName == "saturn") {
-        return REQ_SATURN*1000.0;
+        return REQ_SATURN * 1000.0;
     } else if (planetSpiceName == "uranus") {
-        return REQ_URANUS*1000.0;
+        return REQ_URANUS * 1000.0;
     } else if (planetSpiceName == "neptune") {
-        return REQ_NEPTUNE*1000.0;
+        return REQ_NEPTUNE * 1000.0;
     } else if (planetSpiceName == "custom") {
         if (rEqCustom <= 0.0) {
             bskLogger.bskLog(BSK_ERROR, "Eclipse: Invalid rEqCustom set.");

--- a/src/simulation/environment/eclipse/eclipse.cpp
+++ b/src/simulation/environment/eclipse/eclipse.cpp
@@ -18,9 +18,11 @@
  */
 
 #include "eclipse.h"
-#include <iostream>
+
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/safeMath.h"
 
 
 Eclipse::Eclipse()

--- a/src/simulation/environment/eclipse/eclipse.h
+++ b/src/simulation/environment/eclipse/eclipse.h
@@ -20,18 +20,15 @@
 #ifndef Eclipse_H
 #define Eclipse_H
 
-#include <vector>
-#include <Eigen/Dense>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-
+#include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 #include "architecture/msgPayloadDefC/EclipseMsgPayload.h"
-#include "architecture/messaging/messaging.h"
-
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/bskLogging.h"
 
+#include <Eigen/Dense>
+#include <vector>
 
 /*! @brief eclipse model class */
 class Eclipse: public SysModel {

--- a/src/simulation/environment/eclipse/eclipse.h
+++ b/src/simulation/environment/eclipse/eclipse.h
@@ -22,17 +22,17 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/EclipseMsgPayload.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
-#include "architecture/msgPayloadDefC/EclipseMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 
 #include <Eigen/Dense>
 #include <vector>
 
 /*! @brief eclipse model class */
-class Eclipse: public SysModel {
-public:
+class Eclipse : public SysModel {
+   public:
     Eclipse();
     ~Eclipse();
 
@@ -42,27 +42,29 @@ public:
     void addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg);
     void addPlanetToModel(Message<SpicePlanetStateMsgPayload> *tmpSpMsg);
 
-public:
-    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;   //!< sun ephemeris input message name
-    std::vector<ReadFunctor<SpicePlanetStateMsgPayload>> planetInMsgs;  //!< A vector of planet incoming state message names ordered by the sequence in which planet are added to the module
-    std::vector<ReadFunctor<SCStatesMsgPayload>> positionInMsgs;  //!< vector of msgs for each spacecraft position state for which to evaluate eclipse conditions.
-    std::vector<Message<EclipseMsgPayload>*> eclipseOutMsgs;//!< vector of eclispe output msg names
-    BSKLogger bskLogger;                        //!< BSK Logging
-    double rEqCustom;  //!< [m] Custom radius
+   public:
+    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;  //!< sun ephemeris input message name
+    std::vector<ReadFunctor<SpicePlanetStateMsgPayload>>
+        planetInMsgs;  //!< A vector of planet incoming state message names ordered by the sequence in which planet are
+                       //!< added to the module
+    std::vector<ReadFunctor<SCStatesMsgPayload>> positionInMsgs;  //!< vector of msgs for each spacecraft position state
+                                                                  //!< for which to evaluate eclipse conditions.
+    std::vector<Message<EclipseMsgPayload> *> eclipseOutMsgs;     //!< vector of eclispe output msg names
+    BSKLogger bskLogger;                                          //!< BSK Logging
+    double rEqCustom;                                             //!< [m] Custom radius
 
-private:
-    std::vector<float> planetRadii; //!< [m] A vector of planet radii ordered by the sequence in which planet names are added to the module
-    std::vector<SCStatesMsgPayload> scStateBuffer;      //!< buffer of the spacecraft state input messages
-    std::vector<SpicePlanetStateMsgPayload> planetBuffer;   //!< buffer of the spacecraft state input messages
-    SpicePlanetStateMsgPayload sunInMsgState;               //!< copy of sun input msg
-    std::vector<double> eclipseShadowFactors;               //!< vector of shadow factor output values
+   private:
+    std::vector<float> planetRadii;  //!< [m] A vector of planet radii ordered by the sequence in which planet names are
+                                     //!< added to the module
+    std::vector<SCStatesMsgPayload> scStateBuffer;         //!< buffer of the spacecraft state input messages
+    std::vector<SpicePlanetStateMsgPayload> planetBuffer;  //!< buffer of the spacecraft state input messages
+    SpicePlanetStateMsgPayload sunInMsgState;              //!< copy of sun input msg
+    std::vector<double> eclipseShadowFactors;              //!< vector of shadow factor output values
 
-private:
+   private:
     void readInputMessages();
     double computePercentShadow(double planetRadius, Eigen::Vector3d r_HB_N, Eigen::Vector3d s_BP_N);
     double getPlanetEquatorialRadius(std::string planetSpiceName);
-
 };
-
 
 #endif

--- a/src/simulation/environment/groundLocation/groundLocation.cpp
+++ b/src/simulation/environment/groundLocation/groundLocation.cpp
@@ -28,15 +28,16 @@
 /*! @brief Creates an instance of the GroundLocation class with a minimum elevation of 10 degrees,
  @return void
  */
-GroundLocation::GroundLocation()
-{
+GroundLocation::GroundLocation() {
     //! - Set some default initial conditions:
-    this->minimumElevation = 10.*D2R; // [rad] minimum elevation above the local horizon needed to see a spacecraft; defaults to 10 degrees
-    this->maximumRange = -1; // [m] Maximum range for the groundLocation to compute access.
+    this->minimumElevation =
+        10. *
+        D2R;  // [rad] minimum elevation above the local horizon needed to see a spacecraft; defaults to 10 degrees
+    this->maximumRange = -1;  // [m] Maximum range for the groundLocation to compute access.
 
     this->currentGroundStateBuffer = this->currentGroundStateOutMsg.zeroMsgPayload;
 
-    this->planetRadius = REQ_EARTH*1e3;
+    this->planetRadius = REQ_EARTH * 1e3;
 
     this->r_LP_P.fill(0.0);
     this->r_LP_P_Init.fill(0.0);
@@ -52,17 +53,15 @@ GroundLocation::GroundLocation()
 /*! Empty destructor method.
  @return void
  */
-GroundLocation::~GroundLocation()
-{
-    for (long unsigned int c=0; c<this->accessOutMsgs.size(); c++) {
+GroundLocation::~GroundLocation() {
+    for (long unsigned int c = 0; c < this->accessOutMsgs.size(); c++) {
         delete this->accessOutMsgs.at(c);
     }
     return;
 }
 
 /*! Resets the internal position to the specified initial position.*/
-void GroundLocation::reset(uint64_t currentSimNanos)
-{
+void GroundLocation::reset(uint64_t currentSimNanos) {
     this->r_LP_P = this->r_LP_P_Init;
 
     if (this->planetRadius < 0) {
@@ -77,8 +76,7 @@ void GroundLocation::reset(uint64_t currentSimNanos)
  * @param alt
  * @return
  */
-void GroundLocation::specifyLocation(double lat, double longitude, double alt)
-{
+void GroundLocation::specifyLocation(double lat, double longitude, double alt) {
     Eigen::Vector3d tmpLLAPosition(lat, longitude, alt);
     this->r_LP_P_Init = LLA2PCPF(tmpLLAPosition, this->planetRadius);
     this->dcm_LP = C_PCPF2SEZ(lat, longitude);
@@ -87,7 +85,7 @@ void GroundLocation::specifyLocation(double lat, double longitude, double alt)
 /*! Specifies the ground location from planet-centered, planet-fixed coordinates
  * @param r_LP_P_Loc
  */
-void GroundLocation::specifyLocationPCPF(Eigen::Vector3d& r_LP_P_Loc){
+void GroundLocation::specifyLocationPCPF(Eigen::Vector3d &r_LP_P_Loc) {
     /* Assign to r_LP_P_Init */
     this->r_LP_P_Init = r_LP_P_Loc;
 
@@ -98,11 +96,10 @@ void GroundLocation::specifyLocationPCPF(Eigen::Vector3d& r_LP_P_Loc){
     this->dcm_LP = C_PCPF2SEZ(tmpLLAPosition[0], tmpLLAPosition[1]);
 }
 
-
-/*! Adds a scState message name to the vector of names to be subscribed to. Also creates a corresponding access message output name.
-*/
-void GroundLocation::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg)
-{
+/*! Adds a scState message name to the vector of names to be subscribed to. Also creates a corresponding access message
+ * output name.
+ */
+void GroundLocation::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg) {
     this->scStateInMsgs.push_back(tmpScMsg->addSubscriber());
 
     /* create output message */
@@ -115,11 +112,9 @@ void GroundLocation::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg)
     this->accessMsgBuffer.push_back(accMsg);
 }
 
-
 /*! Read module messages
-*/
-bool GroundLocation::ReadMessages()
-{
+ */
+bool GroundLocation::ReadMessages() {
     SCStatesMsgPayload scMsg;
 
     /* clear out the vector of spacecraft states.  This is created freshly below. */
@@ -127,8 +122,7 @@ bool GroundLocation::ReadMessages()
 
     //! - read in the spacecraft state messages
     bool scRead;
-    if(!this->scStateInMsgs.empty())
-    {
+    if (!this->scStateInMsgs.empty()) {
         scRead = true;
         for (long unsigned int c = 0; c < this->scStateInMsgs.size(); c++) {
             scMsg = this->scStateInMsgs.at(c)();
@@ -139,83 +133,85 @@ bool GroundLocation::ReadMessages()
         bskLogger.bskLog(BSK_ERROR, "Ground location has no spacecraft to track.");
         scRead = false;
     }
-    //! - Read in the optional planet message.  if no planet message is set, then a zero planet position, velocity and orientation is assumed
+    //! - Read in the optional planet message.  if no planet message is set, then a zero planet position, velocity and
+    //! orientation is assumed
     bool planetRead = true;
-    if(this->planetInMsg.isLinked())
-    {
+    if (this->planetInMsg.isLinked()) {
         planetRead = this->planetInMsg.isWritten();
         this->planetState = this->planetInMsg();
     }
 
-    return(planetRead && scRead);
+    return (planetRead && scRead);
 }
 
 /*! write module messages
-*/
-void GroundLocation::WriteMessages(uint64_t CurrentClock)
-{
+ */
+void GroundLocation::WriteMessages(uint64_t CurrentClock) {
     //! - write access message for each spacecraft
-    for (long unsigned int c=0; c< this->accessMsgBuffer.size(); c++) {
+    for (long unsigned int c = 0; c < this->accessMsgBuffer.size(); c++) {
         this->accessOutMsgs.at(c)->write(&this->accessMsgBuffer.at(c), this->moduleID, CurrentClock);
     }
     this->currentGroundStateOutMsg.write(&this->currentGroundStateBuffer, this->moduleID, CurrentClock);
 }
 
-void GroundLocation::updateInertialPositions()
-{
+void GroundLocation::updateInertialPositions() {
     // First, get the rotation matrix from the inertial to planet frame from SPICE:
     this->dcm_PN = cArray2EigenMatrix3d(*this->planetState.J20002Pfix);
     this->dcm_PN_dot = cArray2EigenMatrix3d(*this->planetState.J20002Pfix_dot);
     this->r_PN_N = cArray2EigenVector3d(this->planetState.PositionVector);
     // Then, transpose it to get the planet to inertial frame
     this->r_LP_N = this->dcm_PN.transpose() * this->r_LP_P_Init;
-    this->rhat_LP_N = this->r_LP_N/this->r_LP_N.norm();
+    this->rhat_LP_N = this->r_LP_N / this->r_LP_N.norm();
     this->r_LN_N = this->r_PN_N + this->r_LP_N;
     // Get planet frame angular velocity vector
-    Eigen::Matrix3d w_tilde_PN = - this->dcm_PN_dot * this->dcm_PN.transpose();
-    this->w_PN << w_tilde_PN(2,1), w_tilde_PN(0,2), w_tilde_PN(1,0);
+    Eigen::Matrix3d w_tilde_PN = -this->dcm_PN_dot * this->dcm_PN.transpose();
+    this->w_PN << w_tilde_PN(2, 1), w_tilde_PN(0, 2), w_tilde_PN(1, 0);
     //  Stash updated position in the groundState message
     eigenVector3d2CArray(this->r_LN_N, this->currentGroundStateBuffer.r_LN_N);
     eigenVector3d2CArray(this->r_LP_N, this->currentGroundStateBuffer.r_LP_N);
 }
 
-void GroundLocation::computeAccess()
-{
+void GroundLocation::computeAccess() {
     // Update the groundLocation's inertial position
     this->updateInertialPositions();
 
     // Iterate over spacecraft position messages and compute the access for each one
     std::vector<AccessMsgPayload>::iterator accessMsgIt;
     std::vector<SCStatesMsgPayload>::iterator scStatesMsgIt;
-    for(scStatesMsgIt = this->scStatesBuffer.begin(), accessMsgIt = accessMsgBuffer.begin(); scStatesMsgIt != scStatesBuffer.end(); scStatesMsgIt++, accessMsgIt++){
+    for (scStatesMsgIt = this->scStatesBuffer.begin(), accessMsgIt = accessMsgBuffer.begin();
+         scStatesMsgIt != scStatesBuffer.end();
+         scStatesMsgIt++, accessMsgIt++) {
         //! Compute the relative position of each spacecraft to the site in the planet-centered inertial frame
         Eigen::Vector3d r_BP_N = cArray2EigenVector3d(scStatesMsgIt->r_BN_N) - this->r_PN_N;
         Eigen::Vector3d r_BL_N = r_BP_N - this->r_LP_N;
         auto r_BL_mag = r_BL_N.norm();
         Eigen::Vector3d relativeHeading_N = r_BL_N / r_BL_mag;
 
-        double viewAngle = (M_PI_2-safeAcos(this->rhat_LP_N.dot(relativeHeading_N)));
+        double viewAngle = (M_PI_2 - safeAcos(this->rhat_LP_N.dot(relativeHeading_N)));
 
         accessMsgIt->slantRange = r_BL_mag;
         accessMsgIt->elevation = viewAngle;
         Eigen::Vector3d r_BL_L = this->dcm_LP * this->dcm_PN * r_BL_N;
         eigenVector3d2CArray(r_BL_L, accessMsgIt->r_BL_L);
-        double cos_az = -r_BL_L[0]/(sqrt(pow(r_BL_L[0],2) + pow(r_BL_L[1],2)));
-        double sin_az = r_BL_L[1]/(sqrt(pow(r_BL_L[0],2) + pow(r_BL_L[1],2)));
+        double cos_az = -r_BL_L[0] / (sqrt(pow(r_BL_L[0], 2) + pow(r_BL_L[1], 2)));
+        double sin_az = r_BL_L[1] / (sqrt(pow(r_BL_L[0], 2) + pow(r_BL_L[1], 2)));
         accessMsgIt->azimuth = atan2(sin_az, cos_az);
 
-        Eigen::Vector3d v_BL_L = this->dcm_LP * this->dcm_PN * (cArray2EigenVector3d(scStatesMsgIt->v_BN_N) - this->w_PN.cross(r_BP_N)); // V observed from gL wrt P frame, expressed in L frame coords (SEZ)
+        Eigen::Vector3d v_BL_L =
+            this->dcm_LP * this->dcm_PN *
+            (cArray2EigenVector3d(scStatesMsgIt->v_BN_N) -
+             this->w_PN.cross(r_BP_N));  // V observed from gL wrt P frame, expressed in L frame coords (SEZ)
         eigenVector3d2CArray(v_BL_L, accessMsgIt->v_BL_L);
-        accessMsgIt->range_dot = v_BL_L.dot(r_BL_L)/r_BL_mag;
-        double xy_norm = sqrt(pow(r_BL_L[0],2)+pow(r_BL_L[1],2));
-        accessMsgIt->az_dot = (-r_BL_L[0]*v_BL_L[1] + r_BL_L[1]*v_BL_L[0])/pow(xy_norm,2);
-        accessMsgIt->el_dot = (v_BL_L[2]/xy_norm - r_BL_L[2]*(r_BL_L[0]*v_BL_L[0] + r_BL_L[1]*v_BL_L[1])/pow(xy_norm,3))/(1+pow(r_BL_L[2]/xy_norm,2));
+        accessMsgIt->range_dot = v_BL_L.dot(r_BL_L) / r_BL_mag;
+        double xy_norm = sqrt(pow(r_BL_L[0], 2) + pow(r_BL_L[1], 2));
+        accessMsgIt->az_dot = (-r_BL_L[0] * v_BL_L[1] + r_BL_L[1] * v_BL_L[0]) / pow(xy_norm, 2);
+        accessMsgIt->el_dot =
+            (v_BL_L[2] / xy_norm - r_BL_L[2] * (r_BL_L[0] * v_BL_L[0] + r_BL_L[1] * v_BL_L[1]) / pow(xy_norm, 3)) /
+            (1 + pow(r_BL_L[2] / xy_norm, 2));
 
-        if( (viewAngle > this->minimumElevation) && (r_BL_mag <= this->maximumRange || this->maximumRange < 0)){
+        if ((viewAngle > this->minimumElevation) && (r_BL_mag <= this->maximumRange || this->maximumRange < 0)) {
             accessMsgIt->hasAccess = 1;
-        }
-        else
-        {
+        } else {
             accessMsgIt->hasAccess = 0;
         }
     }
@@ -225,10 +221,8 @@ void GroundLocation::computeAccess()
  update module
  @param currentSimNanos
  */
-void GroundLocation::updateState(uint64_t currentSimNanos)
-{
+void GroundLocation::updateState(uint64_t currentSimNanos) {
     this->ReadMessages();
     this->computeAccess();
     this->WriteMessages(currentSimNanos);
-
 }

--- a/src/simulation/environment/groundLocation/groundLocation.cpp
+++ b/src/simulation/environment/groundLocation/groundLocation.cpp
@@ -18,9 +18,12 @@
  */
 
 #include "simulation/environment/groundLocation/groundLocation.h"
+
+#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/geodeticConversion.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include <iostream>
+#include "architecture/utilities/safeMath.h"
 
 /*! @brief Creates an instance of the GroundLocation class with a minimum elevation of 10 degrees,
  @return void

--- a/src/simulation/environment/groundLocation/groundLocation.h
+++ b/src/simulation/environment/groundLocation/groundLocation.h
@@ -17,69 +17,75 @@
 
  */
 
-
 #ifndef GROUND_LOCATION_H
 #define GROUND_LOCATION_H
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
-#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/AccessMsgPayload.h"
 #include "architecture/msgPayloadDefC/GroundStateMsgPayload.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+#include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 
 #include "architecture/utilities/bskLogging.h"
 
 #include <Eigen/Dense>
-#include <vector>
 #include <string>
+#include <vector>
 /*! @brief ground location class */
-class GroundLocation:  public SysModel {
-public:
+class GroundLocation : public SysModel {
+   public:
     GroundLocation();
     ~GroundLocation();
     void updateState(uint64_t currentSimNanos);
     void reset(uint64_t currentSimNanos);
     bool ReadMessages();
     void WriteMessages(uint64_t CurrentClock);
-    void addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg);
+    void addSpacecraftToModel(Message<SCStatesMsgPayload>* tmpScMsg);
     void specifyLocation(double lat, double longitude, double alt);
     void specifyLocationPCPF(Eigen::Vector3d& r_LP_P_Loc);
 
-private:
+   private:
     void updateInertialPositions();
     void computeAccess();
 
-public:
-    double planetRadius; //!< [m] Planet radius in meters.
-    double minimumElevation; //!< [rad] minimum elevation above the local horizon needed to see a spacecraft; defaults to 10 degrees equivalent.
-    double maximumRange; //!< [m] (optional) Maximum slant range to compute access for; defaults to -1, which represents no maximum range.
+   public:
+    double planetRadius;      //!< [m] Planet radius in meters.
+    double minimumElevation;  //!< [rad] minimum elevation above the local horizon needed to see a spacecraft; defaults
+                              //!< to 10 degrees equivalent.
+    double maximumRange;      //!< [m] (optional) Maximum slant range to compute access for; defaults to -1, which
+                              //!< represents no maximum range.
 
-    ReadFunctor<SpicePlanetStateMsgPayload> planetInMsg;            //!< planet state input message
-    Message<GroundStateMsgPayload> currentGroundStateOutMsg;    //!< ground location output message
-    std::vector<Message<AccessMsgPayload>*> accessOutMsgs;           //!< vector of ground location access messages
-    std::vector<ReadFunctor<SCStatesMsgPayload>> scStateInMsgs; //!< vector of sc state input messages
-    Eigen::Vector3d r_LP_P_Init; //!< [m] Initial position of the location in planet-centric coordinates; can also be set using setGroundLocation.
-    BSKLogger bskLogger;         //!< -- BSK Logging
+    ReadFunctor<SpicePlanetStateMsgPayload> planetInMsg;         //!< planet state input message
+    Message<GroundStateMsgPayload> currentGroundStateOutMsg;     //!< ground location output message
+    std::vector<Message<AccessMsgPayload>*> accessOutMsgs;       //!< vector of ground location access messages
+    std::vector<ReadFunctor<SCStatesMsgPayload>> scStateInMsgs;  //!< vector of sc state input messages
+    Eigen::Vector3d r_LP_P_Init;  //!< [m] Initial position of the location in planet-centric coordinates; can also be
+                                  //!< set using setGroundLocation.
+    BSKLogger bskLogger;          //!< -- BSK Logging
 
-private:
-    std::vector<AccessMsgPayload> accessMsgBuffer;                  //!< buffer of access output data
-    std::vector<SCStatesMsgPayload> scStatesBuffer;             //!< buffer of spacecraft states
-    SpicePlanetStateMsgPayload planetState;                         //!< buffer of planet data
-    GroundStateMsgPayload currentGroundStateBuffer;                 //!< buffer of ground station output data
+   private:
+    std::vector<AccessMsgPayload> accessMsgBuffer;   //!< buffer of access output data
+    std::vector<SCStatesMsgPayload> scStatesBuffer;  //!< buffer of spacecraft states
+    SpicePlanetStateMsgPayload planetState;          //!< buffer of planet data
+    GroundStateMsgPayload currentGroundStateBuffer;  //!< buffer of ground station output data
 
-    Eigen::Matrix3d dcm_LP; //!< Rotation matrix from planet-centered, planet-fixed frame P to site-local topographic (SEZ) frame L coordinates.
-    Eigen::Matrix3d dcm_PN; //!< Rotation matrix from inertial frame N to planet-centered to planet-fixed frame P.
-    Eigen::Matrix3d dcm_PN_dot; //!< Rotation matrix derivative from inertial frame N to planet-centered to planet-fixed frame P.
-    Eigen::Vector3d w_PN; //!< [rad/s] Angular velocity of planet-fixed frame P relative to inertial frame N.
-    Eigen::Vector3d r_PN_N; //!< [m] Planet position vector relative to inertial frame origin.
-    Eigen::Vector3d r_LP_P; //!< [m] Ground Location position vector relative to to planet origin vector in planet frame coordinates.
-    Eigen::Vector3d r_LP_N; //!< [m] Gound Location position vector relative to planet origin vector in inertial coordinates.
-    Eigen::Vector3d rhat_LP_N;//!< [-] Surface normal vector from the target location in inertial coordinates.
-    Eigen::Vector3d r_LN_N; //!< [m] Ground Location position vector relative to inertial frame origin in inertial coordinates.
-    Eigen::Vector3d r_North_N; //!<[-] Inertial 3rd axis, defined internally as "North".
+    Eigen::Matrix3d dcm_LP;  //!< Rotation matrix from planet-centered, planet-fixed frame P to site-local topographic
+                             //!< (SEZ) frame L coordinates.
+    Eigen::Matrix3d dcm_PN;  //!< Rotation matrix from inertial frame N to planet-centered to planet-fixed frame P.
+    Eigen::Matrix3d
+        dcm_PN_dot;  //!< Rotation matrix derivative from inertial frame N to planet-centered to planet-fixed frame P.
+    Eigen::Vector3d w_PN;    //!< [rad/s] Angular velocity of planet-fixed frame P relative to inertial frame N.
+    Eigen::Vector3d r_PN_N;  //!< [m] Planet position vector relative to inertial frame origin.
+    Eigen::Vector3d r_LP_P;  //!< [m] Ground Location position vector relative to to planet origin vector in planet
+                             //!< frame coordinates.
+    Eigen::Vector3d
+        r_LP_N;  //!< [m] Gound Location position vector relative to planet origin vector in inertial coordinates.
+    Eigen::Vector3d rhat_LP_N;  //!< [-] Surface normal vector from the target location in inertial coordinates.
+    Eigen::Vector3d
+        r_LN_N;  //!< [m] Ground Location position vector relative to inertial frame origin in inertial coordinates.
+    Eigen::Vector3d r_North_N;  //!<[-] Inertial 3rd axis, defined internally as "North".
 };
-
 
 #endif /* GroundLocation */

--- a/src/simulation/environment/groundLocation/groundLocation.h
+++ b/src/simulation/environment/groundLocation/groundLocation.h
@@ -21,21 +21,19 @@
 #ifndef GROUND_LOCATION_H
 #define GROUND_LOCATION_H
 
-#include <Eigen/Dense>
-#include <vector>
-#include <string>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 
+#include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/AccessMsgPayload.h"
 #include "architecture/msgPayloadDefC/GroundStateMsgPayload.h"
-#include "architecture/messaging/messaging.h"
 
-#include "architecture/utilities/geodeticConversion.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/bskLogging.h"
 
+#include <Eigen/Dense>
+#include <vector>
+#include <string>
 /*! @brief ground location class */
 class GroundLocation:  public SysModel {
 public:

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -17,25 +17,24 @@
 
 */
 
-
 #include "simulation/environment//groundMapping/groundMapping.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/safeMath.h"
-#include <iostream>
 #include <math.h>
+#include <iostream>
 
 /*! This is the constructor for the module class.  It sets default variable
     values and initializes the various parts of the model */
-GroundMapping::GroundMapping()
-{
+GroundMapping::GroundMapping() {
     //! - Set some default initial conditions:
-    this->minimumElevation = 0.*D2R; // [rad] minimum elevation above the local horizon needed to see a spacecraft; defaults to 0 degrees
-    this->maximumRange = -1; // [m] Maximum range for the groundLocation to compute access.
-    this->halfFieldOfView = 10.*D2R;  // [rad] half-angle field-of-view of the instrument
-    this->cameraPos_B.setZero(3);  // Default to zero
-    this->nHat_B.setZero(3);  // Default to zero
+    this->minimumElevation =
+        0. * D2R;  // [rad] minimum elevation above the local horizon needed to see a spacecraft; defaults to 0 degrees
+    this->maximumRange = -1;            // [m] Maximum range for the groundLocation to compute access.
+    this->halfFieldOfView = 10. * D2R;  // [rad] half-angle field-of-view of the instrument
+    this->cameraPos_B.setZero(3);       // Default to zero
+    this->nHat_B.setZero(3);            // Default to zero
 
     this->planetInMsgBuffer = this->planetInMsg.zeroMsgPayload;
     this->planetInMsgBuffer.J20002Pfix[0][0] = 1;
@@ -46,8 +45,7 @@ GroundMapping::GroundMapping()
 }
 
 /*! Module Destructor */
-GroundMapping::~GroundMapping()
-{
+GroundMapping::~GroundMapping() {
     for (long unsigned int c = 0; c < this->accessOutMsgs.size(); c++) {
         delete this->accessOutMsgs.at(c);
         delete this->currentGroundStateOutMsgs.at(c);
@@ -57,25 +55,22 @@ GroundMapping::~GroundMapping()
 /*! This method is used to reset the module and checks that required input messages are connect.
     @return void
 */
-void GroundMapping::reset(uint64_t currentSimNanos)
-{
+void GroundMapping::reset(uint64_t currentSimNanos) {
     // check that required input messages are connected
     if (!this->scStateInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "GroundMapping.scStateInMsg was not linked.");
     }
 
     // check that the direction of the camera is provided
-    if (this->nHat_B.isZero()){
+    if (this->nHat_B.isZero()) {
         bskLogger.bskLog(BSK_ERROR, "GroundMapping.nHat_B vector not set.");
     }
 }
 
 /*! Read module messages
-*/
-void GroundMapping::ReadMessages(){
-
-    if(this->planetInMsg.isLinked())
-    {
+ */
+void GroundMapping::ReadMessages() {
+    if (this->planetInMsg.isLinked()) {
         this->planetInMsgBuffer = this->planetInMsg();
     }
 
@@ -85,7 +80,7 @@ void GroundMapping::ReadMessages(){
 /*! Method to add map points
  * @param r_LP_P_init: mapping point in planet-fixed frame
  */
-void GroundMapping::addPointToModel(Eigen::Vector3d& r_LP_P_init){
+void GroundMapping::addPointToModel(Eigen::Vector3d &r_LP_P_init) {
     /* Add the mapping point */
     this->mappingPoints.push_back(r_LP_P_init);
 
@@ -111,14 +106,14 @@ void GroundMapping::addPointToModel(Eigen::Vector3d& r_LP_P_init){
 /*! Method to compute whether or not the spacecraft has access to the location
  * @param c: index of the given location
  */
-void GroundMapping::computeAccess(uint64_t c){
+void GroundMapping::computeAccess(uint64_t c) {
     //! Zero the output message buffers
     this->accessMsgBuffer.at(c) = this->accessOutMsgs.at(c)->zeroMsgPayload;
     this->currentGroundStateMsgBuffer.at(c) = this->currentGroundStateOutMsgs.at(c)->zeroMsgPayload;
 
     //! Compute the planet to inertial frame location position
     this->r_LP_N = this->dcm_PN.transpose() * this->mappingPoints[c];
-    this->rhat_LP_N = this->r_LP_N/this->r_LP_N.norm();
+    this->rhat_LP_N = this->r_LP_N / this->r_LP_N.norm();
     this->r_LN_N = this->r_PN_N + this->r_LP_N;
 
     //!  Stash updated position in the groundState message
@@ -130,39 +125,41 @@ void GroundMapping::computeAccess(uint64_t c){
     auto r_BL_mag = r_BL_N.norm();
     Eigen::Vector3d relativeHeading_N = r_BL_N / r_BL_mag;
 
-    double viewAngle = (M_PI_2-safeAcos(this->rhat_LP_N.dot(relativeHeading_N)));
+    double viewAngle = (M_PI_2 - safeAcos(this->rhat_LP_N.dot(relativeHeading_N)));
 
     this->accessMsgBuffer.at(c).slantRange = r_BL_mag;
     this->accessMsgBuffer.at(c).elevation = viewAngle;
     Eigen::Vector3d r_BL_L = this->dcm_LP * this->dcm_PN * r_BL_N;
     eigenVector3d2CArray(r_BL_L, this->accessMsgBuffer.at(c).r_BL_L);
-    double cos_az = -r_BL_L[0]/(sqrt(pow(r_BL_L[0],2) + pow(r_BL_L[1],2)));
-    double sin_az = r_BL_L[1]/(sqrt(pow(r_BL_L[0],2) + pow(r_BL_L[1],2)));
+    double cos_az = -r_BL_L[0] / (sqrt(pow(r_BL_L[0], 2) + pow(r_BL_L[1], 2)));
+    double sin_az = r_BL_L[1] / (sqrt(pow(r_BL_L[0], 2) + pow(r_BL_L[1], 2)));
     this->accessMsgBuffer.at(c).azimuth = atan2(sin_az, cos_az);
 
-    Eigen::Vector3d v_BL_L = this->dcm_LP * this->dcm_PN * (cArray2EigenVector3d(scStateInMsgBuffer.v_BN_N) - this->w_PN.cross(r_BP_N)); // V observed from gL wrt P frame, expressed in L frame coords (SEZ)
+    Eigen::Vector3d v_BL_L =
+        this->dcm_LP * this->dcm_PN *
+        (cArray2EigenVector3d(scStateInMsgBuffer.v_BN_N) -
+         this->w_PN.cross(r_BP_N));  // V observed from gL wrt P frame, expressed in L frame coords (SEZ)
     eigenVector3d2CArray(v_BL_L, this->accessMsgBuffer.at(c).v_BL_L);
-    this->accessMsgBuffer.at(c).range_dot = v_BL_L.dot(r_BL_L)/r_BL_mag;
-    double xy_norm = sqrt(pow(r_BL_L[0],2)+pow(r_BL_L[1],2));
-    this->accessMsgBuffer.at(c).az_dot = (-r_BL_L[0]*v_BL_L[1] + r_BL_L[1]*v_BL_L[0])/pow(xy_norm,2);
-    this->accessMsgBuffer.at(c).el_dot = (v_BL_L[2]/xy_norm - r_BL_L[2]*(r_BL_L[0]*v_BL_L[0] + r_BL_L[1]*v_BL_L[1])/pow(xy_norm,3))/(1+pow(r_BL_L[2]/xy_norm,2));
+    this->accessMsgBuffer.at(c).range_dot = v_BL_L.dot(r_BL_L) / r_BL_mag;
+    double xy_norm = sqrt(pow(r_BL_L[0], 2) + pow(r_BL_L[1], 2));
+    this->accessMsgBuffer.at(c).az_dot = (-r_BL_L[0] * v_BL_L[1] + r_BL_L[1] * v_BL_L[0]) / pow(xy_norm, 2);
+    this->accessMsgBuffer.at(c).el_dot =
+        (v_BL_L[2] / xy_norm - r_BL_L[2] * (r_BL_L[0] * v_BL_L[0] + r_BL_L[1] * v_BL_L[1]) / pow(xy_norm, 3)) /
+        (1 + pow(r_BL_L[2] / xy_norm, 2));
 
     uint64_t within_view = this->checkInstrumentFOV();
 
-    if( (viewAngle > this->minimumElevation) && (r_BL_mag <= this->maximumRange || this->maximumRange < 0) && within_view){
+    if ((viewAngle > this->minimumElevation) && (r_BL_mag <= this->maximumRange || this->maximumRange < 0) &&
+        within_view) {
         this->accessMsgBuffer.at(c).hasAccess = 1;
-    }
-    else
-    {
+    } else {
         this->accessMsgBuffer.at(c).hasAccess = 0;
     }
-
 }
 
 /*! Method to update the relevant rotations matrices
  */
-void GroundMapping::updateInertialPositions()
-{
+void GroundMapping::updateInertialPositions() {
     // First, get the rotation matrix from the inertial to planet frame from SPICE:
     this->dcm_PN = cArray2EigenMatrix3d(*this->planetInMsgBuffer.J20002Pfix);
     this->dcm_PN_dot = cArray2EigenMatrix3d(*this->planetInMsgBuffer.J20002Pfix_dot);
@@ -175,21 +172,24 @@ void GroundMapping::updateInertialPositions()
     this->dcm_NB = cArray2EigenMatrixXd(*dcm_BN, 3, 3);
 
     // Get planet frame angular velocity vector
-    Eigen::Matrix3d w_tilde_PN = - this->dcm_PN_dot * this->dcm_PN.transpose();
-    this->w_PN << w_tilde_PN(2,1), w_tilde_PN(0,2), w_tilde_PN(1,0);
+    Eigen::Matrix3d w_tilde_PN = -this->dcm_PN_dot * this->dcm_PN.transpose();
+    this->w_PN << w_tilde_PN(2, 1), w_tilde_PN(0, 2), w_tilde_PN(1, 0);
 }
 
 /*! Method to compute whether or not the mapping point is in the instrument's FOV
  */
-uint64_t GroundMapping::checkInstrumentFOV(){
+uint64_t GroundMapping::checkInstrumentFOV() {
     /* Compute the projection of the mapping point along the instrument's boresight */
-    double boresightNormalProj = ((this->r_LP_N - (this->r_BP_N + this->dcm_NB*cameraPos_B)).transpose())*(dcm_NB*this->nHat_B);
+    double boresightNormalProj =
+        ((this->r_LP_N - (this->r_BP_N + this->dcm_NB * cameraPos_B)).transpose()) * (dcm_NB * this->nHat_B);
 
     /* Check that the normal projection is within the maximum range*/
-    if ((boresightNormalProj >= 0) && (boresightNormalProj <= this->maximumRange)){
+    if ((boresightNormalProj >= 0) && (boresightNormalProj <= this->maximumRange)) {
         /* Compute the radius of the instrument's cone at the projection distance */
-        double coneRadius = boresightNormalProj*tan(this->halfFieldOfView);
-        double orthDistance = (this->r_LP_N - (this->r_BP_N + this->dcm_NB*cameraPos_B)  - boresightNormalProj*dcm_NB*this->nHat_B).norm();
+        double coneRadius = boresightNormalProj * tan(this->halfFieldOfView);
+        double orthDistance =
+            (this->r_LP_N - (this->r_BP_N + this->dcm_NB * cameraPos_B) - boresightNormalProj * dcm_NB * this->nHat_B)
+                .norm();
         /* Check that the orthogonal distance is less than the cone radius */
         if (orthDistance < coneRadius) {
             return 1;
@@ -198,28 +198,26 @@ uint64_t GroundMapping::checkInstrumentFOV(){
         }
     }
     /* If the first condition does not pass, return 0 */
-    else{
+    else {
         return 0;
     }
 }
 
 /*! write module messages
-*/
-void GroundMapping::WriteMessages(uint64_t CurrentClock)
-{
+ */
+void GroundMapping::WriteMessages(uint64_t CurrentClock) {
     //! - write access message for each spacecraft
-    for (long unsigned int c=0; c< this->accessMsgBuffer.size(); c++) {
+    for (long unsigned int c = 0; c < this->accessMsgBuffer.size(); c++) {
         this->accessOutMsgs.at(c)->write(&this->accessMsgBuffer.at(c), this->moduleID, CurrentClock);
-        this->currentGroundStateOutMsgs.at(c)->write(&this->currentGroundStateMsgBuffer.at(c), this->moduleID, CurrentClock);
+        this->currentGroundStateOutMsgs.at(c)->write(
+            &this->currentGroundStateMsgBuffer.at(c), this->moduleID, CurrentClock);
     }
-
 }
 
 /*! This is the main method that gets called every time the module is updated.  Provide an appropriate description.
     @return void
 */
-void GroundMapping::updateState(uint64_t currentSimNanos)
-{
+void GroundMapping::updateState(uint64_t currentSimNanos) {
     // Read messages
     this->ReadMessages();
 

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -22,6 +22,7 @@
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 #include <iostream>
 #include <math.h>
 

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -18,27 +18,26 @@
  */
 
 #include "magneticFieldWMM.h"
+#include "EGM9615.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/safeMath.h"
-#include "EGM9615.h"
 
-/*! The constructor method initializes the dipole parameters to zero, resuling in a zero magnetic field result by default.
+/*! The constructor method initializes the dipole parameters to zero, resuling in a zero magnetic field result by
+ default.
  @return void
  */
-MagneticFieldWMM::MagneticFieldWMM()
-{
+MagneticFieldWMM::MagneticFieldWMM() {
     //! - Set the default magnetic field properties
-    this->planetRadius = REQ_EARTH*1000.;   // must be the radius of Earth for WMM
-    this->magneticModels[0] = nullptr;      // a nullptr means no WMM coefficients have been loaded
-    this->epochDateFractionalYear = -1;     // negative value means this variable has not been set
+    this->planetRadius = REQ_EARTH * 1000.;  // must be the radius of Earth for WMM
+    this->magneticModels[0] = nullptr;       // a nullptr means no WMM coefficients have been loaded
+    this->epochDateFractionalYear = -1;      // negative value means this variable has not been set
 }
 
 /*! Clean up any memory allocations.
  @return void
  */
-MagneticFieldWMM::~MagneticFieldWMM()
-{
+MagneticFieldWMM::~MagneticFieldWMM() {
     if (this->magneticModels[0] != nullptr) {
         cleanupEarthMagFieldModel();
     }
@@ -47,8 +46,7 @@ MagneticFieldWMM::~MagneticFieldWMM()
 /*! Custom reset() method.  This loads the WMM coefficient file and gets the model setup.
  @return void
  */
-void MagneticFieldWMM::customreset(uint64_t CurrentClock)
-{
+void MagneticFieldWMM::customreset(uint64_t CurrentClock) {
     if (this->magneticModels[0] != nullptr) {
         /* clean up the prior initialization */
         cleanupEarthMagFieldModel();
@@ -56,7 +54,7 @@ void MagneticFieldWMM::customreset(uint64_t CurrentClock)
     }
 
     //! - Check that required module variables are set
-    if(this->dataPath == "") {
+    if (this->dataPath == "") {
         bskLogger.bskLog(BSK_ERROR, "WMM data path was not set.  No WMM.");
         return;
     }
@@ -65,12 +63,13 @@ void MagneticFieldWMM::customreset(uint64_t CurrentClock)
     initializeWmm();
 }
 
-/*! Custom customSetEpochFromVariable() method.  This allows specifying epochDateFractionYear directly from Python.  If an epoch message is set then this variable is not used.
+/*! Custom customSetEpochFromVariable() method.  This allows specifying epochDateFractionYear directly from Python.  If
+ an epoch message is set then this variable is not used.
  @return void
  */
-void MagneticFieldWMM::customSetEpochFromVariable()
-{
-    //! - only convert if the fraction year variable was set to a non-zero value.  Otherwise use the BSK epoch default setup by the base class.
+void MagneticFieldWMM::customSetEpochFromVariable() {
+    //! - only convert if the fraction year variable was set to a non-zero value.  Otherwise use the BSK epoch default
+    //! setup by the base class.
     if (this->epochDateFractionalYear > 0.0) {
         decimalYear2Gregorian(this->epochDateFractionalYear, &this->epochDateTime);
     }
@@ -79,8 +78,7 @@ void MagneticFieldWMM::customSetEpochFromVariable()
 /*! Convert a fraction year double value into a time structure with gregorian date/time information
  @return void
  */
-void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *gregorian)
-{
+void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *gregorian) {
     //! -Use the WMM routine to get the year, month and day information
     MAGtype_Date calendar;
     char Error[255];
@@ -93,21 +91,20 @@ void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *g
     //! - Find the unused remained of the fractional year and add to the gregorian calendar
     //! - determine number of days in this year
     double daysInYear = 365;
-    if((calendar.Year % 4 == 0 && calendar.Year % 100 != 0) || calendar.Year % 400 == 0)
-        daysInYear = 366;
+    if ((calendar.Year % 4 == 0 && calendar.Year % 100 != 0) || calendar.Year % 400 == 0) daysInYear = 366;
 
     //! - determine missing hours
     MAG_DateToYear(&calendar, Error);
     double diff = this->epochDateFractionalYear - calendar.DecimalYear;
-    this->epochDateTime.tm_hour = (int) round(diff * (24. * daysInYear));
-    diff -= this->epochDateTime.tm_hour / ( 24. * daysInYear);
+    this->epochDateTime.tm_hour = (int)round(diff * (24. * daysInYear));
+    diff -= this->epochDateTime.tm_hour / (24. * daysInYear);
 
     //! - determine missing minutes
-    this->epochDateTime.tm_min = (int) round(diff * (24. * 60 * daysInYear));
+    this->epochDateTime.tm_min = (int)round(diff * (24. * 60 * daysInYear));
     diff -= this->epochDateTime.tm_min / (24. * 60 * daysInYear);
 
     //! - determine missing seconds
-    this->epochDateTime.tm_sec = (int) round(diff * (24. * 60 * 60 * daysInYear));
+    this->epochDateTime.tm_sec = (int)round(diff * (24. * 60 * 60 * daysInYear));
 
     //! - ensure that daylight saving flag is off
     this->epochDateTime.tm_isdst = 0;
@@ -119,29 +116,27 @@ void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *g
 /*! Convert a time structure with gregorian date/time information into a fraction year value.
  @return double
  */
-double MagneticFieldWMM::gregorian2DecimalYear(double currentTime)
-{
-    double decimalYear;                 // [years]  fraction year date/time format
-    struct tm localDateTime{};            // []       date/time structure
+double MagneticFieldWMM::gregorian2DecimalYear(double currentTime) {
+    double decimalYear;         // [years]  fraction year date/time format
+    struct tm localDateTime{};  // []       date/time structure
 
     //! - compute current decimalYear value
     MAGtype_Date calendar;
     char Error_Message[255];
     localDateTime = this->epochDateTime;
-    localDateTime.tm_sec += (int) round(currentTime);   // sets the current seconds
+    localDateTime.tm_sec += (int)round(currentTime);  // sets the current seconds
     mktime(&localDateTime);
 
     calendar.Year = localDateTime.tm_year + 1900;
     calendar.Month = localDateTime.tm_mon + 1;
     calendar.Day = localDateTime.tm_mday;
-    if (!MAG_DateToYear(&calendar, Error_Message)){
+    if (!MAG_DateToYear(&calendar, Error_Message)) {
         bskLogger.bskLog(BSK_ERROR, "Could not convert date to decimal year. \nError message: %s", Error_Message);
     }
 
     //! - determine number of days in this year
     double daysInYear = 365;
-    if((calendar.Year % 4 == 0 && calendar.Year % 100 != 0) || calendar.Year % 400 == 0)
-        daysInYear = 366;
+    if ((calendar.Year % 4 == 0 && calendar.Year % 100 != 0) || calendar.Year % 400 == 0) daysInYear = 366;
 
     decimalYear = calendar.DecimalYear;
     decimalYear += localDateTime.tm_hour / (24. * daysInYear);
@@ -156,17 +151,16 @@ double MagneticFieldWMM::gregorian2DecimalYear(double currentTime)
  @param currentTime current time (s)
  @return void
  */
-void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, double currentTime)
-{
-    Eigen::Vector3d rHat_P;             // []    normalized position vector in E frame components
-    double phi;                         // [rad] latitude
-    double lambda;                      // [rad] longitude
-    double h;                           // [m]   height above geoid
-    double PM[3][3];                    // []    DCM from magnetic field frame to planet frame P
-    double NM[3][3];                    // []    DCM from magnetic field frame to inertial frame N
-    double B_M[3];                      // [T]   magnetic field in Magnetic field aligned frame
-    double M2[3][3];                    // []    2nd axis rotation DCM
-    double M3[3][3];                    // []    3rd axis rotation DCM
+void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, double currentTime) {
+    Eigen::Vector3d rHat_P;  // []    normalized position vector in E frame components
+    double phi;              // [rad] latitude
+    double lambda;           // [rad] longitude
+    double h;                // [m]   height above geoid
+    double PM[3][3];         // []    DCM from magnetic field frame to planet frame P
+    double NM[3][3];         // []    DCM from magnetic field frame to inertial frame N
+    double B_M[3];           // [T]   magnetic field in Magnetic field aligned frame
+    double M2[3][3];         // []    2nd axis rotation DCM
+    double M3[3][3];         // []    3rd axis rotation DCM
 
     if (this->magneticModels[0] == nullptr) {
         // no magnetic field was setup, set field to zero and return
@@ -180,7 +174,7 @@ void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, 
     //! - compute spacecraft latitude and longitude
     phi = safeAsin(rHat_P[2]);
     lambda = atan2(rHat_P[1], rHat_P[0]);
-    h = (this->orbitRadius - this->planetRadius)/1000.; /* must be in km */
+    h = (this->orbitRadius - this->planetRadius) / 1000.; /* must be in km */
 
     //! - evaluate NED magnetic field
     computeWmmField(gregorian2DecimalYear(currentTime), phi, lambda, h, B_M);
@@ -196,23 +190,21 @@ void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, 
 /*! Performs memory cleanup necessary for magnetic field models
  @return void
  */
-void MagneticFieldWMM::cleanupEarthMagFieldModel()
-{
+void MagneticFieldWMM::cleanupEarthMagFieldModel() {
     MAG_FreeMagneticModelMemory(timedMagneticModel);
     MAG_FreeMagneticModelMemory(magneticModels[0]);
 }
 
-void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double lambda, double h, double B_M[3])
-{
-    MAGtype_CoordSpherical      coordSpherical{};
-    MAGtype_CoordGeodetic       coordGeodetic{};
+void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double lambda, double h, double B_M[3]) {
+    MAGtype_CoordSpherical coordSpherical{};
+    MAGtype_CoordGeodetic coordGeodetic{};
     MAGtype_GeoMagneticElements geoMagneticElements{};
     MAGtype_GeoMagneticElements errors{};
 
     this->userDate.DecimalYear = decimalYear;
 
     /* set the Geodetic coordinates of the satellite */
-    coordGeodetic.phi = phi * R2D; /* degrees North */
+    coordGeodetic.phi = phi * R2D;       /* degrees North */
     coordGeodetic.lambda = lambda * R2D; /* degrees East  */
     /* If height is given above WGS-84 */
     coordGeodetic.HeightAboveEllipsoid = h; /* km */
@@ -233,26 +225,23 @@ void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double la
     v3Scale(1e-9, B_M, B_M); /* convert nano-Tesla to Tesla */
 }
 
-void MagneticFieldWMM::initializeWmm()
-{
+void MagneticFieldWMM::initializeWmm() {
     int nMax = 0;
     int nTerms;
     auto fileName = this->dataPath + "WMM.COF";
 
-    if (!MAG_robustReadMagModels(const_cast<char*>(fileName.c_str()),
-                                 &(this->magneticModels),
-                                 1)) {
+    if (!MAG_robustReadMagModels(const_cast<char *>(fileName.c_str()), &(this->magneticModels), 1)) {
         bskLogger.bskLog(BSK_ERROR, "WMM unable to load file %s", fileName.c_str());
         return;
     }
 
-    if(nMax < magneticModels[0]->nMax) {
+    if (nMax < magneticModels[0]->nMax) {
         nMax = magneticModels[0]->nMax;
     }
     nTerms = ((nMax + 1) * (nMax + 2) / 2);
     /* For storing the time modified WMM Model parameters */
     this->timedMagneticModel = MAG_AllocateModelMemory(nTerms);
-    if(this->magneticModels[0] == nullptr || this->timedMagneticModel == nullptr) {
+    if (this->magneticModels[0] == nullptr || this->timedMagneticModel == nullptr) {
         MAG_Error(2);
     }
     /* Set default values and constants */

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -20,6 +20,7 @@
 #include "magneticFieldWMM.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 #include "EGM9615.h"
 
 /*! The constructor method initializes the dipole parameters to zero, resuling in a zero magnetic field result by default.

--- a/src/simulation/environment/spacecraftLocation/spacecraftLocation.cpp
+++ b/src/simulation/environment/spacecraftLocation/spacecraftLocation.cpp
@@ -23,12 +23,10 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/safeMath.h"
 
-
 /*! @brief Creates an instance of the SpacecraftLocation class
  @return void
  */
-SpacecraftLocation::SpacecraftLocation()
-{
+SpacecraftLocation::SpacecraftLocation() {
     this->rEquator = -1.0;
     this->rPolar = -1.0;
     this->maximumRange = -1.0;
@@ -41,25 +39,24 @@ SpacecraftLocation::SpacecraftLocation()
     this->planetState.J20002Pfix[0][0] = 1;
     this->planetState.J20002Pfix[1][1] = 1;
     this->planetState.J20002Pfix[2][2] = 1;
-
 }
 
 /*! Empty destructor method.
  @return void
  */
-SpacecraftLocation::~SpacecraftLocation()
-{
-    for (long unsigned int c=0; c<this->accessOutMsgs.size(); c++) {
+SpacecraftLocation::~SpacecraftLocation() {
+    for (long unsigned int c = 0; c < this->accessOutMsgs.size(); c++) {
         delete this->accessOutMsgs.at(c);
     }
     return;
 }
 
 /*! Resets the internal position to the specified initial position.*/
-void SpacecraftLocation::reset(uint64_t currentSimNanos)
-{
+void SpacecraftLocation::reset(uint64_t currentSimNanos) {
     if (this->scStateInMsgs.size() == 0) {
-        bskLogger.bskLog(BSK_ERROR, "SpacecraftLocation module must have at least one spacecraft added through `addSpacecraftToModel`");
+        bskLogger.bskLog(
+            BSK_ERROR,
+            "SpacecraftLocation module must have at least one spacecraft added through `addSpacecraftToModel`");
     }
 
     if (!this->primaryScStateInMsg.isLinked()) {
@@ -70,12 +67,12 @@ void SpacecraftLocation::reset(uint64_t currentSimNanos)
         bskLogger.bskLog(BSK_ERROR, "SpacecraftLocation rEquator must be set to the planet equatorial radius");
     }
     /* if the polar radius is not specified, then it is set equal to the equatorial radius */
-    if (this->rEquator > 0.0 && this->rPolar<0.0) {
+    if (this->rEquator > 0.0 && this->rPolar < 0.0) {
         this->rPolar = rEquator;
     }
     this->zScale = this->rEquator / this->rPolar;
 
-    if (this->aHat_B.norm() > 0.1 ) {
+    if (this->aHat_B.norm() > 0.1) {
         if (this->theta < 0.0) {
             bskLogger.bskLog(BSK_ERROR, "SpacecraftLocation must set theta if you specify aHat_B");
         }
@@ -83,11 +80,10 @@ void SpacecraftLocation::reset(uint64_t currentSimNanos)
     }
 }
 
-
-/*! Adds a scState message name to the vector of names to be subscribed to. Also creates a corresponding access message output name.
-*/
-void SpacecraftLocation::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg)
-{
+/*! Adds a scState message name to the vector of names to be subscribed to. Also creates a corresponding access message
+ * output name.
+ */
+void SpacecraftLocation::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpScMsg) {
     this->scStateInMsgs.push_back(tmpScMsg->addSubscriber());
 
     /* create output message */
@@ -100,11 +96,9 @@ void SpacecraftLocation::addSpacecraftToModel(Message<SCStatesMsgPayload> *tmpSc
     this->accessMsgBuffer.push_back(accMsg);
 }
 
-
 /*! Read module messages
-*/
-bool SpacecraftLocation::ReadMessages()
-{
+ */
+bool SpacecraftLocation::ReadMessages() {
     SCStatesMsgPayload scMsg;
 
     /* clear out the vector of spacecraft states.  This is created freshly below. */
@@ -116,8 +110,7 @@ bool SpacecraftLocation::ReadMessages()
 
     // read in the spacecraft state messages
     bool scRead;
-    if(!this->scStateInMsgs.empty())
-    {
+    if (!this->scStateInMsgs.empty()) {
         scRead = true;
         for (long unsigned int c = 0; c < this->scStateInMsgs.size(); c++) {
             scMsg = this->scStateInMsgs.at(c)();
@@ -128,32 +121,30 @@ bool SpacecraftLocation::ReadMessages()
         bskLogger.bskLog(BSK_ERROR, "Spacecraft location has no other spacecraft to track.");
         scRead = false;
     }
-    //! - Read in the optional planet message.  if no planet message is set, then a zero planet position, velocity and orientation is assumed
+    //! - Read in the optional planet message.  if no planet message is set, then a zero planet position, velocity and
+    //! orientation is assumed
     bool planetRead = true;
-    if(this->planetInMsg.isLinked())
-    {
+    if (this->planetInMsg.isLinked()) {
         planetRead = this->planetInMsg.isWritten();
         this->planetState = this->planetInMsg();
     }
 
-    return(planetRead && scRead);
+    return (planetRead && scRead);
 }
 
 /*! write module messages
-*/
-void SpacecraftLocation::WriteMessages(uint64_t CurrentClock)
-{
+ */
+void SpacecraftLocation::WriteMessages(uint64_t CurrentClock) {
     //! - write access message for each spacecraft
-    for (long unsigned int c=0; c< this->accessMsgBuffer.size(); c++) {
+    for (long unsigned int c = 0; c < this->accessMsgBuffer.size(); c++) {
         this->accessOutMsgs.at(c)->write(&this->accessMsgBuffer.at(c), this->moduleID, CurrentClock);
     }
 }
 
 /*! compute the spacecraft to spacecraft access messages
  */
-void SpacecraftLocation::computeAccess()
-{
-    Eigen::Vector3d r_LP_P; //!< [m] spacecraft Location relative to planet origin vector
+void SpacecraftLocation::computeAccess() {
+    Eigen::Vector3d r_LP_P;  //!< [m] spacecraft Location relative to planet origin vector
 
     // get planet position and orientation relative to inertial frame
     this->dcm_PN = cArray2EigenMatrix3d(*this->planetState.J20002Pfix);
@@ -168,10 +159,10 @@ void SpacecraftLocation::computeAccess()
     r_LP_P[2] = r_LP_P[2] * this->zScale;
 
     // compute other spacecraft positions relative to planet
-    for (long unsigned int c=0; c < this->scStateInMsgs.size(); c++) {
-        Eigen::Vector3d r_SN_N;     // other satellite position relative to inertial
-        Eigen::Vector3d r_SP_P;     // other satellite position relative to planet
-        Eigen::Vector3d r_SL_P;     // other satellite position relative to primary spacecraft location L
+    for (long unsigned int c = 0; c < this->scStateInMsgs.size(); c++) {
+        Eigen::Vector3d r_SN_N;  // other satellite position relative to inertial
+        Eigen::Vector3d r_SP_P;  // other satellite position relative to planet
+        Eigen::Vector3d r_SL_P;  // other satellite position relative to primary spacecraft location L
 
         r_SN_N = cArray2EigenVector3d(this->scStatesBuffer.at(c).r_BN_N);
         r_SP_P = this->dcm_PN * (r_SN_N - this->r_PN_N);
@@ -182,13 +173,13 @@ void SpacecraftLocation::computeAccess()
         r_SL_P = r_SP_P - r_LP_P;
 
         // compute point of closest approach
-        double param;               // line scaling parameter
-        param = - r_LP_P.dot(r_SL_P)/r_SL_P.dot(r_SL_P);
+        double param;  // line scaling parameter
+        param = -r_LP_P.dot(r_SL_P) / r_SL_P.dot(r_SL_P);
         Eigen::Vector3d rClose = r_LP_P + param * r_SL_P;
 
         // check for out of bounds condition.
-        param = std::min(param, 1.0); // If param > 1, the closest point on segment is the other satellite
-        param = std::max(param, 0.0); // If param < 0, the closest point on segment is the primary satellite
+        param = std::min(param, 1.0);  // If param > 1, the closest point on segment is the other satellite
+        param = std::max(param, 0.0);  // If param < 0, the closest point on segment is the primary satellite
 
         // determine access output message
         this->accessMsgBuffer.at(c) = this->accessOutMsgs.at(c)->zeroMsgPayload;
@@ -205,8 +196,8 @@ void SpacecraftLocation::computeAccess()
 
             // check if other spacecraft is within sensor/communication boresight axis
             if (this->theta > 0.0) {
-                Eigen::Vector3d aHat_P;     // sensor axis in planet frame components
-                double phi;                 // angle between relative positin vector and aHat
+                Eigen::Vector3d aHat_P;  // sensor axis in planet frame components
+                double phi;              // angle between relative positin vector and aHat
                 aHat_P = this->dcm_PN * dcm_NB * this->aHat_B;
                 phi = safeAcos(r_SL_P.dot(aHat_P) / range);
                 this->accessMsgBuffer.at(c).elevation = M_PI_2 - phi;
@@ -223,10 +214,8 @@ void SpacecraftLocation::computeAccess()
  update module
  @param currentSimNanos
  */
-void SpacecraftLocation::updateState(uint64_t currentSimNanos)
-{
+void SpacecraftLocation::updateState(uint64_t currentSimNanos) {
     this->ReadMessages();
     this->computeAccess();
     this->WriteMessages(currentSimNanos);
-
 }

--- a/src/simulation/environment/spacecraftLocation/spacecraftLocation.cpp
+++ b/src/simulation/environment/spacecraftLocation/spacecraftLocation.cpp
@@ -18,11 +18,11 @@
  */
 
 #include "simulation/environment/spacecraftLocation/spacecraftLocation.h"
+#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/safeMath.h"
 
-#include <iostream>
 
 /*! @brief Creates an instance of the SpacecraftLocation class
  @return void

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
@@ -23,15 +23,14 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/safeMath.h"
-#include <iostream>
 #include <math.h>
+#include <iostream>
 
-
-/*! @brief Creates an instance of the PinholeCamera class with a prescribed focal direction in camera frame and -90º of Sun's mask angle (that is, no lighting constraint).
+/*! @brief Creates an instance of the PinholeCamera class with a prescribed focal direction in camera frame and -90º of
+ Sun's mask angle (that is, no lighting constraint).
  @return void
  */
-PinholeCamera::PinholeCamera()
-{
+PinholeCamera::PinholeCamera() {
     /* Set focal direction to be +z axis in camera frame */
     this->eC_C << 0, 0, 1;
 
@@ -42,18 +41,15 @@ PinholeCamera::PinholeCamera()
 /*! Empty destructor method.
  @return void
  */
-PinholeCamera::~PinholeCamera()
-{
-    for (long unsigned int i = 0; i < this->landmarkOutMsgs.size(); i++){
+PinholeCamera::~PinholeCamera() {
+    for (long unsigned int i = 0; i < this->landmarkOutMsgs.size(); i++) {
         delete this->landmarkOutMsgs.at(i);
     }
     return;
 }
 
-
 /*! Resets the module.*/
-void PinholeCamera::reset(uint64_t currentSimNanos)
-{
+void PinholeCamera::reset(uint64_t currentSimNanos) {
     /* Get number of landmarks */
     this->n = int(this->r_LP_P.size());
 
@@ -66,21 +62,21 @@ void PinholeCamera::reset(uint64_t currentSimNanos)
     }
 
     /* Compute field of view */
-    this->FOVx = 2 * atan2(this->nxPixel*this->wPixel, 2*this->f);
-    this->FOVy = 2 * atan2(this->nyPixel*this->wPixel, 2*this->f);
+    this->FOVx = 2 * atan2(this->nxPixel * this->wPixel, 2 * this->f);
+    this->FOVy = 2 * atan2(this->nyPixel * this->wPixel, 2 * this->f);
 }
 
 /*! Method to add landmarks
  * @param pos: landmark position in planet-rotating frame
  * @param normal: landmark surface normal in planet-rotating frame
  */
-void PinholeCamera::addLandmark(Eigen::Vector3d& pos, Eigen::Vector3d& normal){
+void PinholeCamera::addLandmark(Eigen::Vector3d& pos, Eigen::Vector3d& normal) {
     /* Add the landmark position and surface normal */
     this->r_LP_P.push_back(pos);
     this->nL_P.push_back(normal);
 
     /* Create buffer output messages */
-    Message<LandmarkMsgPayload> *msg;
+    Message<LandmarkMsgPayload>* msg;
     msg = new Message<LandmarkMsgPayload>;
     this->landmarkOutMsgs.push_back(msg);
 
@@ -90,9 +86,8 @@ void PinholeCamera::addLandmark(Eigen::Vector3d& pos, Eigen::Vector3d& normal){
 }
 
 /*! Loop through landmarks
-*/
-void PinholeCamera::loopLandmarks()
-{
+ */
+void PinholeCamera::loopLandmarks() {
     /* Define ith landmark position, surface normal, camera pixel
      and field of view/lighting flags */
     Eigen::Vector3d rLmk, nLmk;
@@ -104,7 +99,7 @@ void PinholeCamera::loopLandmarks()
     this->pixelLmk.setZero(this->n, 2);
 
     /* Loop through landmarks */
-    for (int i = 0; i < this->n; i++){
+    for (int i = 0; i < this->n; i++) {
         /* Extract ith landmark position and its normal */
         rLmk = this->r_LP_P[i];
         nLmk = this->nL_P[i];
@@ -115,27 +110,25 @@ void PinholeCamera::loopLandmarks()
         flagLighting = this->checkLighting(nLmk);
 
         /* Add pixel */
-        if (flagFOV && flagLighting){
+        if (flagFOV && flagLighting) {
             this->pixelLmk.row(i) = pLmk;
             this->isvisibleLmk(i) = 1;
         }
     }
 }
 
-
 /*! Check lighting condition of a landmark
  * @param nLmk: landmark surface normal in planet-rotating frame
-*/
-bool PinholeCamera::checkLighting(Eigen::Vector3d nLmk)
-{
+ */
+bool PinholeCamera::checkLighting(Eigen::Vector3d nLmk) {
     /* Compute Sun's incident angle */
     double angleSun;
-    angleSun = M_PI_2 - safeAcos(nLmk.dot(this->e_SP_P) / (this->e_SP_P.norm()*nLmk.norm()));
+    angleSun = M_PI_2 - safeAcos(nLmk.dot(this->e_SP_P) / (this->e_SP_P.norm() * nLmk.norm()));
 
     /* Check if the landmark is illuminated */
     bool flagLighting;
     flagLighting = false;
-    if (angleSun > this->maskSun){
+    if (angleSun > this->maskSun) {
         /* Set lighting condition to true */
         flagLighting = true;
     }
@@ -147,8 +140,8 @@ bool PinholeCamera::checkLighting(Eigen::Vector3d nLmk)
  * @param pLmk: landmark pixel
  * @param rLmk: landmark position in planet-rotating frame
  * @param nLmk: landmark surface normal in planet-rotating frame
-*/
-bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::Vector3d nLmk){
+ */
+bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::Vector3d nLmk) {
     /* Define relative position from landmark to spacecraft and its unit-vector */
     Eigen::Vector3d dr, eLmk_P;
     dr = this->r_BP_P - rLmk;
@@ -161,13 +154,13 @@ bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::
     bool flagFOV;
     flagFOV = false;
     double angleFOV1, angleFOV2;
-    angleFOV1 = M_PI_2 - safeAcos(-this->eC_P.dot(eLmk_P) / (this->eC_P.norm()*eLmk_P.norm()));
-    angleFOV2 = M_PI_2 - safeAcos(-this->eC_P.dot(nLmk) / (this->eC_P.norm()*nLmk.norm()));
+    angleFOV1 = M_PI_2 - safeAcos(-this->eC_P.dot(eLmk_P) / (this->eC_P.norm() * eLmk_P.norm()));
+    angleFOV2 = M_PI_2 - safeAcos(-this->eC_P.dot(nLmk) / (this->eC_P.norm() * nLmk.norm()));
 
     /* If both angles are positive */
-    if (angleFOV1 > 0 && angleFOV2 > 0){
+    if (angleFOV1 > 0 && angleFOV2 > 0) {
         /* Check if landmark actually falls within camera field of view*/
-        if ((abs(2*pLmk(0)) <= this->nxPixel) && (abs(2*pLmk(1)) <= this->nyPixel)){
+        if ((abs(2 * pLmk(0)) <= this->nxPixel) && (abs(2 * pLmk(1)) <= this->nyPixel)) {
             /* Set field of view flag to true */
             flagFOV = true;
         }
@@ -178,9 +171,8 @@ bool PinholeCamera::checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::
 
 /*! Compute pixel from 3D coordinates
  * @param rLmk: landmark position in planet-rotating frame
-*/
-Eigen::Vector2i PinholeCamera::computePixel(Eigen::Vector3d rLmk)
-{
+ */
+Eigen::Vector2i PinholeCamera::computePixel(Eigen::Vector3d rLmk) {
     /* Compute relative distance between landmark and spacecraft
      in camera frame */
     Eigen::Vector3d dr;
@@ -193,22 +185,18 @@ Eigen::Vector2i PinholeCamera::computePixel(Eigen::Vector3d rLmk)
     v = this->f * dr(1) / (dr(2) * this->wPixel);
 
     /* Apply pixelization */
-    if (u > 0){
+    if (u > 0) {
         p(0) = int(ceil(u));
-    }
-    else if (u < 0){
+    } else if (u < 0) {
         p(0) = int(floor(u));
-    }
-    else{
+    } else {
         p(0) = 1;
     }
-    if (v > 0){
+    if (v > 0) {
         p(1) = int(ceil(v));
-    }
-    else if (v < 0){
+    } else if (v < 0) {
         p(1) = int(floor(v));
-    }
-    else{
+    } else {
         p(1) = 1;
     }
 
@@ -216,9 +204,8 @@ Eigen::Vector2i PinholeCamera::computePixel(Eigen::Vector3d rLmk)
 }
 
 /*! Process input messages to module variables
-*/
-void PinholeCamera::processInputs()
-{
+ */
+void PinholeCamera::processInputs() {
     /* Extract planet dcm */
     double dcm_PN_array[3][3];
     MRP2C(this->ephemerisPlanet.sigma_BN, dcm_PN_array);
@@ -230,7 +217,8 @@ void PinholeCamera::processInputs()
     this->e_SP_P = this->dcm_PN * (-r_PS_N / r_PS_N.norm());
 
     /* Compute spacecraft position in the planet rotating frame P */
-    this->r_BP_P = this->dcm_PN * (cArray2EigenVector3d(this->spacecraftState.r_BN_N) -  cArray2EigenVector3d(this->ephemerisPlanet.r_BdyZero_N));
+    this->r_BP_P = this->dcm_PN * (cArray2EigenVector3d(this->spacecraftState.r_BN_N) -
+                                   cArray2EigenVector3d(this->ephemerisPlanet.r_BdyZero_N));
 
     /* Compute spacecraft dcm with respect to planet rotating frame */
     double dcm_BN_array[3][3];
@@ -238,24 +226,22 @@ void PinholeCamera::processInputs()
     this->dcm_BP = cArray2EigenMatrix3d(*dcm_BN_array) * this->dcm_PN.transpose();
 
     /* Camera focal direction in planet frame */
-    this->eC_P = (this->dcm_CB * this->dcm_BP).transpose()*this->eC_C;
+    this->eC_P = (this->dcm_CB * this->dcm_BP).transpose() * this->eC_C;
 }
 
 /*! Read module input messages
-*/
-void PinholeCamera::readInputMessages()
-{
+ */
+void PinholeCamera::readInputMessages() {
     /* Read planet ephemeris and spacecraft state messages */
     this->ephemerisPlanet = this->ephemerisInMsg();
     this->spacecraftState = this->scStateInMsg();
 }
 
 /*! Write module output messages
-*/
-void PinholeCamera::writeOutputMessages(uint64_t CurrentClock)
-{
+ */
+void PinholeCamera::writeOutputMessages(uint64_t CurrentClock) {
     /* Loop through landmarks */
-    for (int i = 0; i < this->n; i++){
+    for (int i = 0; i < this->n; i++) {
         /* Zero the output message buffers */
         this->landmarkMsgBuffer.at(i) = this->landmarkOutMsgs.at(i)->zeroMsgPayload;
 
@@ -266,13 +252,11 @@ void PinholeCamera::writeOutputMessages(uint64_t CurrentClock)
     }
 }
 
-
 /*!
  Update module
  @param currentSimNanos
  */
-void PinholeCamera::updateState(uint64_t currentSimNanos)
-{
+void PinholeCamera::updateState(uint64_t currentSimNanos) {
     /* Read messages */
     this->readInputMessages();
 
@@ -292,15 +276,18 @@ void PinholeCamera::updateState(uint64_t currentSimNanos)
  * @param mrpBatch_BP: batch of spacecraft MRPs w.r.t. planet-rotating frame
  * @param eBatch_SP_P: batch unit-vectors from planet to Sun in planet-rotating frame
  * @param show_progress: boolean variable that prints batch processing status when true
-*/
-void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mrpBatch_BP, Eigen::MatrixXd eBatch_SP_P, bool show_progress){
+ */
+void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P,
+                                 Eigen::MatrixXd mrpBatch_BP,
+                                 Eigen::MatrixXd eBatch_SP_P,
+                                 bool show_progress) {
     /* Obtain number of samples in the batch to be processed */
     int nBatch;
     nBatch = int(rBatch_BP_P.rows());
 
     /* Preallocate batches of pixel landmarks and visibility status. These
      are the variables the user should extract */
-    this->pixelBatchLmk.setZero(nBatch, 2*this->n);
+    this->pixelBatchLmk.setZero(nBatch, 2 * this->n);
     this->isvisibleBatchLmk.setZero(nBatch, this->n);
 
     /* Define direction cosine matrix and MRP of the spacecraft body
@@ -309,16 +296,16 @@ void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mr
     double mrp_BP[3];
 
     /* Print initialization */
-    if (show_progress){
+    if (show_progress) {
         std::cout << "--- Initialization of loop through " << nBatch << " samples ---" << '\n';
     }
 
     /* Loop through batch */
-    for (int i = 0; i < nBatch; i++){
+    for (int i = 0; i < nBatch; i++) {
         /* Print progress after each 5% of the batch is completed */
-        if (show_progress){
-            if (i % (int(nBatch/20)) == 0){
-                std::cout << i / (int(nBatch/100)) << "% completed" << '\n';
+        if (show_progress) {
+            if (i % (int(nBatch / 20)) == 0) {
+                std::cout << i / (int(nBatch / 100)) << "% completed" << '\n';
             }
         }
 
@@ -333,7 +320,7 @@ void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mr
         this->dcm_BP = cArray2EigenMatrix3d(*dcm_BP_array);
 
         /* Compute camera focal direction in planet frame */
-        this->eC_P = (this->dcm_CB * this->dcm_BP).transpose()*this->eC_C;
+        this->eC_P = (this->dcm_CB * this->dcm_BP).transpose() * this->eC_C;
 
         /* Loop through landmarks */
         this->loopLandmarks();
@@ -345,7 +332,7 @@ void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mr
     }
 
     /* Declare initialization */
-    if (show_progress){
+    if (show_progress) {
         std::cout << "--- Batch has been processed ---" << '\n';
     }
 }

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
@@ -18,9 +18,11 @@
  */
 
 #include "pinholeCamera.h"
+#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/safeMath.h"
 #include <iostream>
 #include <math.h>
 

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.h
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.h
@@ -21,16 +21,16 @@
 #ifndef PINHOLE_CAMERA_H
 #define PINHOLE_CAMERA_H
 
-#include <Eigen/Dense>
-#include <vector>
-#include <string>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/LandmarkMsgPayload.h"
-#include "architecture/messaging/messaging.h"
-#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/bskLogging.h"
+
+#include <Eigen/Dense>
+#include <vector>
+#include <string>
 
 /*! @brief Pinhole camera class */
 class PinholeCamera:  public SysModel {

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.h
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.h
@@ -17,24 +17,23 @@
 
  */
 
-
 #ifndef PINHOLE_CAMERA_H
 #define PINHOLE_CAMERA_H
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
-#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/LandmarkMsgPayload.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 
 #include <Eigen/Dense>
-#include <vector>
 #include <string>
+#include <vector>
 
 /*! @brief Pinhole camera class */
-class PinholeCamera:  public SysModel {
-public:
+class PinholeCamera : public SysModel {
+   public:
     PinholeCamera();
     ~PinholeCamera();
     void updateState(uint64_t currentSimNanos);
@@ -43,65 +42,68 @@ public:
     void writeOutputMessages(uint64_t CurrentClock);
 
     void addLandmark(Eigen::Vector3d& pos, Eigen::Vector3d& normal);
-    void processBatch(Eigen::MatrixXd rBatch_BP_P, Eigen::MatrixXd mrpBatch_BP, Eigen::MatrixXd eBatch_SP_P, bool show_progress);
+    void processBatch(Eigen::MatrixXd rBatch_BP_P,
+                      Eigen::MatrixXd mrpBatch_BP,
+                      Eigen::MatrixXd eBatch_SP_P,
+                      bool show_progress);
 
-private:
+   private:
     void processInputs();
     void loopLandmarks();
     bool checkLighting(Eigen::Vector3d nLmk);
     bool checkFOV(Eigen::Vector2i pLmk, Eigen::Vector3d rLmk, Eigen::Vector3d nLmk);
     Eigen::Vector2i computePixel(Eigen::Vector3d rLmk);
 
-public:
+   public:
     /* Pinhole camera properties */
-    double f; //!< [m] camera focal length
-    double FOVx; //!< [rad] horizontal field of view
-    double FOVy; //!< [rad] vertical field of view
-    double nxPixel; //!< [-] number of horizontal pixels
-    double nyPixel; //!< [-] number of vertical pixels
-    double wPixel; //!< [m] pixel width
-    Eigen::Matrix3d dcm_CB; //!< [-] dcm from body to camera
+    double f;                //!< [m] camera focal length
+    double FOVx;             //!< [rad] horizontal field of view
+    double FOVy;             //!< [rad] vertical field of view
+    double nxPixel;          //!< [-] number of horizontal pixels
+    double nyPixel;          //!< [-] number of vertical pixels
+    double wPixel;           //!< [m] pixel width
+    Eigen::Matrix3d dcm_CB;  //!< [-] dcm from body to camera
 
     /* Module outputs */
-    Eigen::VectorXi isvisibleLmk; //!< [-] flag telling if a landmark is visible
-    Eigen::MatrixXi pixelLmk; //!< [-] pixels for landmarks
+    Eigen::VectorXi isvisibleLmk;  //!< [-] flag telling if a landmark is visible
+    Eigen::MatrixXi pixelLmk;      //!< [-] pixels for landmarks
 
     /* Landmark distribution */
-    std::vector<Eigen::Vector3d> r_LP_P; //!< [m] landmark positions in planet frame
-    std::vector<Eigen::Vector3d> nL_P; //!< [-] landmark normals in planet frame
+    std::vector<Eigen::Vector3d> r_LP_P;  //!< [m] landmark positions in planet frame
+    std::vector<Eigen::Vector3d> nL_P;    //!< [-] landmark normals in planet frame
 
-    double maskSun; //!< [-] minimum slant range for Sun lighting
+    double maskSun;  //!< [-] minimum slant range for Sun lighting
 
     /* Messages definition */
-    ReadFunctor<EphemerisMsgPayload> ephemerisInMsg; //!< planet ephemeris input message
-    ReadFunctor<SCStatesMsgPayload> scStateInMsg; //!< spacecraft state input msg
+    ReadFunctor<EphemerisMsgPayload> ephemerisInMsg;  //!< planet ephemeris input message
+    ReadFunctor<SCStatesMsgPayload> scStateInMsg;     //!< spacecraft state input msg
 
-    SCStatesMsgPayload spacecraftState; //!< input spacecraft state
-    EphemerisMsgPayload ephemerisPlanet;  //!< input planet ephemeris
-    std::vector<Message<LandmarkMsgPayload>*> landmarkOutMsgs; //!< vector of landmark messages
-    std::vector<LandmarkMsgPayload> landmarkMsgBuffer; //!< buffer of landmark output data
+    SCStatesMsgPayload spacecraftState;                         //!< input spacecraft state
+    EphemerisMsgPayload ephemerisPlanet;                        //!< input planet ephemeris
+    std::vector<Message<LandmarkMsgPayload>*> landmarkOutMsgs;  //!< vector of landmark messages
+    std::vector<LandmarkMsgPayload> landmarkMsgBuffer;          //!< buffer of landmark output data
 
-    BSKLogger bskLogger;         //!< -- BSK Logging
+    BSKLogger bskLogger;  //!< -- BSK Logging
 
     /* Batch variables */
-    Eigen::MatrixXi pixelBatchLmk; //!< [-] batch of landmark pixels
-    Eigen::MatrixXi isvisibleBatchLmk; //!< [-] batch of landmark visibility stauts
+    Eigen::MatrixXi pixelBatchLmk;      //!< [-] batch of landmark pixels
+    Eigen::MatrixXi isvisibleBatchLmk;  //!< [-] batch of landmark visibility stauts
 
-private:
-    int n; //!< [-] number of landmarks
+   private:
+    int n;  //!< [-] number of landmarks
 
     /* Positions */
-    Eigen::Vector3d r_PN_N; //!< [m] current planet position in inertial frame
-    Eigen::Vector3d r_BP_P; //!< [m] current spacecraft position w.r.t. planet in planet frame
+    Eigen::Vector3d r_PN_N;  //!< [m] current planet position in inertial frame
+    Eigen::Vector3d r_BP_P;  //!< [m] current spacecraft position w.r.t. planet in planet frame
 
     /* Direction cosine matrices */
-    Eigen::Matrix3d dcm_BP; //!< [-] current direction cosine matrix from planet to spacecraft body frame
-    Eigen::Matrix3d dcm_PN; //!< [-] current direction cosine matrix from inertial to planet frame
+    Eigen::Matrix3d dcm_BP;  //!< [-] current direction cosine matrix from planet to spacecraft body frame
+    Eigen::Matrix3d dcm_PN;  //!< [-] current direction cosine matrix from inertial to planet frame
 
     /* Unit-vectors */
-    Eigen::Vector3d e_SP_P; //!< [-] current unit-vector pointing from planet to Sun in planet frame
-    Eigen::Vector3d eC_C; //!< [-] focal direction unit-vector in camera frame
-    Eigen::Vector3d eC_P; //!< [-] focal direction unit-vector in planet frame
+    Eigen::Vector3d e_SP_P;  //!< [-] current unit-vector pointing from planet to Sun in planet frame
+    Eigen::Vector3d eC_C;    //!< [-] focal direction unit-vector in camera frame
+    Eigen::Vector3d eC_P;    //!< [-] focal direction unit-vector in planet frame
 };
 
 #endif


### PR DESCRIPTION
* **Tickets addressed:** #416
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The math functions which bound the returned values (prevent NaN) are moved to a separate file. This allows for their usage without including linearAlgebra.h. The primary reason here is that we don't want to conflate the intent of which linear algebra api should be used (Eigen should be the only one used in the C++ fsw modules). 

I went ahead and fixed the ordering dependency where avsEigenMRP needed Eigen to be included before. Now it can be included independently. While in the neighborhood, I placed the `newtonRaphsonSolve` in the context of its only usage site removing it from the avsEigenSupport (where `newtonRaphsonSolve` makes no use of the Eigen library).
 
## Verification
All tests run and pass as usual.

## Documentation
None

## Future work
None 