### PR TITLE
Feature/1827 rw eff cnt separation

### DIFF
--- a/examples/BskSim/models/BSK_FormationFsw.py
+++ b/examples/BskSim/models/BSK_FormationFsw.py
@@ -253,8 +253,8 @@ class BSKFswModels():
         self.attRef2Msg = messaging.AttRefMsg()
         self.attGuidMsg = messaging.AttGuidMsg()
         self.attGuid2Msg = messaging.AttGuidMsg()
-        self.cmdRwMotorMsg = messaging.ArrayMotorTorqueMsg()
-        self.cmdRwMotor2Msg = messaging.ArrayMotorTorqueMsg()
+        self.cmdRwMotorMsg = messaging.RwMotorTorqueMsg()
+        self.cmdRwMotor2Msg = messaging.RwMotorTorqueMsg()
 
         self.zeroGateWayMsgs()
 
@@ -272,5 +272,5 @@ class BSKFswModels():
         self.attRef2Msg.write(messaging.AttRefMsgPayload())
         self.attGuidMsg.write(messaging.AttGuidMsgPayload())
         self.attGuid2Msg.write(messaging.AttGuidMsgPayload())
-        self.cmdRwMotorMsg.write(messaging.ArrayMotorTorqueMsgPayload())
-        self.cmdRwMotor2Msg.write(messaging.ArrayMotorTorqueMsgPayload())
+        self.cmdRwMotorMsg.write(messaging.RwMotorTorqueMsgPayload())
+        self.cmdRwMotor2Msg.write(messaging.RwMotorTorqueMsgPayload())

--- a/examples/BskSim/models/BSK_Fsw.py
+++ b/examples/BskSim/models/BSK_Fsw.py
@@ -273,7 +273,7 @@ class BSKFswModels:
                                ["self.modeRequest == 'dvBurn'"],
                                ["self.fswProc.disableTasks()",
                                 "from Basilisk.architecture import messaging",
-                                "self.FSWModels.cmdRwMotorMsg.write(messaging.ArrayMotorTorqueMsgPayload())",
+                                "self.FSWModels.cmdRwMotorMsg.write(messaging.RwMotorTorqueMsgPayload())",
                                 "self.enableTask('dvPointTask')",
                                 "self.enableTask('mrpFeedbackTHsTask')",
                                 "self.enableTask('dvBurnTask')",
@@ -603,7 +603,7 @@ class BSKFswModels:
         self.cmdTorqueDirectMsg = messaging.CmdTorqueBodyMsg()
         self.attRefMsg = messaging.AttRefMsg()
         self.attGuidMsg = messaging.AttGuidMsg()
-        self.cmdRwMotorMsg = messaging.ArrayMotorTorqueMsg()
+        self.cmdRwMotorMsg = messaging.RwMotorTorqueMsg()
         self.acsOnTimeCmdMsg = messaging.THRArrayOnTimeCmdMsg()
         self.dvOnTimeCmdMsg = messaging.THRArrayOnTimeCmdMsg()
 
@@ -624,7 +624,7 @@ class BSKFswModels:
         self.cmdTorqueDirectMsg.write(messaging.CmdTorqueBodyMsgPayload())
         self.attRefMsg.write(messaging.AttRefMsgPayload())
         self.attGuidMsg.write(messaging.AttGuidMsgPayload())
-        self.cmdRwMotorMsg.write(messaging.ArrayMotorTorqueMsgPayload())
+        self.cmdRwMotorMsg.write(messaging.RwMotorTorqueMsgPayload())
         self.acsOnTimeCmdMsg.write(messaging.THRArrayOnTimeCmdMsgPayload())
         self.dvOnTimeCmdMsg.write(messaging.THRArrayOnTimeCmdMsgPayload())
         self.dvBurnCmdMsg.write(messaging.DvBurnCmdMsgPayload())

--- a/src/architecture/msgPayloadDef/RWArrayConfigMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RWArrayConfigMsgPayload.h
@@ -27,7 +27,7 @@
 typedef struct {
     double GsMatrix_B[3 * RW_EFF_CNT];  //!< [-]    The RW spin axis matrix in body frame components
     double JsList[RW_EFF_CNT];          //!< [kgm2] The spin axis inertia for RWs
-    int numRW;                           //!< [-]    The number of reaction wheels available on vehicle
+    int numRW;                          //!< [-]    The number of reaction wheels available on vehicle
     double uMax[RW_EFF_CNT];            //!< [Nm]   The maximum RW motor torque
 } RWArrayConfigMsgPayload;
 

--- a/src/architecture/msgPayloadDef/RWArrayConfigMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RWArrayConfigMsgPayload.h
@@ -25,10 +25,10 @@
 
 /*! @brief RW array configuration FSW msg */
 typedef struct {
-    double GsMatrix_B[3 * MAX_EFF_CNT];  //!< [-]    The RW spin axis matrix in body frame components
-    double JsList[MAX_EFF_CNT];          //!< [kgm2] The spin axis inertia for RWs
+    double GsMatrix_B[3 * RW_EFF_CNT];  //!< [-]    The RW spin axis matrix in body frame components
+    double JsList[RW_EFF_CNT];          //!< [kgm2] The spin axis inertia for RWs
     int numRW;                           //!< [-]    The number of reaction wheels available on vehicle
-    double uMax[MAX_EFF_CNT];            //!< [Nm]   The maximum RW motor torque
+    double uMax[RW_EFF_CNT];            //!< [Nm]   The maximum RW motor torque
 } RWArrayConfigMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/RWAvailabilityMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RWAvailabilityMsgPayload.h
@@ -25,7 +25,7 @@
 
 /*! @brief Array with availability of RW */
 typedef struct {
-    FSWdeviceAvailability wheelAvailability[MAX_EFF_CNT];  //!< The current state of the wheel
+    FSWdeviceAvailability wheelAvailability[RW_EFF_CNT];  //!< The current state of the wheel
 } RWAvailabilityMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/RWConstellationMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RWConstellationMsgPayload.h
@@ -26,7 +26,7 @@
 /*! @brief Message used to define an array of RW FSW configurations  */
 typedef struct {
     int numRW;                                              //!< [-] number of RWs
-    RWConfigElementMsgPayload reactionWheels[MAX_EFF_CNT];  //!< [-] array of the reaction wheels
+    RWConfigElementMsgPayload reactionWheels[RW_EFF_CNT];  //!< [-] array of the reaction wheels
 } RWConstellationMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/RWConstellationMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RWConstellationMsgPayload.h
@@ -25,7 +25,7 @@
 
 /*! @brief Message used to define an array of RW FSW configurations  */
 typedef struct {
-    int numRW;                                              //!< [-] number of RWs
+    int numRW;                                             //!< [-] number of RWs
     RWConfigElementMsgPayload reactionWheels[RW_EFF_CNT];  //!< [-] array of the reaction wheels
 } RWConstellationMsgPayload;
 

--- a/src/architecture/msgPayloadDef/RWSpeedMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RWSpeedMsgPayload.h
@@ -24,8 +24,8 @@
 
 /*! @brief Structure used to define the output definition for reaction wheel speeds*/
 typedef struct {
-    double wheelSpeeds[MAX_EFF_CNT];  //!< r/s The current angular velocities of the RW wheel
-    double wheelThetas[MAX_EFF_CNT];  //!< rad The current angle of the RW if jitter is enabled
+    double wheelSpeeds[RW_EFF_CNT];  //!< r/s The current angular velocities of the RW wheel
+    double wheelThetas[RW_EFF_CNT];  //!< rad The current angle of the RW if jitter is enabled
 } RWSpeedMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h
@@ -16,25 +16,15 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module rwNullSpace
-%{
-   #include "rwNullSpace.h"
-%}
 
-%pythoncode %{
-    from Basilisk.architecture.swig_common_model import *
-%}
+#ifndef RW_MOTOR_TORQUE_H
+#define RW_MOTOR_TORQUE_H
 
-%include "sys_model.i"
-%include "swig_conly_data.i"
+#include "definitions.h"
 
-%include "rwNullSpace.h"
+/*! @brief Structure used to define the message format of the motor torque */
+typedef struct {
+    double motorTorque[MAX_EFF_CNT];  //!< [Nm]  motor torque array
+} RwMotorTorqueMsgPayload;
 
-%include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
-%include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
-%include "architecture/msgPayloadDef/RWConstellationMsgPayload.h"
-
-%pythoncode %{
-import sys
-protectAllClasses(sys.modules[__name__])
-%}
+#endif

--- a/src/architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h
@@ -24,7 +24,7 @@
 
 /*! @brief Structure used to define the message format of the motor torque */
 typedef struct {
-    double motorTorque[MAX_EFF_CNT];  //!< [Nm]  motor torque array
+    double motorTorque[RW_EFF_CNT];  //!< [Nm]  motor torque array
 } RwMotorTorqueMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h
@@ -24,7 +24,7 @@
 
 /*! @brief Structure used to define the message format of the motor voltage input  */
 typedef struct {
-    double voltage[MAX_EFF_CNT];  //!< [V]     Motor voltage input value
+    double voltage[RW_EFF_CNT];  //!< [V]     Motor voltage input value
 } RwMotorVoltageMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h
@@ -25,6 +25,6 @@
 /*! @brief Structure used to define the message format of the motor voltage input  */
 typedef struct {
     double voltage[MAX_EFF_CNT];  //!< [V]     Motor voltage input value
-} ArrayMotorVoltageMsgPayload;
+} RwMotorVoltageMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/VSCMGArrayTorqueMsgPayload.h
+++ b/src/architecture/msgPayloadDef/VSCMGArrayTorqueMsgPayload.h
@@ -24,8 +24,8 @@
 
 /*! @brief Structure used to define the output definition for vehicle effectors*/
 typedef struct {
-    double wheelTorque[MAX_EFF_CNT];   //!< [N-m] VSCMG wheel torque array
-    double gimbalTorque[MAX_EFF_CNT];  //!< [N-m] VSCMG gimbal torque array
+    double wheelTorque[RW_EFF_CNT];   //!< [N-m] VSCMG wheel torque array
+    double gimbalTorque[RW_EFF_CNT];  //!< [N-m] VSCMG gimbal torque array
 } VSCMGArrayTorqueMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/VSCMGSpeedMsgPayload.h
+++ b/src/architecture/msgPayloadDef/VSCMGSpeedMsgPayload.h
@@ -24,9 +24,9 @@
 
 /*! @brief Structure used to define the output definition for VSCMG speeds*/
 typedef struct {
-    double wheelSpeeds[MAX_EFF_CNT];   //!< r/s The current angular velocities of the VSCMG wheel
-    double gimbalAngles[MAX_EFF_CNT];  //!< r The current angles of the VSCMG gimbal
-    double gimbalRates[MAX_EFF_CNT];   //!< r/s The current angular velocities of the VSCMG gimbal
+    double wheelSpeeds[RW_EFF_CNT];   //!< r/s The current angular velocities of the VSCMG wheel
+    double gimbalAngles[RW_EFF_CNT];  //!< r The current angles of the VSCMG gimbal
+    double gimbalRates[RW_EFF_CNT];   //!< r/s The current angular velocities of the VSCMG gimbal
 } VSCMGSpeedMsgPayload;
 
 #endif

--- a/src/architecture/msgPayloadDef/definitions.h
+++ b/src/architecture/msgPayloadDef/definitions.h
@@ -3,5 +3,6 @@
 
 #define MAX_NUM_CSS_SENSORS 32
 #define MAX_EFF_CNT 36
+#define RW_EFF_CNT 36
 
 #endif  // MSG_DEFINITIONS_H

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/_UnitTest/test_mtbMomentumManagement.py
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/_UnitTest/test_mtbMomentumManagement.py
@@ -52,7 +52,7 @@ def test_mtbMomentumManagement():     # update "module" in this function name to
     variables
 
     - ``mtbDipoleCmds[MAX_EFF_CNT]``
