### PR TITLE
Feature/fix star tracker rate

### DIFF
--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -196,29 +196,22 @@ def test_starTracker(show_plots, useFlag, testCase):
     elif testCase == 'angular velocity check':
         # Check computed platform angular velocity
         omega_CN_CTruth = [np.zeros((1, 3))]
-        previousSimTime = timespan[0]
         currentSimTime = timespan[0]
         for idx in range(1, len(timespan)):
-            # Group quaternion components without beta_0
-            epsilon_CN = np.array(beta_CN[idx, 1:]).reshape(3, 1)
-            epsilonPrevious_CN = np.array(beta_CN[idx-1, 1:]).reshape(3, 1)
+            # Grab the current and previous quaternions for numerical differentiation
+            beta_current_cn = np.array(beta_CN[idx, :])
+            beta_previous_cn = np.array(beta_CN[idx-1, :])
 
-            # Determine CRPs (Gibbs Vector)
-            q_CN = epsilon_CN / beta_CN[idx, 0]
-            qPrevious_CN = epsilonPrevious_CN / beta_CN[idx-1, 0]
-
-            # Compute qDot_PN
+            # Compute beta_dot_cn
             previousSimTime = currentSimTime
             currentSimTime = timespan[idx]
             dt = currentSimTime - previousSimTime
-            qDot_CN = (q_CN - qPrevious_CN) / dt
+            beta_dot_cn = (beta_current_cn - beta_previous_cn) / dt
 
-            # Solve for platform rate using Eq. 3.137 from Schaub and Junkins Pg 120
-            qTilde_CN = rbk.v3Tilde(q_CN.flatten())
-            qTilde_CN = np.array(qTilde_CN)
-            I = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
-            omega_cn_c = (2.0 / (1.0 + np.dot(q_CN.flatten(), q_CN.flatten()))) * (I - qTilde_CN) @ qDot_CN
-            omega_cn_c = omega_cn_c.reshape(1, 3)
+            # Solve for platform rate using Eq. 3.106 from Schaub and Junkins 3rd edition Pg 111
+            b_inv = rbk.BinvEP(beta_current_cn)
+
+            omega_cn_c = 2 * b_inv.dot(beta_dot_cn)
             omega_CN_CTruth.append(macros.R2D * omega_cn_c)  # [deg]
 
         omega_CN_CTruth = np.vstack(omega_CN_CTruth)

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -110,8 +110,8 @@ def test_starTracker(show_plots, useFlag, testCase):
 
     # This test checks the computed platform rate
     elif testCase == 'angular velocity check':
-        prv_CB = [0.0, 0.0, 10.0 * macros.D2R]
-        dcm_CB = rbk.PRV2C(prv_CB)
+        prv_cb = [10.0 * macros.D2R, 0.0, 0.0]
+        dcm_CB = rbk.PRV2C(prv_cb)
         strTracker.setDcmCB(dcm_CB)
         simStopTime = unitProcRate_s
         sigma_BN = np.array([0, 0, 0])
@@ -136,11 +136,11 @@ def test_starTracker(show_plots, useFlag, testCase):
     sigma_BNList = [np.array([0.0, 0.0, 0.0])]
     if testCase == 'angular velocity check':
         rotAxis_N = np.array([1.0, 0.0, 0.0])  # Hub rotation axis
-        prvAngleList = np.array([0.0, 0.25, 0.6, 1.0, 1.1])  # Truth hub attitudes
+        prv_angle_list = np.array([0.0, 169.0, 169.9, 170.1, 171.2]) * macros.D2R  # Truth hub attitudes
 
-        for idx in range(1, len(prvAngleList)):
+        for idx in range(1, len(prv_angle_list)):
             # Compute hub inertial attitude
-            prv_BN = prvAngleList[idx] * rotAxis_N
+            prv_BN = prv_angle_list[idx] * rotAxis_N
             sigma_BN = np.array(rbk.PRV2MRP(prv_BN))
             sigma_BNList.append(sigma_BN)
 
@@ -239,5 +239,5 @@ if __name__ == "__main__":
     test_starTracker(
         False,  # show_plots
         False,  # useFlag
-        'walk bounds'  # testCase
+        'angular velocity check'  # testCase
     )

