### PR TITLE
Refactor mrpSteering module

### DIFF
--- a/src/fswAlgorithms/attControl/mrpSteering/_UnitTest/test_MRP_steeringUnit.py
+++ b/src/fswAlgorithms/attControl/mrpSteering/_UnitTest/test_MRP_steeringUnit.py
@@ -24,19 +24,12 @@ from Basilisk.fswAlgorithms import mrpSteering  # import the module that is to b
 from Basilisk.utilities import RigidBodyKinematics
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+import numpy.testing
 
 
 @pytest.mark.parametrize("K1", [0.15, 0])
 @pytest.mark.parametrize("K3", [1, 0])
 @pytest.mark.parametrize("omegaMax", [1.5 * macros.D2R, 0.001 * macros.D2R])
-
-
-# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
-# @pytest.mark.skipif(conditionstring)
-# uncomment this line if this test has an expected failure, adjust message as needed
-# @pytest.mark.xfail() # need to update how the RW states are defined
-# provide a unique test method name, starting with test_
 def test_mrp_steering_tracking(show_plots, K1, K3, omegaMax):
     r"""
     **Validation Test Description**
@@ -57,110 +50,53 @@ def test_mrp_steering_tracking(show_plots, K1, K3, omegaMax):
     :return: void
 
     """
-    [testResults, testMessage] = mrp_steering_tracking(show_plots, K1, K3, omegaMax)
-    assert testResults < 1, testMessage
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
 
-
-def mrp_steering_tracking(show_plots, K1, K3, omegaMax):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty list to store test log messages
-    unitTaskName = "unitTask"  # arbitrary name (don't change)
-    unitProcessName = "TestProcess"  # arbitrary name (don't change)
-
-    #   Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
-
-    # Create test thread
-    testProcessRate = macros.sec2nano(0.5)  # update process rate update time
+    testProcessRate = macros.sec2nano(0.5)
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
-    # Construct algorithm and associated C++ container
     module = mrpSteering.MrpSteering()
     module.modelTag = "mrpSteering"
-
-
-    # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, module)
 
-    # Initialize the test module configuration data
-    module.K1 = K1
-    module.K3 = K3
-    module.omega_max = omegaMax
+    module.setK1(K1)
+    module.setK3(K3)
+    module.setOmegaMax(omegaMax)
 
-    #   Create input message and size it because the regular creator of that message
-    #   is not part of the test.
-    guidCmdData = messaging.AttGuidMsgPayload()  # Create a structure for the input message
+    guidCmdData = messaging.AttGuidMsgPayload()
     sigma_BR = np.array([0.3, -0.5, 0.7])
     guidCmdData.sigma_BR = sigma_BR
-    omega_BR_B = np.array([0.010, -0.020, 0.015])
-    guidCmdData.omega_BR_B = omega_BR_B
-    omega_RN_B = np.array([-0.02, -0.01, 0.005])
-    guidCmdData.omega_RN_B = omega_RN_B
-    domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
-    guidCmdData.domega_RN_B = domega_RN_B
+    guidCmdData.omega_BR_B = np.array([0.010, -0.020, 0.015])
+    guidCmdData.omega_RN_B = np.array([-0.02, -0.01, 0.005])
+    guidCmdData.domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
     guidInMsg = messaging.AttGuidMsg().write(guidCmdData)
 
-    # Setup logging on the test module output message so that we get all the writes to it
     dataLog = module.rateCmdOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    # connect messages
     module.guidInMsg.subscribeTo(guidInMsg)
 
-    # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
-
-    # Step the simulation to 3*process rate so 4 total steps including zero
-    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))  # seconds to stop simulation
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
     unitTestSim.ExecuteSimulation()
 
-    # Compute truth states
     omegaAstTrue, omegaAstPTrue = findTrueValues(guidCmdData, module)
 
-    # compare the module results to the truth values
-    accuracy = 1e-12
-    for i in range(0, len(omegaAstTrue)):
-        # check a vector values
-        if not unitTestSupport.isArrayEqual(dataLog.omega_BastR_B[i], omegaAstTrue[i], 3, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + module.modelTag + " Module failed omega_BastR_B unit test at t="
-                                + str(dataLog.times()[i] * macros.NANO2SEC) + "sec \n")
+    numpy.testing.assert_allclose(dataLog.omega_BastR_B, omegaAstTrue, atol=1e-12)
+    numpy.testing.assert_allclose(dataLog.omegap_BastR_B, omegaAstPTrue, atol=1e-12)
 