-    - ``motorTorque[MAX_EFF_CNT]``
+    - ``motorTorque[RW_EFF_CNT]``
     """
     # each test method requires a single assert method to be called
     # pass on the testPlotFixture so that the main test function may set the DataStore attributes

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/_UnitTest/test_mtbMomentumManagement.py
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/_UnitTest/test_mtbMomentumManagement.py
@@ -112,9 +112,9 @@ def mtbMomentumManagementModuleTestFunction():
     rwSpeedsInMsg = messaging.RWSpeedMsg().write(rwSpeedsInMsgContainer)
 
     # attControl message
-    rwMotorTorqueInMsgContainer = messaging.ArrayMotorTorqueMsgPayload()
+    rwMotorTorqueInMsgContainer = messaging.RwMotorTorqueMsgPayload()
     rwMotorTorqueInMsgContainer.motorTorque = [0., 0., 0., 0.]
-    rwMotorTorqueInMsg = messaging.ArrayMotorTorqueMsg().write(rwMotorTorqueInMsgContainer)
+    rwMotorTorqueInMsg = messaging.RwMotorTorqueMsg().write(rwMotorTorqueInMsgContainer)
 
     # Setup logging on the test module output message so that we get all the writes to it
     resultMtbCmdOutMsg = module.mtbCmdOutMsg.recorder()

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.cpp
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.cpp
@@ -18,9 +18,9 @@
  */
 
 #include "mtbMomentumManagement.h"
-#include "string.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/svd.h"
+#include "string.h"
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.  The local copy of the
@@ -28,24 +28,23 @@
  @return void
  @param callTime [ns] time the method is called
 */
-void MtbMomentumManagement::reset(uint64_t callTime)
-{
+void MtbMomentumManagement::reset(uint64_t callTime) {
     /*
      * Check if the required input messages are linked.
      */
-    if (!this->rwParamsInMsg.isLinked()){
+    if (!this->rwParamsInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.rwParamsInMsg is not connected.");
     }
-    if(!this->mtbParamsInMsg.isLinked()){
+    if (!this->mtbParamsInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.mtbParamsInMsg is not connected.");
     }
-    if (!this->tamSensorBodyInMsg.isLinked()){
+    if (!this->tamSensorBodyInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.tamSensorBodyInMsg is not connected.");
     }
-    if (!this->rwSpeedsInMsg.isLinked()){
+    if (!this->rwSpeedsInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.rwSpeedsInMsg is not connected.");
     }
-    if (!this->rwMotorTorqueInMsg.isLinked()){
+    if (!this->rwMotorTorqueInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.rwMotorTorqueInMsg is not connected.");
     }
 
@@ -56,25 +55,23 @@ void MtbMomentumManagement::reset(uint64_t callTime)
     return;
 }
 
-
 /*! Computes the appropriate wheel torques and magnetic torque bar dipoles to bias the wheels to their desired speeds.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */
-void MtbMomentumManagement::updateState(uint64_t callTime)
-{
+void MtbMomentumManagement::updateState(uint64_t callTime) {
     /*
      * Declare and initialize local variables.
      */
     int numRW = this->rwConfigParams.numRW;
     int numMTB = this->mtbConfigParams.numMTB;
     int j = 0;
-    double BTilde_B[3*3];
-    double BGt[3*MAX_EFF_CNT];
-    double BGtPsuedoInverse[MAX_EFF_CNT*3];
+    double BTilde_B[3 * 3];
+    double BGt[3 * MAX_EFF_CNT];
+    double BGtPsuedoInverse[MAX_EFF_CNT * 3];
     double uDelta_B[3];
     double uDelta_W[RW_EFF_CNT];
-    double GsPsuedoInverse[RW_EFF_CNT*3];
+    double GsPsuedoInverse[RW_EFF_CNT * 3];
     double Gs[3 * RW_EFF_CNT];
     mSetZero(BTilde_B, 3, 3);
     mSetZero(BGt, 3, numMTB);
@@ -117,8 +114,7 @@ void MtbMomentumManagement::updateState(uint64_t callTime)
     /*
      * Saturate dipoles.
      */
-    for (j = 0; j < numMTB; j++)
-    {
+    for (j = 0; j < numMTB; j++) {
         if (mtbCmdOutputMsgBuffer.mtbDipoleCmds[j] > this->mtbConfigParams.maxMtbDipoles[j])
             mtbCmdOutputMsgBuffer.mtbDipoleCmds[j] = this->mtbConfigParams.maxMtbDipoles[j];
 
@@ -153,8 +149,7 @@ void MtbMomentumManagement::updateState(uint64_t callTime)
 /*
  * Returns the tilde matrix in the form of a 1-D array.
  */
-void v3TildeM(double v[3], double *m_result)
-{
+void v3TildeM(double v[3], double *m_result) {
     m_result[MXINDEX(3, 0, 0)] = 0.0;
     m_result[MXINDEX(3, 0, 1)] = -v[2];
     m_result[MXINDEX(3, 0, 2)] = v[1];

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.cpp
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.cpp
@@ -97,9 +97,9 @@ void MtbMomentumManagement::updateState(uint64_t callTime)
      */
     TAMSensorBodyMsgPayload tamSensorBodyInMsgBuffer = this->tamSensorBodyInMsg();
     RWSpeedMsgPayload rwSpeedsInMsgBuffer = this->rwSpeedsInMsg();
-    ArrayMotorTorqueMsgPayload rwMotorTorqueInMsgBuffer = this->rwMotorTorqueInMsg();
+    RwMotorTorqueMsgPayload rwMotorTorqueInMsgBuffer = this->rwMotorTorqueInMsg();
     MTBCmdMsgPayload mtbCmdOutputMsgBuffer = {};
-    ArrayMotorTorqueMsgPayload rwMotorTorqueOutMsgBuffer = rwMotorTorqueInMsgBuffer;
+    RwMotorTorqueMsgPayload rwMotorTorqueOutMsgBuffer = rwMotorTorqueInMsgBuffer;
 
     /*! - Compute the wheel speed feedback.*/
     vSubtract(rwSpeedsInMsgBuffer.wheelSpeeds, numRW, this->wheelSpeedBiases, this->wheelSpeedError_W);

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.cpp
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.cpp
@@ -73,9 +73,9 @@ void MtbMomentumManagement::updateState(uint64_t callTime)
     double BGt[3*MAX_EFF_CNT];
     double BGtPsuedoInverse[MAX_EFF_CNT*3];
     double uDelta_B[3];
-    double uDelta_W[MAX_EFF_CNT];
-    double GsPsuedoInverse[MAX_EFF_CNT*3];
-    double Gs[3 * MAX_EFF_CNT];
+    double uDelta_W[RW_EFF_CNT];
+    double GsPsuedoInverse[RW_EFF_CNT*3];
+    double Gs[3 * RW_EFF_CNT];
     mSetZero(BTilde_B, 3, 3);
     mSetZero(BGt, 3, numMTB);
     mSetZero(BGtPsuedoInverse, numMTB, 3);

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.h
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.h
@@ -22,7 +22,7 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/MTBArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/MTBCmdMsgPayload.h"
 #include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
@@ -50,13 +50,13 @@ class MtbMomentumManagement : public SysModel {
     ReadFunctor<TAMSensorBodyMsgPayload>
         tamSensorBodyInMsg;                        //!< input message for magnetic field sensor data in the Body frame
     ReadFunctor<RWSpeedMsgPayload> rwSpeedsInMsg;  //!< input message for RW speeds
-    ReadFunctor<ArrayMotorTorqueMsgPayload> rwMotorTorqueInMsg;  //!< input message for RW motor torques
+    ReadFunctor<RwMotorTorqueMsgPayload> rwMotorTorqueInMsg;  //!< input message for RW motor torques
 
     /*
      * Outputs.
      */
     Message<MTBCmdMsgPayload> mtbCmdOutMsg;                   //!< output message for MTB dipole commands
-    Message<ArrayMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< output message for RW motor torques
+    Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< output message for RW motor torques
 
     /*
      * Other.

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.h
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.h
@@ -22,11 +22,11 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/MTBArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/MTBCmdMsgPayload.h"
 #include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/TAMSensorBodyMsgPayload.h"
 #include "architecture/msgPayloadDef/definitions.h"
 
@@ -40,7 +40,7 @@ class MtbMomentumManagement : public SysModel {
      * Configs.
      */
     double wheelSpeedBiases[RW_EFF_CNT];  //!< [rad/s] reaction wheel speed biases
-    double cGain;                          //!<[1/s]  reaction wheel momentum feedback gain
+    double cGain;                         //!<[1/s]  reaction wheel momentum feedback gain
 
     /*
      * Inputs.
@@ -55,17 +55,17 @@ class MtbMomentumManagement : public SysModel {
     /*
      * Outputs.
      */
-    Message<MTBCmdMsgPayload> mtbCmdOutMsg;                   //!< output message for MTB dipole commands
+    Message<MTBCmdMsgPayload> mtbCmdOutMsg;                //!< output message for MTB dipole commands
     Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< output message for RW motor torques
 
     /*
      * Other.
      */
-    BSKLogger bskLogger = {};   //!< BSK Logging
-    double tauDesiredMTB_B[3];  //!< [N-m] desired torque produced by the magnetic torque bars in the Body frame
-    double tauDesiredRW_B[3];   //!< [N-m]  desired torque produced by the reaction wheels in the Body frame
+    BSKLogger bskLogger = {};           //!< BSK Logging
+    double tauDesiredMTB_B[3];          //!< [N-m] desired torque produced by the magnetic torque bars in the Body frame
+    double tauDesiredRW_B[3];           //!< [N-m]  desired torque produced by the reaction wheels in the Body frame
     double hDeltaWheels_W[RW_EFF_CNT];  //!<  [N-m-s] momentum of each wheel
-    double hDeltaWheels_B[3];            //!<  [N-m-s] momentum of reaction wheels in the Body frame
+    double hDeltaWheels_B[3];           //!<  [N-m-s] momentum of reaction wheels in the Body frame
     double tauDesiredRW_W[RW_EFF_CNT];  //!<  [N-m] Desired individual wheel torques
     double tauIdealRW_W[RW_EFF_CNT];    //!<  [N-m-s] Ideal individual wheel torques
     double tauIdealRW_B[RW_EFF_CNT];    //!<  [N-m-s] Ideal wheel torque in the body frame

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.h
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.h
@@ -39,7 +39,7 @@ class MtbMomentumManagement : public SysModel {
     /*
      * Configs.
      */
-    double wheelSpeedBiases[MAX_EFF_CNT];  //!< [rad/s] reaction wheel speed biases
+    double wheelSpeedBiases[RW_EFF_CNT];  //!< [rad/s] reaction wheel speed biases
     double cGain;                          //!<[1/s]  reaction wheel momentum feedback gain
 
     /*
@@ -64,13 +64,13 @@ class MtbMomentumManagement : public SysModel {
     BSKLogger bskLogger = {};   //!< BSK Logging
     double tauDesiredMTB_B[3];  //!< [N-m] desired torque produced by the magnetic torque bars in the Body frame
     double tauDesiredRW_B[3];   //!< [N-m]  desired torque produced by the reaction wheels in the Body frame
-    double hDeltaWheels_W[MAX_EFF_CNT];  //!<  [N-m-s] momentum of each wheel
+    double hDeltaWheels_W[RW_EFF_CNT];  //!<  [N-m-s] momentum of each wheel
     double hDeltaWheels_B[3];            //!<  [N-m-s] momentum of reaction wheels in the Body frame
-    double tauDesiredRW_W[MAX_EFF_CNT];  //!<  [N-m] Desired individual wheel torques
-    double tauIdealRW_W[MAX_EFF_CNT];    //!<  [N-m-s] Ideal individual wheel torques
-    double tauIdealRW_B[MAX_EFF_CNT];    //!<  [N-m-s] Ideal wheel torque in the body frame
+    double tauDesiredRW_W[RW_EFF_CNT];  //!<  [N-m] Desired individual wheel torques
+    double tauIdealRW_W[RW_EFF_CNT];    //!<  [N-m-s] Ideal individual wheel torques
+    double tauIdealRW_B[RW_EFF_CNT];    //!<  [N-m-s] Ideal wheel torque in the body frame
     double
-        wheelSpeedError_W[MAX_EFF_CNT];  //!<  [N-m-s] difference between current wheel speeds and desired wheel speeds
+        wheelSpeedError_W[RW_EFF_CNT];  //!<  [N-m-s] difference between current wheel speeds and desired wheel speeds
     RWArrayConfigMsgPayload rwConfigParams;    //!< configuration for RW's
     MTBArrayConfigMsgPayload mtbConfigParams;  //!< configuration for MTB layout
 };

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.i
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.i
@@ -36,7 +36,7 @@
 %include "architecture/msgPayloadDef/TAMSensorBodyMsgPayload.h"
 %include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
 %include "architecture/msgPayloadDef/MTBCmdMsgPayload.h"
-%include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 
 %pythoncode %{
 import sys

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.rst
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.rst
@@ -47,4 +47,3 @@ The optional module list ``wheelSpeedBiases`` can be set to desired RW spin rate
 the default values are zero rates.
 
 Note that the MTB input configuration message variable ``GtMatrix_B`` must be provided in a row major format.
-

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.rst
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/mtbMomentumManagement.rst
@@ -29,13 +29,13 @@ provides information on what this message is used for.
       - :ref:`RWSpeedMsgPayload`
       - input message for RW speeds
     * - rwMotorTorqueInMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - input message for RW motor torques
     * - mtbCmdOutMsg
       - :ref:`MTBCmdMsgPayload`
       - output message for MTB dipole commands
     * - rwMotorTorqueOutMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - output message for RW motor torques
 
 User Guide

--- a/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.cpp
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.cpp
@@ -71,7 +71,7 @@ void MtbMomentumManagementSimple::updateState(uint64_t callTime)
      * Initialize local variables.
      */
     double hWheels_B[3] = {0.0, 0.0, 0.0};                      // the net momentum of the reaction wheels in the body frame
-    double hWheels_W[MAX_EFF_CNT];                              // array of individual wheel momentum values
+    double hWheels_W[RW_EFF_CNT];                              // array of individual wheel momentum values
     vSetZero(hWheels_W, this->rwConfigParams.numRW);
 
     /*

--- a/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.cpp
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.cpp
@@ -17,7 +17,6 @@
 
 */
 
-
 #include "mtbMomentumManagementSimple.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include <stdio.h>
@@ -28,15 +27,14 @@
  @return void
  @param callTime [ns] time the method is called
 */
-void MtbMomentumManagementSimple::reset(uint64_t callTime)
-{
+void MtbMomentumManagementSimple::reset(uint64_t callTime) {
     /*
      * Check if the required input messages are connected.
      */
-    if (!this->rwParamsInMsg.isLinked()){
+    if (!this->rwParamsInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.rwParamsInMsg is not connected.");
     }
-    if (!this->rwSpeedsInMsg.isLinked()){
+    if (!this->rwSpeedsInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: mtbMomentumManagement.rwSpeedsInMsg is not connected.");
     }
 
@@ -54,24 +52,21 @@ void MtbMomentumManagementSimple::reset(uint64_t callTime)
     /*
      * Sanity check configs.
      */
-    if (this->Kp < 0.0)
-        this->bskLogger.bskLog(BSK_ERROR, "Error: k < 0.0");
+    if (this->Kp < 0.0) this->bskLogger.bskLog(BSK_ERROR, "Error: k < 0.0");
 
     return;
 }
-
 
 /*! This routine calculate the current desired torque in the Body frame to meet the momentum target.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */
-void MtbMomentumManagementSimple::updateState(uint64_t callTime)
-{
+void MtbMomentumManagementSimple::updateState(uint64_t callTime) {
     /*
      * Initialize local variables.
      */
-    double hWheels_B[3] = {0.0, 0.0, 0.0};                      // the net momentum of the reaction wheels in the body frame
-    double hWheels_W[RW_EFF_CNT];                              // array of individual wheel momentum values
+    double hWheels_B[3] = {0.0, 0.0, 0.0};  // the net momentum of the reaction wheels in the body frame
+    double hWheels_W[RW_EFF_CNT];           // array of individual wheel momentum values
     vSetZero(hWheels_W, this->rwConfigParams.numRW);
 
     /*
@@ -82,7 +77,8 @@ void MtbMomentumManagementSimple::updateState(uint64_t callTime)
 
     /*! - Compute wheel momentum in Body frame components by calculating it first in the wheel frame and then
          transforming it from the wheel space into the body frame using Gs.*/
-    vElementwiseMult(rwSpeedsInMsgBuffer.wheelSpeeds, this->rwConfigParams.numRW, this->rwConfigParams.JsList, hWheels_W);
+    vElementwiseMult(
+        rwSpeedsInMsgBuffer.wheelSpeeds, this->rwConfigParams.numRW, this->rwConfigParams.JsList, hWheels_W);
     mMultV(this->Gs, 3, this->rwConfigParams.numRW, hWheels_W, hWheels_B);
 
     /*! - Compute the feedback torque command by multiplying the wheel momentum in the Body frame by the proportional

--- a/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.h
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.h
@@ -47,7 +47,7 @@ class MtbMomentumManagementSimple : public SysModel {
 
     /* Other. */
     RWArrayConfigMsgPayload rwConfigParams;  //!< configuration for RW's
-    double Gs[3 * RW_EFF_CNT];              //!< transformation from the wheelspace to the Body frame
+    double Gs[3 * RW_EFF_CNT];               //!< transformation from the wheelspace to the Body frame
     BSKLogger bskLogger = {};                //!< BSK Logging
 };
 

--- a/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.h
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/mtbMomentumManagementSimple.h
@@ -47,7 +47,7 @@ class MtbMomentumManagementSimple : public SysModel {
 
     /* Other. */
     RWArrayConfigMsgPayload rwConfigParams;  //!< configuration for RW's
-    double Gs[3 * MAX_EFF_CNT];              //!< transformation from the wheelspace to the Body frame
+    double Gs[3 * RW_EFF_CNT];              //!< transformation from the wheelspace to the Body frame
     BSKLogger bskLogger = {};                //!< BSK Logging
 };
 

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorque.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorque.py
@@ -130,7 +130,7 @@ def rwMotorTorqueTest(show_plots):
     # print('\n', moduleOutput)
 
     # set the output truth states
-    ans = [0]*messaging.MAX_EFF_CNT
+    ans = [0]*messaging.RW_EFF_CNT
     ans[0:4] = [-0.8, 0.7000000000000001, -0.5, -0.3464101615137755]
     trueVector = [
                    ans,

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorqueParametrized.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorqueParametrized.py
@@ -51,7 +51,7 @@ from Support import results_rwMotorTorque
 # The following 'parametrize' function decorator provides the parameters and expected results for each
 #   of the multiple test runs for this test.
 @pytest.mark.parametrize("numControlAxes", [0, 1, 2, 3])
-@pytest.mark.parametrize("numWheels", [2, 4, messaging.MAX_EFF_CNT])
+@pytest.mark.parametrize("numWheels", [2, 4, messaging.RW_EFF_CNT])
 @pytest.mark.parametrize("numInputCmdTorques", [1, 2])
 @pytest.mark.parametrize("RWAvailMsg",["NO", "ON", "OFF", "MIXED"])
 
@@ -124,9 +124,9 @@ def rwMotorTorqueTest(show_plots, numControlAxes, numWheels, numInputCmdTorques,
 
     # wheelConfigData message
     rwConfigParams = messaging.RWArrayConfigMsgPayload()
-    MAX_EFF_CNT = messaging.MAX_EFF_CNT
+    RW_EFF_CNT = messaging.RW_EFF_CNT
 
-    if numWheels == MAX_EFF_CNT:
+    if numWheels == RW_EFF_CNT:
         rwConfigParams.GsMatrix_B = [
             0.4835867893995201, 0.7025829597277155, 0.5220354411517549,
             0.6274167231454653, 0.4634123147571517, 0.6257773422303058,
@@ -226,14 +226,14 @@ def rwMotorTorqueTest(show_plots, numControlAxes, numWheels, numInputCmdTorques,
     moduleOutput = dataLog.motorTorque
 
     trueVector = np.array([
-        [0.0] * MAX_EFF_CNT,
-        [0.0] * MAX_EFF_CNT
+        [0.0] * RW_EFF_CNT,
+        [0.0] * RW_EFF_CNT
     ])
 
     # set the output truth states
     trueVector[0] = results_rwMotorTorque.computeTorqueU(np.array(controlAxes_B),
                                                                    np.array(rwConfigParams.GsMatrix_B).reshape((
-                                                                       3, MAX_EFF_CNT), order='F'),
+                                                                       3, RW_EFF_CNT), order='F'),
                                                                    requestedTorque,
                                                                    avail)
     trueVector[1] = trueVector[0]
@@ -241,10 +241,10 @@ def rwMotorTorqueTest(show_plots, numControlAxes, numWheels, numInputCmdTorques,
     # compare the module results to the truth values
     accuracy = 1e-8
     testFailCount, testMessages = unitTestSupport.compareArrayND(trueVector, moduleOutput, accuracy, "rwMotorTorques",
-                                                                 MAX_EFF_CNT, testFailCount, testMessages)
+                                                                 RW_EFF_CNT, testFailCount, testMessages)
 
 
-    GsMatrix = np.transpose(np.reshape(rwConfigParams.GsMatrix_B,(MAX_EFF_CNT,3),"C"))
+    GsMatrix = np.transpose(np.reshape(rwConfigParams.GsMatrix_B,(RW_EFF_CNT,3),"C"))
     F = np.transpose(moduleOutput[0])
     receivedTorque = -1.0*np.array([np.matmul(GsMatrix,F)])
     receivedTorque = np.append(np.array([]), receivedTorque)

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.cpp
@@ -174,7 +174,7 @@ void RwMotorTorque::updateState(uint64_t callTime)
     }
 
     /* store the output message */
-    ArrayMotorTorqueMsgPayload rwMotorTorques = {};
+    RwMotorTorqueMsgPayload rwMotorTorques = {};
     vCopy(us, this->rwConfigParams.numRW, rwMotorTorques.motorTorque);
     this->rwMotorTorqueOutMsg.write(&rwMotorTorques, this->moduleID, callTime);
 

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.cpp
@@ -78,12 +78,12 @@ void RwMotorTorque::updateState(uint64_t callTime)
     CmdTorqueBodyMsgPayload LrInput2Msg;            /*!< Msg containing optional Lr control torque */
     double Lr_B[3];                             /*!< [Nm]    commanded ADCS control torque in body frame*/
     double Lr_C[3];                             /*!< [Nm]    commanded ADCS control torque projected onto control axes */
-    double us[MAX_EFF_CNT];                     /*!< [Nm]    commanded ADCS control torque projected onto RWs g_s-Frames */
-    double CGs[3][MAX_EFF_CNT];                 /*!< []      projection matrix from gs_i onto control axes */
+    double us[RW_EFF_CNT];                     /*!< [Nm]    commanded ADCS control torque projected onto RWs g_s-Frames */
+    double CGs[3][RW_EFF_CNT];                 /*!< []      projection matrix from gs_i onto control axes */
 
     /*! - zero control torque and RW motor torque variables */
     v3SetZero(Lr_C);
-    vSetZero(us, MAX_EFF_CNT);
+    vSetZero(us, RW_EFF_CNT);
     // wheelAvailability set to 0 (AVAILABLE) by default
 
     // check if the required input messages are included
@@ -127,7 +127,7 @@ void RwMotorTorque::updateState(uint64_t callTime)
     mMultV(this->controlAxes_B, this->numControlAxes, 3, Lr_B, Lr_C);
 
     /*! - compute [CGs] */
-    mSetZero(CGs, 3, MAX_EFF_CNT);
+    mSetZero(CGs, 3, RW_EFF_CNT);
     for (uint32_t i=0; i<this->numControlAxes; i++) {
         for (int j=0; j<this->numAvailRW; j++) {
             CGs[i][j] = v3Dot(&this->GsMatrix_B[j * 3], &this->controlAxes_B[3 * i]);
@@ -138,7 +138,7 @@ void RwMotorTorque::updateState(uint64_t callTime)
     if (this->numAvailRW >= (int) this->numControlAxes){
         double v3_temp[3]; /* inv([M]) [Lr_C] */
         double M33[3][3]; /* [M] = [CGs][CGs].T */
-        double us_avail[MAX_EFF_CNT];   /* matrix of available RW motor torques */
+        double us_avail[RW_EFF_CNT];   /* matrix of available RW motor torques */
 
         v3SetZero(v3_temp);
         mSetIdentity(M33, 3, 3);
@@ -155,7 +155,7 @@ void RwMotorTorque::updateState(uint64_t callTime)
 
         /*! - compute the desired RW motor torques */
         /* us = [CGs].T v3_temp */
-        vSetZero(us_avail, MAX_EFF_CNT);
+        vSetZero(us_avail, RW_EFF_CNT);
         for (int i=0; i<this->numAvailRW; i++) {
             for (uint32_t j=0; j<this->numControlAxes; j++) {
                 us_avail[i] += CGs[j][i] * v3_temp[j];

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.cpp
@@ -22,31 +22,29 @@
  */
 
 #include "fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void RwMotorTorque::reset(uint64_t callTime)
-{
-    double *pAxis;                 /* pointer to the current control axis */
+void RwMotorTorque::reset(uint64_t callTime) {
+    double *pAxis; /* pointer to the current control axis */
     int i;
 
     /*!- configure the number of axes that are controlled.
      This is determined by checking for a zero row to determinate search */
     this->numControlAxes = 0;
-    for (i = 0; i < 3; i++)
-    {
+    for (i = 0; i < 3; i++) {
         pAxis = this->controlAxes_B + 3 * this->numControlAxes;
         if (v3Norm(pAxis) > 0.0) {
             this->numControlAxes += 1;
         }
     }
     if (this->numControlAxes == 0) {
-        this->bskLogger.bskLog(BSK_INFORMATION,"rwMotorTorque() is not setup to control any axes!");
+        this->bskLogger.bskLog(BSK_INFORMATION, "rwMotorTorque() is not setup to control any axes!");
     }
 
     // check if the required input messages are included
@@ -61,7 +59,7 @@ void RwMotorTorque::reset(uint64_t callTime)
      and create the [Gs] projection matrix once */
     if (!this->rwAvailInMsg.isLinked()) {
         this->numAvailRW = this->rwConfigParams.numRW;
-        for (i = 0; i < this->rwConfigParams.numRW; i++){
+        for (i = 0; i < this->rwConfigParams.numRW; i++) {
             v3Copy(&this->rwConfigParams.GsMatrix_B[i * 3], &this->GsMatrix_B[i * 3]);
         }
     }
@@ -71,15 +69,14 @@ void RwMotorTorque::reset(uint64_t callTime)
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void RwMotorTorque::updateState(uint64_t callTime)
-{
-    RWAvailabilityMsgPayload wheelsAvailability = {};    /*!< Msg containing RW availability */
-    CmdTorqueBodyMsgPayload LrInputMsg;             /*!< Msg containing Lr control torque */
-    CmdTorqueBodyMsgPayload LrInput2Msg;            /*!< Msg containing optional Lr control torque */
-    double Lr_B[3];                             /*!< [Nm]    commanded ADCS control torque in body frame*/
-    double Lr_C[3];                             /*!< [Nm]    commanded ADCS control torque projected onto control axes */
-    double us[RW_EFF_CNT];                     /*!< [Nm]    commanded ADCS control torque projected onto RWs g_s-Frames */
-    double CGs[3][RW_EFF_CNT];                 /*!< []      projection matrix from gs_i onto control axes */
+void RwMotorTorque::updateState(uint64_t callTime) {
+    RWAvailabilityMsgPayload wheelsAvailability = {}; /*!< Msg containing RW availability */
+    CmdTorqueBodyMsgPayload LrInputMsg;               /*!< Msg containing Lr control torque */
+    CmdTorqueBodyMsgPayload LrInput2Msg;              /*!< Msg containing optional Lr control torque */
+    double Lr_B[3];                                   /*!< [Nm]    commanded ADCS control torque in body frame*/
+    double Lr_C[3];            /*!< [Nm]    commanded ADCS control torque projected onto control axes */
+    double us[RW_EFF_CNT];     /*!< [Nm]    commanded ADCS control torque projected onto RWs g_s-Frames */
+    double CGs[3][RW_EFF_CNT]; /*!< []      projection matrix from gs_i onto control axes */
 
     /*! - zero control torque and RW motor torque variables */
     v3SetZero(Lr_C);
@@ -102,16 +99,14 @@ void RwMotorTorque::updateState(uint64_t callTime)
     }
 
     /*! - Check if RW availability message is available */
-    if (this->rwAvailInMsg.isLinked())
-    {
+    if (this->rwAvailInMsg.isLinked()) {
         int numAvailRW = 0;
 
         /*! - Read in current RW availabilit Msg */
         wheelsAvailability = this->rwAvailInMsg();
         /*! - create the current [Gs] projection matrix with the available RWs */
         for (int i = 0; i < this->rwConfigParams.numRW; i++) {
-            if (wheelsAvailability.wheelAvailability[i] == AVAILABLE)
-            {
+            if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) {
                 v3Copy(&this->rwConfigParams.GsMatrix_B[i * 3], &this->GsMatrix_B[numAvailRW * 3]);
                 numAvailRW += 1;
             }
@@ -128,25 +123,26 @@ void RwMotorTorque::updateState(uint64_t callTime)
 
     /*! - compute [CGs] */
     mSetZero(CGs, 3, RW_EFF_CNT);
-    for (uint32_t i=0; i<this->numControlAxes; i++) {
-        for (int j=0; j<this->numAvailRW; j++) {
+    for (uint32_t i = 0; i < this->numControlAxes; i++) {
+        for (int j = 0; j < this->numAvailRW; j++) {
             CGs[i][j] = v3Dot(&this->GsMatrix_B[j * 3], &this->controlAxes_B[3 * i]);
         }
     }
     /*! - Compute minimum norm inverse for us = [CGs].T inv([CGs][CGs].T) [Lr_C]
-     Having at least the same # of RW as # of control axes is necessary condition to guarantee inverse matrix exists. If matrix to invert it not full rank, the control torque output is zero. */
-    if (this->numAvailRW >= (int) this->numControlAxes){
-        double v3_temp[3]; /* inv([M]) [Lr_C] */
-        double M33[3][3]; /* [M] = [CGs][CGs].T */
-        double us_avail[RW_EFF_CNT];   /* matrix of available RW motor torques */
+     Having at least the same # of RW as # of control axes is necessary condition to guarantee inverse matrix exists. If
+     matrix to invert it not full rank, the control torque output is zero. */
+    if (this->numAvailRW >= (int)this->numControlAxes) {
+        double v3_temp[3];           /* inv([M]) [Lr_C] */
+        double M33[3][3];            /* [M] = [CGs][CGs].T */
+        double us_avail[RW_EFF_CNT]; /* matrix of available RW motor torques */
 
         v3SetZero(v3_temp);
         mSetIdentity(M33, 3, 3);
-        for (uint32_t i=0; i<this->numControlAxes; i++) {
-            for (uint32_t j=0; j<this->numControlAxes; j++) {
+        for (uint32_t i = 0; i < this->numControlAxes; i++) {
+            for (uint32_t j = 0; j < this->numControlAxes; j++) {
                 M33[i][j] = 0.0;
-                for (int k=0; k < this->numAvailRW; k++) {
-                    M33[i][j] += CGs[i][k]*CGs[j][k];
+                for (int k = 0; k < this->numAvailRW; k++) {
+                    M33[i][j] += CGs[i][k] * CGs[j][k];
                 }
             }
         }
@@ -156,8 +152,8 @@ void RwMotorTorque::updateState(uint64_t callTime)
         /*! - compute the desired RW motor torques */
         /* us = [CGs].T v3_temp */
         vSetZero(us_avail, RW_EFF_CNT);
-        for (int i=0; i<this->numAvailRW; i++) {
-            for (uint32_t j=0; j<this->numControlAxes; j++) {
+        for (int i = 0; i < this->numAvailRW; i++) {
+            for (uint32_t j = 0; j < this->numControlAxes; j++) {
                 us_avail[i] += CGs[j][i] * v3_temp[j];
             }
         }
@@ -165,8 +161,7 @@ void RwMotorTorque::updateState(uint64_t callTime)
         /*! - map the desired RW motor torques to the available RWs */
         int j = 0;
         for (int i = 0; i < this->rwConfigParams.numRW; i++) {
-            if (wheelsAvailability.wheelAvailability[i] == AVAILABLE)
-            {
+            if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) {
                 us[i] = us_avail[j];
                 j += 1;
             }

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h
@@ -24,10 +24,10 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/CmdTorqueBodyMsgPayload.h"
 #include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/RWAvailabilityMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 
 #include "architecture/utilities/bskLogging.h"
 
@@ -41,16 +41,16 @@ class RwMotorTorque : public SysModel {
     uint32_t numControlAxes;      //!< [-] counter indicating how many orthogonal axes are controlled
     int numAvailRW;               //!< [-] number of reaction wheels available
     RWArrayConfigMsgPayload
-        rwConfigParams;  //!< [-] struct to store message containing RW config parameters in body B frame
+        rwConfigParams;                 //!< [-] struct to store message containing RW config parameters in body B frame
     double GsMatrix_B[3 * RW_EFF_CNT];  //!< [-] The RW spin axis matrix in body frame components
     double CGs[3][RW_EFF_CNT];          //!< [-] Projection matrix that defines the controlled body axes
 
     /* declare module IO interfaces */
-    Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< RW motor torque output message
-    ReadFunctor<CmdTorqueBodyMsgPayload> vehControlInMsg;     //!<  vehicle control (Lr) Input message
-    ReadFunctor<CmdTorqueBodyMsgPayload> vehControlIn2Msg;    //!<  optional vehicle control input message
-    ReadFunctor<RWArrayConfigMsgPayload> rwParamsInMsg;       //!<  RW Array input message
-    ReadFunctor<RWAvailabilityMsgPayload> rwAvailInMsg;       //!< optional RWs availability input message
+    Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;   //!< RW motor torque output message
+    ReadFunctor<CmdTorqueBodyMsgPayload> vehControlInMsg;   //!<  vehicle control (Lr) Input message
+    ReadFunctor<CmdTorqueBodyMsgPayload> vehControlIn2Msg;  //!<  optional vehicle control input message
+    ReadFunctor<RWArrayConfigMsgPayload> rwParamsInMsg;     //!<  RW Array input message
+    ReadFunctor<RWAvailabilityMsgPayload> rwAvailInMsg;     //!< optional RWs availability input message
 
     BSKLogger bskLogger = {};  //!< BSK Logging
 };

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h
@@ -24,7 +24,7 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/CmdTorqueBodyMsgPayload.h"
 #include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/RWAvailabilityMsgPayload.h"
@@ -46,7 +46,7 @@ class RwMotorTorque : public SysModel {
     double CGs[3][MAX_EFF_CNT];          //!< [-] Projection matrix that defines the controlled body axes
 
     /* declare module IO interfaces */
-    Message<ArrayMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< RW motor torque output message
+    Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< RW motor torque output message
     ReadFunctor<CmdTorqueBodyMsgPayload> vehControlInMsg;     //!<  vehicle control (Lr) Input message
     ReadFunctor<CmdTorqueBodyMsgPayload> vehControlIn2Msg;    //!<  optional vehicle control input message
     ReadFunctor<RWArrayConfigMsgPayload> rwParamsInMsg;       //!<  RW Array input message

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.h
@@ -42,8 +42,8 @@ class RwMotorTorque : public SysModel {
     int numAvailRW;               //!< [-] number of reaction wheels available
     RWArrayConfigMsgPayload
         rwConfigParams;  //!< [-] struct to store message containing RW config parameters in body B frame
-    double GsMatrix_B[3 * MAX_EFF_CNT];  //!< [-] The RW spin axis matrix in body frame components
-    double CGs[3][MAX_EFF_CNT];          //!< [-] Projection matrix that defines the controlled body axes
+    double GsMatrix_B[3 * RW_EFF_CNT];  //!< [-] The RW spin axis matrix in body frame components
+    double CGs[3][RW_EFF_CNT];          //!< [-] Projection matrix that defines the controlled body axes
 
     /* declare module IO interfaces */
     Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;  //!< RW motor torque output message

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.i
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.i
@@ -31,7 +31,7 @@
 %include "rwMotorTorque.h"
 
 %include "architecture/msgPayloadDef/CmdTorqueBodyMsgPayload.h"
-%include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 %include "architecture/msgPayloadDef/RWAvailabilityMsgPayload.h"
 %include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.rst
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.rst
@@ -35,5 +35,3 @@ provides information on what this message is used for.
     * - rwAvailInMsg
       - :ref:`RWAvailabilityMsgPayload`
       - (optional) RW device availability message
-
-

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.rst
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorque.rst
@@ -21,7 +21,7 @@ provides information on what this message is used for.
       - Msg Type
       - Description
     * - rwMotorTorqueOutMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - RW motor torque output message
     * - vehControlInMsg
       - :ref:`CmdTorqueBodyMsgPayload`

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/_UnitTest/test_rwMotorVoltage.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/_UnitTest/test_rwMotorVoltage.py
@@ -132,7 +132,7 @@ def run(show_plots, useLargeVoltage, useAvailability, useTorqueLoop, testName):
     # create RW availability message
     if useAvailability:
         rwAvailabilityMessage = messaging.RWAvailabilityMsgPayload()
-        rwAvailArray = np.zeros(messaging.MAX_EFF_CNT, dtype=int)
+        rwAvailArray = np.zeros(messaging.RW_EFF_CNT, dtype=int)
         rwAvailArray.fill(messaging.AVAILABLE)
         rwAvailArray[2] = messaging.UNAVAILABLE        # make 3rd RW unavailable
         rwAvailabilityMessage.wheelAvailability = rwAvailArray

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/_UnitTest/test_rwMotorVoltage.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/_UnitTest/test_rwMotorVoltage.py
@@ -121,12 +121,12 @@ def run(show_plots, useLargeVoltage, useAvailability, useTorqueLoop, testName):
     numRW = fswSetupRW.getNumOfDevices()
 
     # Create RW motor torque input message
-    usMessageData = messaging.ArrayMotorTorqueMsgPayload()
+    usMessageData = messaging.RwMotorTorqueMsgPayload()
     if useLargeVoltage:
         usMessageData.motorTorque = [0.5, 0.0, -0.15, -0.5]           # [Nm] RW motor torque cmds
     else:
         usMessageData.motorTorque = [0.05, 0.0, -0.15, -0.2]  # [Nm] RW motor torque cmds
-    rwMotorTorqueInMsg = messaging.ArrayMotorTorqueMsg().write(usMessageData)
+    rwMotorTorqueInMsg = messaging.RwMotorTorqueMsg().write(usMessageData)
     module.torqueInMsg.subscribeTo(rwMotorTorqueInMsg)
 
     # create RW availability message

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.cpp
@@ -58,8 +58,8 @@ void RwMotorVoltage::updateState(uint64_t callTime)
 {
     /* - Read the input messages */
 //    double              torqueCmd[MAX_EFF_CNT];     /*!< [Nm]   copy of RW motor torque input vector */
-    ArrayMotorTorqueMsgPayload torqueCmd;           /*!< copy of RW motor torque input message*/
-    ArrayMotorVoltageMsgPayload voltageOut = {};            /*!< -- copy of the output message */
+    RwMotorTorqueMsgPayload torqueCmd;           /*!< copy of RW motor torque input message*/
+    RwMotorVoltageMsgPayload voltageOut = {};            /*!< -- copy of the output message */
 
     // check if the required input messages are included
     if (!this->torqueInMsg.isLinked()) {

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.cpp
@@ -22,17 +22,16 @@
  */
 
 #include "fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h"
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
 #include <string.h>
 
-/*! This method performs a reset of the module as far as closed loop control is concerned.  Local module variables that retain
- time varying states between function calls are reset to their default values.
+/*! This method performs a reset of the module as far as closed loop control is concerned.  Local module variables that
+ retain time varying states between function calls are reset to their default values.
  @return void
  @param callTime Sim time in nanos
  */
-void RwMotorVoltage::reset(uint64_t callTime)
-{
+void RwMotorVoltage::reset(uint64_t callTime) {
     // check if the required input messages are included
     if (!this->rwParamsInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: rwMotorVoltage.rwParamsInMsg wasn't connected.");
@@ -42,7 +41,7 @@ void RwMotorVoltage::reset(uint64_t callTime)
     this->rwConfigParams = this->rwParamsInMsg();
 
     /* reset variables */
-    memset(this->rwSpeedOld, 0, sizeof(double)*RW_EFF_CNT);
+    memset(this->rwSpeedOld, 0, sizeof(double) * RW_EFF_CNT);
     this->resetFlag = BOOL_TRUE;
 
     /* Reset the prior time flag state.
@@ -50,16 +49,16 @@ void RwMotorVoltage::reset(uint64_t callTime)
     this->priorTime = 0;
 }
 
-/*! Update performs the torque to voltage conversion. If a wheel speed message was provided, it also does closed loop control of the voltage sent. It then writes the voltage message.
+/*! Update performs the torque to voltage conversion. If a wheel speed message was provided, it also does closed loop
+ control of the voltage sent. It then writes the voltage message.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void RwMotorVoltage::updateState(uint64_t callTime)
-{
+void RwMotorVoltage::updateState(uint64_t callTime) {
     /* - Read the input messages */
-//    double              torqueCmd[RW_EFF_CNT];     /*!< [Nm]   copy of RW motor torque input vector */
-    RwMotorTorqueMsgPayload torqueCmd;           /*!< copy of RW motor torque input message*/
-    RwMotorVoltageMsgPayload voltageOut = {};            /*!< -- copy of the output message */
+    //    double              torqueCmd[RW_EFF_CNT];     /*!< [Nm]   copy of RW motor torque input vector */
+    RwMotorTorqueMsgPayload torqueCmd;        /*!< copy of RW motor torque input message*/
+    RwMotorVoltageMsgPayload voltageOut = {}; /*!< -- copy of the output message */
 
     // check if the required input messages are included
     if (!this->torqueInMsg.isLinked()) {
@@ -68,29 +67,30 @@ void RwMotorVoltage::updateState(uint64_t callTime)
 
     torqueCmd = this->torqueInMsg();
 
-    RWSpeedMsgPayload  rwSpeed = {};                    /*!< [r/s] Reaction wheel speed estimates */
-    if(this->rwSpeedInMsg.isLinked()) {
+    RWSpeedMsgPayload rwSpeed = {}; /*!< [r/s] Reaction wheel speed estimates */
+    if (this->rwSpeedInMsg.isLinked()) {
         rwSpeed = this->rwSpeedInMsg();
     }
-    RWAvailabilityMsgPayload  rwAvailability = {};
-    if (this->rwAvailInMsg.isLinked()){
+    RWAvailabilityMsgPayload rwAvailability = {};
+    if (this->rwAvailInMsg.isLinked()) {
         rwAvailability = this->rwAvailInMsg();
     }
 
     /* zero the output voltage vector */
-    double  voltage[RW_EFF_CNT];       /*!< [V]   RW voltage output commands */
-    memset(voltage, 0, sizeof(double)*RW_EFF_CNT);
+    double voltage[RW_EFF_CNT]; /*!< [V]   RW voltage output commands */
+    memset(voltage, 0, sizeof(double) * RW_EFF_CNT);
 
     /* if the torque closed-loop is on, evaluate the feedback term */
     if (this->rwSpeedInMsg.isLinked()) {
         /* make sure the clock didn't just initialize, or the module was recently reset */
         if (this->priorTime != 0) {
             double dt = (callTime - this->priorTime) * NANO2SEC; /*!< [s]   control update period */
-            double              OmegaDot[RW_EFF_CNT];     /*!< [r/s^2] RW angular acceleration */
-            for (int i=0; i<this->rwConfigParams.numRW; i++) {
+            double OmegaDot[RW_EFF_CNT];                         /*!< [r/s^2] RW angular acceleration */
+            for (int i = 0; i < this->rwConfigParams.numRW; i++) {
                 if (rwAvailability.wheelAvailability[i] == AVAILABLE && this->resetFlag == BOOL_FALSE) {
-                    OmegaDot[i] = (rwSpeed.wheelSpeeds[i] - this->rwSpeedOld[i])/dt;
-                    torqueCmd.motorTorque[i] -= this->K * (this->rwConfigParams.JsList[i] * OmegaDot[i] - torqueCmd.motorTorque[i]);
+                    OmegaDot[i] = (rwSpeed.wheelSpeeds[i] - this->rwSpeedOld[i]) / dt;
+                    torqueCmd.motorTorque[i] -=
+                        this->K * (this->rwConfigParams.JsList[i] * OmegaDot[i] - torqueCmd.motorTorque[i]);
                 }
                 this->rwSpeedOld[i] = rwSpeed.wheelSpeeds[i];
             }
@@ -100,17 +100,16 @@ void RwMotorVoltage::updateState(uint64_t callTime)
     }
 
     /* evaluate the feedforward mapping of torque into voltage */
-    for (int i=0; i<this->rwConfigParams.numRW; i++) {
+    for (int i = 0; i < this->rwConfigParams.numRW; i++) {
         if (rwAvailability.wheelAvailability[i] == AVAILABLE) {
-            voltage[i] = (this->VMax - this->VMin)/this->rwConfigParams.uMax[i]
-                        * torqueCmd.motorTorque[i];
-            if (voltage[i]>0.0) voltage[i] += this->VMin;
-            if (voltage[i]<0.0) voltage[i] -= this->VMin;
+            voltage[i] = (this->VMax - this->VMin) / this->rwConfigParams.uMax[i] * torqueCmd.motorTorque[i];
+            if (voltage[i] > 0.0) voltage[i] += this->VMin;
+            if (voltage[i] < 0.0) voltage[i] -= this->VMin;
         }
     }
 
     /* check for voltage saturation */
-    for (int i=0; i<this->rwConfigParams.numRW; i++) {
+    for (int i = 0; i < this->rwConfigParams.numRW; i++) {
         if (voltage[i] > this->VMax) {
             voltage[i] = this->VMax;
         }

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.cpp
@@ -42,7 +42,7 @@ void RwMotorVoltage::reset(uint64_t callTime)
     this->rwConfigParams = this->rwParamsInMsg();
 
     /* reset variables */
-    memset(this->rwSpeedOld, 0, sizeof(double)*MAX_EFF_CNT);
+    memset(this->rwSpeedOld, 0, sizeof(double)*RW_EFF_CNT);
     this->resetFlag = BOOL_TRUE;
 
     /* Reset the prior time flag state.
@@ -57,7 +57,7 @@ void RwMotorVoltage::reset(uint64_t callTime)
 void RwMotorVoltage::updateState(uint64_t callTime)
 {
     /* - Read the input messages */
-//    double              torqueCmd[MAX_EFF_CNT];     /*!< [Nm]   copy of RW motor torque input vector */
+//    double              torqueCmd[RW_EFF_CNT];     /*!< [Nm]   copy of RW motor torque input vector */
     RwMotorTorqueMsgPayload torqueCmd;           /*!< copy of RW motor torque input message*/
     RwMotorVoltageMsgPayload voltageOut = {};            /*!< -- copy of the output message */
 
@@ -78,15 +78,15 @@ void RwMotorVoltage::updateState(uint64_t callTime)
     }
 
     /* zero the output voltage vector */
-    double  voltage[MAX_EFF_CNT];       /*!< [V]   RW voltage output commands */
-    memset(voltage, 0, sizeof(double)*MAX_EFF_CNT);
+    double  voltage[RW_EFF_CNT];       /*!< [V]   RW voltage output commands */
+    memset(voltage, 0, sizeof(double)*RW_EFF_CNT);
 
     /* if the torque closed-loop is on, evaluate the feedback term */
     if (this->rwSpeedInMsg.isLinked()) {
         /* make sure the clock didn't just initialize, or the module was recently reset */
         if (this->priorTime != 0) {
             double dt = (callTime - this->priorTime) * NANO2SEC; /*!< [s]   control update period */
-            double              OmegaDot[MAX_EFF_CNT];     /*!< [r/s^2] RW angular acceleration */
+            double              OmegaDot[RW_EFF_CNT];     /*!< [r/s^2] RW angular acceleration */
             for (int i=0; i<this->rwConfigParams.numRW; i++) {
                 if (rwAvailability.wheelAvailability[i] == AVAILABLE && this->resetFlag == BOOL_FALSE) {
                     OmegaDot[i] = (rwSpeed.wheelSpeeds[i] - this->rwSpeedOld[i])/dt;

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h
@@ -24,12 +24,12 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
-#include "architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h"
 #include "architecture/msgPayloadDef/CmdTorqueBodyMsgPayload.h"
 #include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/RWAvailabilityMsgPayload.h"
 #include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h"
 
 #include "architecture/utilities/bskLogging.h"
 
@@ -41,20 +41,20 @@ class RwMotorVoltage : public SysModel {
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
     /* declare module private variables */
-    double VMin;                    /*!< [V]    minimum voltage below which the torque is zero */
-    double VMax;                    /*!< [V]    maximum output voltage */
-    double K;                       /*!< [V/Nm] torque tracking gain for closed loop control.*/
+    double VMin;                   /*!< [V]    minimum voltage below which the torque is zero */
+    double VMax;                   /*!< [V]    maximum output voltage */
+    double K;                      /*!< [V/Nm] torque tracking gain for closed loop control.*/
     double rwSpeedOld[RW_EFF_CNT]; /*!< [r/s]  the RW spin rates from the prior control step */
-    uint64_t priorTime;             /*!< [ns]   Last time the module control was called */
-    int resetFlag;                  /*!< []     Flag indicating that a module reset occured */
+    uint64_t priorTime;            /*!< [ns]   Last time the module control was called */
+    int resetFlag;                 /*!< []     Flag indicating that a module reset occured */
 
     /* declare module IO interfaces */
-    Message<RwMotorVoltageMsgPayload> voltageOutMsg;  /*!< voltage output message*/
-    ReadFunctor<RwMotorTorqueMsgPayload> torqueInMsg; /*!< Input torque message*/
-    ReadFunctor<RWArrayConfigMsgPayload> rwParamsInMsg;  /*!< RW array input message*/
-    ReadFunctor<RWSpeedMsgPayload> rwSpeedInMsg;         /*!< [] The name for the reaction wheel speeds message. Must be
-                                                            provided to enable speed tracking loop */
-    ReadFunctor<RWAvailabilityMsgPayload> rwAvailInMsg;  /*!< [-] The name of the RWs availability message*/
+    Message<RwMotorVoltageMsgPayload> voltageOutMsg;    /*!< voltage output message*/
+    ReadFunctor<RwMotorTorqueMsgPayload> torqueInMsg;   /*!< Input torque message*/
+    ReadFunctor<RWArrayConfigMsgPayload> rwParamsInMsg; /*!< RW array input message*/
+    ReadFunctor<RWSpeedMsgPayload> rwSpeedInMsg;        /*!< [] The name for the reaction wheel speeds message. Must be
+                                                           provided to enable speed tracking loop */
+    ReadFunctor<RWAvailabilityMsgPayload> rwAvailInMsg; /*!< [-] The name of the RWs availability message*/
 
     RWArrayConfigMsgPayload
         rwConfigParams; /*!< [-] struct to store message containing RW config parameters in body B frame */

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h
@@ -44,7 +44,7 @@ class RwMotorVoltage : public SysModel {
     double VMin;                    /*!< [V]    minimum voltage below which the torque is zero */
     double VMax;                    /*!< [V]    maximum output voltage */
     double K;                       /*!< [V/Nm] torque tracking gain for closed loop control.*/
-    double rwSpeedOld[MAX_EFF_CNT]; /*!< [r/s]  the RW spin rates from the prior control step */
+    double rwSpeedOld[RW_EFF_CNT]; /*!< [r/s]  the RW spin rates from the prior control step */
     uint64_t priorTime;             /*!< [ns]   Last time the module control was called */
     int resetFlag;                  /*!< []     Flag indicating that a module reset occured */
 

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.h
@@ -24,8 +24,8 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
-#include "architecture/msgPayloadDef/ArrayMotorVoltageMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h"
 #include "architecture/msgPayloadDef/CmdTorqueBodyMsgPayload.h"
 #include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/RWAvailabilityMsgPayload.h"
@@ -49,8 +49,8 @@ class RwMotorVoltage : public SysModel {
     int resetFlag;                  /*!< []     Flag indicating that a module reset occured */
 
     /* declare module IO interfaces */
-    Message<ArrayMotorVoltageMsgPayload> voltageOutMsg;  /*!< voltage output message*/
-    ReadFunctor<ArrayMotorTorqueMsgPayload> torqueInMsg; /*!< Input torque message*/
+    Message<RwMotorVoltageMsgPayload> voltageOutMsg;  /*!< voltage output message*/
+    ReadFunctor<RwMotorTorqueMsgPayload> torqueInMsg; /*!< Input torque message*/
     ReadFunctor<RWArrayConfigMsgPayload> rwParamsInMsg;  /*!< RW array input message*/
     ReadFunctor<RWSpeedMsgPayload> rwSpeedInMsg;         /*!< [] The name for the reaction wheel speeds message. Must be
                                                             provided to enable speed tracking loop */

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.i
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.i
@@ -30,11 +30,11 @@
 
 %include "rwMotorVoltage.h"
 
-%include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 %include "architecture/msgPayloadDef/RWAvailabilityMsgPayload.h"
 %include "architecture/msgPayloadDef/RWArrayConfigMsgPayload.h"
 %include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
-%include "architecture/msgPayloadDef/ArrayMotorVoltageMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h"
 
 %include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 %include "architecture/utilities/macroDefinitions.h"

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.rst
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.rst
@@ -37,6 +37,3 @@ provides information on what this message is used for.
     * - rwSpeedInMsg
       - :ref:`RWSpeedMsgPayload`
       - (optional) RW device speed message
-
- 
-

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.rst
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.rst
@@ -23,10 +23,10 @@ provides information on what this message is used for.
       - Msg Type
       - Description
     * - voltageOutMsg
-      - :ref:`ArrayMotorVoltageMsgPayload`
+      - :ref:`RwMotorVoltageMsgPayload`
       - RW motor voltage output message
     * - torqueInMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - commanded RW motor torque input message
     * - rwParamsInMsg
       - :ref:`RWArrayConfigMsgPayload`

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/_UnitTest/test_rwNullSpace.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/_UnitTest/test_rwNullSpace.py
@@ -109,7 +109,7 @@ def rwNullSpaceTestFunction(numWheels, defaultDesired):
     # Set the array of the reaction wheels in RWConstellationFswMsg to the list created above
     inputRWConstellationMsg.reactionWheels = rwConfigElementList
 
-    inputRWCmdMsg = messaging.ArrayMotorTorqueMsgPayload()
+    inputRWCmdMsg = messaging.RwMotorTorqueMsgPayload()
     usControl = [0.1, 0.2, 0.15] # [Nm] RW motor torque array
     if numWheels == 4:
         usControl.append(-0.2) # [Nm]
@@ -119,7 +119,7 @@ def rwNullSpaceTestFunction(numWheels, defaultDesired):
     # Set these messages
     rwSpeedMsg = messaging.RWSpeedMsg().write(inputSpeedMsg)
     rwConfigMsg = messaging.RWConstellationMsg().write(inputRWConstellationMsg)
-    rwCmdMsg = messaging.ArrayMotorTorqueMsg().write(inputRWCmdMsg)
+    rwCmdMsg = messaging.RwMotorTorqueMsg().write(inputRWCmdMsg)
 
     dataLog = module.rwMotorTorqueOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.cpp
@@ -21,18 +21,18 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
 
-/*! @brief This resets the module to original states by reading in the RW configuration messages and recreating any module specific variables.  The output message is reset to zero.
+/*! @brief This resets the module to original states by reading in the RW configuration messages and recreating any
+   module specific variables.  The output message is reset to zero.
     @return void
     @param callTime The clock time at which the function was called (nanoseconds)
  */
-void RwNullSpace::reset(uint64_t callTime)
-{
-    double GsMatrix[3*RW_EFF_CNT];                 /* [-]  [Gs] projection matrix where gs_hat_B RW spin axis form each colum */
-    double GsTranspose[3 * RW_EFF_CNT];            /* [-]  [Gs]^T */
-    double GsInvHalf[3 * 3];                        /* [-]  ([Gs][Gs]^T)^-1 */
-    double identMatrix[RW_EFF_CNT*RW_EFF_CNT];    /* [-]  [I_NxN] identity matrix */
-    double GsTemp[RW_EFF_CNT*RW_EFF_CNT];         /* [-]  temp matrix */
-    RWConstellationMsgPayload localRWData;          /*      local copy of RW configuration data */
+void RwNullSpace::reset(uint64_t callTime) {
+    double GsMatrix[3 * RW_EFF_CNT];    /* [-]  [Gs] projection matrix where gs_hat_B RW spin axis form each colum */
+    double GsTranspose[3 * RW_EFF_CNT]; /* [-]  [Gs]^T */
+    double GsInvHalf[3 * 3];            /* [-]  ([Gs][Gs]^T)^-1 */
+    double identMatrix[RW_EFF_CNT * RW_EFF_CNT]; /* [-]  [I_NxN] identity matrix */
+    double GsTemp[RW_EFF_CNT * RW_EFF_CNT];      /* [-]  temp matrix */
+    RWConstellationMsgPayload localRWData;       /*      local copy of RW configuration data */
 
     // check if the required input messages are included
     if (!this->rwConfigInMsg.isLinked()) {
@@ -49,48 +49,46 @@ void RwNullSpace::reset(uint64_t callTime)
     localRWData = this->rwConfigInMsg();
 
     /* create the 3xN [Gs] RW spin axis projection matrix */
-    this->numWheels = (uint32_t) localRWData.numRW;
+    this->numWheels = (uint32_t)localRWData.numRW;
     if (this->numWheels > RW_EFF_CNT) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: rwNullSpace.numWheels is larger that max effector count.");
     }
-    for(uint32_t i=0; i<this->numWheels; i=i+1)
-    {
-        for(int j=0; j<3; j=j+1)
-        {
-            GsMatrix[j*(int) this->numWheels+i] = localRWData.reactionWheels[i].gsHat_B[j];
+    for (uint32_t i = 0; i < this->numWheels; i = i + 1) {
+        for (int j = 0; j < 3; j = j + 1) {
+            GsMatrix[j * (int)this->numWheels + i] = localRWData.reactionWheels[i].gsHat_B[j];
         }
     }
 
     /* find the [tau] null space projection matrix [tau]= ([I] - [Gs]^T.([Gs].[Gs]^T) */
-    mTranspose(GsMatrix, 3, this->numWheels, GsTranspose);            /* find [Gs]^T */
-    mMultM(GsMatrix, 3, this->numWheels, GsTranspose,
-           this->numWheels, 3, GsInvHalf);                            /* find [Gs].[Gs]^T */
-    m33Inverse(RECAST3X3 GsInvHalf, RECAST3X3 GsInvHalf);                   /* find ([Gs].[Gs]^T)^-1 */
-    mMultM(GsInvHalf, 3, 3, GsMatrix, 3, this->numWheels,
-           this->tau);                                                /* find ([Gs].[Gs]^T)^-1.[Gs] */
-    mMultM(GsTranspose, this->numWheels, 3, this->tau, 3,
-           this->numWheels, GsTemp);                                  /* find [Gs]^T.([Gs].[Gs]^T)^-1.[Gs] */
+    mTranspose(GsMatrix, 3, this->numWheels, GsTranspose);                            /* find [Gs]^T */
+    mMultM(GsMatrix, 3, this->numWheels, GsTranspose, this->numWheels, 3, GsInvHalf); /* find [Gs].[Gs]^T */
+    m33Inverse(RECAST3X3 GsInvHalf, RECAST3X3 GsInvHalf);                             /* find ([Gs].[Gs]^T)^-1 */
+    mMultM(GsInvHalf, 3, 3, GsMatrix, 3, this->numWheels, this->tau);                 /* find ([Gs].[Gs]^T)^-1.[Gs] */
+    mMultM(
+        GsTranspose, this->numWheels, 3, this->tau, 3, this->numWheels, GsTemp); /* find [Gs]^T.([Gs].[Gs]^T)^-1.[Gs] */
     mSetIdentity(identMatrix, this->numWheels, this->numWheels);
-    mSubtract(identMatrix, this->numWheels, this->numWheels,    /* find ([I] - [Gs]^T.([Gs].[Gs]^T)^-1.[Gs]) */
-              GsTemp, this->tau);
-
+    mSubtract(identMatrix,
+              this->numWheels,
+              this->numWheels, /* find ([I] - [Gs]^T.([Gs].[Gs]^T)^-1.[Gs]) */
+              GsTemp,
+              this->tau);
 }
 
 /*! This method takes the input reaction wheel commands as well as the observed
     reaction wheel speeds and balances the commands so that the overall vehicle
-	momentum is minimized.
+    momentum is minimized.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
  */
-void RwNullSpace::updateState(uint64_t callTime)
-{
-    RwMotorTorqueMsgPayload cntrRequest;        /* [Nm]  array of the RW motor torque solution vector from the control module */
-    RWSpeedMsgPayload rwSpeeds;                    /* [r/s] array of RW speeds */
-    RWSpeedMsgPayload rwDesiredSpeeds = {};             /* [r/s] array of RW speeds */
-	RwMotorTorqueMsgPayload finalControl = {};       /* [Nm]  array of final RW motor torques containing both
-                                                       the control and null motion torques */
-	double dVector[RW_EFF_CNT];                   /* [Nm]  null motion wheel speed control array */
-    double DeltaOmega[RW_EFF_CNT];                /* [r/s] difference in RW speeds */
+void RwNullSpace::updateState(uint64_t callTime) {
+    RwMotorTorqueMsgPayload
+        cntrRequest;            /* [Nm]  array of the RW motor torque solution vector from the control module */
+    RWSpeedMsgPayload rwSpeeds; /* [r/s] array of RW speeds */
+    RWSpeedMsgPayload rwDesiredSpeeds = {};    /* [r/s] array of RW speeds */
+    RwMotorTorqueMsgPayload finalControl = {}; /* [Nm]  array of final RW motor torques containing both
+                                                 the control and null motion torques */
+    double dVector[RW_EFF_CNT];                /* [Nm]  null motion wheel speed control array */
+    double DeltaOmega[RW_EFF_CNT];             /* [r/s] difference in RW speeds */
 
     /* Read the input RW commands to get the raw RW requests*/
     cntrRequest = this->rwMotorTorqueInMsg();
@@ -103,15 +101,13 @@ void RwNullSpace::updateState(uint64_t callTime)
 
     /* compute the wheel speed control vector d = -K.DeltaOmega */
     vSubtract(rwSpeeds.wheelSpeeds, this->numWheels, rwDesiredSpeeds.wheelSpeeds, DeltaOmega);
-	vScale(-this->OmegaGain, DeltaOmega, this->numWheels, dVector);
+    vScale(-this->OmegaGain, DeltaOmega, this->numWheels, dVector);
 
     /* compute the RW null space motor torque solution to reduce the wheel speeds */
-	mMultV(this->tau, this->numWheels, this->numWheels,
-		dVector, finalControl.motorTorque);
+    mMultV(this->tau, this->numWheels, this->numWheels, dVector, finalControl.motorTorque);
 
     /* add the null motion RW torque solution to the RW feedback control torque solution */
-	vAdd(finalControl.motorTorque, this->numWheels,
-		cntrRequest.motorTorque, finalControl.motorTorque);
+    vAdd(finalControl.motorTorque, this->numWheels, cntrRequest.motorTorque, finalControl.motorTorque);
 
     /* write the final RW torque solution to the output message */
     this->rwMotorTorqueOutMsg.write(&finalControl, this->moduleID, callTime);

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.cpp
@@ -84,10 +84,10 @@ void RwNullSpace::reset(uint64_t callTime)
  */
 void RwNullSpace::updateState(uint64_t callTime)
 {
-    ArrayMotorTorqueMsgPayload cntrRequest;        /* [Nm]  array of the RW motor torque solution vector from the control module */
+    RwMotorTorqueMsgPayload cntrRequest;        /* [Nm]  array of the RW motor torque solution vector from the control module */
     RWSpeedMsgPayload rwSpeeds;                    /* [r/s] array of RW speeds */
     RWSpeedMsgPayload rwDesiredSpeeds = {};             /* [r/s] array of RW speeds */
-	ArrayMotorTorqueMsgPayload finalControl = {};       /* [Nm]  array of final RW motor torques containing both
+	RwMotorTorqueMsgPayload finalControl = {};       /* [Nm]  array of final RW motor torques containing both
                                                        the control and null motion torques */
 	double dVector[MAX_EFF_CNT];                   /* [Nm]  null motion wheel speed control array */
     double DeltaOmega[MAX_EFF_CNT];                /* [r/s] difference in RW speeds */

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.cpp
@@ -27,11 +27,11 @@
  */
 void RwNullSpace::reset(uint64_t callTime)
 {
-    double GsMatrix[3*MAX_EFF_CNT];                 /* [-]  [Gs] projection matrix where gs_hat_B RW spin axis form each colum */
-    double GsTranspose[3 * MAX_EFF_CNT];            /* [-]  [Gs]^T */
+    double GsMatrix[3*RW_EFF_CNT];                 /* [-]  [Gs] projection matrix where gs_hat_B RW spin axis form each colum */
+    double GsTranspose[3 * RW_EFF_CNT];            /* [-]  [Gs]^T */
     double GsInvHalf[3 * 3];                        /* [-]  ([Gs][Gs]^T)^-1 */
-    double identMatrix[MAX_EFF_CNT*MAX_EFF_CNT];    /* [-]  [I_NxN] identity matrix */
-    double GsTemp[MAX_EFF_CNT*MAX_EFF_CNT];         /* [-]  temp matrix */
+    double identMatrix[RW_EFF_CNT*RW_EFF_CNT];    /* [-]  [I_NxN] identity matrix */
+    double GsTemp[RW_EFF_CNT*RW_EFF_CNT];         /* [-]  temp matrix */
     RWConstellationMsgPayload localRWData;          /*      local copy of RW configuration data */
 
     // check if the required input messages are included
@@ -50,7 +50,7 @@ void RwNullSpace::reset(uint64_t callTime)
 
     /* create the 3xN [Gs] RW spin axis projection matrix */
     this->numWheels = (uint32_t) localRWData.numRW;
-    if (this->numWheels > MAX_EFF_CNT) {
+    if (this->numWheels > RW_EFF_CNT) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: rwNullSpace.numWheels is larger that max effector count.");
     }
     for(uint32_t i=0; i<this->numWheels; i=i+1)
@@ -89,8 +89,8 @@ void RwNullSpace::updateState(uint64_t callTime)
     RWSpeedMsgPayload rwDesiredSpeeds = {};             /* [r/s] array of RW speeds */
 	RwMotorTorqueMsgPayload finalControl = {};       /* [Nm]  array of final RW motor torques containing both
                                                        the control and null motion torques */
-	double dVector[MAX_EFF_CNT];                   /* [Nm]  null motion wheel speed control array */
-    double DeltaOmega[MAX_EFF_CNT];                /* [r/s] difference in RW speeds */
+	double dVector[RW_EFF_CNT];                   /* [Nm]  null motion wheel speed control array */
+    double DeltaOmega[RW_EFF_CNT];                /* [r/s] difference in RW speeds */
 
     /* Read the input RW commands to get the raw RW requests*/
     cntrRequest = this->rwMotorTorqueInMsg();

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.h
@@ -22,7 +22,7 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/RWConstellationMsgPayload.h"
 #include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
 
@@ -35,11 +35,11 @@ class RwNullSpace : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
-    ReadFunctor<ArrayMotorTorqueMsgPayload> rwMotorTorqueInMsg;  //!< [-] The name of the Input message
+    ReadFunctor<RwMotorTorqueMsgPayload> rwMotorTorqueInMsg;  //!< [-] The name of the Input message
     ReadFunctor<RWSpeedMsgPayload> rwSpeedsInMsg;                //!< [-] The name of the input RW speeds
     ReadFunctor<RWSpeedMsgPayload> rwDesiredSpeedsInMsg;         //!< [-] (optional) The name of the desired RW speeds
     ReadFunctor<RWConstellationMsgPayload> rwConfigInMsg;        //!< [-] The name of the RWA configuration message
-    Message<ArrayMotorTorqueMsgPayload> rwMotorTorqueOutMsg;     //!< [-] The name of the output message
+    Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;     //!< [-] The name of the output message
 
     double tau[MAX_EFF_CNT * MAX_EFF_CNT];  //!< [-] RW nullspace project matrix
     double OmegaGain;                       //!< [-] The gain factor applied to the RW speeds

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.h
@@ -22,9 +22,9 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/RWConstellationMsgPayload.h"
 #include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 
 #include "architecture/utilities/bskLogging.h"
 #include <stdint.h>
@@ -36,14 +36,14 @@ class RwNullSpace : public SysModel {
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
     ReadFunctor<RwMotorTorqueMsgPayload> rwMotorTorqueInMsg;  //!< [-] The name of the Input message
-    ReadFunctor<RWSpeedMsgPayload> rwSpeedsInMsg;                //!< [-] The name of the input RW speeds
-    ReadFunctor<RWSpeedMsgPayload> rwDesiredSpeedsInMsg;         //!< [-] (optional) The name of the desired RW speeds
-    ReadFunctor<RWConstellationMsgPayload> rwConfigInMsg;        //!< [-] The name of the RWA configuration message
+    ReadFunctor<RWSpeedMsgPayload> rwSpeedsInMsg;             //!< [-] The name of the input RW speeds
+    ReadFunctor<RWSpeedMsgPayload> rwDesiredSpeedsInMsg;      //!< [-] (optional) The name of the desired RW speeds
+    ReadFunctor<RWConstellationMsgPayload> rwConfigInMsg;     //!< [-] The name of the RWA configuration message
     Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;     //!< [-] The name of the output message
 
     double tau[RW_EFF_CNT * RW_EFF_CNT];  //!< [-] RW nullspace project matrix
-    double OmegaGain;                       //!< [-] The gain factor applied to the RW speeds
-    uint32_t numWheels;                     //!< [-] The number of reaction wheels we have
+    double OmegaGain;                     //!< [-] The gain factor applied to the RW speeds
+    uint32_t numWheels;                   //!< [-] The number of reaction wheels we have
 
     BSKLogger bskLogger = {};  //!< BSK Logging
 };

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.h
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.h
@@ -41,7 +41,7 @@ class RwNullSpace : public SysModel {
     ReadFunctor<RWConstellationMsgPayload> rwConfigInMsg;        //!< [-] The name of the RWA configuration message
     Message<RwMotorTorqueMsgPayload> rwMotorTorqueOutMsg;     //!< [-] The name of the output message
 
-    double tau[MAX_EFF_CNT * MAX_EFF_CNT];  //!< [-] RW nullspace project matrix
+    double tau[RW_EFF_CNT * RW_EFF_CNT];  //!< [-] RW nullspace project matrix
     double OmegaGain;                       //!< [-] The gain factor applied to the RW speeds
     uint32_t numWheels;                     //!< [-] The number of reaction wheels we have
 

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.rst
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.rst
@@ -39,8 +39,3 @@ provides information on what this message is used for.
     * - rwMotorTorqueOutMsg
       - :ref:`RwMotorTorqueMsgPayload`
       - RW motor torque output message
-
-
-
-
-

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.rst
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpace.rst
@@ -25,7 +25,7 @@ provides information on what this message is used for.
       - Msg Type
       - Description
     * - rwMotorTorqueInMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - RW motor torque input message
     * - rwSpeedsInMsg
       - :ref:`RWSpeedMsgPayload`
@@ -37,7 +37,7 @@ provides information on what this message is used for.
       - :ref:`RWConstellationMsgPayload`
       - RW constellation configuration input message
     * - rwMotorTorqueOutMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - RW motor torque output message
 
 

--- a/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.h
@@ -43,7 +43,7 @@ class ThrustRWDesat : public SysModel {
         vecConfigInMsg; /*!< [-] The name of the input spacecraft mass properties message*/
     Message<THRArrayOnTimeCmdMsgPayload> thrCmdOutMsg; /*!< (-) The name of the output thrust command block*/
 
-    double rwAlignMap[3 * RW_EFF_CNT];   /*!< (-) Alignment of the reaction wheel spin axes*/
+    double rwAlignMap[3 * RW_EFF_CNT];    /*!< (-) Alignment of the reaction wheel spin axes*/
     double thrAlignMap[3 * MAX_EFF_CNT];  /*!< (-) Alignment of the vehicle thrusters*/
     double thrTorqueMap[3 * MAX_EFF_CNT]; /*!< (-) Alignment of the vehicle thruster torques*/
     double maxFiring;                     /*!< (s) Maximum time to fire a jet for*/

--- a/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrustRWDesat/thrustRWDesat.h
@@ -43,7 +43,7 @@ class ThrustRWDesat : public SysModel {
         vecConfigInMsg; /*!< [-] The name of the input spacecraft mass properties message*/
     Message<THRArrayOnTimeCmdMsgPayload> thrCmdOutMsg; /*!< (-) The name of the output thrust command block*/
 
-    double rwAlignMap[3 * MAX_EFF_CNT];   /*!< (-) Alignment of the reaction wheel spin axes*/
+    double rwAlignMap[3 * RW_EFF_CNT];   /*!< (-) Alignment of the reaction wheel spin axes*/
     double thrAlignMap[3 * MAX_EFF_CNT];  /*!< (-) Alignment of the vehicle thrusters*/
     double thrTorqueMap[3 * MAX_EFF_CNT]; /*!< (-) Alignment of the vehicle thruster torques*/
     double maxFiring;                     /*!< (s) Maximum time to fire a jet for*/

--- a/src/simulation/deviceInterface/encoder/encoder.cpp
+++ b/src/simulation/deviceInterface/encoder/encoder.cpp
@@ -60,7 +60,7 @@ void Encoder::reset(uint64_t currentSimNanos) {
     this->rwSpeedConverted = RWSpeedMsgPayload{};
 
     // Loop through the RW to set some internal parameters to default
-    for (int i = 0; i < MAX_EFF_CNT; i++) {
+    for (int i = 0; i < RW_EFF_CNT; i++) {
         // set all reaction wheels signal to nominal
         this->rwSignalState[i] = SIGNAL_NOMINAL;
         // set the remaining clicks to zero

--- a/src/simulation/deviceInterface/encoder/encoder.h
+++ b/src/simulation/deviceInterface/encoder/encoder.h
@@ -41,14 +41,14 @@ class Encoder : public SysModel {
    public:
     Message<RWSpeedMsgPayload> rwSpeedOutMsg;     //!< [rad/s] reaction wheel speed output message
     ReadFunctor<RWSpeedMsgPayload> rwSpeedInMsg;  //!< [rad/s] reaction wheel speed input message
-    int rwSignalState[RW_EFF_CNT];               //!< vector of reaction wheel signal states
+    int rwSignalState[RW_EFF_CNT];                //!< vector of reaction wheel signal states
     int clicksPerRotation;                        //!< number of clicks per full rotation
     int numRW;                                    //!< number of reaction wheels
     BSKLogger bskLogger;                          //!< -- BSK Logging
 
    private:
-    RWSpeedMsgPayload rwSpeedBuffer;      //!< reaction wheel speed buffer for internal calculations
-    RWSpeedMsgPayload rwSpeedConverted;   //!< reaction wheel speed buffer for converted values
+    RWSpeedMsgPayload rwSpeedBuffer;     //!< reaction wheel speed buffer for internal calculations
+    RWSpeedMsgPayload rwSpeedConverted;  //!< reaction wheel speed buffer for converted values
     double remainingClicks[RW_EFF_CNT];  //!< remaining clicks from the previous iteration
 
     uint64_t prevTime;  //!< -- Previous simulation time observed

--- a/src/simulation/deviceInterface/encoder/encoder.h
+++ b/src/simulation/deviceInterface/encoder/encoder.h
@@ -41,7 +41,7 @@ class Encoder : public SysModel {
    public:
     Message<RWSpeedMsgPayload> rwSpeedOutMsg;     //!< [rad/s] reaction wheel speed output message
     ReadFunctor<RWSpeedMsgPayload> rwSpeedInMsg;  //!< [rad/s] reaction wheel speed input message
-    int rwSignalState[MAX_EFF_CNT];               //!< vector of reaction wheel signal states
+    int rwSignalState[RW_EFF_CNT];               //!< vector of reaction wheel signal states
     int clicksPerRotation;                        //!< number of clicks per full rotation
     int numRW;                                    //!< number of reaction wheels
     BSKLogger bskLogger;                          //!< -- BSK Logging
@@ -49,7 +49,7 @@ class Encoder : public SysModel {
    private:
     RWSpeedMsgPayload rwSpeedBuffer;      //!< reaction wheel speed buffer for internal calculations
     RWSpeedMsgPayload rwSpeedConverted;   //!< reaction wheel speed buffer for converted values
-    double remainingClicks[MAX_EFF_CNT];  //!< remaining clicks from the previous iteration
+    double remainingClicks[RW_EFF_CNT];  //!< remaining clicks from the previous iteration
 
     uint64_t prevTime;  //!< -- Previous simulation time observed
 };

--- a/src/simulation/deviceInterface/motorVoltageInterface/_UnitTest/test_motorVoltageInterface.py
+++ b/src/simulation/deviceInterface/motorVoltageInterface/_UnitTest/test_motorVoltageInterface.py
@@ -119,9 +119,9 @@ def run(show_plots, voltage):
 
     # Create input message and size it because the regular creator of that message
     # is not part of the test.
-    voltageData = messaging.ArrayMotorVoltageMsgPayload()
+    voltageData = messaging.RwMotorVoltageMsgPayload()
     voltageData.voltage = [voltage, voltage+1.0, voltage+1.5]
-    voltageMsg = messaging.ArrayMotorVoltageMsg().write(voltageData)
+    voltageMsg = messaging.RwMotorVoltageMsg().write(voltageData)
     testModule.motorVoltageInMsg.subscribeTo(voltageMsg)
 
     # Setup logging on the test module output message so that we get all the writes to it

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
@@ -22,11 +22,11 @@
     values and initializes the various parts of the model */
 MotorVoltageInterface::MotorVoltageInterface() {
     this->prevTime = 0;
-    this->bias.resize(MAX_EFF_CNT);
+    this->bias.resize(RW_EFF_CNT);
     this->bias.fill(0.0);
-    this->scaleFactor.resize(MAX_EFF_CNT);
+    this->scaleFactor.resize(RW_EFF_CNT);
     this->scaleFactor.fill(1.0);
-    this->voltage2TorqueGain.resize(MAX_EFF_CNT);
+    this->voltage2TorqueGain.resize(RW_EFF_CNT);
     this->voltage2TorqueGain.fill(1.0);
     return;
 }
@@ -57,7 +57,7 @@ void MotorVoltageInterface::readInputMessages() {
  @return void
  */
 void MotorVoltageInterface::computeMotorTorque() {
-    this->outputTorqueBuffer = ArrayMotorTorqueMsgPayload{};
+    this->outputTorqueBuffer = RwMotorTorqueMsgPayload{};
     for (uint64_t i = 0; i < MAX_EFF_CNT; i++) {
         this->outputTorqueBuffer.motorTorque[i] =
             this->inputVoltageBuffer.voltage[i] * this->voltage2TorqueGain(i) * this->scaleFactor(i) + this->bias(i);

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.cpp
@@ -58,7 +58,7 @@ void MotorVoltageInterface::readInputMessages() {
  */
 void MotorVoltageInterface::computeMotorTorque() {
     this->outputTorqueBuffer = RwMotorTorqueMsgPayload{};
-    for (uint64_t i = 0; i < MAX_EFF_CNT; i++) {
+    for (uint64_t i = 0; i < RW_EFF_CNT; i++) {
         this->outputTorqueBuffer.motorTorque[i] =
             this->inputVoltageBuffer.voltage[i] * this->voltage2TorqueGain(i) * this->scaleFactor(i) + this->bias(i);
     }

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.h
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.h
@@ -51,16 +51,16 @@ class MotorVoltageInterface : public SysModel {
 
    public:
     ReadFunctor<RwMotorVoltageMsgPayload>
-        motorVoltageInMsg;                                  //!< --     Message that contains motor voltage input states
+        motorVoltageInMsg;                               //!< --     Message that contains motor voltage input states
     Message<RwMotorTorqueMsgPayload> motorTorqueOutMsg;  //!< --     Output Message for motor torques
-    Eigen::VectorXd voltage2TorqueGain;                     //!< Nm/V   gain to convert voltage to motor torque
-    Eigen::VectorXd scaleFactor;                            //!<        scale the output - like a constant gain error
-    Eigen::VectorXd bias;                                   //!< Nm     A bias to add to the torque output
-    BSKLogger bskLogger;                                    //!< -- BSK Logging
+    Eigen::VectorXd voltage2TorqueGain;                  //!< Nm/V   gain to convert voltage to motor torque
+    Eigen::VectorXd scaleFactor;                         //!<        scale the output - like a constant gain error
+    Eigen::VectorXd bias;                                //!< Nm     A bias to add to the torque output
+    BSKLogger bskLogger;                                 //!< -- BSK Logging
 
    private:
     RwMotorTorqueMsgPayload outputTorqueBuffer;   //!< [Nm] copy of module output buffer
-    uint64_t prevTime;                               //!< -- Previous simulation time observed
+    uint64_t prevTime;                            //!< -- Previous simulation time observed
     RwMotorVoltageMsgPayload inputVoltageBuffer;  //!< [V] One-time allocation for time savings
 };
 

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.h
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.h
@@ -24,8 +24,8 @@
 #include "architecture/messaging/messaging.h"
 #include <vector>
 
-#include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
-#include "architecture/msgPayloadDef/ArrayMotorVoltageMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h"
 
 #include "../../../architecture/utilities/bskLogging.h"
 #include "../../../architecture/utilities/macroDefinitions.h"
@@ -50,18 +50,18 @@ class MotorVoltageInterface : public SysModel {
                                              //!< leaving blanks up to MAX_EFF_COUNT
 
    public:
-    ReadFunctor<ArrayMotorVoltageMsgPayload>
+    ReadFunctor<RwMotorVoltageMsgPayload>
         motorVoltageInMsg;                                  //!< --     Message that contains motor voltage input states
-    Message<ArrayMotorTorqueMsgPayload> motorTorqueOutMsg;  //!< --     Output Message for motor torques
+    Message<RwMotorTorqueMsgPayload> motorTorqueOutMsg;  //!< --     Output Message for motor torques
     Eigen::VectorXd voltage2TorqueGain;                     //!< Nm/V   gain to convert voltage to motor torque
     Eigen::VectorXd scaleFactor;                            //!<        scale the output - like a constant gain error
     Eigen::VectorXd bias;                                   //!< Nm     A bias to add to the torque output
     BSKLogger bskLogger;                                    //!< -- BSK Logging
 
    private:
-    ArrayMotorTorqueMsgPayload outputTorqueBuffer;   //!< [Nm] copy of module output buffer
+    RwMotorTorqueMsgPayload outputTorqueBuffer;   //!< [Nm] copy of module output buffer
     uint64_t prevTime;                               //!< -- Previous simulation time observed
-    ArrayMotorVoltageMsgPayload inputVoltageBuffer;  //!< [V] One-time allocation for time savings
+    RwMotorVoltageMsgPayload inputVoltageBuffer;  //!< [V] One-time allocation for time savings
 };
 
 #endif

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.i
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.i
@@ -31,9 +31,9 @@ from Basilisk.architecture.swig_common_model import *
 %include "sys_model.i"
 %include "motorVoltageInterface.h"
 
-%include "architecture/msgPayloadDef/ArrayMotorVoltageMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorVoltageMsgPayload.h"
 
-%include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 
 
 %include "architecture/utilities/macroDefinitions.h"

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.rst
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.rst
@@ -18,10 +18,10 @@ provides information on what this message is used for.
       - Msg Type
       - Description
     * - motorVoltageInMsg
-      - :ref:`ArrayMotorVoltageMsgPayload`
+      - :ref:`RwMotorVoltageMsgPayload`
       - Message that contains motor voltage input states
     * - motorTorqueOutMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - Output message for motor torques
 
 Detailed Model Description

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_RWUpdate.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_RWUpdate.py
@@ -140,9 +140,9 @@ def RWUpdateTest(show_plots, accuracy):
     rwFactory.addToSpacecraft(rwStateEffector.modelTag, rwStateEffector, scObject)
 
     # set RW torque command
-    cmdArray = messaging.ArrayMotorTorqueMsgPayload()
+    cmdArray = messaging.RwMotorTorqueMsgPayload()
     cmdArray.motorTorque = [0.4, 0.1, -0.5]  # [Nm]
-    cmdMsg = messaging.ArrayMotorTorqueMsg().write(cmdArray)
+    cmdMsg = messaging.RwMotorTorqueMsg().write(cmdArray)
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(cmdMsg)
     trueTorque = [[0.4, 0., -0.5]]
 

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
@@ -172,14 +172,14 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
     rwFactory.addToSpacecraft("ReactionWheels", rwStateEffector, scObject)
 
     # set RW torque command
-    cmdArray = messaging.ArrayMotorTorqueMsgPayload()
+    cmdArray = messaging.RwMotorTorqueMsgPayload()
     if testCase == 'BalancedWheels' or testCase == 'JitterSimple' or testCase == 'JitterFullyCoupled':
         cmdArray.motorTorque = [0.20, 0.10, -0.50] # [Nm]
     if testCase == 'BOE' or testCase == 'FrictionSpinDown':
         cmdArray.motorTorque = [0.0] # [Nm]
     if testCase == 'FrictionSpinUp':
         cmdArray.motorTorque = [0.1, -0.1]
-    cmdMsg = messaging.ArrayMotorTorqueMsg().write(cmdArray)
+    cmdMsg = messaging.RwMotorTorqueMsg().write(cmdArray)
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(cmdMsg)
 
     # Add test module to runtime call list

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -497,7 +497,7 @@ void ReactionWheelStateEffector::ReadInputs() {
         this->incomingCmdBuffer = this->rwMotorCmdInMsg();
         this->prevCommandTime = this->rwMotorCmdInMsg.timeWritten();
     } else {
-        this->incomingCmdBuffer = ArrayMotorTorqueMsgPayload{};
+        this->incomingCmdBuffer = RwMotorTorqueMsgPayload{};
     }
 
     //! - Set the NewRWCmds vector.  Using the data() method for raw speed

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
@@ -28,7 +28,7 @@
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include <Eigen/Dense>
 
-#include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/RWCmdMsgPayload.h"
 #include "architecture/msgPayloadDef/RWConfigLogMsgPayload.h"
 #include "architecture/msgPayloadDef/RWConfigMsgPayload.h"
@@ -72,7 +72,7 @@ class ReactionWheelStateEffector : public SysModel, public StateEffector {
    public:
     std::vector<RWConfigMsgPayload*> ReactionWheelData;  //!< -- RW information
 
-    ReadFunctor<ArrayMotorTorqueMsgPayload> rwMotorCmdInMsg;  //!< -- RW motor torque array cmd input message
+    ReadFunctor<RwMotorTorqueMsgPayload> rwMotorCmdInMsg;  //!< -- RW motor torque array cmd input message
     Message<RWSpeedMsgPayload> rwSpeedOutMsg;                 //!< -- RW speed array output message
     std::vector<Message<RWConfigLogMsgPayload>*> rwOutMsgs;   //!< -- vector of RW log output messages
 
@@ -85,7 +85,7 @@ class ReactionWheelStateEffector : public SysModel, public StateEffector {
     BSKLogger bskLogger;                         //!< -- BSK Logging
 
    private:
-    ArrayMotorTorqueMsgPayload incomingCmdBuffer = {};  //!< -- One-time allocation for savings
+    RwMotorTorqueMsgPayload incomingCmdBuffer = {};  //!< -- One-time allocation for savings
     uint64_t prevCommandTime;                           //!< -- Time for previous valid thruster firing
 
     StateData* hubSigma;     //!< class variable

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
@@ -28,11 +28,11 @@
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include <Eigen/Dense>
 
-#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 #include "architecture/msgPayloadDef/RWCmdMsgPayload.h"
 #include "architecture/msgPayloadDef/RWConfigLogMsgPayload.h"
 #include "architecture/msgPayloadDef/RWConfigMsgPayload.h"
 #include "architecture/msgPayloadDef/RWSpeedMsgPayload.h"
+#include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 
 #include "architecture/messaging/messaging.h"
 #include "architecture/utilities/bskLogging.h"
@@ -72,9 +72,9 @@ class ReactionWheelStateEffector : public SysModel, public StateEffector {
    public:
     std::vector<RWConfigMsgPayload*> ReactionWheelData;  //!< -- RW information
 
-    ReadFunctor<RwMotorTorqueMsgPayload> rwMotorCmdInMsg;  //!< -- RW motor torque array cmd input message
-    Message<RWSpeedMsgPayload> rwSpeedOutMsg;                 //!< -- RW speed array output message
-    std::vector<Message<RWConfigLogMsgPayload>*> rwOutMsgs;   //!< -- vector of RW log output messages
+    ReadFunctor<RwMotorTorqueMsgPayload> rwMotorCmdInMsg;    //!< -- RW motor torque array cmd input message
+    Message<RWSpeedMsgPayload> rwSpeedOutMsg;                //!< -- RW speed array output message
+    std::vector<Message<RWConfigLogMsgPayload>*> rwOutMsgs;  //!< -- vector of RW log output messages
 
     std::vector<RWCmdMsgPayload> NewRWCmds;      //!< -- Incoming attitude commands
     RWSpeedMsgPayload rwSpeedMsgBuffer = {};     //!< (-) Output data from the reaction wheels
@@ -86,7 +86,7 @@ class ReactionWheelStateEffector : public SysModel, public StateEffector {
 
    private:
     RwMotorTorqueMsgPayload incomingCmdBuffer = {};  //!< -- One-time allocation for savings
-    uint64_t prevCommandTime;                           //!< -- Time for previous valid thruster firing
+    uint64_t prevCommandTime;                        //!< -- Time for previous valid thruster firing
 
     StateData* hubSigma;     //!< class variable
     StateData* hubOmega;     //!< class variable

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
@@ -45,7 +45,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "architecture/msgPayloadDef/RWConfigMsgPayload.h"
 %include "architecture/msgPayloadDef/RWConfigLogMsgPayload.h"
 
-%include "architecture/msgPayloadDef/ArrayMotorTorqueMsgPayload.h"
+%include "architecture/msgPayloadDef/RwMotorTorqueMsgPayload.h"
 
 
 %include "std_vector.i"

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
@@ -33,17 +33,3 @@ provides information on what this message is used for.
     * - rwOutMsgs
       - :ref:`RWConfigLogMsgPayload`
       - vector of RW log output messages
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
@@ -25,7 +25,7 @@ provides information on what this message is used for.
       - Msg Type
       - Description
     * - rwMotorCmdInMsg
-      - :ref:`ArrayMotorTorqueMsgPayload`
+      - :ref:`RwMotorTorqueMsgPayload`
       - (optional) RW motor torque array cmd input message.  If not connected the motor torques are set to zero.
     * - rwSpeedOutMsg
       - :ref:`RWSpeedMsgPayload`

--- a/src/simulation/thermal/motorThermal/_UnitTest/test_motorThermal.py
+++ b/src/simulation/thermal/motorThermal/_UnitTest/test_motorThermal.py
@@ -157,9 +157,9 @@ def motorThermalTest(show_plots, accuracy):
     rwFactory.addToSpacecraft(rwStateEffector.modelTag, rwStateEffector, scObject)
 
     # set RW torque command
-    cmdArray = messaging.ArrayMotorTorqueMsgPayload()
+    cmdArray = messaging.RwMotorTorqueMsgPayload()
     cmdArray.motorTorque = [50, 0, 0]  # [Nm]
-    cmdMsg = messaging.ArrayMotorTorqueMsg().write(cmdArray)
+    cmdMsg = messaging.RwMotorTorqueMsg().write(cmdArray)
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(cmdMsg)
 
     #


### PR DESCRIPTION
* **Tickets addressed:** bsk-1827 #518 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The first commit separates the RW voltage and torque messages from the ambiguous array messages that are used for both RW modules as well as rigid body modules.
The second and third commit replace the MAX_EFF_CNT constant with RW_EFF_CNT in all cases where MAX_EFF_CNT was actually used for reaction wheels.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
Unit tests pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The same will be done for other effectors such as thrusters, and the effector count numbers will be changed to more reasonable numbers such as 4 RWs. This will require an update of unit tests.