--- a/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
+++ b/src/simulation/sensors/starTracker/_UnitTest/test_star_tracker.py
@@ -24,207 +24,206 @@ from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 
-def listStack(vec, simStopTime, unitProcRate):
+def list_stack(vec, sim_stop_time, unit_proc_rate):
     # returns a list duplicated the number of times needed to be consistent with module output
-    return [vec] * int(simStopTime / (float(unitProcRate) / float(macros.sec2nano(1))))
+    return [vec] * int(sim_stop_time / (float(unit_proc_rate) / float(macros.sec2nano(1))))
 
-def setRandomWalk(self, senNoiseStd = 0.0, errorBounds = [[1e6],[1e6],[1e6]]):
+def set_random_walk(self, sen_noise_std = 0.0, error_bounds = [[1e6], [1e6], [1e6]]):
     # sets the module random walk variables
-    PMatrix = [[senNoiseStd, 0., 0.], [0., senNoiseStd, 0.], [0., 0., senNoiseStd]]
-    self.setPMatrix(PMatrix)
-    self.setWalkBounds(errorBounds)
+    p_matrix = [[sen_noise_std, 0., 0.], [0., sen_noise_std, 0.], [0., 0., sen_noise_std]]
+    self.setPMatrix(p_matrix)
+    self.setWalkBounds(error_bounds)
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)
 # uncomment this line if this test has an expected failure, adjust message as needed
