### PR TITLE
Convert thrForceMapping to adapter

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
@@ -19,12 +19,6 @@
 
 #include "fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h"
 
-#include <math.h>
-
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/macroDefinitions.h"
-#include "architecture/utilities/safeMath.h"
-
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
@@ -19,13 +19,11 @@
 
 #include "fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h"
 
-/*! This method performs a complete reset of the module.  Local module variables that retain
- time varying states between function calls are reset to their default values.
+/*! Reset method for the BSK module adapter interface. This method also calls the algorithm reset method.
  @return void
- @param callTime The clock time at which the function was called (nanoseconds)
+ @param callTime [ns] Time the method is called
  */
 void ThrForceMapping::reset(uint64_t callTime) {
-    // check if the required input messages are included
     assert(this->thrConfigInMsg.isLinked() && this->vehConfigInMsg.isLinked() && this->cmdTorqueInMsg.isLinked());
 
     auto localThrConfigInMsg = THRArrayConfigMsgPayload();
@@ -33,12 +31,13 @@ void ThrForceMapping::reset(uint64_t callTime) {
         localThrConfigInMsg = this->thrConfigInMsg();
     }
 
+    // Call the algorithm reset method
     this->algorithm.reset(callTime, localThrConfigInMsg);
 }
 
-/*! The module takes a body frame torque vector and projects it onto available RCS or DV thrusters.
+/*! Update method for the BSK module adapter interface. This method also calls the algorithm update method.
  @return void
- @param callTime The clock time at which the function was called (nanoseconds)
+ @param callTime [ns] Time the method is called
  */
 void ThrForceMapping::updateState(uint64_t callTime) {
     auto LrInputMsg = CmdTorqueBodyMsgPayload();
@@ -50,7 +49,9 @@ void ThrForceMapping::updateState(uint64_t callTime) {
         localVehConfigInMsg = this->vehConfigInMsg();
     }
 
+    // Call the algorithm update method
     THRArrayCmdForceMsgPayload thrusterForceOut = this->algorithm.update(callTime, LrInputMsg, localVehConfigInMsg);
+
     this->thrForceCmdOutMsg.write(&thrusterForceOut, this->moduleID, callTime);
 }
 

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
@@ -25,24 +25,12 @@
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/safeMath.h"
 
-int8_t asInt(ThrForceSign value) { return static_cast<int8_t>(value); }
-
-void substractMin(Eigen::Vector<double, MAX_EFF_CNT>& F, uint32_t size);
-
-double computeTorqueAngErr(Eigen::Matrix<double, 3, MAX_EFF_CNT> D,
-                           const Eigen::Vector3d& BLr_B,
-                           uint32_t numForces,
-                           double epsilon,
-                           Eigen::Vector<double, MAX_EFF_CNT> F,
-                           Eigen::Vector<double, MAX_EFF_CNT> FMag);
-
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
 void ThrForceMapping::reset(uint64_t callTime) {
-    assert(this->numControlAxes > 0);
     // check if the required input messages are included
     if (!this->thrConfigInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: thrForceMapping.thrConfigInMsg wasn't connected.");
@@ -54,22 +42,8 @@ void ThrForceMapping::reset(uint64_t callTime) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: thrForceMapping.cmdTorqueInMsg wasn't connected.");
     }
 
-    /*! - read in the support thruster and vehicle configuration messages */
-    THRArrayConfigMsgPayload localThrusterData = this->thrConfigInMsg();
-    this->sc = this->vehConfigInMsg();
-
-    /*! - copy the thruster position and thruster force heading information into the module configuration data */
-    this->numThrusters = localThrusterData.numThrusters;
-    for (uint32_t i = 0; i < this->numThrusters; ++i) {
-        this->rThruster_B.row(i) = Eigen::Map<Eigen::Vector3d>(localThrusterData.thrusters[i].rThrust_B);
-        this->gtThruster_B.row(i) =
-            Eigen::Map<Eigen::Vector3d>(localThrusterData.thrusters[i].tHatThrust_B).transpose();
-        if (localThrusterData.thrusters[i].maxThrust <= 0.0) {
-            assert("thruster has a non-sensible saturation limit of <= 0 N." && false);
-        } else {
-            this->thrForceMag(i) = localThrusterData.thrusters[i].maxThrust;
-        }
-    }
+    THRArrayConfigMsgPayload thrConfigInMsg = this->thrConfigInMsg();
+    this->algorithm.reset(callTime, thrConfigInMsg);
 }
 
 /*! The module takes a body frame torque vector and projects it onto available RCS or DV thrusters.
@@ -79,289 +53,81 @@ void ThrForceMapping::reset(uint64_t callTime) {
 void ThrForceMapping::updateState(uint64_t callTime) {
     /*! - Read the input messages */
     CmdTorqueBodyMsgPayload LrInputMsg = this->cmdTorqueInMsg();
