### PR TITLE
Convert ephemNavConverter to adapter

### DIFF
--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.cpp
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.h"
-#include "architecture/utilities/linearAlgebra.h"
 
 /*! Reset method for the module adapter interface.
  @return void

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.cpp
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.cpp
@@ -20,35 +20,29 @@
 #include "fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.h"
 #include "architecture/utilities/linearAlgebra.h"
 
-/*! This resets the module to original states.
+/*! Reset method for the module adapter interface.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void EphemNavConverter::reset(uint64_t callTime)
-{
+void EphemNavConverter::reset(uint64_t callTime) {
     // check if the required message has not been connected
     if (!this->ephInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: ephemNavConverter.ephInMsg wasn't connected.");
     }
 }
 
-/*! This method reads in the ephemeris messages and copies the translation
-    ephemeris to the navigation translation interface message.
+/*! Update method for the module adapter interface. This method also calls the algorithm update method.
  @return void
- @param callTime The clock time at which the function was called (nanoseconds)
+ @param callTime [ns] Time the method is called
  */
-void EphemNavConverter::updateState(uint64_t callTime)
-{
-    NavTransMsgPayload tmpOutputState = {};
+void EphemNavConverter::updateState(uint64_t callTime) {
+    auto localEphemInMsg = EphemerisMsgPayload();
+    if (this->ephInMsg.isWritten()) {
+        localEphemInMsg = this->ephInMsg();
+    }
 
-    /*! - read input ephemeris message */
-    EphemerisMsgPayload tmpEphemeris  = this->ephInMsg();
+    // Call the algorithm update method
+    NavTransMsgPayload navTransMsgPayload = this->algorithm.update(callTime, localEphemInMsg);
 
-    /*! - map timeTag, position and velocity vector to output message */
-	tmpOutputState.timeTag = tmpEphemeris.timeTag;
-	v3Copy(tmpEphemeris.r_BdyZero_N, tmpOutputState.r_BN_N);
-	v3Copy(tmpEphemeris.v_BdyZero_N, tmpOutputState.v_BN_N);
-
-    /*! - write output message */
-    this->stateOutMsg.write(&tmpOutputState, this->moduleID, callTime);
+    this->stateOutMsg.write(&navTransMsgPayload, this->moduleID, callTime);
 }

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.cpp
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.cpp
@@ -35,13 +35,13 @@ void EphemNavConverter::reset(uint64_t callTime) {
  @param callTime [ns] Time the method is called
  */
 void EphemNavConverter::updateState(uint64_t callTime) {
-    auto localEphemInMsg = EphemerisMsgPayload();
+    auto ephemMsgPayload = EphemerisMsgPayload();
     if (this->ephInMsg.isWritten()) {
-        localEphemInMsg = this->ephInMsg();
+        ephemMsgPayload = this->ephInMsg();
     }
 
     // Call the algorithm update method
-    NavTransMsgPayload navTransMsgPayload = this->algorithm.update(callTime, localEphemInMsg);
+    NavTransMsgPayload navTransMsgPayload = this->algorithm.update(callTime, ephemMsgPayload);
 
     this->stateOutMsg.write(&navTransMsgPayload, this->moduleID, callTime);
 }

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.h
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverter.h
@@ -25,17 +25,24 @@
 #include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
 #include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
+#include "fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.h"
 
 /*! @brief The ephemNavConverter class.*/
 class EphemNavConverter : public SysModel {
-public:
-    void updateState(uint64_t callTime) override;
+   public:
+    EphemNavConverter() = default;
+    ~EphemNavConverter() = default;
+
     void reset(uint64_t callTime) override;
+    void updateState(uint64_t callTime) override;
 
-    Message<NavTransMsgPayload> stateOutMsg; //!< [-] output navigation message for pos/vel
-    ReadFunctor<EphemerisMsgPayload> ephInMsg; //!< ephemeris input message
+    Message<NavTransMsgPayload> stateOutMsg;    //!< [-] output navigation message for pos/vel
+    ReadFunctor<EphemerisMsgPayload> ephInMsg;  //!< ephemeris input message
 
-    BSKLogger bskLogger{};   //!< BSK Logging
+    BSKLogger bskLogger{};  //!< BSK Logging
+
+   private:
+    EphemNavConverterAlgorithm algorithm;  //!< Algorithm for ephemNavConverter control logic (BSK-agnostic)
 };
 
 #endif

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.cpp
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.cpp
@@ -1,0 +1,39 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.h"
+#include "architecture/utilities/linearAlgebra.h"
+
+/*! Update method for the ephemNavConverter algorithm. This method reads in the ephemeris messages and copies the
+ translation ephemeris to the navigation translation interface message.
+ @return NavTransMsgPayload Translational navigation message
+ @param callTime [ns] Time the method is called
+ @param ephemerisInMsg Ephemeris message
+ */
+NavTransMsgPayload EphemNavConverterAlgorithm::update(uint64_t callTime, EphemerisMsgPayload ephemerisInMsg) {
+    // Create the output message
+    auto navTransMsgBuffer = NavTransMsgPayload{};
+
+    // Map timeTag, position and velocity vector to output message
+    navTransMsgBuffer.timeTag = ephemerisInMsg.timeTag;
+    v3Copy(ephemerisInMsg.r_BdyZero_N, navTransMsgBuffer.r_BN_N);
+    v3Copy(ephemerisInMsg.v_BdyZero_N, navTransMsgBuffer.v_BN_N);
+
+    return navTransMsgBuffer;
+}

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.cpp
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.cpp
@@ -18,7 +18,12 @@
  */
 
 #include "fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.h"
-#include "architecture/utilities/linearAlgebra.h"
+
+inline void v3Copy(double const v[3], double result[3]) {
+    result[0] = v[0];
+    result[1] = v[1];
+    result[2] = v[2];
+}
 
 /*! Update method for the ephemNavConverter algorithm. This method reads in the ephemeris messages and copies the
  translation ephemeris to the navigation translation interface message.

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.h
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/ephemNavConverterAlgorithm.h
@@ -1,0 +1,36 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef EPHEM_NAV_CONVERTER_ALGORITHM_H
+#define EPHEM_NAV_CONVERTER_ALGORITHM_H
+
+#include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+#include <stdint.h>
+
+/*! @brief The ephemNavConverter algorithm class.*/
+class EphemNavConverterAlgorithm {
+   public:
+    EphemNavConverterAlgorithm() = default;   //!< Constructor
+    ~EphemNavConverterAlgorithm() = default;  //!< Destructor
+
+    NavTransMsgPayload update(uint64_t callTime, EphemerisMsgPayload ephemerisInMsg);
+};
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** #449 
* **Review:** By commit  by commit
* **Merge strategy:** Merge (no squash)  merge (no squash)

## Description
To enable easy relocation of fsw algorithms use the adapter pattern for `ephemNavConverter`.
This allows for relocation of fsw algorithms and then inclusion of bsk modules in any language with a c ffi/abi.

## Verification
The module unit test is checked to pass with these changes

## Documentation
N/A

## Future work
N/A