### PR TITLE
Roll back SWIG thread changes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     permissions:
       actions: read
       contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "basilisk"
 version = "0.1.0"
 description = "Basilisk: Flexible, Fast, and Reconfigurable Space Simulation Framework"
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9, <3.12"
 dependencies = [
     "bokeh",
     "dask==2024.8.0; python_version < '3.10'",

--- a/src/architecture/_GeneralModuleFiles/py_sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/py_sys_model.i
@@ -1,5 +1,5 @@
 
-%module(directors="1",threads="1") sysModel
+%module(directors="1") sysModel
 %{
    #include "sys_model.h"
 %}

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -1,6 +1,6 @@
 
 
-%module(threads="1") {type}Payload
+%module {type}Payload
 %{{
     #include "{baseDir}/{type}Payload.h"
     #include "architecture/messaging/messaging.h"

--- a/src/architecture/system_model/sim_model.i
+++ b/src/architecture/system_model/sim_model.i
@@ -16,7 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module(threads="1") sim_model
+%module sim_model
 %{
    #include "sim_model.h"
 %}

--- a/src/architecture/system_model/sys_model_task.i
+++ b/src/architecture/system_model/sys_model_task.i
@@ -16,7 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module(threads="1") sys_model_task
+%module sys_model_task
 %{
    #include "sys_model_task.h"
 %}


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR roles back the adjustments made to accommodate python 3.12's stricter management of the GIL. Unfortunately, these changes aren't sufficient for anything more than the toy problem simulation's in the project's examples and tests. The issues with bsk's threading implementation are significantly deeper than first realized. 

## Verification
All tests and complex simulations run successfully again.

## Documentation
None

## Future work
Work is now being under taken to refactor, if not redesign and rewrite (likely) the threading implementation in bsk. 
