### PR TITLE
Incorrect checking of isLinked()

### DIFF
--- a/src/fswAlgorithms/attDetermination/sunlineEphem/_UnitTest/test_sunlineEphem.py
+++ b/src/fswAlgorithms/attDetermination/sunlineEphem/_UnitTest/test_sunlineEphem.py
@@ -17,7 +17,7 @@
 #
 
 import numpy as np
-import pytest
+
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import sunlineEphem
 from Basilisk.utilities import SimulationBaseClass

--- a/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.cpp
@@ -21,6 +21,12 @@
 
 SunlineEphem::SunlineEphem() { this->algorithm = SunlineEphemAlgorithm(); }
 
+void SunlineEphem::reset(uint64_t callTime) {
+    assert(this->sunPositionInMsg.isLinked());
+    assert(this->scPositionInMsg.isLinked());
+    assert(this->scAttitudeInMsg.isLinked());
+}
+
 void SunlineEphem::updateState(uint64_t callTime) {
     EphemerisMsgPayload sunPos = this->sunPositionInMsg();
     NavTransMsgPayload scPos = this->scPositionInMsg();

--- a/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.h
+++ b/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphem.h
@@ -27,6 +27,7 @@
 class SunlineEphem : public SysModel {
    public:
     SunlineEphem();
+    void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
     Message<NavAttMsgPayload> navStateOutMsg;           /*!< The name of the output message*/
     ReadFunctor<EphemerisMsgPayload> sunPositionInMsg;  //!< The name of the sun ephemeris input message

--- a/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphemAlgorithm.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineEphem/sunlineEphemAlgorithm.cpp
@@ -21,9 +21,6 @@
 NavAttMsgPayload SunlineEphemAlgorithm::updateState(const EphemerisMsgPayload &sunPos,
                                                     const NavTransMsgPayload &scPos,
                                                     const NavAttMsgPayload &scAtt) const {
-    assert(!sunPos.isLinked());
-    assert(!scPos.isLinked());
-    assert(!scAtt.isLinked());
     // Get sun position
     const Eigen::Vector3d rSun(sunPos.r_BdyZero_N[0], sunPos.r_BdyZero_N[1], sunPos.r_BdyZero_N[2]);
     const Eigen::Vector3d rSc(scPos.r_BN_N[0], scPos.r_BN_N[1], scPos.r_BN_N[2]);


### PR DESCRIPTION
* **Tickets addressed:** hot-fix 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The `isLinked()` functions were called on the payload type and not the message type. The assert was inverted. This wasn't picked up because a test run was not completed with a debug build profile. The `isLinked()` checks are moved to a the module's `reset()` function so they are only called on reset rather than every update.

## Verification
Test were run in a debug build profile and on CI.

## Documentation
None

## Future work
We will look at updating CI tests to run against debug build profiles.
