### PR TITLE
Add default CMAKE_INSTALL_PREFIX to 'base' cmake preset

### DIFF
--- a/src/CMakePresets.json
+++ b/src/CMakePresets.json
@@ -18,6 +18,8 @@
           "Debug",
         "CMAKE_INSTALL_MODE":
           "SYMLINK_OR_COPY",
+        "CMAKE_INSTALL_PREFIX":
+          "${sourceDir}/../dist",
         "XMERA_MODULE_ROOTS":
           "${sourceDir}/fswAlgorithms/;${sourceDir}/simulation/;${sourceDir}/moduleTemplates/",
         "XMERA_ENABLE_GROUPS":


### PR DESCRIPTION
* **Tickets addressed:** #550
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds default CMAKE_INSTALL_PREFIX value. Having this value (which is the one we use manually already) enables other tools (IDEs etc.) to automatically build and install in a single step. From then on it's only incremental rebuilds.

## Verification
Tested the process on CLion.

## Documentation
None for now, but when the docs are merged this will be added.

## Future work
None
