### PR TITLE
Limit built OpenCV features to those used

### DIFF
--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -5,7 +5,11 @@
     "cppzmq",
     "eigen3",
     "gtest",
-    "opencv4",
+    {
+      "name": "opencv4",
+      "default-features": false,
+      "features": [ "dnn", "jpeg", "png", "tiff", "webp"]
+    },
     "protobuf"
   ],
   "overrides": [


### PR DESCRIPTION
* **Tickets addressed:** #456
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR limits the built OpenCV features to those used to reduce any overhead that may be incurred when downloading and building the OpenCV dependency via vcpkg.

## Verification
Project builds and test complete.

## Documentation
NA

## Future work
None