-@pytest.mark.parametrize("useFlag, testCase", [
+@pytest.mark.parametrize("use_flag, test_case", [
     (False, 'basic'),
     (False, 'noise'),
     (False, 'walk bounds'),
     (False, 'angular velocity check')
 ])
-def test_starTracker(show_plots, useFlag, testCase):
-    unitTaskName = "unitTask"
-    unitProcName = "TestProcess"
+def test_starTracker(show_plots, use_flag, test_case):
+    unit_task_name = "unitTask"
+    unit_proc_name = "TestProcess"
 
     # Create a sim module as an empty container
-    unitSim = SimulationBaseClass.SimBaseClass()
+    unit_sim = SimulationBaseClass.SimBaseClass()
 
-    unitProcRate = macros.sec2nano(0.1)
-    unitProcRate_s = macros.NANO2SEC*unitProcRate
-    unitProc = unitSim.CreateNewProcess(unitProcName)
-    unitProc.addTask(unitSim.CreateNewTask(unitTaskName, unitProcRate))
+    unit_proc_rate = macros.sec2nano(0.1)
+    unit_proc_rate_s = macros.NANO2SEC*unit_proc_rate
+    unit_proc = unit_sim.CreateNewProcess(unit_proc_name)
+    unit_proc.addTask(unit_sim.CreateNewTask(unit_task_name, unit_proc_rate))
 
     # Configure the starTracker module
-    strTracker = starTracker.StarTracker()
-    strTracker.modelTag = "starTracker"
-    setRandomWalk(strTracker)
-    unitSim.AddModelToTask(unitTaskName, strTracker)
+    str_tracker = starTracker.StarTracker()
+    str_tracker.modelTag = "starTracker"
+    set_random_walk(str_tracker)
+    unit_sim.AddModelToTask(unit_task_name, str_tracker)
 
     # Configure starTracker SCState input message
-    scStatesMessageData = messaging.SCStatesMsgPayload()
-    scStatesMessageData.r_BN_N = [0, 0, 0]
-    scStatesMessageData.v_BN_N = [0, 0, 0]
-    scStatesMessageData.sigma_BN = [0, 0, 0]
-    scStatesMessageData.omega_BN_B = [0, 0, 0]
-    scStatesMessageData.TotalAccumDVBdy = [0, 0, 0]
-    scStatesMessageData.MRPSwitchCount = 0
+    sc_states_message_data = messaging.SCStatesMsgPayload()
+    sc_states_message_data.r_BN_N = [0, 0, 0]
+    sc_states_message_data.v_BN_N = [0, 0, 0]
+    sc_states_message_data.sigma_BN = [0, 0, 0]
+    sc_states_message_data.omega_BN_B = [0, 0, 0]
+    sc_states_message_data.TotalAccumDVBdy = [0, 0, 0]
+    sc_states_message_data.MRPSwitchCount = 0
 
-    trueVector = dict()
+    true_vector = dict()
 
     # This test verifies basic input and output
-    if testCase == 'basic':
-        simStopTime = 0.5
-        prv_CB = [0.0, 0.0, 10.0 * macros.D2R]
-        dcm_CB = rbk.PRV2C(prv_CB)
-        strTracker.setDcmCB(dcm_CB)
-        sigma_BN = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
-        sigma_CB = rbk.C2MRP(dcm_CB)
-        sigma_CN = rbk.addMRP(sigma_BN, sigma_CB)
-        beta_CN = rbk.MRP2EP(sigma_CN)
-        scStatesMessageData.sigma_BN = sigma_BN
-        trueVector['qInrtl2Case'] = listStack(beta_CN, simStopTime, unitProcRate)
-        trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
+    if test_case == 'basic':
+        sim_stop_time = 0.5
+        prv_cb = [0.0, 0.0, 10.0 * macros.D2R]
+        dcm_cb = rbk.PRV2C(prv_cb)
+        str_tracker.setDcmCB(dcm_cb)
+        sigma_bn = np.array([-0.390614710591786, -0.503642740963740, 0.462959869561285])
+        sigma_cb = rbk.C2MRP(dcm_cb)
+        sigma_cn = rbk.addMRP(sigma_bn, sigma_cb)
+        beta_cn = rbk.MRP2EP(sigma_cn)
+        sc_states_message_data.sigma_BN = sigma_bn
+        true_vector['qInrtl2Case'] = list_stack(beta_cn, sim_stop_time, unit_proc_rate)
+        true_vector['timeTag'] = np.arange(0, 0 + sim_stop_time*1E9, unit_proc_rate_s*1E9)
 
-    elif testCase == 'noise':
-        simStopTime = 1000.
-        noiseStd = 0.1
-        stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
-        setRandomWalk(strTracker, noiseStd*stdCorrectionFactor, [[1.0e-13], [1.0e-13], [1.0e-13]])
-        sigma_BN = np.array([0, 0, 0])
-        scStatesMessageData.sigma_BN = sigma_BN
-        trueVector['qInrtl2Case'] = [noiseStd] * 3
-        trueVector['timeTag'] = np.arange(0, 0 + simStopTime*1E9, unitProcRate_s*1E9)
+    elif test_case == 'noise':
+        sim_stop_time = 1000.
+        noise_std = 0.1
+        std_correction_factor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
+        set_random_walk(str_tracker, noise_std * std_correction_factor, [[1.0e-13], [1.0e-13], [1.0e-13]])
+        sigma_bn = np.array([0, 0, 0])
+        sc_states_message_data.sigma_BN = sigma_bn
+        true_vector['qInrtl2Case'] = [noise_std] * 3
+        true_vector['timeTag'] = np.arange(0, 0 + sim_stop_time*1E9, unit_proc_rate_s*1E9)
 
     # This test checks the walk bounds of random walk
-    elif testCase == 'walk bounds':
-        simStopTime = 1000.
-        noiseStd = 0.01
-        stdCorrectionFactor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
-        walkBound = 0.1
-        setRandomWalk(strTracker, noiseStd*stdCorrectionFactor, [[walkBound], [walkBound], [walkBound]])
-        sigma_BN = np.array([0, 0, 0])
-        scStatesMessageData.sigma_BN = sigma_BN
-        trueVector['qInrtl2Case'] = [walkBound + noiseStd*3] * 3
-        trueVector['timeTag'] = np.arange(0, 0+simStopTime*1E9, unitProcRate_s*1E9)
+    elif test_case == 'walk bounds':
+        sim_stop_time = 1000.
+        noise_std = 0.01
+        std_correction_factor = 1.5  # This needs to be used because of the Gauss Markov module. need to fix the GM module
+        walk_bound = 0.1
+        set_random_walk(str_tracker, noise_std * std_correction_factor, [[walk_bound], [walk_bound], [walk_bound]])
+        sigma_bn = np.array([0, 0, 0])
+        sc_states_message_data.sigma_BN = sigma_bn
+        true_vector['qInrtl2Case'] = [walk_bound + noise_std*3] * 3
+        true_vector['timeTag'] = np.arange(0, 0+sim_stop_time*1E9, unit_proc_rate_s*1E9)
 
     # This test checks the computed platform rate
-    elif testCase == 'angular velocity check':
+    elif test_case == 'angular velocity check':
         prv_cb = [10.0 * macros.D2R, 0.0, 0.0]
-        dcm_CB = rbk.PRV2C(prv_cb)
-        strTracker.setDcmCB(dcm_CB)
-        simStopTime = unitProcRate_s
-        sigma_BN = np.array([0, 0, 0])
-        scStatesMessageData.sigma_BN = sigma_BN
-
+        dcm_cb = rbk.PRV2C(prv_cb)
+        str_tracker.setDcmCB(dcm_cb)
+        sim_stop_time = unit_proc_rate_s
+        sigma_bn = np.array([0, 0, 0])
+        sc_states_message_data.sigma_BN = sigma_bn
     else:
         raise Exception('invalid test case')
 
     # Set up data logging
-    starTrackerSensorMsgDataLog = strTracker.sensorOutMsg.recorder()
-    unitSim.AddModelToTask(unitTaskName, starTrackerSensorMsgDataLog)
+    star_tracker_sensor_msg_data_log = str_tracker.sensorOutMsg.recorder()
+    unit_sim.AddModelToTask(unit_task_name, star_tracker_sensor_msg_data_log)
 
     # Configure spacecraft state message
-    scStatesMessage = messaging.SCStatesMsg().write(scStatesMessageData)
-    strTracker.scStateInMsg.subscribeTo(scStatesMessage)
+    sc_states_message = messaging.SCStatesMsg().write(sc_states_message_data)
+    str_tracker.scStateInMsg.subscribeTo(sc_states_message)
 
-    unitSim.InitializeSimulation()
-    unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
-    unitSim.ExecuteSimulation()
+    unit_sim.InitializeSimulation()
+    unit_sim.ConfigureStopTime(macros.sec2nano(sim_stop_time))
+    unit_sim.ExecuteSimulation()
 
     # Run additional simulation chunks for angular velocity test check
-    sigma_BNList = [np.array([0.0, 0.0, 0.0])]
-    if testCase == 'angular velocity check':
-        rotAxis_N = np.array([1.0, 0.0, 0.0])  # Hub rotation axis
+    sigma_bn_list = [np.array([0.0, 0.0, 0.0])]
+    if test_case == 'angular velocity check':
+        rot_axis_n = np.array([1.0, 0.0, 0.0])  # Hub rotation axis
         prv_angle_list = np.array([0.0, 169.0, 169.9, 170.1, 171.2]) * macros.D2R  # Truth hub attitudes
 
         for idx in range(1, len(prv_angle_list)):
             # Compute hub inertial attitude
-            prv_BN = prv_angle_list[idx] * rotAxis_N
-            sigma_BN = np.array(rbk.PRV2MRP(prv_BN))
-            sigma_BNList.append(sigma_BN)
+            prv_bn = prv_angle_list[idx] * rot_axis_n
+            sigma_bn = np.array(rbk.PRV2MRP(prv_bn))
+            sigma_bn_list.append(sigma_bn)
 
             # Update and connect the sc state message to the star tracker module
-            scStatesMessageData = messaging.SCStatesMsgPayload()
-            scStatesMessageData.r_BN_N = [0, 0, 0]
-            scStatesMessageData.v_BN_N = [0, 0, 0]
-            scStatesMessageData.sigma_BN = sigma_BN
-            scStatesMessageData.omega_BN_B = [0, 0, 0]
-            scStatesMessageData.TotalAccumDVBdy = [0, 0, 0]
-            scStatesMessageData.MRPSwitchCount = 0
-            scStatesMessage = messaging.SCStatesMsg().write(scStatesMessageData)
-            strTracker.scStateInMsg.subscribeTo(scStatesMessage)
+            sc_states_message_data = messaging.SCStatesMsgPayload()
+            sc_states_message_data.r_BN_N = [0, 0, 0]
+            sc_states_message_data.v_BN_N = [0, 0, 0]
+            sc_states_message_data.sigma_BN = sigma_bn
+            sc_states_message_data.omega_BN_B = [0, 0, 0]
+            sc_states_message_data.TotalAccumDVBdy = [0, 0, 0]
+            sc_states_message_data.MRPSwitchCount = 0
+            sc_states_message = messaging.SCStatesMsg().write(sc_states_message_data)
+            str_tracker.scStateInMsg.subscribeTo(sc_states_message)
 
             # Execute simulation chunk for updated spacecraft attitude
-            simStopTime = simStopTime + unitProcRate_s
-            unitSim.ConfigureStopTime(macros.sec2nano(simStopTime))
-            unitSim.ExecuteSimulation()
+            sim_stop_time = sim_stop_time + unit_proc_rate_s
+            unit_sim.ConfigureStopTime(macros.sec2nano(sim_stop_time))
+            unit_sim.ExecuteSimulation()
 
-        sigma_BNList = np.vstack(sigma_BNList)
+        sigma_bn_list = np.vstack(sigma_bn_list)
 
     # Extract logged data for test check
-    timespan = macros.NANO2SEC * starTrackerSensorMsgDataLog.times()  # [s]
-    beta_CN = starTrackerSensorMsgDataLog.qInrtl2Case
-    omega_CN_C = macros.R2D * starTrackerSensorMsgDataLog.omega_CN_C  # [rad/s]
+    timespan = macros.NANO2SEC * star_tracker_sensor_msg_data_log.times()  # [s]
+    beta_cn = star_tracker_sensor_msg_data_log.qInrtl2Case
+    omega_cn_c_module = macros.R2D * star_tracker_sensor_msg_data_log.omega_CN_C  # [rad/s]
 
     # Convert quaternion output to prv
-    prv_CN = np.zeros([int(simStopTime/unitProcRate_s)+1, 3])
-    for i in range(0, int(simStopTime/unitProcRate_s)+1):
-        if not np.allclose(beta_CN[i], [1.0, 0.0, 0.0, 0.0]):
-            prv_CN[i] = rbk.EP2PRV(beta_CN[i])
+    prv_cn = np.zeros([int(sim_stop_time/unit_proc_rate_s)+1, 3])
+    for i in range(0, int(sim_stop_time/unit_proc_rate_s)+1):
+        if not np.allclose(beta_cn[i], [1.0, 0.0, 0.0, 0.0]):
+            prv_cn[i] = rbk.EP2PRV(beta_cn[i])
         else:
-            prv_CN[i] = [0.0, 0.0, 0.0]
+            prv_cn[i] = [0.0, 0.0, 0.0]
 
     accuracy = 1e-6
-    if testCase == 'noise':
-        boundArray = np.full((int(simStopTime/unitProcRate_s)+1), 0.01)
+    if test_case == 'noise':
+        bound_array = np.full((int(sim_stop_time/unit_proc_rate_s)+1), 0.01)
         for i in range(0, 3):
-            np.testing.assert_array_less(np.abs(np.mean(prv_CN[:, i])),
-                                         boundArray,
+            np.testing.assert_array_less(np.abs(np.mean(prv_cn[:, i])),
+                                         bound_array,
                                          verbose=True)
 
-            np.testing.assert_array_less(np.abs(np.std(prv_CN[:, i]) - trueVector['qInrtl2Case'][i]),
-                                         boundArray,
+            np.testing.assert_array_less(np.abs(np.std(prv_cn[:, i]) - true_vector['qInrtl2Case'][i]),
+                                         bound_array,
                                          verbose=True)
 
-    elif testCase == 'walk bounds':
+    elif test_case == 'walk bounds':
         for i in range(0, 3):
-            np.testing.assert_array_less(np.max(np.abs(np.asarray(prv_CN[i]))),
-                                         trueVector['qInrtl2Case'][i],
+            np.testing.assert_array_less(np.max(np.abs(np.asarray(prv_cn[i]))),
+                                         true_vector['qInrtl2Case'][i],
                                          verbose=True)
 
-    elif testCase == 'angular velocity check':
+    elif test_case == 'angular velocity check':
         # Check computed platform angular velocity
-        omega_CN_CTruth = [np.zeros((1, 3))]
-        currentSimTime = timespan[0]
+        omega_cn_c_truth = [np.zeros((1, 3))]
+        current_sim_time = timespan[0]
         for idx in range(1, len(timespan)):
             # Grab the current and previous quaternions for numerical differentiation
-            beta_current_cn = np.array(beta_CN[idx, :])
-            beta_previous_cn = np.array(beta_CN[idx-1, :])
+            beta_current_cn = np.array(beta_cn[idx, :])
+            beta_previous_cn = np.array(beta_cn[idx-1, :])
 
             # Compute beta_dot_cn
-            previousSimTime = currentSimTime
-            currentSimTime = timespan[idx]
-            dt = currentSimTime - previousSimTime
+            previous_sim_time = current_sim_time
+            current_sim_time = timespan[idx]
+            dt = current_sim_time - previous_sim_time
             beta_dot_cn = (beta_current_cn - beta_previous_cn) / dt
 
             # Solve for platform rate using Eq. 3.106 from Schaub and Junkins 3rd edition Pg 111
             b_inv = rbk.BinvEP(beta_current_cn)
 
             omega_cn_c = 2 * b_inv.dot(beta_dot_cn)
-            omega_CN_CTruth.append(macros.R2D * omega_cn_c)  # [deg]
+            omega_cn_c_truth.append(macros.R2D * omega_cn_c)  # [deg]
 
-        omega_CN_CTruth = np.vstack(omega_CN_CTruth)
+        omega_cn_c_truth = np.vstack(omega_cn_c_truth)
 
-        np.testing.assert_allclose(omega_CN_C,
-                                   omega_CN_CTruth,
+        np.testing.assert_allclose(omega_cn_c_module,
+                                   omega_cn_c_truth,
                                    atol=accuracy,
                                    verbose=True)
 
     else:
-        for i in range(0, len(trueVector['qInrtl2Case'])):
-            np.testing.assert_allclose(beta_CN[i],
-                                       trueVector['qInrtl2Case'][i],
+        for i in range(0, len(true_vector['qInrtl2Case'])):
+            np.testing.assert_allclose(beta_cn[i],
+                                       true_vector['qInrtl2Case'][i],
                                        atol=accuracy,
                                        verbose=True)
 

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -114,26 +114,18 @@ void StarTracker::computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* 
     compute platform angular velocity from sensed quaternions
  */
 void StarTracker::computeAngularVelocity(uint64_t currentSimNanos) {
-    // Group quaternion components without beta_0
-    Eigen::Vector3d epsilon_CN = {
-        this->sensedValues.qInrtl2Case[1], this->sensedValues.qInrtl2Case[2], this->sensedValues.qInrtl2Case[3]};
-    Eigen::Vector3d epsilonPrevious_CN = this->betaPrevious_CN.tail<3>();
+    Eigen::Vector4d beta_CN = cArrayAsEigenVector(this->sensedValues.qInrtl2Case);
 
-    // Determine CRPs (Gibbs Vector)
-    Eigen::Vector3d q_CN = (1 / this->sensedValues.qInrtl2Case[0]) * epsilon_CN;
-    Eigen::Vector3d qPrevious_CN = (1 / this->betaPrevious_CN[0]) * epsilonPrevious_CN;
-
-    // Determine qDot_CN
-    Eigen::Vector3d qDot_CN = Eigen::Vector3d::Zero();
+    // Determine betaDot_CN
+    Eigen::Vector4d betaDot_CN = Eigen::Vector4d::Zero();
     if (currentSimNanos != this->previousSimTime) {
         double dt = (currentSimNanos - this->previousSimTime) * NANO2SEC;
-        qDot_CN = (q_CN - qPrevious_CN) / dt;
+        betaDot_CN = (beta_CN - this->betaPrevious_CN) / dt;
     }
 
-    // Solve for platform rate using Eq. 3.137 from Schaub and Junkins Pg 120
-    Eigen::Matrix3d qTilde_CN = eigenTilde(q_CN);
-    Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
-    Eigen::Vector3d omega_CN_C = (2.0 / (1.0 + q_CN.transpose() * q_CN)) * (I - qTilde_CN) * qDot_CN;
+    Eigen::Matrix<double, 3, 4> bInv = binvEp(beta_CN);
+
+    Eigen::Vector3d omega_CN_C = 2 * bInv * betaDot_CN;
     eigenVectorToCArray(omega_CN_C, this->sensedValues.omega_CN_C);
 }
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-513
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
The star tracker model estimates the angular velocity by using the crp kinematic differential equation. However, there is a singularity that occurs at 180 degrees. This PR converts this calculation to using the quaternion kinematic differential equation, avoiding the 180 degree singularity. 

## Verification
The test was updated to using this method. The test was also updated to verify the behavior at the singularity. It was confirmed that the previous implementation would not pass the singularity check, but the new implementation does. 

## Documentation
None

## Future work
Interestingly, there is a still a numerical differentiation nuance: since we use MRPs in dynamics, and we switch to the shadow set, we introduce a numerical differentiation issue when solving for the rate at 180 degrees. It's not a singularity, meaning that the solution does not blow up to infinity, however, it does cause some numerical inaccuracies around 180. Since we normally simulate at a high frequency, this is not a large issue, and can be ignored for now.