-    this->sc = this->vehConfigInMsg();
-
-    /*! - copy the request 3D attitude control torque vector */
-    Eigen::Vector3d Lr_B = Eigen::Map<Eigen::Vector3d>(LrInputMsg.torqueRequestBody);  // [Nm] commanded control torque
-
-    /*! - compute thruster locations relative to COM */
-    /* Part 1 of Eq. 4 */
-    Eigen::Matrix<double, MAX_EFF_CNT, 3> rThrusterRelCOM_B =
-        this->rThruster_B.rowwise() - Eigen::Map<Eigen::Vector3d>(this->sc.CoM_B).transpose();
-
-    /*! - compute general thruster force mapping matrix */
-    Eigen::Vector3d Lr_offset = Eigen::Vector3d::Zero();
-    Eigen::Matrix<double, 3, MAX_EFF_CNT> D =
-        Eigen::Matrix<double, 3, MAX_EFF_CNT>::Zero();  // [m] mapping matrix from thruster forces to body torque
-    for (uint32_t i = 0; i < this->numThrusters; ++i) {
-        Eigen::Vector3d rCrossGt = rThrusterRelCOM_B.row(i).cross(this->gtThruster_B.row(i)); /* Eq. 6 */
-        D.col(i) = rCrossGt;
-        /* Handles the case where there is translational motion imparted during off-pulsing*/
-        if (this->thrForceSign == ThrForceSign::NEGATIVE) {
-            /* Computing local torques from each thruster -- Individual terms in Eq. 7*/
-            Eigen::Vector3d LrLocal = rCrossGt * this->thrForceMag(i); /* [Nm] Torque provided by individual thruster */
-            Lr_offset = Lr_offset - LrLocal; /* Summing of individual torques -- Eq. 5 & Eq. 7 */
-        }
-    }
-
-    Lr_B = Lr_B + Lr_offset;
-
-    /*! Map the control torque onto the control axes
-     * Note: Lr_B_Bar is projected only onto the available control axes.
-     * i.e. if using DV thrusters with only 1 control axis,
-     * Lr_B_Bar = [#, 0, 0]
-     */
-    Eigen::Vector3d Lr_B_Bar = this->controlAxes_B * Lr_B;  // [Nm] Control torque that we actually control
-
-    // 1st iteration of finding a set of force vectors to implement the control torque
-    Eigen::Vector<double, MAX_EFF_CNT> F =
-        this->findMinimumNormForce(D, Lr_B_Bar, this->numThrusters); /* [N] vector of commanded thruster forces */
-
-    /*! - Remove forces components that are contributing to the RCS Null space (this is due to the geometry of the
-     * thrusters) */
-    if (this->thrForceSign == ThrForceSign::POSITIVE) {
-        substractMin(F, this->numThrusters);
-    }
-
-    if ((this->thrForceSign == ThrForceSign::NEGATIVE && this->numControlAxes < 3) || this->use2ndLoop) {
-        // Array of flags indicating if this thruster is used for the Lr_j
-        std::array<bool, MAX_EFF_CNT> thrusterUsed{};
-        // Reduced mapping matrix
-        Eigen::Matrix<double, 3, MAX_EFF_CNT> Dbar = Eigen::Matrix<double, 3, MAX_EFF_CNT>::Zero();  // [m]
-        int counterPosForces = 0;  // counter for number of positive thruster forces
-        for (uint32_t i = 0; i < this->numThrusters; ++i) {
-            if (F(i) * asInt(this->thrForceSign) > 0) {
-                thrusterUsed[i] = true; /* Eq. 11 */
-                for (uint32_t j = 0; j < 3; ++j) {
-                    Dbar(j, counterPosForces) = D(j, i); /* Eq. 12 */
-                }
-                counterPosForces += 1;
-            }
-        }
-
-        // [N] vector of intermediate thruster forces
-        Eigen::Vector<double, MAX_EFF_CNT> Fbar = this->findMinimumNormForce(Dbar, Lr_B_Bar, counterPosForces);
-        if (this->thrForceSign == ThrForceSign::POSITIVE) {
-            substractMin(Fbar, counterPosForces);
-        }
-        uint32_t c = 0;
-        for (uint32_t i = 0; i < this->numThrusters; ++i) {
-            if (thrusterUsed[i]) {
-                F(i) = Fbar(c);
-                c++;
-            } else {
-                F(i) = 0.0;
-            }
-        }
-    }
-
-    this->outTorqAngErr =
-        computeTorqueAngErr(D, Lr_B_Bar, this->numThrusters, this->epsilon, F, this->thrForceMag); /* Eq. 16*/
-    /*  check if the angle between the request and actual torque exceeds a limit.  If so, then uniformly scale
-        all thruster forces values to not exceed saturation.
-        If the angle threshold is negative, then this scaling is bypassed.*/
-    if (this->outTorqAngErr > this->angErrThresh) {
-        double maxFractUse = 0.0;  // ratio of maximum requested thruster force relative to maximum thruster limit
-        for (uint32_t i = 0; i < this->numThrusters; ++i) {
-            if (this->thrForceMag(i) > 0.0 &&
-                std::fabs(F(i)) / this->thrForceMag(i) > maxFractUse) /* confirming that maxThrust > 0 */
-            {
-                maxFractUse = std::fabs(F(i)) / this->thrForceMag(i);
-            }
-        }
-        /* only scale the requested thruster force if one or more thrusters are saturated */
-        if (maxFractUse > 1.0) {
-            F *= 1.0 / maxFractUse;
-            this->outTorqAngErr =
-                computeTorqueAngErr(D, Lr_B_Bar, this->numThrusters, this->epsilon, F, this->thrForceMag);
-        }
-    }
+    VehicleConfigMsgPayload vehConfigInMsg = this->vehConfigInMsg();
 
     /* store the output message */
-    THRArrayCmdForceMsgPayload thrusterForceOut{};
-    for (int i = 0; i < F.size(); ++i) {
-        thrusterForceOut.thrForce[i] = F(i);
-    }
+    THRArrayCmdForceMsgPayload thrusterForceOut = this->algorithm.update(callTime, LrInputMsg, vehConfigInMsg);
     this->thrForceCmdOutMsg.write(&thrusterForceOut, this->moduleID, callTime);
-}
-
-/*!
- Take a stack of force values find the smallest value, and subtract if from all force values.  Here the smallest values
- will become zero, while other forces increase.  This assumes that the thrusters are aligned such that if all
- thrusters are firing, then no torque or force is applied.  This ensures only positive force values are computed.
- */
-void substractMin(Eigen::Vector<double, MAX_EFF_CNT>& F, uint32_t size) {
-    double minValue = 0.0;
-    for (uint32_t i = 0; i < size; ++i) {
-        if (F(i) < minValue) {
-            minValue = F(i);
-        }
-    }
-    for (uint32_t i = 0; i < size; ++i) {
-        F(i) -= minValue;
-    }
-}
-
-/*!
- * @brief Find the minimum norm solution to the least squares problem. Use a least square inverse to determine
- * the smallest set of thruster forces that yield the desired torque vector. Note that this routine does not
- * constrain yet the forces to be either positive or negative.
- * @param D 3x32 matrix that maps the thruster forces F[i] to the spacecraft torque.
- * @param Lr_B The vector representing the requested control torque.
- * @param numForces The number of thrusters to include in the minimum norm computation
- * @return A vector containing the thruster force solutions to the least squares problem.
- */
-Eigen::Vector<double, MAX_EFF_CNT> ThrForceMapping::findMinimumNormForce(const Eigen::Matrix<double, 3, MAX_EFF_CNT>& D,
-                                                                         const Eigen::Vector3d& Lr_B_Bar,
-                                                                         uint32_t numForces) const {
-    /* find [D].[D]^T */
-    // [C].[D] matrix -- Thrusters in body frame mapped on control axes
-    Eigen::Matrix<double, 3, MAX_EFF_CNT> CD = this->controlAxes_B * D;  // [m^2]
-    Eigen::Matrix3d CDCDT = Eigen::Matrix3d::Identity();                 // [m^2]  [CD].[CD]^T matrix
-    for (uint32_t i = 0; i < this->numControlAxes; ++i) {
-        for (uint32_t j = 0; j < this->numControlAxes; ++j) {
-            CDCDT(i, j) = 0.0;
-            for (uint32_t k = 0; k < numForces; ++k) {
-                CDCDT(i, j) += CD(i, k) * CD(j, k); /* Part of Eq. 9 */
-            }
-        }
-    }
-
-    Eigen::Matrix3d CDCDTInv = Eigen::Matrix3d::Zero(); /* [m^2]  ([CD].[CD]^T)^-1 matrix */
-    if (CDCDT.determinant() > this->epsilon) {
-        CDCDTInv = CDCDT.inverse();
-    }  // else CDCDTInv is already initialized to zeros
-
-    /* If fewer than 3 control axes, then the 1's along the diagonal of DDTInv will
-     * not conflict with the mapping, as Lr_B_Bar contains the necessary zeros
-     * to inhibit projection */
-    Eigen::Vector3d CDCDTInvLr = CDCDTInv * Lr_B_Bar;
-    Eigen::Vector<double, MAX_EFF_CNT> F = CD.transpose() * CDCDTInvLr; /* Eq. 15 */
-    return F;
-}
-
-/*!
- * @brief  Determine the angle between the desired torque vector and the actual torque vector.
- * @param D 3x32 matrix that maps the thruster forces F[i] to the spacecraft torque.
- * @param BLr_B The vector representing the requested control torque.
- * @param numForces The number of thrusters to include in the computation
- * @param epsilon The threshold value for above which a vector norm is valid
- * @param F The force vectors which implement the control torque
- * @param FMag The force magnitudes of the thrusters
- * @return A vector containing the thruster force solutions to the least squares problem.
- */
-double computeTorqueAngErr(Eigen::Matrix<double, 3, MAX_EFF_CNT> D,
-                           const Eigen::Vector3d& BLr_B,
-                           uint32_t numForces,
-                           double epsilon,
-                           Eigen::Vector<double, MAX_EFF_CNT> F,
-                           Eigen::Vector<double, MAX_EFF_CNT> FMag) {
-    double returnAngle = 0.0;  // [rad] angle between requested and actual torque vector
-    /*! - make sure a control torque is requested, otherwise just return a zero angle error */
-    if (BLr_B.norm() > epsilon) {
-        Eigen::Matrix<double, MAX_EFF_CNT, 3> DT = D.transpose();
-        Eigen::Vector3d BLr_hat_B = BLr_B.normalized();         // normalized BLr_B vector
-        Eigen::Vector3d tauActual_B = Eigen::Vector3d::Zero();  // [Nm] control torque with current thruster solution
-
-        /*! - loop over all thrusters and compute the actual torque to be applied */
-        for (uint32_t i = 0; i < numForces; ++i) {
-            /* This could produce inf's as F(i) approaches 0 if FMag(i) is 0, as such we
-             * assert if FMag(i) is equal to zero in reset() */
-            double thrusterForce = std::fabs(F(i)) < FMag(i) ? F(i)
-                                                             : FMag(i) * std::fabs(F(i)) /
-                                                                   F(i); /* [N] saturation constrained thruster force */
-            Eigen::Vector3d LrEffector_B = DT.row(i) * thrusterForce;  // [Nm] torque of an individual thruster effector
-            tauActual_B += LrEffector_B;
-        }
-
-        /*! - evaluate the angle between the requested and thruster implemented torque vector */
-        tauActual_B.normalize();
-        if (BLr_hat_B.dot(tauActual_B) < 1.0) {
-            returnAngle = safeAcos(BLr_hat_B.dot(tauActual_B)); /* Eq 16 */
-        }
-    }
-    return returnAngle;
 }
 
 /**
  * @brief Get the control axes in the body frame.
  * @return 3x3 matrix representing the control axes in the body frame.
  */