-    # compare the module results to the truth values
-    accuracy = 1e-12
-    for i in range(0, len(omegaAstPTrue)):
-        # check a vector values
-        if not unitTestSupport.isArrayEqual(dataLog.omegap_BastR_B[i], omegaAstPTrue[i], 3, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + module.modelTag + " Module failed omegap_BastR_B unit test at t="
-                                + str(dataLog.times()[i] * macros.NANO2SEC) + "sec \n")
 
-    # If the argument provided at commandline "--show_plots" evaluates as true,
-    # plot all figures
-    if show_plots:
-        plt.show()
-
-    # print out success message if no error were found
-    if testFailCount == 0:
-        print("PASSED: " + module.modelTag)
-
-    # return fail count and join into a single string all messages in the list
-    # testMessage
-    return [testFailCount, ''.join(testMessages)]
 
 
 def findTrueValues(guidCmdData, module):
 
-    omegaMax = module.omega_max
+    omegaMax = module.getOmegaMax()
     sigma = np.asarray(guidCmdData.sigma_BR)
-    K1 = np.asarray(module.K1)
-    K3 = np.asarray(module.K3)
+    K1 = np.asarray(module.getK1())
+    K3 = np.asarray(module.getK3())
     Bmat = RigidBodyKinematics.BmatMRP(sigma)
     omegaAst = []   #np.asarray([0, 0, 0])
     omegaAst_P = []

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.cpp
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.cpp
@@ -22,11 +22,8 @@
  */
 
 #include "fswAlgorithms/attControl/mrpSteering/mrpSteering.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
-#include <math.h>
+#include "architecture/utilities/avsEigenSupport.h"
 
