### PR TITLE
Remove pyswice from opnav scenario

### DIFF
--- a/docs/source/codeSamples/making-pyModules.py
+++ b/docs/source/codeSamples/making-pyModules.py
@@ -19,8 +19,7 @@
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.moduleTemplates import cppModuleTemplate
-from Basilisk.architecture import sysModel
-from Basilisk.architecture import bskLogging
+from Basilisk.architecture import sim_model
 from Basilisk.architecture import messaging
 
 import numpy as np
@@ -81,7 +80,7 @@ def run():
     return
 
 
-class TestPythonModule(sysModel.SysModel):
+class TestPythonModule(sim_model.SysModel):
     def __init__(self, *args):
         super().__init__(*args)
         self.dataInMsg = messaging.ModuleTemplateMsgReader()
@@ -91,7 +90,7 @@ class TestPythonModule(sysModel.SysModel):
         # Ensure that self.dataInMsg is linked
         if not self.dataInMsg.isLinked():
             self.bskLogger.bskLog(
-                bskLogging.BSK_ERROR, "TestPythonModule.dataInMsg is not linked."
+                sim_model.BSK_ERROR, "TestPythonModule.dataInMsg is not linked."
             )
 
         # Initialiazing self.dataOutMsg
@@ -99,7 +98,7 @@ class TestPythonModule(sysModel.SysModel):
         payload.dataVector = np.array([0, 0, 0])
         self.dataOutMsg.write(payload, currentSimNanos, self.moduleID)
 
-        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, "Reset in TestPythonModule")
+        self.bskLogger.bskLog(sim_model.BSK_INFORMATION, "Reset in TestPythonModule")
 
     def updateState(self, currentSimNanos):
         # Read input message
@@ -114,7 +113,7 @@ class TestPythonModule(sysModel.SysModel):
         self.dataOutMsg.write(payload, currentSimNanos, self.moduleID)
 
         self.bskLogger.bskLog(
-            bskLogging.BSK_INFORMATION,
+            sim_model.BSK_INFORMATION,
             f"Python Module ID {self.moduleID} ran Update at {currentSimNanos*1e-9}s",
         )
 

--- a/examples/OpNavScenarios/modelsOpNav/BSK_OpNavDynamics.py
+++ b/examples/OpNavScenarios/modelsOpNav/BSK_OpNavDynamics.py
@@ -32,12 +32,13 @@ import math
 import os
 
 import numpy as np
+import spiceypy as spice
+
 from Basilisk import __path__
 from Basilisk.simulation import (spacecraft, extForceTorque, simpleNav,
                                  reactionWheelStateEffector, coarseSunSensor, eclipse,
                                  thrusterDynamicEffector, ephemerisConverter, vizInterface,
                                  camera)
-from Basilisk.topLevelModules import pyswice
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import macros as mc
 from Basilisk.utilities import simIncludeThruster, simIncludeRW, simIncludeGravBody
@@ -223,10 +224,10 @@ class BSKDynamicModels():
         self.gravFactory.spiceObject.referenceBase = "J2000"
         self.gravFactory.spiceObject.zeroBase = 'mars barycenter'
 
-        pyswice.furnsh_c(self.gravFactory.spiceObject.SPICEDataPath + 'de430.bsp')  # solar system bodies
-        pyswice.furnsh_c(self.gravFactory.spiceObject.SPICEDataPath + 'naif0012.tls')  # leap second file
-        pyswice.furnsh_c(self.gravFactory.spiceObject.SPICEDataPath + 'de-403-masses.tpc')  # solar system masses
-        pyswice.furnsh_c(self.gravFactory.spiceObject.SPICEDataPath + 'pck00010.tpc')  # generic Planetary Constants
+        spice.furnsh(self.gravFactory.spiceObject.SPICEDataPath + 'de430.bsp')  # solar system bodies
+        spice.furnsh(self.gravFactory.spiceObject.SPICEDataPath + 'naif0012.tls')  # leap second file
+        spice.furnsh(self.gravFactory.spiceObject.SPICEDataPath + 'de-403-masses.tpc')  # solar system masses
+        spice.furnsh(self.gravFactory.spiceObject.SPICEDataPath + 'pck00010.tpc')  # generic Planetary Constants
 
     def SetEclipseObject(self):
         self.eclipseObject.sunInMsg.subscribeTo(self.gravFactory.spiceObject.planetStateOutMsgs[self.sun])

--- a/src/simulation/environment/dentonFluxModel/_UnitTest/test_dentonFluxModel.py
+++ b/src/simulation/environment/dentonFluxModel/_UnitTest/test_dentonFluxModel.py
@@ -45,7 +45,6 @@ LTs = [0.00, 14.73]
 z_offsets = [0., 3500e3]
 r_EN_Ns = np.array([[0., 0., 0.], [400e3, 300e3, -200e3]])
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("accuracy", [1e2])
 @pytest.mark.parametrize("param1_Kp, param2_LT, param3_z, param4_r_EN", [
     (Kps[0], LTs[0], z_offsets[0], r_EN_Ns[0]),


### PR DESCRIPTION
* **Tickets addressed:** #538
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
`test_bskTestOpNav.py` got missed when `pyswice` was removed from the project. This PR fixes that oversight in the first commit. 

The second commit removes the `xfail` decorator from the denton flux model. This `xfail` was for windows targets which are not currently supported. The third fixes a refactor that got missed in the recent rebuild the build PR.

## Verification
All local and remote CI runs.

## Documentation
None

## Future work
None