-Eigen::Matrix3d ThrForceMapping::getControlAxesB() const { return this->controlAxes_B; }
+Eigen::Matrix3d ThrForceMapping::getControlAxesB() const { return this->algorithm.getControlAxesB(); }
 
 /**
  * @brief Set the control axes in body frame.
  * @param axes A 3x3 matrix representing the control axes in body frame.
  */
-void ThrForceMapping::setControlAxesB(const Eigen::Matrix3d& axes) {
-    this->controlAxes_B = axes;
-    this->numControlAxes = 0;
-    for (uint32_t i = 0; i < 3; ++i) {
-        if (this->controlAxes_B.col(i).norm() > this->epsilon) {
-            this->controlAxes_B.col(i).normalize();
-            this->numControlAxes++;
-        } else {
-            break;
-        }
-    }
-}
+void ThrForceMapping::setControlAxesB(const Eigen::Matrix3d& axes) { this->algorithm.setControlAxesB(axes); }
 
 /**
  * @brief Get the thruster force magnitudes.
  * @return A vector of thruster force magnitudes.
  */
-Vector36d ThrForceMapping::getThrForceMag() const { return this->thrForceMag; }
+Vector36d ThrForceMapping::getThrForceMag() const { return this->algorithm.getThrForceMag(); }
 
 /**
  * @brief Set the thruster force magnitudes.
  * @param forceMag A vector of thruster force magnitudes.
  */
-void ThrForceMapping::setThrForceMag(const Vector36d& forceMag) { this->thrForceMag = forceMag; }
+void ThrForceMapping::setThrForceMag(const Vector36d& forceMag) { this->algorithm.setThrForceMag(forceMag); }
 
 /**
  * @brief Get the sign of the thruster forces.
  * @return The sign of the thruster forces (POSITIVE or NEGATIVE).
  */
-ThrForceSign ThrForceMapping::getThrForceSign() const { return this->thrForceSign; }
+ThrForceSign ThrForceMapping::getThrForceSign() const { return this->algorithm.getThrForceSign(); }
 
 /**
  * @brief Set the sign of the thruster forces.
  * @param sign The sign of the thruster forces (POSITIVE or NEGATIVE).
  */
-void ThrForceMapping::setThrForceSign(ThrForceSign sign) { this->thrForceSign = sign; }
+void ThrForceMapping::setThrForceSign(ThrForceSign sign) { this->algorithm.setThrForceSign(sign); }
 
 /**
  * @brief Get the angular error threshold.
  * @return The angular error threshold.
  */
-double ThrForceMapping::getAngErrThresh() const { return this->angErrThresh; }
+double ThrForceMapping::getAngErrThresh() const { return this->algorithm.getAngErrThresh(); }
 
 /**
  * @brief Set the angular error threshold.
  * @param The new angular error threshold.
  */
-void ThrForceMapping::setAngErrThresh(double thresh) { this->angErrThresh = thresh; }
+void ThrForceMapping::setAngErrThresh(double thresh) { this->algorithm.setAngErrThresh(thresh); }
 
 /**
  * @brief Get the epsilon value.
  * @return The epsilon value.
  */
-double ThrForceMapping::getEpsilon() const { return this->epsilon; }
+double ThrForceMapping::getEpsilon() const { return this->algorithm.getEpsilon(); }
 
 /**
  * @brief Set the epsilon value.
  * @param The new epsilon value.
  */
-void ThrForceMapping::setEpsilon(double eps) { this->epsilon = eps; }
+void ThrForceMapping::setEpsilon(double eps) { this->algorithm.setEpsilon(eps); }
 
 /**
  * @brief Check if the second least squares fitting loop should be used.
  * @return True if the 2nd loop should be used, false otherwise.
  */
-bool ThrForceMapping::getUse2ndLoop() const { return this->use2ndLoop; }
+bool ThrForceMapping::getUse2ndLoop() const { return this->algorithm.getUse2ndLoop(); }
 
 /**
  * @brief Set if the second least squares fitting loop should be used.
  * @return True if the 2nd loop should be used, false otherwise.
  */