-static void MRPSteeringLaw(MrpSteering *configData, double sigma_BR[3], double omega_ast[3], double omega_ast_p[3]);
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
@@ -35,12 +32,11 @@ static void MRPSteeringLaw(MrpSteering *configData, double sigma_BR[3], double o
 */
 void MrpSteering::reset(uint64_t callTime)
 {
-    // check for required input message
     if (!this->guidInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mrpSteering.guidInMsg wasn't connected.");
     }
 
-    return;
+    this->algorithm.reset(callTime);
 }
 
 /*! This method takes the attitude and rate errors relative to the Reference frame, as well as
@@ -50,57 +46,22 @@ void MrpSteering::reset(uint64_t callTime)
  */
 void MrpSteering::updateState(uint64_t callTime)
 {
-    AttGuidMsgPayload guidCmd;              /* Guidance Message */
-    RateCmdMsgPayload outMsg = {};          /* copy of output message */
+    AttGuidMsgPayload guidCmd = {};
+    if (this->guidInMsg.isWritten()) {
+        guidCmd = this->guidInMsg();
+    }
 
-    /*! - Read the dynamic input messages */
-    guidCmd = this->guidInMsg();
+    RateCmdMsgPayload outMsg = this->algorithm.update(callTime, guidCmd);
 
-    /*! - evalute MRP kinematic steering law */
-    MRPSteeringLaw(this, guidCmd.sigma_BR, outMsg.omega_BastR_B, outMsg.omegap_BastR_B);
-
-    /*! - Store the output message and pass it to the message bus */
     this->rateCmdOutMsg.write(&outMsg, moduleID, callTime);
-
-    return;
 }
 
-/*! This method computes the MRP Steering law.  A commanded body rate is returned given the MRP
- attitude error measure of the body relative to a reference frame.  The function returns the commanded
- body rate, as well as the body frame derivative of this rate command.
- @return void
- @param this  The configuration data associated with this module
- @param sigma_BR    MRP attitude error of B relative to R
- @param omega_ast   Commanded body rates
- @param omega_ast_p Body frame derivative of the commanded body rates
- */
-void MRPSteeringLaw(MrpSteering *configData, double sigma_BR[3], double omega_ast[3], double omega_ast_p[3])
-{
-    double  sigma_i;        /* ith component of sigma_B/R */
-    double  B[3][3];        /* B-matrix of MRP differential kinematic equations */
-    double  sigma_p[3];     /* MRP rates */
-    double  value;
-    int     i;
+void MrpSteering::setK1(double k1) { this->algorithm.setK1(k1); }
+double MrpSteering::getK1() const { return this->algorithm.getK1(); }
+void MrpSteering::setK3(double k3) { this->algorithm.setK3(k3); }
+double MrpSteering::getK3() const { return this->algorithm.getK3(); }
+void MrpSteering::setOmegaMax(double omegaMax) { this->algorithm.setOmegaMax(omegaMax); }
+double MrpSteering::getOmegaMax() const { return this->algorithm.getOmegaMax(); }
+void MrpSteering::setIgnoreOuterLoopFeedforward(bool flag) { this->algorithm.setIgnoreOuterLoopFeedforward(flag); }
+bool MrpSteering::getIgnoreOuterLoopFeedforward() const { return this->algorithm.getIgnoreOuterLoopFeedforward(); }
 
-    /* Equation (18): Determine the desired steering rates  */
-    for (i=0;i<3;i++) {
-        sigma_i  = sigma_BR[i];
-        value        = atan(M_PI_2/configData->omega_max*(configData->K1*sigma_i
-                       + configData->K3*sigma_i*sigma_i*sigma_i))/M_PI_2*configData->omega_max;
-        omega_ast[i] = -value;
-    }
-    v3SetZero(omega_ast_p);
-    if (!configData->ignoreOuterLoopFeedforward) {
-        /* Equation (21): Determine the body frame derivative of the steering rates */
-        BmatMRP(sigma_BR, B);
-        m33MultV3(B, omega_ast, sigma_p);
-        v3Scale(0.25, sigma_p, sigma_p);
-        for (i=0;i<3;i++) {
-            sigma_i  = sigma_BR[i];
-            value = (3*configData->K3*sigma_i*sigma_i + configData->K1)/
-                                (pow(M_PI_2/configData->omega_max*(configData->K1*sigma_i + configData->K3*sigma_i*sigma_i*sigma_i),2) + 1);
-            omega_ast_p[i] = - value*sigma_p[i];
-        }
-    }
-    return;
-}

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.h
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.h
@@ -24,28 +24,36 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
 #include "architecture/msgPayloadDefC/RateCmdMsgPayload.h"
-#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h"
+#include <cstdint>
 
 
 
 /*! @brief Data structure for the MRP feedback attitude control routine. */
 class MrpSteering : public SysModel {
-public:
+  public:
+    MrpSteering() = default;
+    ~MrpSteering() = default;
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 
-    /* declare module public variables */
-    double K1;                          //!< [rad/sec] Proportional gain applied to MRP errors
-    double K3;                          //!< [rad/sec] Cubic gain applied to MRP error in steering saturation function
-    double omega_max;                   //!< [rad/sec] Maximum rate command of steering control
+    void setK1(double k1);
+    double getK1() const;
+    void setK3(double k3);
+    double getK3() const;
+    void setOmegaMax(double omegaMax);
+    double getOmegaMax() const;
+    void setIgnoreOuterLoopFeedforward(bool flag);
+    bool getIgnoreOuterLoopFeedforward() const;
 
-    uint32_t ignoreOuterLoopFeedforward;//!< []      Boolean flag indicating if outer feedforward term should be included
+    Message<RateCmdMsgPayload> rateCmdOutMsg;  //!< rate command output message
+    ReadFunctor<AttGuidMsgPayload> guidInMsg;   //!< attitude guidance input message
 
-    /* declare module IO interfaces */
-    Message<RateCmdMsgPayload> rateCmdOutMsg;                 //!< rate command output message
-    ReadFunctor<AttGuidMsgPayload> guidInMsg;                             //!< attitude guidance input message
+    BSKLogger bskLogger = {};  //!< BSK Logging
 
-    BSKLogger bskLogger = {};                             //!< BSK Logging
+  private:
+    MrpSteeringAlgorithm algorithm;
 };
 
 #endif

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.cpp
@@ -1,0 +1,55 @@
+#include "fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h"
+
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/rigidBodyKinematics.hpp"
+#include <cassert>
+#include <cmath>
+
+void MrpSteeringAlgorithm::reset(uint64_t /*callTime*/) {}
+
+RateCmdMsgPayload MrpSteeringAlgorithm::update(uint64_t /*callTime*/, AttGuidMsgPayload &guidCmd) {
+    Eigen::Vector3d sigma_BR = cArray2EigenVector3d(guidCmd.sigma_BR);
+
+    Eigen::Vector3d omega_ast = Eigen::Vector3d::Zero();
+    Eigen::Vector3d omega_ast_p = Eigen::Vector3d::Zero();
+
+    for (int i = 0; i < 3; ++i) {
+        double sigma_i = sigma_BR(i);
+        double value = std::atan((M_PI_2 / this->omega_max) *
+                                 (this->K1 * sigma_i + this->K3 * sigma_i * sigma_i * sigma_i)) /
+                       M_PI_2 * this->omega_max;
+        omega_ast(i) = -value;
+    }
+
+    if (!this->ignoreOuterLoopFeedforward) {
+        Eigen::Matrix3d B = bmatMrp(sigma_BR);
+        Eigen::Vector3d sigma_p = 0.25 * B * omega_ast;
+
+        for (int i = 0; i < 3; ++i) {
+            double sigma_i = sigma_BR(i);
+            double denom = std::pow((M_PI_2 / this->omega_max) *
+                                        (this->K1 * sigma_i + this->K3 * sigma_i * sigma_i * sigma_i),
+                                    2.0) +
+                            1.0;
+            double value = (3.0 * this->K3 * sigma_i * sigma_i + this->K1) / denom;
+            omega_ast_p(i) = -value * sigma_p(i);
+        }
+    }
+
+    RateCmdMsgPayload out{};
+    eigenVector3d2CArray(omega_ast, out.omega_BastR_B);
+    eigenVector3d2CArray(omega_ast_p, out.omegap_BastR_B);
+
+    return out;
+}
+
+void MrpSteeringAlgorithm::setK1(double k1) { this->K1 = k1; }
+double MrpSteeringAlgorithm::getK1() const { return this->K1; }
+void MrpSteeringAlgorithm::setK3(double k3) { this->K3 = k3; }
+double MrpSteeringAlgorithm::getK3() const { return this->K3; }
+void MrpSteeringAlgorithm::setOmegaMax(double omegaMax) { this->omega_max = omegaMax; }
+double MrpSteeringAlgorithm::getOmegaMax() const { return this->omega_max; }
+void MrpSteeringAlgorithm::setIgnoreOuterLoopFeedforward(bool flag) { this->ignoreOuterLoopFeedforward = flag; }
+bool MrpSteeringAlgorithm::getIgnoreOuterLoopFeedforward() const { return this->ignoreOuterLoopFeedforward; }
+
+

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h
@@ -1,0 +1,34 @@
+#ifndef BASILISK_MRP_STEERING_ALGORITHM_H
+#define BASILISK_MRP_STEERING_ALGORITHM_H
+
+#include <Eigen/Dense>
+#include <cstdint>
+
+#include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+#include "architecture/msgPayloadDefC/RateCmdMsgPayload.h"
+
+class MrpSteeringAlgorithm {
+  public:
+    MrpSteeringAlgorithm() = default;
+    ~MrpSteeringAlgorithm() = default;
+
+    void reset(uint64_t callTime);
+    RateCmdMsgPayload update(uint64_t callTime, AttGuidMsgPayload &guidCmd);
+
+    void setK1(double k1);
+    double getK1() const;
+    void setK3(double k3);
+    double getK3() const;
+    void setOmegaMax(double omegaMax);
+    double getOmegaMax() const;
+    void setIgnoreOuterLoopFeedforward(bool flag);
+    bool getIgnoreOuterLoopFeedforward() const;
+
+  private:
+    double K1{};
+    double K3{};
+    double omega_max{};
+    bool ignoreOuterLoopFeedforward{false};
+};
+
+#endif


### PR DESCRIPTION
## Summary
- refactor mrpSteering into adapter/algorithm pair using Eigen
- expose configuration accessors
- update unit test to use numpy testing

## Testing
- `pytest src/fswAlgorithms/attControl/mrpSteering/_UnitTest/test_MRP_steeringUnit.py -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684b1dab10a883328595fa5b22aa3847