### PR TITLE
Feature/541 update att ref correction

### DIFF
--- a/examples/BskSim/models/BSK_Fsw.py
+++ b/examples/BskSim/models/BSK_Fsw.py
@@ -314,7 +314,7 @@ class BSKFswModels:
 
     def SetAttRefCorrection(self):
         """Define the attitude reference correction module"""
-        self.attRefCorrection.sigma_BcB = [0., 0., 0.]
+        self.attRefCorrection.sigma_RR0 = [0., 0., 0.]
         self.attRefCorrection.attRefInMsg.subscribeTo(self.attRefMsg)
         self.attRefCorrection.attRefOutMsg = self.attRefMsg
 

--- a/examples/BskSim/scenarios/scenario_ClosedLoopManeuver.py
+++ b/examples/BskSim/scenarios/scenario_ClosedLoopManeuver.py
@@ -136,8 +136,8 @@ class scenario_ClosedLoopManeuver(BSKSim, BSKScenario):
         dcm_BcB = np.array([[0., 0., 1.],
                             [0., 1., 0.],
                             [-1., 0., 0.]])
-        sigma_BcB = RigidBodyKinematics.C2MRP(dcm_BcB)
-        FswModel.attRefCorrection.sigma_BcB = sigma_BcB
+        sigma_RR0 = -RigidBodyKinematics.C2MRP(dcm_BcB)
+        FswModel.attRefCorrection.sigma_RR0 = sigma_RR0
 
         tManeuver = 15.
         # use stand-alone message to write DvBurnCmdMsg

--- a/examples/scenarioAttitudePrescribed.py
+++ b/examples/scenarioAttitudePrescribed.py
@@ -207,7 +207,7 @@ def run(show_plots, useAltBodyFrame):
         attRefCor = attRefCorrection.AttRefCorrection()
         attRefCor.modelTag = "attRefCor"
         scSim.AddModelToTask(simTaskName, attRefCor)
-        attRefCor.sigma_BcB = [0.0, 0.0, math.tan(math.pi/8)]
+        attRefCor.sigma_RR0 = [0.0, 0.0, -math.tan(math.pi/8)]
         attRefCor.attRefInMsg.subscribeTo(attGuidance.attRefOutMsg)
         scObject.attRefInMsg.subscribeTo(attRefCor.attRefOutMsg)
     else:

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/CMakeLists.txt
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/CMakeLists.txt
@@ -10,5 +10,5 @@ target_sources("${module}" PRIVATE
 )
 
 target_link_libraries("${module}" PRIVATE
-  ArchitectureUtilities
+  Eigen3::Eigen
 )

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
@@ -36,12 +36,12 @@ def test_att_ref_correction():
     module = attRefCorrection.AttRefCorrection()
     module.modelTag = "attRefCorrectionTag"
     unit_test_sim.AddModelToTask(unit_task_name, module)
-    sigma_RR0 = [[-math.tan(math.pi/4)], [0.0], [0.0]]
-    module.setSigmaRR0(sigma_RR0)
+    sigma_RR0 = [[math.tan(math.pi/16)], [0.0], [0.0]]
+    module.sigma_RR0 = sigma_RR0
 
     # Configure blank module input messages
     att_ref_in_msg_data = messaging.AttRefMsgPayload()
-    att_ref_in_msg_data.sigma_RN = [math.tan(math.pi/8), 0.0, 0.0]
+    att_ref_in_msg_data.sigma_RN = [math.tan(math.pi/16), 0.0, 0.0]
     att_ref_in_msg = messaging.AttRefMsg().write(att_ref_in_msg_data)
 
     # subscribe input messages to module
@@ -57,13 +57,14 @@ def test_att_ref_correction():
 
     # pull module data and make sure it is correct
     true_vector = [
-        [-math.tan(math.pi / 8), 0.0, 0.0],
-        [-math.tan(math.pi / 8), 0.0, 0.0],
-        [-math.tan(math.pi / 8), 0.0, 0.0]
+        [math.tan(math.pi / 8), 0.0, 0.0],
+        [math.tan(math.pi / 8), 0.0, 0.0],
+        [math.tan(math.pi / 8), 0.0, 0.0]
     ]
 
     # compare the module results to the truth values
     accuracy = 1e-12
