### PR TITLE
Convert rateDamp to adapter

### DIFF
--- a/src/fswAlgorithms/attControl/rateDamp/_UnitTest/test_rateDamp.py
+++ b/src/fswAlgorithms/attControl/rateDamp/_UnitTest/test_rateDamp.py
@@ -15,22 +15,14 @@
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-import inspect
-import os
 
 import numpy as np
 import pytest
 
-filename = inspect.getframeinfo(inspect.currentframe()).filename
-path = os.path.dirname(os.path.abspath(filename))
-
-
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.fswAlgorithms import rateDamp  # import the module that is to be tested
+from Basilisk.fswAlgorithms import rateDamp
 from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
-from Basilisk.architecture import bskLogging
-
 
 @pytest.mark.parametrize("P", [0.0, 2.0])
 @pytest.mark.parametrize("accuracy", [1e-12])

--- a/src/fswAlgorithms/attControl/rateDamp/_UnitTest/test_rateDamp.py
+++ b/src/fswAlgorithms/attControl/rateDamp/_UnitTest/test_rateDamp.py
@@ -25,12 +25,9 @@ from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
 
 @pytest.mark.parametrize("P", [0.0, 2.0])
-@pytest.mark.parametrize("accuracy", [1e-12])
-def test_rateDamp(show_plots, P, accuracy):
-
+def test_rateDamp(show_plots, P):
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -40,47 +37,37 @@ def test_rateDamp(show_plots, P, accuracy):
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
-    # Construct algorithm and associated C++ container
+    # Create the rateDamp module
     attControl = rateDamp.RateDamp()
     attControl.setRateGain(P)
     attControl.modelTag = "rateDamp"
-
-    # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, attControl)
 
-    # Initialize the test module configuration data
-    # These will eventually become input messages
-
+    # Create the rateDamp module input navigation message
     omega_BN_B = np.array([0.1, -0.2, 0.3])
-
-    # Create input navigation message
     NavAttMessageData = messaging.NavAttMsgPayload()
     NavAttMessageData.omega_BN_B = omega_BN_B
     NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
     attControl.attNavInMsg.subscribeTo(NavAttMsg)
 
-    # Setup logging on the test module output message so that we get all the writes to it
+    # Set up data logging
     dataLog = attControl.cmdTorqueOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    # Need to call the self-init and cross-init methods
+    # Run the simulation
     unitTestSim.InitializeSimulation()
-
-    # Set the simulation time.
     unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
-
-    # Begin the simulation time run set above
     unitTestSim.ExecuteSimulation()
 
+    # Extract the logged data
     moduleOutput = dataLog.torqueRequestBody[0]
 
+    # Compute the truth command torque
     truth = -attControl.getRateGain() * omega_BN_B
 
-    # set the filtered output truth states
+    # Check that the module-output command torque vector matches the computed truth value
+    accuracy = 1e-12
     np.testing.assert_allclose(moduleOutput, truth, rtol=0, atol=accuracy, verbose=True)
 
-    return
-
-
 if __name__ == "__main__":
-    test_rateDamp(False, 1, 1e-12)
+    test_rateDamp(False, 1)

--- a/src/fswAlgorithms/attControl/rateDamp/_UnitTest/test_rateDamp.py
+++ b/src/fswAlgorithms/attControl/rateDamp/_UnitTest/test_rateDamp.py
@@ -51,8 +51,8 @@ def test_rateDamp(show_plots, P):
     attControl.attNavInMsg.subscribeTo(NavAttMsg)
 
     # Set up data logging
-    dataLog = attControl.cmdTorqueOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    cmdTorqueDataLog = attControl.cmdTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, cmdTorqueDataLog)
 
     # Run the simulation
     unitTestSim.InitializeSimulation()
@@ -60,14 +60,14 @@ def test_rateDamp(show_plots, P):
     unitTestSim.ExecuteSimulation()
 
     # Extract the logged data
-    moduleOutput = dataLog.torqueRequestBody[0]
+    cmdTorqueData = cmdTorqueDataLog.torqueRequestBody[0]
 
     # Compute the truth command torque
-    truth = -attControl.getRateGain() * omega_BN_B
+    truthCmdTorque = -attControl.getRateGain() * omega_BN_B
 
     # Check that the module-output command torque vector matches the computed truth value
     accuracy = 1e-12
