### PR TITLE
Set opencv version to 4.5.5

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.11'
       - id: file_changes
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v46
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+  USERNAME: ${{github.repository_owner}}
+  FEED_URL: https://nuget.pkg.github.com/${{github.repository_owner}}/index.json
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{github.repository_owner}}/index.json,readwrite"
 
 jobs:
   pre-commit:
@@ -66,7 +68,8 @@ jobs:
             libxft-dev libxext-dev libgles2-mesa-dev \
             libxi-dev libxtst-dev libxrandr-dev libltdl-dev \
             gtk2.0 libgtk2.0-dev \
-            python3-setuptools python3-jinja2 python3-tk
+            python3-setuptools python3-jinja2 python3-tk \
+            mono-complete
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
@@ -78,6 +81,21 @@ jobs:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           vcpkgJsonGlob: "src/vcpkg.json"
           vcpkgConfigurationJsonGlob: "src/vcpkg-configuration.json"
+      - name: Add NuGet sources
+        shell: bash
+        env:
+          VCPKG_EXE: ${{ runner.workspace }}/b/vcpkg/vcpkg
+        run: |
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            sources add \
+            -Source "${{ env.FEED_URL }}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${{ env.USERNAME }}" \
+            -Password "${{ secrets.GH_VCPKG_PACKAGES_TOKEN }}"
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            setapikey "${{ secrets.GH_VCPKG_PACKAGES_TOKEN }}" \
+            -Source "${{ env.FEED_URL }}"
       - name: "Create virtual Environment"
         run: |
           python${{ matrix.python-version }} -m venv .venv
@@ -86,6 +104,8 @@ jobs:
       - name: "Install required Python dependencies"
         run: source .venv/bin/activate && pip3 install -r requirements.txt
       - name: "Generate build recipes"
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,${{env.FEED_URL}},readwrite"
         run: source .venv/bin/activate && cd src/ && cmake --preset ci-test
       - name: "Build basilisk"
         run: source .venv/bin/activate && cd src/ && ninja -C ../dist3/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -61,7 +61,9 @@ jobs:
             pkg-config autoconf automake libtool \
             zip unzip \
             bison swig \
-            libx11-dev libxft-dev libxext-dev libgles2-mesa-dev \
+            libdrm-dev \
+            libx11-dev libxkbcommon-x11-dev libx11-xcb-dev \
+            libxft-dev libxext-dev libgles2-mesa-dev \
             libxi-dev libxtst-dev libxrandr-dev libltdl-dev \
             gtk2.0 libgtk2.0-dev \
             python3-setuptools python3-jinja2 python3-tk

--- a/src/vcpkg-configuration.json
+++ b/src/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "3289c7a9988d0db584efeb910c3f4bbec50e5a50",
+    "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -5,13 +5,17 @@
     "cppzmq",
     "eigen3",
     "gtest",
-    "opencv",
+    "opencv4",
     "protobuf"
   ],
   "overrides": [
     {
       "name": "protobuf",
       "version": "3.18.0"
+    },
+    {
+      "name": "opencv4",
+      "version": "4.5.5"
     }
   ]
 }


### PR DESCRIPTION
* **Tickets addressed:** #432 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The opencv dependency version is specified to 4.5.5. The vcpkg cache mechanism is also changed to use nuget github packages as cache. Packages are uploaded/cached to here https://github.com/orgs/lasp/packages

## Verification
The current test suite is insufficient in this area. Manual testing demonstrates correct operation. New tickets will be created to update the testing.

## Documentation
Non needed.

## Future work
The opencv usage will be updated to accommodated opencv4.8