+    np.testing.assert_allclose(sigma_RR0, module.sigma_RR0, atol=accuracy, verbose=True)
     np.testing.assert_allclose(att_ref_out_msg_rec.sigma_RN, true_vector, atol=accuracy, rtol=0, verbose=True)
 
 

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
@@ -18,40 +18,14 @@
 #
 
 import math
+import numpy as np
 
-import pytest
 from xmera.architecture import messaging
 from xmera.fswAlgorithms import attRefCorrection
 from xmera.utilities import SimulationBaseClass
 from xmera.utilities import macros
-from xmera.utilities import unitTestSupport
 
-
-@pytest.mark.parametrize("accuracy", [1e-12])
-
-def test_att_ref_correction(show_plots, accuracy):
-    r"""
-    **Validation Test Description**
-
-    Checks the output of the module that the correct orientation adjustment is applied
-
-    **Test Parameters**
-
-    Args:
-        accuracy (float): absolute accuracy value used in the validation tests
-
-    **Description of Variables Being Tested**
-
-    The ``sigma_RN`` variable of the output message is tested
-    """
-    [test_results, test_message] = att_ref_correction_test_function(show_plots, accuracy)
-    assert test_results < 1, test_message
-
-
-def att_ref_correction_test_function(show_plots, accuracy):
-    """Test method"""
-    test_fail_count = 0
-    test_messages = []
+def test_att_ref_correction():
     unit_task_name = "unitTask"
     unit_process_name = "TestProcess"
 
@@ -88,22 +62,11 @@ def att_ref_correction_test_function(show_plots, accuracy):
         [-math.tan(math.pi / 8), 0.0, 0.0],
         [-math.tan(math.pi / 8), 0.0, 0.0]
     ]
+
     # compare the module results to the truth values
-    for i in range(0, len(true_vector)):
-        # check a vector values
-        if not unitTestSupport.isArrayEqual(att_ref_out_msg_rec.sigma_RN[i], true_vector[i], 3, accuracy):
-            test_fail_count += 1
-            test_messages.append("FAILED: " + module.modelTag + " Module failed sigma_RN unit test at t=" +
-                                str(att_ref_out_msg_rec.times()[i] * macros.NANO2SEC) +
-                                "sec\n")
-
-    if test_fail_count == 0:
-        print("PASSED: " + module.modelTag)
-    else:
-        print(test_messages)
-
-    return [test_fail_count, "".join(test_messages)]
+    accuracy = 1e-12
+    np.testing.assert_allclose(att_ref_out_msg_rec.sigma_RN, true_vector, atol=accuracy, rtol=0, verbose=True)
 
 
 if __name__ == "__main__":
-    test_att_ref_correction(False, 1e-12)
+    test_att_ref_correction()

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
@@ -29,7 +29,7 @@ from xmera.utilities import unitTestSupport
 
 @pytest.mark.parametrize("accuracy", [1e-12])
 
-def test_attRefCorrection(show_plots, accuracy):
+def test_att_ref_correction(show_plots, accuracy):
     r"""
     **Validation Test Description**
 
@@ -44,66 +44,66 @@ def test_attRefCorrection(show_plots, accuracy):
 
     The ``sigma_RN`` variable of the output message is tested
     """
-    [testResults, testMessage] = attRefCorrectionTestFunction(show_plots, accuracy)
-    assert testResults < 1, testMessage
+    [test_results, test_message] = att_ref_correction_test_function(show_plots, accuracy)
+    assert test_results < 1, test_message
 
 
-def attRefCorrectionTestFunction(show_plots, accuracy):
+def att_ref_correction_test_function(show_plots, accuracy):
     """Test method"""