-    np.testing.assert_allclose(moduleOutput, truth, rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(cmdTorqueData, truthCmdTorque, rtol=0, atol=accuracy, verbose=True)
 
 if __name__ == "__main__":
     test_rateDamp(False, 1)

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
@@ -20,16 +20,11 @@
 #include "rateDamp.h"
 #include <cassert>
 
-/*! Reset method for the BSK module adapter interface. This method also calls the algorithm reset method.
+/*! Reset method for the BSK module adapter interface.
  @return void
  @param currentSimNanos [ns] Time the method is called
  */
-void RateDamp::reset(uint64_t currentSimNanos) {
-    assert(this->attNavInMsg.isLinked());
-
-    // Call the algorithm reset method
-    this->algorithm.reset(currentSimNanos);
-}
+void RateDamp::reset(uint64_t currentSimNanos) { assert(this->attNavInMsg.isLinked()); }
 
 /*! Update method for the BSK module adapter interface. This method also calls the algorithm update method.
  @return void

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
@@ -36,7 +36,10 @@ void RateDamp::reset(uint64_t currentSimNanos) {
  @param currentSimNanos [ns] Time the method is called
  */
 void RateDamp::updateState(uint64_t currentSimNanos) {
-    NavAttMsgPayload attNavInBuffer = this->attNavInMsg();
+    auto attNavInBuffer = NavAttMsgPayload();
+    if (this->attNavInMsg.isWritten()) {
+        attNavInBuffer = this->attNavInMsg();
+    }
 
     // Call the algorithm update method
     CmdTorqueBodyMsgPayload cmdTorqueOutBuffer = this->algorithm.update(currentSimNanos, attNavInBuffer);

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
@@ -20,26 +20,27 @@
 #include "rateDamp.h"
 #include <cassert>
 
-/*! This method is used to reset the module.
+/*! Reset method for the BSK module adapter interface. This method also calls the algorithm reset method.
  @return void
+ @param currentSimNanos [ns] Time the method is called
  */
 void RateDamp::reset(uint64_t currentSimNanos) {
     assert(this->attNavInMsg.isLinked());
+
+    // Call the algorithm reset method
     this->algorithm.reset(currentSimNanos);
 }
 
-/*! This method is the main carrier for the computation of the control torque.
+/*! Update method for the BSK module adapter interface. This method also calls the algorithm update method.
  @return void
- @param currentSimNanos The current simulation time for system
+ @param currentSimNanos [ns] Time the method is called
  */
 void RateDamp::updateState(uint64_t currentSimNanos) {
-    /*! Read input attitude navigation msg */
     NavAttMsgPayload attNavInBuffer = this->attNavInMsg();
 
-    /*! Create and populate cmd torque buffer message */
+    // Call the algorithm update method
     CmdTorqueBodyMsgPayload cmdTorqueOutBuffer = this->algorithm.update(currentSimNanos, attNavInBuffer);
 
-    /*! Write output messages */
     this->cmdTorqueOutMsg.write(&cmdTorqueOutBuffer, this->moduleID, currentSimNanos);
 }
 

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
@@ -46,7 +46,7 @@ void RateDamp::updateState(uint64_t currentSimNanos) {
     @param double P
     @return void
     */
-void RateDamp::setRateGain(const double p) { this->algorithm.setRateGain(p); }
+void RateDamp::setRateGain(double p) { this->algorithm.setRateGain(p); }
 
 /*! Get the module rate feedback gain
     @param double measurementNoiseScale

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.cpp
@@ -22,24 +22,19 @@
 /*! This method is used to reset the module.
  @return void
  */
-void RateDamp::reset(uint64_t currentSimNanos)
-{
-    assert(this->attNavInMsg.isLinked());
-}
-
+void RateDamp::reset(uint64_t currentSimNanos) { assert(this->attNavInMsg.isLinked()); }
 
 /*! This method is the main carrier for the computation of the control torque.
  @return void
  @param currentSimNanos The current simulation time for system
  */
-void RateDamp::updateState(uint64_t currentSimNanos)
-{
+void RateDamp::updateState(uint64_t currentSimNanos) {
     /*! Read input attitude navigation msg */
     NavAttMsgPayload attNavInBuffer = this->attNavInMsg();
 
     /*! Create and populate cmd torque buffer message */
     CmdTorqueBodyMsgPayload cmdTorqueOutBuffer;
-    for (int i=0; i<3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         cmdTorqueOutBuffer.torqueRequestBody[i] = -this->P * attNavInBuffer.omega_BN_B[i];
     }
 
@@ -51,14 +46,10 @@ void RateDamp::updateState(uint64_t currentSimNanos)
     @param double P
     @return void
     */
-void RateDamp::setRateGain(const double p) {
-    this->P = p;
-}
+void RateDamp::setRateGain(const double p) { this->P = p; }
 
 /*! Get the module rate feedback gain
     @param double measurementNoiseScale
     @return void
     */
-double RateDamp::getRateGain() const {
-    return this->P;
-}
+double RateDamp::getRateGain() const { return this->P; }

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
@@ -21,30 +21,27 @@
 #define _RATE_DAMP_
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/bskLogging.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include "architecture/msgPayloadDefC/CmdForceBodyMsgPayload.h"
 #include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
-
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/bskLogging.h"
 
 /*! @brief A class to compute rate damping control */
-class RateDamp: public SysModel {
-public:
+class RateDamp : public SysModel {
+   public:
     void reset(uint64_t currentSimNanos);
     void updateState(uint64_t currentSimNanos);
 
-    ReadFunctor<NavAttMsgPayload>          attNavInMsg;           //!< input msg measured attitude
-    Message<CmdTorqueBodyMsgPayload>       cmdTorqueOutMsg;       //!< commanded torque output message
+    ReadFunctor<NavAttMsgPayload> attNavInMsg;         //!< input msg measured attitude
+    Message<CmdTorqueBodyMsgPayload> cmdTorqueOutMsg;  //!< commanded torque output message
 
     void setRateGain(double const p);
     double getRateGain() const;
 
-private:
-    double P;       //!< [N*m*s] Rate feedback gain
-
+   private:
+    double P;  //!< [N*m*s] Rate feedback gain
 };
-
 
 #endif

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
@@ -27,23 +27,21 @@
 #include "architecture/utilities/bskLogging.h"
 #include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
 
-/*! @brief A class to compute rate damping control */
+/*! @brief Rate damp class */
 class RateDamp : public SysModel {
    public:
-    RateDamp() = default;   //!< Constructor
-    ~RateDamp() = default;  //!< Destructor
+    RateDamp() = default;                                 //!< Constructor
+    ~RateDamp() = default;                                //!< Destructor
+    void reset(uint64_t currentSimNanos) override;        //!< Reset method
+    void updateState(uint64_t currentSimNanos) override;  //!< Update method
+    void setRateGain(double const p);                     //!< Setter method for rate feedback gain
+    double getRateGain() const;                           //!< Getter method for rate feedback gain
 
-    void reset(uint64_t currentSimNanos) override;
-    void updateState(uint64_t currentSimNanos) override;
-
-    ReadFunctor<NavAttMsgPayload> attNavInMsg;         //!< input msg measured attitude
-    Message<CmdTorqueBodyMsgPayload> cmdTorqueOutMsg;  //!< commanded torque output message
-
-    void setRateGain(double const p);
-    double getRateGain() const;
+    ReadFunctor<NavAttMsgPayload> attNavInMsg;         //!< Navigation input message
+    Message<CmdTorqueBodyMsgPayload> cmdTorqueOutMsg;  //!< Command torque output message
 
    private:
-    RateDampAlgorithm algorithm;
+    RateDampAlgorithm algorithm;  //!< Algorithm for rateDamp control logic (BSK-agnostic)
 };
 
 #endif

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
@@ -30,8 +30,8 @@
 /*! @brief A class to compute rate damping control */
 class RateDamp : public SysModel {
    public:
-    void reset(uint64_t currentSimNanos);
-    void updateState(uint64_t currentSimNanos);
+    void reset(uint64_t currentSimNanos) override;
+    void updateState(uint64_t currentSimNanos) override;
 
     ReadFunctor<NavAttMsgPayload> attNavInMsg;         //!< input msg measured attitude
     Message<CmdTorqueBodyMsgPayload> cmdTorqueOutMsg;  //!< commanded torque output message

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
@@ -30,6 +30,9 @@
 /*! @brief A class to compute rate damping control */
 class RateDamp : public SysModel {
    public:
+    RateDamp() = default;   //!< Constructor
+    ~RateDamp() = default;  //!< Destructor
+
     void reset(uint64_t currentSimNanos) override;
     void updateState(uint64_t currentSimNanos) override;
 

--- a/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDamp.h
@@ -34,7 +34,7 @@ class RateDamp : public SysModel {
     ~RateDamp() = default;                                //!< Destructor
     void reset(uint64_t currentSimNanos) override;        //!< Reset method
     void updateState(uint64_t currentSimNanos) override;  //!< Update method
-    void setRateGain(double const p);                     //!< Setter method for rate feedback gain
+    void setRateGain(double p);                           //!< Setter method for rate feedback gain
     double getRateGain() const;                           //!< Getter method for rate feedback gain
 
     ReadFunctor<NavAttMsgPayload> attNavInMsg;         //!< Navigation input message

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
@@ -19,14 +19,6 @@
 
 #include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
 
-/*! Reset method for the rateDamp control algorithm.
- @return void
- @param currentSimNanos [ns] Time the method is called
- */
-void RateDampAlgorithm::reset(uint64_t currentSimNanos) {
-    // Reset the algorithm
-}
-
 /*! Update method for the rateDamp control algorithm. This method computes the required control torque command.
  @return void
  @param currentSimNanos [ns] Time the method is called

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
+#include <cmath>
 
 /*! Update method for the rateDamp control algorithm. This method computes the required control torque command.
  @return void
@@ -38,7 +39,7 @@ CmdTorqueBodyMsgPayload RateDampAlgorithm::update(uint64_t currentSimNanos, NavA
     @param double P
     @return void
     */
-void RateDampAlgorithm::setRateGain(const double p) { this->P = p; }
+void RateDampAlgorithm::setRateGain(double p) { this->P = std::abs(p); }
 
 /*! Get the module rate feedback gain
     @return double

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
+#include <cassert>
 #include <cmath>
 
 /*! Update method for the rateDamp control algorithm. This method computes the required control torque command.
@@ -39,7 +40,10 @@ CmdTorqueBodyMsgPayload RateDampAlgorithm::update(uint64_t currentSimNanos, NavA
     @param double P
     @return void
     */
-void RateDampAlgorithm::setRateGain(double p) { this->P = std::abs(p); }
+void RateDampAlgorithm::setRateGain(double p) {
+    assert(p > 0.0);
+    this->P = std::abs(p);
+}
 
 /*! Get the module rate feedback gain
     @return double

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -17,40 +17,36 @@
 
  */
 
-#include "rateDamp.h"
-#include <cassert>
+#include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
 
 /*! This method is used to reset the module.
  @return void
  */
-void RateDamp::reset(uint64_t currentSimNanos) {
-    assert(this->attNavInMsg.isLinked());
-    this->algorithm.reset(currentSimNanos);
+void RateDampAlgorithm::reset(uint64_t currentSimNanos) {
+    // Reset the algorithm
 }
 
 /*! This method is the main carrier for the computation of the control torque.
  @return void
  @param currentSimNanos The current simulation time for system
  */
-void RateDamp::updateState(uint64_t currentSimNanos) {
-    /*! Read input attitude navigation msg */
-    NavAttMsgPayload attNavInBuffer = this->attNavInMsg();
-
+CmdTorqueBodyMsgPayload RateDampAlgorithm::update(uint64_t currentSimNanos, NavAttMsgPayload& attNavInMsg) {
     /*! Create and populate cmd torque buffer message */
-    CmdTorqueBodyMsgPayload cmdTorqueOutBuffer = this->algorithm.update(currentSimNanos, attNavInBuffer);
+    CmdTorqueBodyMsgPayload cmdTorqueOutBuffer{};
+    for (int i = 0; i < 3; ++i) {
+        cmdTorqueOutBuffer.torqueRequestBody[i] = -this->P * attNavInMsg.omega_BN_B[i];
+    }
 
-    /*! Write output messages */
-    this->cmdTorqueOutMsg.write(&cmdTorqueOutBuffer, this->moduleID, currentSimNanos);
+    return cmdTorqueOutBuffer;
 }
 
 /*! Set the module rate feedback gain
     @param double P
     @return void
     */
-void RateDamp::setRateGain(const double p) { this->algorithm.setRateGain(p); }
+void RateDampAlgorithm::setRateGain(const double p) { this->P = p; }
 
 /*! Get the module rate feedback gain
-    @param double measurementNoiseScale
-    @return void
+    @return double
     */
-double RateDamp::getRateGain() const { return this->algorithm.getRateGain(); }
+double RateDampAlgorithm::getRateGain() const { return this->P; }

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.cpp
@@ -19,20 +19,22 @@
 
 #include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
 
-/*! This method is used to reset the module.
+/*! Reset method for the rateDamp control algorithm.
  @return void
+ @param currentSimNanos [ns] Time the method is called
  */
 void RateDampAlgorithm::reset(uint64_t currentSimNanos) {
     // Reset the algorithm
 }
 
-/*! This method is the main carrier for the computation of the control torque.
+/*! Update method for the rateDamp control algorithm. This method computes the required control torque command.
  @return void
- @param currentSimNanos The current simulation time for system
+ @param currentSimNanos [ns] Time the method is called
+ @param attNavInMsg Attitude navigation message
  */
 CmdTorqueBodyMsgPayload RateDampAlgorithm::update(uint64_t currentSimNanos, NavAttMsgPayload& attNavInMsg) {
-    /*! Create and populate cmd torque buffer message */
-    CmdTorqueBodyMsgPayload cmdTorqueOutBuffer{};
+    // Create and populate the output command torque message
+    auto cmdTorqueOutBuffer = CmdTorqueBodyMsgPayload();
     for (int i = 0; i < 3; ++i) {
         cmdTorqueOutBuffer.torqueRequestBody[i] = -this->P * attNavInMsg.omega_BN_B[i];
     }

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
@@ -27,7 +27,6 @@
 /*! @brief Rate damp algorithm class */
 class RateDampAlgorithm {
    public:
-    void reset(uint64_t currentSimNanos);  //!< Algorithm reset method
     CmdTorqueBodyMsgPayload update(uint64_t currentSimNanos,
                                    NavAttMsgPayload& attNavInMsg);  //!< Algorithm update method
     void setRateGain(double const p);                               //!< Setter method for rate feedback gain

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
@@ -24,14 +24,14 @@
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
 #include <cstdint>
 
+/*! @brief Rate damp algorithm class */
 class RateDampAlgorithm {
    public:
-    void reset(uint64_t currentSimNanos);
+    void reset(uint64_t currentSimNanos);  //!< Algorithm reset method
     CmdTorqueBodyMsgPayload update(uint64_t currentSimNanos,
                                    NavAttMsgPayload& attNavInMsg);  //!< Algorithm update method
-
-    void setRateGain(double const p);
-    double getRateGain() const;
+    void setRateGain(double const p);                               //!< Setter method for rate feedback gain
+    double getRateGain() const;                                     //!< Getter method for rate feedback gain
 
    private:
     double P;  //!< [N*m*s] Rate feedback gain

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
@@ -33,7 +33,7 @@ class RateDampAlgorithm {
     double getRateGain() const;                                     //!< Getter method for rate feedback gain
 
    private:
-    double P;  //!< [N*m*s] Rate feedback gain
+    double P{};  //!< [N*m*s] Rate feedback gain
 };
 
 #endif

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
@@ -29,7 +29,7 @@ class RateDampAlgorithm {
    public:
     CmdTorqueBodyMsgPayload update(uint64_t currentSimNanos,
                                    NavAttMsgPayload& attNavInMsg);  //!< Algorithm update method
-    void setRateGain(double const p);                               //!< Setter method for rate feedback gain
+    void setRateGain(double p);                                     //!< Setter method for rate feedback gain
     double getRateGain() const;                                     //!< Getter method for rate feedback gain
 
    private:

--- a/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
+++ b/src/fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2024, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -17,30 +17,24 @@
 
  */
 
-#ifndef BASILISK_RATE_DAMP_H
-#define BASILISK_RATE_DAMP_H
+#ifndef _RATE_DAMP_ALGORITHM_H
+#define _RATE_DAMP_ALGORITHM_H
 
-#include "architecture/_GeneralModuleFiles/sys_model.h"
-#include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
-#include "architecture/utilities/bskLogging.h"
-#include "fswAlgorithms/attControl/rateDamp/rateDampAlgorithm.h"
+#include <cstdint>
 
-/*! @brief A class to compute rate damping control */
-class RateDamp : public SysModel {
+class RateDampAlgorithm {
    public:
     void reset(uint64_t currentSimNanos);
-    void updateState(uint64_t currentSimNanos);
-
-    ReadFunctor<NavAttMsgPayload> attNavInMsg;         //!< input msg measured attitude
-    Message<CmdTorqueBodyMsgPayload> cmdTorqueOutMsg;  //!< commanded torque output message
+    CmdTorqueBodyMsgPayload update(uint64_t currentSimNanos,
+                                   NavAttMsgPayload& attNavInMsg);  //!< Algorithm update method
 
     void setRateGain(double const p);
     double getRateGain() const;
 
    private:
-    RateDampAlgorithm algorithm;
+    double P;  //!< [N*m*s] Rate feedback gain
 };
 
 #endif


### PR DESCRIPTION
* **Tickets addressed:** #420 
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
To enable easy relocation of fsw algorithms use the adapter pattern for rateDamp.
This allows for relocation of fsw algorithms and then inclusion of bsk modules in any language with a c ffi/abi.

## Verification
Unit test passes with these changes.

## Documentation
N/A

## Future work
N/A