-void ThrForceMapping::setUse2ndLoop(bool loopFlag) { this->use2ndLoop = loopFlag; }
+void ThrForceMapping::setUse2ndLoop(bool loopFlag) { this->algorithm.setUse2ndLoop(loopFlag); }

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.cpp
@@ -26,18 +26,14 @@
  */
 void ThrForceMapping::reset(uint64_t callTime) {
     // check if the required input messages are included
-    if (!this->thrConfigInMsg.isLinked()) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error: thrForceMapping.thrConfigInMsg wasn't connected.");
-    }
-    if (!this->vehConfigInMsg.isLinked()) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error: thrForceMapping.vehConfigInMsg wasn't connected.");
-    }
-    if (!this->cmdTorqueInMsg.isLinked()) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error: thrForceMapping.cmdTorqueInMsg wasn't connected.");
+    assert(this->thrConfigInMsg.isLinked() && this->vehConfigInMsg.isLinked() && this->cmdTorqueInMsg.isLinked());
+
+    auto localThrConfigInMsg = THRArrayConfigMsgPayload();
+    if (this->thrConfigInMsg.isWritten()) {
+        localThrConfigInMsg = this->thrConfigInMsg();
     }
 
-    THRArrayConfigMsgPayload thrConfigInMsg = this->thrConfigInMsg();
-    this->algorithm.reset(callTime, thrConfigInMsg);
+    this->algorithm.reset(callTime, localThrConfigInMsg);
 }
 
 /*! The module takes a body frame torque vector and projects it onto available RCS or DV thrusters.
@@ -45,12 +41,16 @@ void ThrForceMapping::reset(uint64_t callTime) {
  @param callTime The clock time at which the function was called (nanoseconds)
  */
 void ThrForceMapping::updateState(uint64_t callTime) {
-    /*! - Read the input messages */
-    CmdTorqueBodyMsgPayload LrInputMsg = this->cmdTorqueInMsg();
-    VehicleConfigMsgPayload vehConfigInMsg = this->vehConfigInMsg();
+    auto LrInputMsg = CmdTorqueBodyMsgPayload();
+    if (this->cmdTorqueInMsg.isWritten()) {
+        LrInputMsg = this->cmdTorqueInMsg();
+    }
+    auto localVehConfigInMsg = VehicleConfigMsgPayload();
+    if (this->vehConfigInMsg.isWritten()) {
+        localVehConfigInMsg = this->vehConfigInMsg();
+    }
 
-    /* store the output message */
-    THRArrayCmdForceMsgPayload thrusterForceOut = this->algorithm.update(callTime, LrInputMsg, vehConfigInMsg);
+    THRArrayCmdForceMsgPayload thrusterForceOut = this->algorithm.update(callTime, LrInputMsg, localVehConfigInMsg);
     this->thrForceCmdOutMsg.write(&thrusterForceOut, this->moduleID, callTime);
 }
 

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h
@@ -36,6 +36,8 @@
 /*!@brief Data structure for module to map a command torque onto thruster forces. */
 class ThrForceMapping : public SysModel {
    public:
+    ThrForceMapping() = default;   //!< Constructor
+    ~ThrForceMapping() = default;  //!< Destructor
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h
@@ -33,28 +33,28 @@
 #include "architecture/utilities/bskLogging.h"
 #include "fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h"
 
-/*!@brief Data structure for module to map a command torque onto thruster forces. */
+/*!@brief Thruster force mapping class. */
 class ThrForceMapping : public SysModel {
    public:
-    ThrForceMapping() = default;   //!< Constructor
-    ~ThrForceMapping() = default;  //!< Destructor
-    void reset(uint64_t callTime) override;
-    void updateState(uint64_t callTime) override;
+    ThrForceMapping() = default;                   //!< Constructor
+    ~ThrForceMapping() = default;                  //!< Destructor
+    void reset(uint64_t callTime) override;        //!< Reset method
+    void updateState(uint64_t callTime) override;  //!< Update method
 
-    Eigen::Matrix3d getControlAxesB() const;
-    void setControlAxesB(const Eigen::Matrix3d& axes);
-    Vector36d getThrForceMag() const;
-    void setThrForceMag(const Vector36d& forceMag);
-    ThrForceSign getThrForceSign() const;
-    void setThrForceSign(ThrForceSign sign);
-    double getAngErrThresh() const;
-    void setAngErrThresh(double thresh);
-    double getEpsilon() const;
-    void setEpsilon(double eps);
-    bool getUse2ndLoop() const;
-    void setUse2ndLoop(bool loopFlag);
+    Eigen::Matrix3d getControlAxesB() const;            //!< Getter method for thruster control axes
+    void setControlAxesB(const Eigen::Matrix3d& axes);  //!< Setter method for thruster control axes
+    Vector36d getThrForceMag() const;                   //!< Getter method for the thruster force magnitude
+    void setThrForceMag(const Vector36d& forceMag);     //!< Setter method for the thruster force magnitude
+    ThrForceSign getThrForceSign() const;               //!< Getter method for the thruster force sign
+    void setThrForceSign(ThrForceSign sign);            //!< Setter method for the thruster force sign
+    double getAngErrThresh() const;                     //!< Getter method for the angular error threshold
+    void setAngErrThresh(double thresh);                //!< Setter method for the angular error threshold
+    double getEpsilon() const;                          //!< Getter method for the epsilon value
+    void setEpsilon(double eps);                        //!< Setter method for the epsilon value
+    bool getUse2ndLoop() const;  //!< Getter method for whether the second least squares fitting loop should be used
+    void setUse2ndLoop(
+        bool loopFlag);  //!< Getter method for whether the second least squares fitting loop should be used
 
-    /* declare module IO interfaces */
     Message<THRArrayCmdForceMsgPayload> thrForceCmdOutMsg;  //!< The name of the output thruster force message
     ReadFunctor<CmdTorqueBodyMsgPayload> cmdTorqueInMsg;    //!< The name of the vehicle control (Lr) Input message
     ReadFunctor<THRArrayConfigMsgPayload> thrConfigInMsg;   //!< The name of the thruster cluster Input message
@@ -63,7 +63,7 @@ class ThrForceMapping : public SysModel {
     BSKLogger bskLogger = {};  //!< BSK Logging
 
    private:
-    ThrForceMappingAlgorithm algorithm;
+    ThrForceMappingAlgorithm algorithm;  //!< Algorithm for thrForceMapping logic (BSK-agnostic)
 };
 
 #endif

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.h
@@ -17,8 +17,8 @@
 
  */
 
-#ifndef _THRUSTER_FORCE_MAPPING_H_
-#define _THRUSTER_FORCE_MAPPING_H_
+#ifndef BASILISK_THRUSTER_FORCE_MAPPING_H
+#define BASILISK_THRUSTER_FORCE_MAPPING_H
 
 #include <stdint.h>
 
@@ -31,10 +31,7 @@
 #include "architecture/msgPayloadDefC/THRArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
-
-typedef Eigen::Vector<double, MAX_EFF_CNT> Vector36d;
-
-enum class ThrForceSign { POSITIVE = +1, NEGATIVE = -1 };
+#include "fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h"
 
 /*!@brief Data structure for module to map a command torque onto thruster forces. */
 class ThrForceMapping : public SysModel {
@@ -60,29 +57,11 @@ class ThrForceMapping : public SysModel {
     ReadFunctor<CmdTorqueBodyMsgPayload> cmdTorqueInMsg;    //!< The name of the vehicle control (Lr) Input message
     ReadFunctor<THRArrayConfigMsgPayload> thrConfigInMsg;   //!< The name of the thruster cluster Input message
     ReadFunctor<VehicleConfigMsgPayload> vehConfigInMsg;    //!< The name of the Input message
-    VehicleConfigMsgPayload sc;                             //!< spacecraft configuration message
 
     BSKLogger bskLogger = {};  //!< BSK Logging
 
    private:
-    Vector36d findMinimumNormForce(const Eigen::Matrix<double, 3, MAX_EFF_CNT>& D,
-                                   const Eigen::Vector3d& Lr_B,
-                                   uint32_t numForces) const;
-
-    Eigen::Matrix3d controlAxes_B{};  //!< [] array of the control unit axes
-    Vector36d thrForceMag{};          //!< vector of thruster force magnitudes
-    ThrForceSign thrForceSign =
-        ThrForceSign::POSITIVE;  //!< [] Flag indicating if positive or negative thruster solutions are found
-    double angErrThresh{};       //!< [r] Angular error at which thruster forces are scaled to not be super-saturated
-    double epsilon{};            //!< variable specifying what is considered a small number
-    bool use2ndLoop{};  //!< [] flag indicating if the 2nd least squares fitting loop should be used (1) or not used (0
-                        //!< - default)
-    uint32_t numControlAxes{};  //!< [] counter indicating how many orthogonal axes are controlled
-    uint32_t numThrusters{};    //!< [] The number of thrusters available on vehicle
-    double outTorqAngErr{};     //!< [r] Angular error of effector torque
-    Eigen::Matrix<double, MAX_EFF_CNT, 3> rThruster_B{};  //!< [m] local copy of the thruster locations
-    Eigen::Matrix<double, MAX_EFF_CNT, 3>
-        gtThruster_B{};  //!< [] local copy of the thruster force unit direction vectors
+    ThrForceMappingAlgorithm algorithm;
 };
 
 #endif

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.i
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMapping.i
@@ -30,6 +30,7 @@
 %include "swig_conly_data.i"
 EIGEN_MAT_WRAP(Vector36d, 157)
 %include "thrForceMapping.h"
+%include "thrForceMappingAlgorithm.h"
 
 %include "architecture/msgPayloadDefC/THRArrayCmdForceMsgPayload.h"
 %include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.cpp
@@ -1,0 +1,358 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h"
+
+#include <math.h>
+
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
+
+int8_t asInt(ThrForceSign value) { return static_cast<int8_t>(value); }
+
+void substractMin(Eigen::Vector<double, MAX_EFF_CNT>& F, uint32_t size);
+
+double computeTorqueAngErr(Eigen::Matrix<double, 3, MAX_EFF_CNT> D,
+                           const Eigen::Vector3d& BLr_B,
+                           uint32_t numForces,
+                           double epsilon,
+                           Eigen::Vector<double, MAX_EFF_CNT> F,
+                           Eigen::Vector<double, MAX_EFF_CNT> FMag);
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param thrConfigInMsg Thruster configuration message
+ */
+void ThrForceMappingAlgorithm::reset(uint64_t callTime, THRArrayConfigMsgPayload& thrConfigInMsg) {
+    assert(this->numControlAxes > 0);
+
+    THRArrayConfigMsgPayload localThrusterData = thrConfigInMsg;
+
+    /*! - copy the thruster position and thruster force heading information into the module configuration data */
+    this->numThrusters = localThrusterData.numThrusters;
+    for (uint32_t i = 0; i < this->numThrusters; ++i) {
+        this->rThruster_B.row(i) = Eigen::Map<Eigen::Vector3d>(localThrusterData.thrusters[i].rThrust_B);
+        this->gtThruster_B.row(i) =
+            Eigen::Map<Eigen::Vector3d>(localThrusterData.thrusters[i].tHatThrust_B).transpose();
+        if (localThrusterData.thrusters[i].maxThrust <= 0.0) {
+            assert("thruster has a non-sensible saturation limit of <= 0 N." && false);
+        } else {
+            this->thrForceMag(i) = localThrusterData.thrusters[i].maxThrust;
+        }
+    }
+}
+
+/*! The module takes a body frame torque vector and projects it onto available RCS or DV thrusters.
+ @return THRArrayCmdForceMsgPayload
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param cmdTorqueInMsg Command torque input message
+ @param vehConfigInMsg Vehicle configuration input message
+ */
+THRArrayCmdForceMsgPayload ThrForceMappingAlgorithm::update(uint64_t callTime,
+                                                            CmdTorqueBodyMsgPayload& cmdTorqueInMsg,
+                                                            VehicleConfigMsgPayload& vehConfigInMsg) {
+    /*! - copy the request 3D attitude control torque vector */
+    Eigen::Vector3d Lr_B =
+        Eigen::Map<Eigen::Vector3d>(cmdTorqueInMsg.torqueRequestBody);  // [Nm] commanded control torque
+
+    /*! - compute thruster locations relative to COM */
+    /* Part 1 of Eq. 4 */
+    Eigen::Matrix<double, MAX_EFF_CNT, 3> rThrusterRelCOM_B =
+        this->rThruster_B.rowwise() - Eigen::Map<Eigen::Vector3d>(vehConfigInMsg.CoM_B).transpose();
+
+    /*! - compute general thruster force mapping matrix */
+    Eigen::Vector3d Lr_offset = Eigen::Vector3d::Zero();
+    Eigen::Matrix<double, 3, MAX_EFF_CNT> D =
+        Eigen::Matrix<double, 3, MAX_EFF_CNT>::Zero();  // [m] mapping matrix from thruster forces to body torque
+    for (uint32_t i = 0; i < this->numThrusters; ++i) {
+        Eigen::Vector3d rCrossGt = rThrusterRelCOM_B.row(i).cross(this->gtThruster_B.row(i)); /* Eq. 6 */
+        D.col(i) = rCrossGt;
+        /* Handles the case where there is translational motion imparted during off-pulsing*/
+        if (this->thrForceSign == ThrForceSign::NEGATIVE) {
+            /* Computing local torques from each thruster -- Individual terms in Eq. 7*/
+            Eigen::Vector3d LrLocal = rCrossGt * this->thrForceMag(i); /* [Nm] Torque provided by individual thruster */
+            Lr_offset = Lr_offset - LrLocal; /* Summing of individual torques -- Eq. 5 & Eq. 7 */
+        }
+    }
+
+    Lr_B = Lr_B + Lr_offset;
+
+    /*! Map the control torque onto the control axes
+     * Note: Lr_B_Bar is projected only onto the available control axes.
+     * i.e. if using DV thrusters with only 1 control axis,
+     * Lr_B_Bar = [#, 0, 0]
+     */
+    Eigen::Vector3d Lr_B_Bar = this->controlAxes_B * Lr_B;  // [Nm] Control torque that we actually control
+
+    // 1st iteration of finding a set of force vectors to implement the control torque
+    Eigen::Vector<double, MAX_EFF_CNT> F =
+        this->findMinimumNormForce(D, Lr_B_Bar, this->numThrusters); /* [N] vector of commanded thruster forces */
+
+    /*! - Remove forces components that are contributing to the RCS Null space (this is due to the geometry of the
+     * thrusters) */
+    if (this->thrForceSign == ThrForceSign::POSITIVE) {
+        substractMin(F, this->numThrusters);
+    }
+
+    if ((this->thrForceSign == ThrForceSign::NEGATIVE && this->numControlAxes < 3) || this->use2ndLoop) {
+        // Array of flags indicating if this thruster is used for the Lr_j
+        std::array<bool, MAX_EFF_CNT> thrusterUsed{};
+        // Reduced mapping matrix
+        Eigen::Matrix<double, 3, MAX_EFF_CNT> Dbar = Eigen::Matrix<double, 3, MAX_EFF_CNT>::Zero();  // [m]
+        int counterPosForces = 0;  // counter for number of positive thruster forces
+        for (uint32_t i = 0; i < this->numThrusters; ++i) {
+            if (F(i) * asInt(this->thrForceSign) > 0) {
+                thrusterUsed[i] = true; /* Eq. 11 */
+                for (uint32_t j = 0; j < 3; ++j) {
+                    Dbar(j, counterPosForces) = D(j, i); /* Eq. 12 */
+                }
+                counterPosForces += 1;
+            }
+        }
+
+        // [N] vector of intermediate thruster forces
+        Eigen::Vector<double, MAX_EFF_CNT> Fbar = this->findMinimumNormForce(Dbar, Lr_B_Bar, counterPosForces);
+        if (this->thrForceSign == ThrForceSign::POSITIVE) {
+            substractMin(Fbar, counterPosForces);
+        }
+        uint32_t c = 0;
+        for (uint32_t i = 0; i < this->numThrusters; ++i) {
+            if (thrusterUsed[i]) {
+                F(i) = Fbar(c);
+                c++;
+            } else {
+                F(i) = 0.0;
+            }
+        }
+    }
+
+    this->outTorqAngErr =
+        computeTorqueAngErr(D, Lr_B_Bar, this->numThrusters, this->epsilon, F, this->thrForceMag); /* Eq. 16*/
+    /*  check if the angle between the request and actual torque exceeds a limit.  If so, then uniformly scale
+        all thruster forces values to not exceed saturation.
+        If the angle threshold is negative, then this scaling is bypassed.*/
+    if (this->outTorqAngErr > this->angErrThresh) {
+        double maxFractUse = 0.0;  // ratio of maximum requested thruster force relative to maximum thruster limit
+        for (uint32_t i = 0; i < this->numThrusters; ++i) {
+            if (this->thrForceMag(i) > 0.0 &&
+                std::fabs(F(i)) / this->thrForceMag(i) > maxFractUse) /* confirming that maxThrust > 0 */
+            {
+                maxFractUse = std::fabs(F(i)) / this->thrForceMag(i);
+            }
+        }
+        /* only scale the requested thruster force if one or more thrusters are saturated */
+        if (maxFractUse > 1.0) {
+            F *= 1.0 / maxFractUse;
+            this->outTorqAngErr =
+                computeTorqueAngErr(D, Lr_B_Bar, this->numThrusters, this->epsilon, F, this->thrForceMag);
+        }
+    }
+
+    /* store the output message */
+    THRArrayCmdForceMsgPayload thrusterForceOut{};
+    for (int i = 0; i < F.size(); ++i) {
+        thrusterForceOut.thrForce[i] = F(i);
+    }
+
+    return thrusterForceOut;
+}
+
+/*!
+ Take a stack of force values find the smallest value, and subtract if from all force values.  Here the smallest values
+ will become zero, while other forces increase.  This assumes that the thrusters are aligned such that if all
+ thrusters are firing, then no torque or force is applied.  This ensures only positive force values are computed.
+ */
+void substractMin(Eigen::Vector<double, MAX_EFF_CNT>& F, uint32_t size) {
+    double minValue = 0.0;
+    for (uint32_t i = 0; i < size; ++i) {
+        if (F(i) < minValue) {
+            minValue = F(i);
+        }
+    }
+    for (uint32_t i = 0; i < size; ++i) {
+        F(i) -= minValue;
+    }
+}
+
+/*!
+ * @brief Find the minimum norm solution to the least squares problem. Use a least square inverse to determine
+ * the smallest set of thruster forces that yield the desired torque vector. Note that this routine does not
+ * constrain yet the forces to be either positive or negative.
+ * @param D 3x32 matrix that maps the thruster forces F[i] to the spacecraft torque.
+ * @param Lr_B The vector representing the requested control torque.
+ * @param numForces The number of thrusters to include in the minimum norm computation
+ * @return A vector containing the thruster force solutions to the least squares problem.
+ */
+Eigen::Vector<double, MAX_EFF_CNT> ThrForceMappingAlgorithm::findMinimumNormForce(
+    const Eigen::Matrix<double, 3, MAX_EFF_CNT>& D,
+    const Eigen::Vector3d& Lr_B_Bar,
+    uint32_t numForces) const {
+    /* find [D].[D]^T */
+    // [C].[D] matrix -- Thrusters in body frame mapped on control axes
+    Eigen::Matrix<double, 3, MAX_EFF_CNT> CD = this->controlAxes_B * D;  // [m^2]
+    Eigen::Matrix3d CDCDT = Eigen::Matrix3d::Identity();                 // [m^2]  [CD].[CD]^T matrix
+    for (uint32_t i = 0; i < this->numControlAxes; ++i) {
+        for (uint32_t j = 0; j < this->numControlAxes; ++j) {
+            CDCDT(i, j) = 0.0;
+            for (uint32_t k = 0; k < numForces; ++k) {
+                CDCDT(i, j) += CD(i, k) * CD(j, k); /* Part of Eq. 9 */
+            }
+        }
+    }
+
+    Eigen::Matrix3d CDCDTInv = Eigen::Matrix3d::Zero(); /* [m^2]  ([CD].[CD]^T)^-1 matrix */
+    if (CDCDT.determinant() > this->epsilon) {
+        CDCDTInv = CDCDT.inverse();
+    }  // else CDCDTInv is already initialized to zeros
+
+    /* If fewer than 3 control axes, then the 1's along the diagonal of DDTInv will
+     * not conflict with the mapping, as Lr_B_Bar contains the necessary zeros
+     * to inhibit projection */
+    Eigen::Vector3d CDCDTInvLr = CDCDTInv * Lr_B_Bar;
+    Eigen::Vector<double, MAX_EFF_CNT> F = CD.transpose() * CDCDTInvLr; /* Eq. 15 */
+    return F;
+}
+
+/*!
+ * @brief  Determine the angle between the desired torque vector and the actual torque vector.
+ * @param D 3x32 matrix that maps the thruster forces F[i] to the spacecraft torque.
+ * @param BLr_B The vector representing the requested control torque.
+ * @param numForces The number of thrusters to include in the computation
+ * @param epsilon The threshold value for above which a vector norm is valid
+ * @param F The force vectors which implement the control torque
+ * @param FMag The force magnitudes of the thrusters
+ * @return A vector containing the thruster force solutions to the least squares problem.
+ */
+double computeTorqueAngErr(Eigen::Matrix<double, 3, MAX_EFF_CNT> D,
+                           const Eigen::Vector3d& BLr_B,
+                           uint32_t numForces,
+                           double epsilon,
+                           Eigen::Vector<double, MAX_EFF_CNT> F,
+                           Eigen::Vector<double, MAX_EFF_CNT> FMag) {
+    double returnAngle = 0.0;  // [rad] angle between requested and actual torque vector
+    /*! - make sure a control torque is requested, otherwise just return a zero angle error */
+    if (BLr_B.norm() > epsilon) {
+        Eigen::Matrix<double, MAX_EFF_CNT, 3> DT = D.transpose();
+        Eigen::Vector3d BLr_hat_B = BLr_B.normalized();         // normalized BLr_B vector
+        Eigen::Vector3d tauActual_B = Eigen::Vector3d::Zero();  // [Nm] control torque with current thruster solution
+
+        /*! - loop over all thrusters and compute the actual torque to be applied */
+        for (uint32_t i = 0; i < numForces; ++i) {
+            /* This could produce inf's as F(i) approaches 0 if FMag(i) is 0, as such we
+             * assert if FMag(i) is equal to zero in reset() */
+            double thrusterForce = std::fabs(F(i)) < FMag(i) ? F(i)
+                                                             : FMag(i) * std::fabs(F(i)) /
+                                                                   F(i); /* [N] saturation constrained thruster force */
+            Eigen::Vector3d LrEffector_B = DT.row(i) * thrusterForce;  // [Nm] torque of an individual thruster effector
+            tauActual_B += LrEffector_B;
+        }
+
+        /*! - evaluate the angle between the requested and thruster implemented torque vector */
+        tauActual_B.normalize();
+        if (BLr_hat_B.dot(tauActual_B) < 1.0) {
+            returnAngle = safeAcos(BLr_hat_B.dot(tauActual_B)); /* Eq 16 */
+        }
+    }
+    return returnAngle;
+}
+
+/**
+ * @brief Get the control axes in the body frame.
+ * @return 3x3 matrix representing the control axes in the body frame.
+ */
+Eigen::Matrix3d ThrForceMappingAlgorithm::getControlAxesB() const { return this->controlAxes_B; }
+
+/**
+ * @brief Set the control axes in body frame.
+ * @param axes A 3x3 matrix representing the control axes in body frame.
+ */
+void ThrForceMappingAlgorithm::setControlAxesB(const Eigen::Matrix3d& axes) {
+    this->controlAxes_B = axes;
+    this->numControlAxes = 0;
+    for (uint32_t i = 0; i < 3; ++i) {
+        if (this->controlAxes_B.col(i).norm() > this->epsilon) {
+            this->controlAxes_B.col(i).normalize();
+            this->numControlAxes++;
+        } else {
+            break;
+        }
+    }
+}
+
+/**
+ * @brief Get the thruster force magnitudes.
+ * @return A vector of thruster force magnitudes.
+ */
+Vector36d ThrForceMappingAlgorithm::getThrForceMag() const { return this->thrForceMag; }
+
+/**
+ * @brief Set the thruster force magnitudes.
+ * @param forceMag A vector of thruster force magnitudes.
+ */
+void ThrForceMappingAlgorithm::setThrForceMag(const Vector36d& forceMag) { this->thrForceMag = forceMag; }
+
+/**
+ * @brief Get the sign of the thruster forces.
+ * @return The sign of the thruster forces (POSITIVE or NEGATIVE).
+ */
+ThrForceSign ThrForceMappingAlgorithm::getThrForceSign() const { return this->thrForceSign; }
+
+/**
+ * @brief Set the sign of the thruster forces.
+ * @param sign The sign of the thruster forces (POSITIVE or NEGATIVE).
+ */
+void ThrForceMappingAlgorithm::setThrForceSign(ThrForceSign sign) { this->thrForceSign = sign; }
+
+/**
+ * @brief Get the angular error threshold.
+ * @return The angular error threshold.
+ */
+double ThrForceMappingAlgorithm::getAngErrThresh() const { return this->angErrThresh; }
+
+/**
+ * @brief Set the angular error threshold.
+ * @param The new angular error threshold.
+ */
+void ThrForceMappingAlgorithm::setAngErrThresh(double thresh) { this->angErrThresh = thresh; }
+
+/**
+ * @brief Get the epsilon value.
+ * @return The epsilon value.
+ */
+double ThrForceMappingAlgorithm::getEpsilon() const { return this->epsilon; }
+
+/**
+ * @brief Set the epsilon value.
+ * @param The new epsilon value.
+ */
+void ThrForceMappingAlgorithm::setEpsilon(double eps) { this->epsilon = eps; }
+
+/**
+ * @brief Check if the second least squares fitting loop should be used.
+ * @return True if the 2nd loop should be used, false otherwise.
+ */
+bool ThrForceMappingAlgorithm::getUse2ndLoop() const { return this->use2ndLoop; }
+
+/**
+ * @brief Set if the second least squares fitting loop should be used.
+ * @return True if the 2nd loop should be used, false otherwise.
+ */
+void ThrForceMappingAlgorithm::setUse2ndLoop(bool loopFlag) { this->use2ndLoop = loopFlag; }

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.cpp
@@ -33,10 +33,9 @@ double computeTorqueAngErr(Eigen::Matrix<double, 3, MAX_EFF_CNT> D,
                            Eigen::Vector<double, MAX_EFF_CNT> F,
                            Eigen::Vector<double, MAX_EFF_CNT> FMag);
 
-/*! This method performs a complete reset of the module.  Local module variables that retain
- time varying states between function calls are reset to their default values.
+/*! Reset method for the thrForceMapping algorithm.
  @return void
- @param callTime The clock time at which the function was called (nanoseconds)
+ @param callTime [ns] Time the method is called
  @param thrConfigInMsg Thruster configuration message
  */
 void ThrForceMappingAlgorithm::reset(uint64_t callTime, THRArrayConfigMsgPayload& thrConfigInMsg) {
@@ -58,9 +57,10 @@ void ThrForceMappingAlgorithm::reset(uint64_t callTime, THRArrayConfigMsgPayload
     }
 }
 
-/*! The module takes a body frame torque vector and projects it onto available RCS or DV thrusters.
- @return THRArrayCmdForceMsgPayload
- @param callTime The clock time at which the function was called (nanoseconds)
+/*! Update method for the thrForceMapping algorithm. The module takes a body frame torque vector and projects
+ it onto available RCS or DV thrusters.
+ @return THRArrayCmdForceMsgPayload Thruster array command force message
+ @param callTime [ns] Time the method is called
  @param cmdTorqueInMsg Command torque input message
  @param vehConfigInMsg Vehicle configuration input message
  */

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.cpp
@@ -19,10 +19,8 @@
 
 #include "fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h"
 
+#include "architecture/utilities/safeMath.h"
 #include <math.h>
-
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 int8_t asInt(ThrForceSign value) { return static_cast<int8_t>(value); }
 

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
@@ -35,6 +35,8 @@ enum class ThrForceSign { POSITIVE = +1, NEGATIVE = -1 };
 
 class ThrForceMappingAlgorithm {
    public:
+    ThrForceMappingAlgorithm() = default;   //!< Constructor
+    ~ThrForceMappingAlgorithm() = default;  //!< Destructor
     void reset(uint64_t callTime, THRArrayConfigMsgPayload& thrConfigInMsg);
     THRArrayCmdForceMsgPayload update(uint64_t callTime,
                                       CmdTorqueBodyMsgPayload& cmdTorqueInMsg,

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
@@ -22,12 +22,12 @@
 
 #include <stdint.h>
 
-#include <Eigen/Dense>
-
 #include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
 #include "architecture/msgPayloadDefC/THRArrayCmdForceMsgPayload.h"
 #include "architecture/msgPayloadDefC/THRArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include <Eigen/Dense>
 
 typedef Eigen::Vector<double, MAX_EFF_CNT> Vector36d;
 

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
@@ -33,27 +33,29 @@ typedef Eigen::Vector<double, MAX_EFF_CNT> Vector36d;
 
 enum class ThrForceSign { POSITIVE = +1, NEGATIVE = -1 };
 
+/*!@brief Thruster force mapping algorithm class. */
 class ThrForceMappingAlgorithm {
    public:
-    ThrForceMappingAlgorithm() = default;   //!< Constructor
-    ~ThrForceMappingAlgorithm() = default;  //!< Destructor
-    void reset(uint64_t callTime, THRArrayConfigMsgPayload& thrConfigInMsg);
+    ThrForceMappingAlgorithm() = default;                                     //!< Constructor
+    ~ThrForceMappingAlgorithm() = default;                                    //!< Destructor
+    void reset(uint64_t callTime, THRArrayConfigMsgPayload& thrConfigInMsg);  //!< Reset method
     THRArrayCmdForceMsgPayload update(uint64_t callTime,
                                       CmdTorqueBodyMsgPayload& cmdTorqueInMsg,
-                                      VehicleConfigMsgPayload& vehConfigInMsg);
+                                      VehicleConfigMsgPayload& vehConfigInMsg);  //!< Update method
 
-    Eigen::Matrix3d getControlAxesB() const;
-    void setControlAxesB(const Eigen::Matrix3d& axes);
-    Vector36d getThrForceMag() const;
-    void setThrForceMag(const Vector36d& forceMag);
-    ThrForceSign getThrForceSign() const;
-    void setThrForceSign(ThrForceSign sign);
-    double getAngErrThresh() const;
-    void setAngErrThresh(double thresh);
-    double getEpsilon() const;
-    void setEpsilon(double eps);
-    bool getUse2ndLoop() const;
-    void setUse2ndLoop(bool loopFlag);
+    Eigen::Matrix3d getControlAxesB() const;            //!< Getter method for thruster control axes
+    void setControlAxesB(const Eigen::Matrix3d& axes);  //!< Setter method for thruster control axes
+    Vector36d getThrForceMag() const;                   //!< Getter method for the thruster force magnitude
+    void setThrForceMag(const Vector36d& forceMag);     //!< Setter method for the thruster force magnitude
+    ThrForceSign getThrForceSign() const;               //!< Getter method for the thruster force sign
+    void setThrForceSign(ThrForceSign sign);            //!< Setter method for the thruster force sign
+    double getAngErrThresh() const;                     //!< Getter method for the angular error threshold
+    void setAngErrThresh(double thresh);                //!< Setter method for the angular error threshold
+    double getEpsilon() const;                          //!< Getter method for the epsilon value
+    void setEpsilon(double eps);                        //!< Setter method for the epsilon value
+    bool getUse2ndLoop() const;  //!< Getter method for whether the second least squares fitting loop should be used
+    void setUse2ndLoop(
+        bool loopFlag);  //!< Getter method for whether the second least squares fitting loop should be used
 
    private:
     Vector36d findMinimumNormForce(const Eigen::Matrix<double, 3, MAX_EFF_CNT>& D,

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/thrForceMappingAlgorithm.h
@@ -1,0 +1,77 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _THRUSTER_FORCE_MAPPING_ALGORITHM_H
+#define _THRUSTER_FORCE_MAPPING_ALGORITHM_H
+
+#include <stdint.h>
+
+#include <Eigen/Dense>
+
+#include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
+#include "architecture/msgPayloadDefC/THRArrayCmdForceMsgPayload.h"
+#include "architecture/msgPayloadDefC/THRArrayConfigMsgPayload.h"
+#include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+
+typedef Eigen::Vector<double, MAX_EFF_CNT> Vector36d;
+
+enum class ThrForceSign { POSITIVE = +1, NEGATIVE = -1 };
+
+class ThrForceMappingAlgorithm {
+   public:
+    void reset(uint64_t callTime, THRArrayConfigMsgPayload& thrConfigInMsg);
+    THRArrayCmdForceMsgPayload update(uint64_t callTime,
+                                      CmdTorqueBodyMsgPayload& cmdTorqueInMsg,
+                                      VehicleConfigMsgPayload& vehConfigInMsg);
+
+    Eigen::Matrix3d getControlAxesB() const;
+    void setControlAxesB(const Eigen::Matrix3d& axes);
+    Vector36d getThrForceMag() const;
+    void setThrForceMag(const Vector36d& forceMag);
+    ThrForceSign getThrForceSign() const;
+    void setThrForceSign(ThrForceSign sign);
+    double getAngErrThresh() const;
+    void setAngErrThresh(double thresh);
+    double getEpsilon() const;
+    void setEpsilon(double eps);
+    bool getUse2ndLoop() const;
+    void setUse2ndLoop(bool loopFlag);
+
+   private:
+    Vector36d findMinimumNormForce(const Eigen::Matrix<double, 3, MAX_EFF_CNT>& D,
+                                   const Eigen::Vector3d& Lr_B,
+                                   uint32_t numForces) const;
+
+    Eigen::Matrix3d controlAxes_B{};  //!< [] array of the control unit axes
+    Vector36d thrForceMag{};          //!< vector of thruster force magnitudes
+    ThrForceSign thrForceSign =
+        ThrForceSign::POSITIVE;  //!< [] Flag indicating if positive or negative thruster solutions are found
+    double angErrThresh{};       //!< [r] Angular error at which thruster forces are scaled to not be super-saturated
+    double epsilon{};            //!< variable specifying what is considered a small number
+    bool use2ndLoop{};  //!< [] flag indicating if the 2nd least squares fitting loop should be used (1) or not used (0
+                        //!< - default)
+    uint32_t numControlAxes{};  //!< [] counter indicating how many orthogonal axes are controlled
+    uint32_t numThrusters{};    //!< [] The number of thrusters available on vehicle
+    double outTorqAngErr{};     //!< [r] Angular error of effector torque
+    Eigen::Matrix<double, MAX_EFF_CNT, 3> rThruster_B{};  //!< [m] local copy of the thruster locations
+    Eigen::Matrix<double, MAX_EFF_CNT, 3>
+        gtThruster_B{};  //!< [] local copy of the thruster force unit direction vectors
+};
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** #422 
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  
* 
## Description
To enable easy relocation of fsw algorithms use the adapter pattern for `thrForceMapping`.
This allows for relocation of fsw algorithms and then inclusion of bsk modules in any language with a c ffi/abi.

## Verification
N/A

## Documentation
N/A

## Future work
N/A