-    testFailCount = 0
-    testMessages = []
-    unitTaskName = "unitTask"
-    unitProcessName = "TestProcess"
+    test_fail_count = 0
+    test_messages = []
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
 
-    unitTestSim = SimulationBaseClass.SimBaseClass()
-    testProcessRate = macros.sec2nano(0.5)
-    testProc = unitTestSim.CreateNewProcess(unitProcessName)
-    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
+    test_process_rate = macros.sec2nano(0.5)
+    test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
+    test_proc.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
 
     # setup module to be tested
     module = attRefCorrection.AttRefCorrection()
     module.modelTag = "attRefCorrectionTag"
-    unitTestSim.AddModelToTask(unitTaskName, module)
+    unit_test_sim.AddModelToTask(unit_task_name, module)
     module.sigma_BcB = [math.tan(math.pi/4), 0.0, 0.0]
 
     # Configure blank module input messages
-    attRefInMsgData = messaging.AttRefMsgPayload()
-    attRefInMsgData.sigma_RN = [math.tan(math.pi/8), 0.0, 0.0]
-    attRefInMsg = messaging.AttRefMsg().write(attRefInMsgData)
+    att_ref_in_msg_data = messaging.AttRefMsgPayload()
+    att_ref_in_msg_data.sigma_RN = [math.tan(math.pi/8), 0.0, 0.0]
+    att_ref_in_msg = messaging.AttRefMsg().write(att_ref_in_msg_data)
 
     # subscribe input messages to module
-    module.attRefInMsg.subscribeTo(attRefInMsg)
+    module.attRefInMsg.subscribeTo(att_ref_in_msg)
 
     # setup output message recorder objects
-    attRefOutMsgRec = module.attRefOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, attRefOutMsgRec)
+    att_ref_out_msg_rec = module.attRefOutMsg.recorder()
+    unit_test_sim.AddModelToTask(unit_task_name, att_ref_out_msg_rec)
 
-    unitTestSim.InitializeSimulation()
-    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
-    unitTestSim.ExecuteSimulation()
+    unit_test_sim.InitializeSimulation()
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(1.0))
+    unit_test_sim.ExecuteSimulation()
 
     # pull module data and make sure it is correct
