### PR TITLE
Feature/fix access to getter method

### DIFF
--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.cpp
@@ -69,14 +69,14 @@ double SunSafePoint::getSmallAngle() const { return this->algorithm.getSmallAngl
 double SunSafePoint::getSunAxisSpinRate() const { return this->algorithm.getSunAxisSpinRate(); }
 
 /*! Getter method for the desired body rate vector if no sun direction is available.
- @return const Eigen::Vector3d&
+ @return Eigen::Vector3d
 */
-const Eigen::Vector3d& SunSafePoint::getOmega_RN_B() const { return this->algorithm.getOmega_RN_B(); }
+Eigen::Vector3d SunSafePoint::getOmega_RN_B() const { return this->algorithm.getOmega_RN_B(); }
 
 /*! Getter method for the desired body vector to point at the sun.
- @return const Eigen::Vector3d&
+ @return Eigen::Vector3d
 */
-const Eigen::Vector3d& SunSafePoint::getSHatBdyCmd() const { return this->algorithm.getSHatBdyCmd(); }
+Eigen::Vector3d SunSafePoint::getSHatBdyCmd() const { return this->algorithm.getSHatBdyCmd(); }
 
 /*! Setter method for the minimally accepted sun body vector norm.
  @return void

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h
@@ -41,10 +41,10 @@ class SunSafePoint : public SysModel {
     double getMinUnitMag() const;       //!< Getter method for the minimally accepted sun body vector norm
     double getSmallAngle() const;       //!< Getter method for the small alignment tolerance angle near 0 or 180 degrees
     double getSunAxisSpinRate() const;  //!< Getter method for the desired constant spin rate about sun heading vector
-    const Eigen::Vector3d& getOmega_RN_B()
+    Eigen::Vector3d getOmega_RN_B()
         const;  //!< Getter method for the desired body rate vector if no sun direction is available
-    const Eigen::Vector3d& getSHatBdyCmd() const;  //!< Getter method for the desired body vector to point at the sun
     void setMinUnitMag(const double minUnitMag);   //!< Setter method for the minimally accepted sun body vector norm
+    Eigen::Vector3d getSHatBdyCmd() const;        //!< Getter method for the desired body vector to point at the sun
     void setSmallAngle(
         const double smallAngle);  //!< Setter method for the small alignment tolerance angle near 0 or 180 degrees
     void setSunAxisSpinRate(

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h
@@ -43,8 +43,8 @@ class SunSafePoint : public SysModel {
     double getSunAxisSpinRate() const;  //!< Getter method for the desired constant spin rate about sun heading vector
     Eigen::Vector3d getOmega_RN_B()
         const;  //!< Getter method for the desired body rate vector if no sun direction is available
-    void setMinUnitMag(const double minUnitMag);   //!< Setter method for the minimally accepted sun body vector norm
     Eigen::Vector3d getSHatBdyCmd() const;        //!< Getter method for the desired body vector to point at the sun
+    void setMinUnitMag(const double minUnitMag);  //!< Setter method for the minimally accepted sun body vector norm
     void setSmallAngle(
         const double smallAngle);  //!< Setter method for the small alignment tolerance angle near 0 or 180 degrees
     void setSunAxisSpinRate(

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.cpp
@@ -146,14 +146,14 @@ double SunSafePointAlgorithm::getSmallAngle() const { return this->smallAngle; }
 double SunSafePointAlgorithm::getSunAxisSpinRate() const { return this->sunAxisSpinRate; }
 
 /*! Getter method for the desired body rate vector if no sun direction is available.
- @return const Eigen::Vector3d&
+ @return Eigen::Vector3d
 */
-const Eigen::Vector3d& SunSafePointAlgorithm::getOmega_RN_B() const { return this->omega_RN_B; }
+Eigen::Vector3d SunSafePointAlgorithm::getOmega_RN_B() const { return this->omega_RN_B; }
 
 /*! Getter method for the desired body vector to point at the sun.
- @return const Eigen::Vector3d&
+ @return Eigen::Vector3d
 */
-const Eigen::Vector3d& SunSafePointAlgorithm::getSHatBdyCmd() const { return this->sHatBdyCmd; }
+Eigen::Vector3d SunSafePointAlgorithm::getSHatBdyCmd() const { return this->sHatBdyCmd; }
 
 /*! Setter method for the minimally accepted sun body vector norm.
  @return void

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.h
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.h
@@ -39,9 +39,9 @@ class SunSafePointAlgorithm {
     double getMinUnitMag() const;       //!< Getter method for the minimally accepted sun body vector norm
     double getSmallAngle() const;       //!< Getter method for the small alignment tolerance angle near 0 or 180 degrees
     double getSunAxisSpinRate() const;  //!< Getter method for the desired constant spin rate about sun heading vector
-    const Eigen::Vector3d& getOmega_RN_B()
+    Eigen::Vector3d getOmega_RN_B()
         const;  //!< Getter method for the desired body rate vector if no sun direction is available
-    const Eigen::Vector3d& getSHatBdyCmd() const;  //!< Getter method for the desired body vector to point at the sun
+    Eigen::Vector3d getSHatBdyCmd() const;  //!< Getter method for the desired body vector to point at the sun
     void setMinUnitMag(double minUnitMag);         //!< Setter method for the minimally accepted sun body vector norm
     void setSmallAngle(
         double smallAngle);  //!< Setter method for the small alignment tolerance angle near 0 or 180 degrees

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.h
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.h
@@ -42,7 +42,7 @@ class SunSafePointAlgorithm {
     Eigen::Vector3d getOmega_RN_B()
         const;  //!< Getter method for the desired body rate vector if no sun direction is available
     Eigen::Vector3d getSHatBdyCmd() const;  //!< Getter method for the desired body vector to point at the sun
-    void setMinUnitMag(double minUnitMag);         //!< Setter method for the minimally accepted sun body vector norm
+    void setMinUnitMag(double minUnitMag);  //!< Setter method for the minimally accepted sun body vector norm
     void setSmallAngle(
         double smallAngle);  //!< Setter method for the small alignment tolerance angle near 0 or 180 degrees
     void setSunAxisSpinRate(


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 
* 
## Description
When accessing the getter functions from python for the `sunSafePoint` algorithm, the pass by reference in the getter methods was causing a swig access issue. Removing the reference fixes the issue. The getter functions for Eigen variables in other algorithms were used as examples, and these getter functions also do not pass by reference.

## Verification
Verification of this was completed by running a scenario accessing these getter functions.

## Documentation
None

## Future work
None
