### PR TITLE
Refactor mrpSteering module

### DIFF
--- a/src/fswAlgorithms/attControl/mrpSteering/_UnitTest/test_MRP_steeringInt.py
+++ b/src/fswAlgorithms/attControl/mrpSteering/_UnitTest/test_MRP_steeringInt.py
@@ -24,7 +24,6 @@ from Basilisk.fswAlgorithms import rateServoFullNonlinear
 from Basilisk.utilities import RigidBodyKinematics
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -59,8 +58,7 @@ def test_mrp_steering_tracking(show_plots,K1, K3, omegaMax):
     :return: void
 
     """
-    [testResults, testMessage] = mrp_steering_tracking(show_plots,K1, K3, omegaMax)
-    assert testResults < 1, testMessage
+    mrp_steering_tracking(show_plots, K1, K3, omegaMax)
 
 
 def mrp_steering_tracking(show_plots,K1, K3, omegaMax):
@@ -69,8 +67,6 @@ def mrp_steering_tracking(show_plots,K1, K3, omegaMax):
     # --fulltrace command line option is specified.
     __tracebackhide__ = True
 
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty list to store test log messages
     unitTaskName = "unitTask"  # arbitrary name (don't change)
     unitProcessName = "TestProcess"  # arbitrary name (don't change)
 
@@ -183,12 +179,14 @@ def mrp_steering_tracking(show_plots,K1, K3, omegaMax):
     # set the filtered output truth states
     # compare the module results to the truth values
     accuracy = 1e-12
-    for i in range(0, len(trueVals)):
-        # check a vector values
-        if not unitTestSupport.isArrayEqual(dataLog.torqueRequestBody[i], trueVals[i], 3, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + module.modelTag + " Module failed torqueRequestBody unit test at t="
-                                + str(dataLog.times[i] * macros.NANO2SEC) + "sec \n")
+    for i in range(len(trueVals)):
+        np.testing.assert_allclose(
+            dataLog.torqueRequestBody[i],
+            trueVals[i],
+            rtol=0,
+            atol=accuracy,
+            err_msg=f"FAILED: {module.modelTag} Module failed torqueRequestBody unit test at t={dataLog.times[i] * macros.NANO2SEC} sec",
+        )
 
 
     # If the argument provided at commandline "--show_plots" evaluates as true,
@@ -197,12 +195,7 @@ def mrp_steering_tracking(show_plots,K1, K3, omegaMax):
         plt.show()
 
     # print out success message if no error were found
-    if testFailCount == 0:
-        print("PASSED: " + module.modelTag)
-
-    # return fail count and join into a single string all messages in the list
-    # testMessage
-    return [testFailCount, ''.join(testMessages)]
+    print("PASSED: " + module.modelTag)
 
 
 def findTrueValues(guidCmdData, module):

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.cpp
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.cpp
@@ -22,11 +22,8 @@
  */
 
 #include "fswAlgorithms/attControl/mrpSteering/mrpSteering.h"
-#include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
-#include <math.h>
 
-static void MRPSteeringLaw(MrpSteering *configData, double sigma_BR[3], double omega_ast[3], double omega_ast_p[3]);
+
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
@@ -50,14 +47,14 @@ void MrpSteering::reset(uint64_t callTime)
  */
 void MrpSteering::updateState(uint64_t callTime)
 {
-    AttGuidMsgPayload guidCmd;              /* Guidance Message */
-    RateCmdMsgPayload outMsg = {};          /* copy of output message */
+    AttGuidMsgPayload guidCmd;      /* Guidance Message */
+    RateCmdMsgPayload outMsg = {};  /* copy of output message */
 
     /*! - Read the dynamic input messages */
     guidCmd = this->guidInMsg();
 
-    /*! - evalute MRP kinematic steering law */
-    MRPSteeringLaw(this, guidCmd.sigma_BR, outMsg.omega_BastR_B, outMsg.omegap_BastR_B);
+    /*! - Call steering algorithm */
+    outMsg = this->algorithm.update(callTime, guidCmd);
 
     /*! - Store the output message and pass it to the message bus */
     this->rateCmdOutMsg.write(&outMsg, moduleID, callTime);
@@ -65,42 +62,17 @@ void MrpSteering::updateState(uint64_t callTime)
     return;
 }
 
-/*! This method computes the MRP Steering law.  A commanded body rate is returned given the MRP
- attitude error measure of the body relative to a reference frame.  The function returns the commanded
- body rate, as well as the body frame derivative of this rate command.
- @return void
- @param this  The configuration data associated with this module
- @param sigma_BR    MRP attitude error of B relative to R
- @param omega_ast   Commanded body rates
- @param omega_ast_p Body frame derivative of the commanded body rates
- */
-void MRPSteeringLaw(MrpSteering *configData, double sigma_BR[3], double omega_ast[3], double omega_ast_p[3])
-{
-    double  sigma_i;        /* ith component of sigma_B/R */
-    double  B[3][3];        /* B-matrix of MRP differential kinematic equations */
-    double  sigma_p[3];     /* MRP rates */
-    double  value;
-    int     i;
-
-    /* Equation (18): Determine the desired steering rates  */
-    for (i=0;i<3;i++) {
-        sigma_i  = sigma_BR[i];
-        value        = atan(M_PI_2/configData->omega_max*(configData->K1*sigma_i
-                       + configData->K3*sigma_i*sigma_i*sigma_i))/M_PI_2*configData->omega_max;
-        omega_ast[i] = -value;
-    }
-    v3SetZero(omega_ast_p);
-    if (!configData->ignoreOuterLoopFeedforward) {
-        /* Equation (21): Determine the body frame derivative of the steering rates */
-        BmatMRP(sigma_BR, B);
-        m33MultV3(B, omega_ast, sigma_p);
-        v3Scale(0.25, sigma_p, sigma_p);
-        for (i=0;i<3;i++) {
-            sigma_i  = sigma_BR[i];
-            value = (3*configData->K3*sigma_i*sigma_i + configData->K1)/
-                                (pow(M_PI_2/configData->omega_max*(configData->K1*sigma_i + configData->K3*sigma_i*sigma_i*sigma_i),2) + 1);
-            omega_ast_p[i] = - value*sigma_p[i];
-        }
-    }
-    return;
+double MrpSteering::getK1() const { return this->algorithm.getK1(); }
+double MrpSteering::getK3() const { return this->algorithm.getK3(); }
+double MrpSteering::getOmegaMax() const { return this->algorithm.getOmegaMax(); }
+bool MrpSteering::getIgnoreOuterLoopFeedforward() const {
+    return this->algorithm.getIgnoreOuterLoopFeedforward();
 }
+void MrpSteering::setK1(double K1) { this->algorithm.setK1(K1); }
+void MrpSteering::setK3(double K3) { this->algorithm.setK3(K3); }
+void MrpSteering::setOmegaMax(double omegaMax) { this->algorithm.setOmegaMax(omegaMax); }
+void MrpSteering::setIgnoreOuterLoopFeedforward(bool ignore) {
+    this->algorithm.setIgnoreOuterLoopFeedforward(ignore);
+}
+
+

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.h
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteering.h
@@ -24,6 +24,7 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
 #include "architecture/msgPayloadDefC/RateCmdMsgPayload.h"
+#include "fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h"
 #include <stdint.h>
 
 
@@ -34,18 +35,23 @@ public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 
-    /* declare module public variables */
-    double K1;                          //!< [rad/sec] Proportional gain applied to MRP errors
-    double K3;                          //!< [rad/sec] Cubic gain applied to MRP error in steering saturation function
-    double omega_max;                   //!< [rad/sec] Maximum rate command of steering control
-
-    uint32_t ignoreOuterLoopFeedforward;//!< []      Boolean flag indicating if outer feedforward term should be included
+    double getK1() const;                       //!< Getter for K1
+    double getK3() const;                       //!< Getter for K3
+    double getOmegaMax() const;                 //!< Getter for omega_max
+    bool getIgnoreOuterLoopFeedforward() const; //!< Getter for ignoreOuterLoopFeedforward
+    void setK1(double K1);                      //!< Setter for K1
+    void setK3(double K3);                      //!< Setter for K3
+    void setOmegaMax(double omegaMax);          //!< Setter for omega_max
+    void setIgnoreOuterLoopFeedforward(bool ignore); //!< Setter for ignoreOuterLoopFeedforward
 
     /* declare module IO interfaces */
     Message<RateCmdMsgPayload> rateCmdOutMsg;                 //!< rate command output message
     ReadFunctor<AttGuidMsgPayload> guidInMsg;                             //!< attitude guidance input message
 
     BSKLogger bskLogger = {};                             //!< BSK Logging
+
+private:
+    MrpSteeringAlgorithm algorithm;  //!< Algorithm for steering logic
 };
 
 #endif

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.cpp
@@ -1,0 +1,69 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h"
+#include "architecture/utilities/avsEigenMRP.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include <cmath>
+
+RateCmdMsgPayload MrpSteeringAlgorithm::update(uint64_t, AttGuidMsgPayload guidCmd) {
+    RateCmdMsgPayload outMsg = {};
+
+    Eigen::Vector3d sigma_BR = cArray2EigenVector3d(guidCmd.sigma_BR);
+    Eigen::Vector3d omega_ast;
+    Eigen::Vector3d omega_ast_p;
+
+    for (int i = 0; i < 3; i++) {
+        double sigma_i = sigma_BR[i];
+        double value = std::atan(M_PI_2 / this->omega_max *
+                                 (this->K1 * sigma_i +
+                                  this->K3 * sigma_i * sigma_i * sigma_i)) /
+                        M_PI_2 * this->omega_max;
+        omega_ast[i] = -value;
+    }
+
+    omega_ast_p.setZero();
+
+    if (!this->ignoreOuterLoopFeedforward) {
+        Eigen::MRPd sigma(sigma_BR);
+        Eigen::Vector3d sigma_p = 0.25 * sigma.Bmat() * omega_ast;
+        for (int i = 0; i < 3; i++) {
+            double sigma_i = sigma_BR[i];
+            double value = (3.0 * this->K3 * sigma_i * sigma_i + this->K1) /
+                           (std::pow(M_PI_2 / this->omega_max *
+                                         (this->K1 * sigma_i +
+                                          this->K3 * sigma_i * sigma_i * sigma_i),
+                                     2.0) +
+                            1.0);
+            omega_ast_p[i] = -value * sigma_p[i];
+        }
+    }
+
+    eigenVector3d2CArray(omega_ast, outMsg.omega_BastR_B);
+    eigenVector3d2CArray(omega_ast_p, outMsg.omegap_BastR_B);
+    return outMsg;
+}
+
+double MrpSteeringAlgorithm::getK1() const { return this->K1; }
+double MrpSteeringAlgorithm::getK3() const { return this->K3; }
+double MrpSteeringAlgorithm::getOmegaMax() const { return this->omega_max; }
+bool MrpSteeringAlgorithm::getIgnoreOuterLoopFeedforward() const { return this->ignoreOuterLoopFeedforward; }
+void MrpSteeringAlgorithm::setK1(double K1) { this->K1 = K1; }
+void MrpSteeringAlgorithm::setK3(double K3) { this->K3 = K3; }
+void MrpSteeringAlgorithm::setOmegaMax(double omegaMax) { this->omega_max = omegaMax; }
+void MrpSteeringAlgorithm::setIgnoreOuterLoopFeedforward(bool ignore) { this->ignoreOuterLoopFeedforward = ignore; }

--- a/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h
+++ b/src/fswAlgorithms/attControl/mrpSteering/mrpSteeringAlgorithm.h
@@ -1,0 +1,50 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MRP_STEERING_ALGORITHM_H_
+#define _MRP_STEERING_ALGORITHM_H_
+
+#include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+#include "architecture/msgPayloadDefC/RateCmdMsgPayload.h"
+#include <Eigen/Dense>
+#include <cstdint>
+
+class MrpSteeringAlgorithm {
+  public:
+    MrpSteeringAlgorithm() = default;
+    ~MrpSteeringAlgorithm() = default;
+
+    RateCmdMsgPayload update(uint64_t callTime, AttGuidMsgPayload guidCmd);
+
+    double getK1() const;
+    double getK3() const;
+    double getOmegaMax() const;
+    bool getIgnoreOuterLoopFeedforward() const;
+    void setK1(double K1);
+    void setK3(double K3);
+    void setOmegaMax(double omegaMax);
+    void setIgnoreOuterLoopFeedforward(bool ignore);
+
+  private:
+    double K1{};
+    double K3{};
+    double omega_max{};
+    bool ignoreOuterLoopFeedforward{false};
+};
+
+#endif


### PR DESCRIPTION
## Summary
- convert mrpSteering to use Eigen math
- add accessor methods for module parameters
- split logic into new `mrpSteeringAlgorithm`
- clean unused includes
- modernize unit test using numpy assertions

## Testing
- `pytest -k mrpSteering -q` *(fails: 313 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684b2d653e9c8332ac3e563e70c9884c