-    trueVector = [
+    true_vector = [
         [-math.tan(math.pi / 8), 0.0, 0.0],
         [-math.tan(math.pi / 8), 0.0, 0.0],
         [-math.tan(math.pi / 8), 0.0, 0.0]
     ]
     # compare the module results to the truth values
-    for i in range(0, len(trueVector)):
+    for i in range(0, len(true_vector)):
         # check a vector values
-        if not unitTestSupport.isArrayEqual(attRefOutMsgRec.sigma_RN[i], trueVector[i], 3, accuracy):
-            testFailCount += 1
-            testMessages.append("FAILED: " + module.modelTag + " Module failed sigma_RN unit test at t=" +
-                                str(attRefOutMsgRec.times()[i] * macros.NANO2SEC) +
+        if not unitTestSupport.isArrayEqual(att_ref_out_msg_rec.sigma_RN[i], true_vector[i], 3, accuracy):
+            test_fail_count += 1
+            test_messages.append("FAILED: " + module.modelTag + " Module failed sigma_RN unit test at t=" +
+                                str(att_ref_out_msg_rec.times()[i] * macros.NANO2SEC) +
                                 "sec\n")
 
-    if testFailCount == 0:
+    if test_fail_count == 0:
         print("PASSED: " + module.modelTag)
     else:
-        print(testMessages)
+        print(test_messages)
 
-    return [testFailCount, "".join(testMessages)]
+    return [test_fail_count, "".join(test_messages)]
 
 
 if __name__ == "__main__":
-    test_attRefCorrection(False, 1e-12)
+    test_att_ref_correction(False, 1e-12)

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
@@ -36,7 +36,8 @@ def test_att_ref_correction():
     module = attRefCorrection.AttRefCorrection()
     module.modelTag = "attRefCorrectionTag"
     unit_test_sim.AddModelToTask(unit_task_name, module)
-    module.sigma_BcB = [math.tan(math.pi/4), 0.0, 0.0]
+    sigma_RR0 = [[-math.tan(math.pi/4)], [0.0], [0.0]]
+    module.setSigmaRR0(sigma_RR0)
 
     # Configure blank module input messages
     att_ref_in_msg_data = messaging.AttRefMsgPayload()

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/_UnitTest/test_attRefCorrection.py
@@ -1,20 +1,18 @@
+# ISC License
 #
-#  ISC License
+#  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 #
-#  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
 #
-#  Permission to use, copy, modify, and/or distribute this software for any
-#  purpose with or without fee is hereby granted, provided that the above
-#  copyright notice and this permission notice appear in all copies.
-#
-#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
 import math

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
@@ -17,9 +17,11 @@
 
 */
 
+#include <architecture/utilities/eigenSupport.h>
+#include <architecture/utilities/rigidBodyKinematics.hpp>
 #include "attRefCorrection.h"
-#include <architecture/utilities/linearAlgebra.h>
-#include <architecture/utilities/rigidBodyKinematics.h>
+
+#include <stdexcept>
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
     time varying states between function calls are reset to their default values.
@@ -39,16 +41,25 @@ void AttRefCorrection::reset(uint64_t callTime) {
  @param callTime The clock time at which the function was called (nanoseconds)
 */
 void AttRefCorrection::updateState(uint64_t callTime) {
-    AttRefMsgPayload attRefMsgBuffer;  //!< local copy of message buffer
-    double sigma_BBc[3];               //!< MRP from corrected body frame to body frame
-
     // read in the input messages
-    attRefMsgBuffer = this->attRefInMsg();
+    AttRefMsgPayload attRefMsgBuffer = this->attRefInMsg();
+    Eigen::Vector3d sigma_RN_local = cArrayAsEigenVector3(attRefMsgBuffer.sigma_RN);
 
     // compute corrected reference orientation
-    v3Scale(-1.0, this->sigma_BcB, sigma_BBc);
-    addMRP(attRefMsgBuffer.sigma_RN, sigma_BBc, attRefMsgBuffer.sigma_RN);
+    sigma_RN_local = addMrp(sigma_RN_local, this->sigma_RR0);
 
     // write to the output messages
+    eigenVectorToCArray(sigma_RN_local, attRefMsgBuffer.sigma_RN);
     this->attRefOutMsg.write(&attRefMsgBuffer, this->moduleID, callTime);
 }
+
+/*! Setter method for the current MRP attitude coordinate set with respect to the input reference
+ @return void
+ @param sigmaRR0 [-] current MRP attitude coordinate set with respect to the input reference
+*/
+void AttRefCorrection::setSigmaRR0(const Eigen::Vector3d& sigma) { this->sigma_RR0 = sigma; }
+
+/*! Getter method for the current MRP attitude coordinate set with respect to the input reference
+ @return const Eigen::Vector3d
+*/
+const Eigen::Vector3d AttRefCorrection::getSigmaRR0() const { return this->sigma_RR0; }

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -40,7 +40,7 @@ void AttRefCorrection::reset(uint64_t callTime) {
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */
-void AttRefCorrection::updateState(uint64_t callTime) {
+void AttRefCorrection::updateState(uint64_t const callTime) {
     // read in the input messages
     AttRefMsgPayload attRefMsgBuffer = this->attRefInMsg();
     Eigen::Vector3d sigma_RN_local = cArrayAsEigenVector3(attRefMsgBuffer.sigma_RN);

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
@@ -32,7 +32,7 @@
 void AttRefCorrection::reset(uint64_t callTime) {
     // check if the required message has not been connected
     if (!this->attRefInMsg.isLinked()) {
-        this->bskLogger.bskLog(BSK_ERROR, "Error: attRefCorrection.attRefInMsg was not connected.");
+        throw std::invalid_argument("attRefCorrection.attRefInMsg wasn't connected.");
     }
 }
 

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h
@@ -23,7 +23,6 @@
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
 #include <architecture/msgPayloadDef/AttRefMsgPayload.h>
-#include <architecture/utilities/bskLogging.h>
 #include <Eigen/Core>
 #include <stdint.h>
 
@@ -42,7 +41,6 @@ class AttRefCorrection : public SysModel {
     Message<AttRefMsgPayload> attRefOutMsg;     //!< corrected attitude reference input message
 
 
-    BSKLogger bskLogger = {};  //!< BSK Logging
 private:
     Eigen::Vector3d sigma_RR0{
         Eigen::Vector3d::Zero()};  //!< [-] current MRP attitude coordinate set with respect to the input reference

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h
@@ -1,7 +1,7 @@
 /*
  ISC License
 
- Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Permission to use, copy, modify, and/or distribute this software for any
  purpose with or without fee is hereby granted, provided that the above
@@ -15,7 +15,7 @@
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-*/
+ */
 
 #ifndef ATTREFCORRECTION_H
 #define ATTREFCORRECTION_H
@@ -27,21 +27,20 @@
 #include <stdint.h>
 
 /*! @brief This module reads in the attitude reference message and adjusts it by a fixed rotation.  This allows a
- * general body-fixed frame B to align with this corrected reference frame Rc.
+ * general body-fixed frame B to align with this corrected reference frame.
  */
 class AttRefCorrection : public SysModel {
    public:
-    void reset(uint64_t callTime) override;
-    void updateState(uint64_t callTime) override;
+    void reset(uint64_t callTime) final;
+    void updateState(uint64_t callTime) final;
+
     void setSigmaRR0(const Eigen::Vector3d& sigma);
     const Eigen::Vector3d getSigmaRR0() const;
 
-    /* declare module IO interfaces */
     ReadFunctor<AttRefMsgPayload> attRefInMsg;  //!< attitude reference input message
     Message<AttRefMsgPayload> attRefOutMsg;     //!< corrected attitude reference input message
 
-
-private:
+   private:
     Eigen::Vector3d sigma_RR0{
         Eigen::Vector3d::Zero()};  //!< [-] current MRP attitude coordinate set with respect to the input reference
 };

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.h
@@ -24,6 +24,7 @@
 #include <architecture/messaging/messaging.h>
 #include <architecture/msgPayloadDef/AttRefMsgPayload.h>
 #include <architecture/utilities/bskLogging.h>
+#include <Eigen/Core>
 #include <stdint.h>
 
 /*! @brief This module reads in the attitude reference message and adjusts it by a fixed rotation.  This allows a
@@ -33,14 +34,18 @@ class AttRefCorrection : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
+    void setSigmaRR0(const Eigen::Vector3d& sigma);
+    const Eigen::Vector3d getSigmaRR0() const;
 
     /* declare module IO interfaces */
     ReadFunctor<AttRefMsgPayload> attRefInMsg;  //!< attitude reference input message
     Message<AttRefMsgPayload> attRefOutMsg;     //!< corrected attitude reference input message
 
-    double sigma_BcB[3];  //!< MRP from from body frame B to the corrected body frame Bc
 
     BSKLogger bskLogger = {};  //!< BSK Logging
+private:
+    Eigen::Vector3d sigma_RR0{
+        Eigen::Vector3d::Zero()};  //!< [-] current MRP attitude coordinate set with respect to the input reference
 };
 
 #endif

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.i
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.i
@@ -22,8 +22,12 @@
     #include "attRefCorrection.h"
 %}
 
+%include <attribute.i>
+%attribute(AttRefCorrection, Eigen::Vector3d, sigma_RR0, getSigmaRR0, setSigmaRR0)
+
 %include <architecture/_GeneralModuleFiles/sys_model.i>
 %include <architecture/_GeneralModuleFiles/swig_conly_data.i>
+%include <architecture/_GeneralModuleFiles/swig_eigen.i>
 
 %include "attRefCorrection.h"
 

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.rst
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.rst
@@ -1,13 +1,14 @@
 Executive Summary
 -----------------
-This module reads in the attitude reference message and adjusts it by a fixed rotation.  This allows a general body-fixed frame
-:math:`B` to align with this corrected reference frame :math:`R_c`.
+This module reads in the attitude reference message and adjusts it by a fixed rotation.  This allows a general
+body-fixed frame
+:math:`B` to align with this corrected reference frame :math:`R`.
 
 Message Connection Descriptions
 -------------------------------
-The following table lists all the module input and output messages.  
-The module msg connection is set by the user from python.  
-The msg type contains a link to the message structure definition, while the description 
+The following table lists all the module input and output messages.
+The module msg connection is set by the user from python.
+The msg type contains a link to the message structure definition, while the description
 provides information on what this message is used for.
 
 .. list-table:: Module I/O Messages
@@ -28,42 +29,20 @@ Detailed Module Description
 ---------------------------
 
 This module is an attitude reference message feed-through module where a fixed orientation offset can be applied
-to the output attitude ``sigma_RN``.  In not all cases do we wish to drive a body-fixed
-frame :math:`\cal B` to a reference frame :math:`\cal R`.  Rather, maybe it is desired to align
-the first :math:`\cal R` frame axis with the 2nd body axis.  Thus, a corrected body frame :math:`{\cal B}_c`
-must align with R.  The can also be achieved by aligning :math:`\cal B` with a corrected attitude
-reference frame :math:`{\cal R}_c`.
-
-Let the rotation between :math:`\cal B` and :math:`{\cal B}_c` be given by the MRP set :math:`\sigma_{B/B_c}`.
-Using DCMs, thus we need
-
-.. math::
-    [BN] = [R_cN]
-
-The original reference frame relates to the body frame through
+to the output attitude :math:`\sigma_{R/N}`.  In not all cases do we wish to drive a body-fixed
+frame :math:`\mathcal B` to a reference frame :math:`\mathcal R`.  Therefore, we introduce a fixed offset :math:`\sigma_{R/R0}`
+and add this to the input :math:`\sigma_{R0/N}`. This resulted in a corrected reference frame to control the
+:math:`\mathcal B` to.
 
 .. math::
 
-    [RN] = [B_cN][BN]
+    [RN] = [R R0][R0 N]
 
-which leads to
-
-.. math::
-
-    [BN] = [B_cN]^T [RN]
-
-Substituting this into the first equatino leads to the desired corrected reference frame:
-
-.. math::
-
-    [R_cN] = [B_cN]^T [RN]
-
-The orientation of :math:`[R_cN]` is then translated to a MRP set for the output message.
-
+This relationship can be found by using the addition of two mrps using the rigid body kinematics library, which is what
+the algorithm uses internally.
 
 User Guide
 ----------
 
-The only variable that is set with this module is the ``sigma_BcB`` MRP to rotate from the original
-body frame and the corrected frame.
-
+The only variable that is set with this module is the ``sigma_RR0`` MRP to rotate from the original
+reference frame to corrected reference frame.


### PR DESCRIPTION
* **Tickets addressed:** bsk-541
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
The previous `attRefCorrection` implementation introduces this idea of a control frame Bc, in which you could control the Body frame to the unchanged reference frame and Bc would be lined up with the reference frame. However, to do this properly, we would have needed to introduce the concept of body frame control as opposed to the changing the reference. This PR changes `attRefCorrection` to be more in line with the current implementation of Xmera: there is a body frame and a reference frame, and the job of the controller is to drive the B frame to the R frame. Therefore, if you want to change which body axes are pointed to which R axes, you should alter the R frame, and be explicit about it. So we introduce the idea of the initial R frame, R0 and the input to the module is a fixed offset between the R0 frame and the new updated R frame. 

## Verification
Originally, the test was adding a 180 degree rotation, which means that you can't test the direction of the offset reference frame. So the test was modified to only do 45 degree rotations.  

## Documentation
Documentation was updated. 

## Future work
None
