### PR TITLE
Remove all traceback hides

### DIFF
--- a/src/fswAlgorithms/attControl/mrpPD_C/_UnitTest/test_mrpPD_C.py
+++ b/src/fswAlgorithms/attControl/mrpPD_C/_UnitTest/test_mrpPD_C.py
@@ -68,11 +68,6 @@ def test_mrp_PD_C_tracking(show_plots, setExtTorque):
 
 
 def mrp_PD_C_tracking(show_plots, setExtTorque):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_PD_C_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     unitTaskName = "unitTask"  # arbitrary name (don't change)

--- a/src/fswAlgorithms/attControl/mrpSteering_C/_UnitTest/test_MRP_steeringInt_C.py
+++ b/src/fswAlgorithms/attControl/mrpSteering_C/_UnitTest/test_MRP_steeringInt_C.py
@@ -64,11 +64,6 @@ def test_mrp_steering_tracking(show_plots,K1, K3, omegaMax):
 
 
 def mrp_steering_tracking(show_plots,K1, K3, omegaMax):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     unitTaskName = "unitTask"  # arbitrary name (don't change)

--- a/src/fswAlgorithms/attControl/mrpSteering_C/_UnitTest/test_MRP_steeringUnit_C.py
+++ b/src/fswAlgorithms/attControl/mrpSteering_C/_UnitTest/test_MRP_steeringUnit_C.py
@@ -62,11 +62,6 @@ def test_mrp_steering_tracking(show_plots, K1, K3, omegaMax):
 
 
 def mrp_steering_tracking(show_plots, K1, K3, omegaMax):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     unitTaskName = "unitTask"  # arbitrary name (don't change)

--- a/src/fswAlgorithms/attControl/rateServoFullNonlinear_C/_UnitTest/test_rateServoFullNonlinear_C.py
+++ b/src/fswAlgorithms/attControl/rateServoFullNonlinear_C/_UnitTest/test_rateServoFullNonlinear_C.py
@@ -53,11 +53,6 @@ def test_rate_servo_full_nonlinear(show_plots, rwNum, intGain, omegap_BastR_B, o
 
 def rate_servo_full_nonlinear(show_plots,rwNum, intGain, omegap_BastR_B, omega_BastR_B, integralLimit,
                               useRwAvailability):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    #__tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     unitTaskName = "unitTask"  # arbitrary name (don't change)

--- a/src/fswAlgorithms/attDetermination/InertialUKF/_UnitTest/test_inertialKF.py
+++ b/src/fswAlgorithms/attDetermination/InertialUKF/_UnitTest/test_inertialKF.py
@@ -211,11 +211,6 @@ def test_stateUpdateInertialAttitude(show_plots):
     assert testResults < 1, testMessage
 def stateUpdateInertialAttitude(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -359,12 +354,6 @@ def BROKENtest_statePropInertialAttitude(show_plots):
     assert testResults < 1, testMessage
 def statePropInertialAttitude(show_plots):
     """Module Unit Test"""
-
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -451,11 +440,6 @@ def test_stateUpdateRWInertialAttitude(show_plots):
     assert testResults < 1, testMessage
 def stateUpdateRWInertialAttitude(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -608,12 +592,6 @@ def BROKENtest_StatePropRateInertialAttitude(show_plots):
     assert testResults < 1, testMessage
 def statePropRateInertialAttitude(show_plots):
     """Module Unit Test"""
-
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -739,11 +717,6 @@ def BROKENtest_FaultScenarios(show_plots):
     assert testResults < 1, testMessage
 def faultScenarios(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/attDetermination/headingSuKF/_UnitTest/test_headingSuKF.py
+++ b/src/fswAlgorithms/attDetermination/headingSuKF/_UnitTest/test_headingSuKF.py
@@ -100,11 +100,6 @@ def test_all_heading_kf(show_plots):
     assert testResults < 1, testMessage
 
 def heading_utilities_test(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -364,7 +359,6 @@ def heading_utilities_test(show_plots):
 
 def StateUpdateSunLine(show_plots):
 
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
@@ -476,7 +470,6 @@ def StateUpdateSunLine(show_plots):
     return [testFailCount, ''.join(testMessages)]
 
 def StatePropSunLine(show_plots):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/test_okeefeEKF.py
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/test_okeefeEKF.py
@@ -86,11 +86,6 @@ def test_all_sunline_oekf(show_plots, SimHalfLength, AddMeasNoise, testVector1, 
 
 
 def sunline_individual_test():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -423,11 +418,6 @@ def sunline_individual_test():
 # Test for the time and update with static states (zero d_dot)
 ####################################################################################
 def StatePropStatic():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     NUMSTATES=3
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
@@ -488,11 +478,6 @@ def StatePropStatic():
 # Test for the time and update with changing states non-zero omega
 ####################################################################################
 def StatePropVariable(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     NUMSTATES=3
 
     testFailCount = 0  # zero unit test result counter
@@ -637,10 +622,6 @@ def StatePropVariable(show_plots):
 # Test for the full filter with time and measurement update
 ####################################################################################
 def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, testVector2, stateGuess):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
     NUMSTATES=3
 
     testFailCount = 0  # zero unit test result counter

--- a/src/fswAlgorithms/attDetermination/sunlineEKF/_UnitTest/test_SunLineEKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineEKF/_UnitTest/test_SunLineEKF.py
@@ -89,11 +89,6 @@ def test_all_sunline_ekf(show_plots, SimHalfLength, AddMeasNoise, testVector1, t
 
 
 def sunline_individual_test():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -408,11 +403,6 @@ def sunline_individual_test():
 # Test for the time and update with static states (zero d_dot)
 ####################################################################################
 def StatePropStatic():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -470,11 +460,6 @@ def StatePropStatic():
 # Test for the time and update with changing states (non-zero d_dot)
 ####################################################################################
 def StatePropVariable(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -603,11 +588,6 @@ def StatePropVariable(show_plots):
 # Test for the full filter with time and measurement update
 ####################################################################################
 def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, testVector2, stateGuess):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/test_SunLineSEKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/test_SunLineSEKF.py
@@ -89,11 +89,6 @@ def test_all_sunline_sekf(show_plots, SimHalfLength, AddMeasNoise, testVector1, 
 
 
 def sunline_individual_test():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -569,10 +564,6 @@ def sunline_individual_test():
 # Test for the time and update with static states (zero d_dot)
 ####################################################################################
 def StatePropStatic():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
     numStates = 5
     numObs = 3
 
@@ -631,11 +622,6 @@ def StatePropStatic():
 # Test for the time and update with changing states (non-zero d_dot)
 ####################################################################################
 def StatePropVariable(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -780,11 +766,6 @@ def StatePropVariable(show_plots):
 # Test for the full filter with time and measurement update
 ####################################################################################
 def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, testVector2, stateGuess):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/attDetermination/sunlineSuKF/_UnitTest/test_SunLineSuKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSuKF/_UnitTest/test_SunLineSuKF.py
@@ -79,11 +79,6 @@ def test_all_sunline_kf(show_plots, kellyOn):
 
 
 def SwitchMethods():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     ###################################################################################
@@ -222,11 +217,6 @@ def SwitchMethods():
     return [testFailCount, ''.join(testMessages)]
 
 def StateUpdateSunLine(show_plots, kellyOn):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -393,11 +383,6 @@ def StateUpdateSunLine(show_plots, kellyOn):
     return [testFailCount, ''.join(testMessages)]
 
 def StatePropSunLine(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -459,11 +444,6 @@ def StatePropSunLine(show_plots):
     return [testFailCount, ''.join(testMessages)]
 
 def FaultScenarios():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/attDetermination/sunlineUKF/_UnitTest/test_SunLineUKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineUKF/_UnitTest/test_SunLineUKF.py
@@ -66,11 +66,6 @@ def test_all_sunline_kf(show_plots, function):
 
 
 def sunline_utilities_test(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -332,11 +327,6 @@ def sunline_utilities_test(show_plots):
     return [testFailCount, ''.join(testMessages)]
 
 def checkStateUpdateSunLine(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -467,12 +457,6 @@ def checkStateUpdateSunLine(show_plots):
 
 
 def checkStatePropSunLine(show_plots):
-
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/_UnitTest/test_pixelLineBiasUKF.py
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/_UnitTest/test_pixelLineBiasUKF.py
@@ -104,11 +104,6 @@ def test_propagation_kf(show_plots):
 
 
 def relOD_method_test(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -236,11 +231,6 @@ def relOD_method_test(show_plots):
 
 
 def StatePropRelOD(show_plots, dt):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/opticalNavigation/positionODuKF/_UnitTest/test_positionODuKF.py
+++ b/src/fswAlgorithms/opticalNavigation/positionODuKF/_UnitTest/test_positionODuKF.py
@@ -102,7 +102,6 @@ def test_measurements_kf(show_plots):
     state_update_test(show_plots)
 
 def state_update_test(show_plots):
-    __tracebackhide__ = True
 
     unit_task_name = "unit_task"
     unit_process_name = "TestProcess"
@@ -224,7 +223,6 @@ def state_update_test(show_plots):
 
 
 def state_propagation_test(show_plots, dt):
-    __tracebackhide__ = True
 
     unit_task_name = "unit_task"  # arbitrary name (don't change)
     unit_process_name = "TestProcess"  # arbitrary name (don't change)

--- a/src/fswAlgorithms/opticalNavigation/relativeODuKF/_UnitTest/test_relativeODuKF.py
+++ b/src/fswAlgorithms/opticalNavigation/relativeODuKF/_UnitTest/test_relativeODuKF.py
@@ -102,11 +102,6 @@ def test_measurements_kf(show_plots):
 
 
 def relOD_method_test(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -165,11 +160,6 @@ def relOD_method_test(show_plots):
 
 
 def StateUpdateRelOD(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -292,11 +282,6 @@ def StateUpdateRelOD(show_plots):
 
 
 def StatePropRelOD(show_plots, dt):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/fswAlgorithms/transDetermination/chebyPosEphem/_UnitTest/test_chebyPosEphem.py
+++ b/src/fswAlgorithms/transDetermination/chebyPosEphem/_UnitTest/test_chebyPosEphem.py
@@ -54,11 +54,6 @@ def test_chebyPosFitAllTest(show_plots, function):
 
 def sineCosine(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -145,11 +140,6 @@ def sineCosine(show_plots):
     return [testFailCount, ''.join(testMessages)]
 
 def earthOrbitFit(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    #__tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/deviceInterface/tempMeasurement/_UnitTest/test_tempMeasurement.py
+++ b/src/simulation/deviceInterface/tempMeasurement/_UnitTest/test_tempMeasurement.py
@@ -56,8 +56,7 @@ def test_sensorThermalFault(tempFault):
     # each test method requires a single assert method to be called
     [testResults, testMessage] = run(tempFault)
     assert testResults < 1, testMessage
-    __tracebackhide__ = True
-
+    
 
 def run(tempFault):
 

--- a/src/simulation/deviceInterface/tempMeasurement/_UnitTest/test_tempMeasurement.py
+++ b/src/simulation/deviceInterface/tempMeasurement/_UnitTest/test_tempMeasurement.py
@@ -56,7 +56,7 @@ def test_sensorThermalFault(tempFault):
     # each test method requires a single assert method to be called
     [testResults, testMessage] = run(tempFault)
     assert testResults < 1, testMessage
-    
+
 
 def run(tempFault):
 

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -38,11 +38,6 @@ path = os.path.dirname(os.path.abspath(filename))
                                                  thrusterStateEffector.ThrusterStateEffector])
 def test_massDepletionTest(show_plots, thrusterConstructor):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     scObject = spacecraft.Spacecraft()
     scObject.modelTag = "spacecraftBody"
 

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_tank_models.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_tank_models.py
@@ -27,11 +27,6 @@ path = os.path.dirname(os.path.abspath(filename))
 
 def test_tankModelConstantVolume(show_plots=False):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     model = fuelTank.FuelTankModelConstantVolume()
     model.propMassInit = 10
     model.r_TcT_TInit = [[1], [1], [1]]
@@ -105,7 +100,6 @@ def test_tankModelConstantVolume(show_plots=False):
 
 
 def test_tankModelConstantDensity(show_plots=False):
-    __tracebackhide__ = True
 
     model = fuelTank.FuelTankModelConstantDensity()
     model.propMassInit = 10
@@ -180,7 +174,6 @@ def test_tankModelConstantDensity(show_plots=False):
 
 
 def test_tankModelEmptying(show_plots=False):
-    __tracebackhide__ = True
 
     model = fuelTank.FuelTankModelEmptying()
     model.propMassInit = 10
@@ -255,7 +248,6 @@ def test_tankModelEmptying(show_plots=False):
 
 
 def test_tankModelUniformBurn(show_plots=False):
-    __tracebackhide__ = True
 
     model = fuelTank.FuelTankModelUniformBurn()
     model.propMassInit = 10
@@ -331,7 +323,6 @@ def test_tankModelUniformBurn(show_plots=False):
 
 
 def test_tankModelCentrifugalBurn(show_plots=False):
-    __tracebackhide__ = True
 
     model = fuelTank.FuelTankModelCentrifugalBurn()
     model.propMassInit = 10

--- a/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
+++ b/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
@@ -56,11 +56,6 @@ def test_fuelSloshAllTest(show_plots,useFlag,testCase):
     assert testResults < 1, testMessage
 
 def fuelSloshTest(show_plots,useFlag,testCase):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
@@ -87,11 +87,6 @@ values have all been confirmed to be conserved.
     assert testResults < 1, testMessage
 
 def nHingedRigidBody(show_plots, testCase):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
+++ b/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
@@ -63,11 +63,6 @@ def test_unitRadiationPressure(show_plots, modelType, eclipseOn):
 
 
 def unitRadiationPressure(show_plots, modelType, eclipseOn):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0
     testMessages = []
     testTaskName = "unitTestTask"

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
@@ -140,11 +140,6 @@ def test_unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, lo
 
 # Run the test
 def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_angle, lat_angle, location, rate, cutoff, rampDown, swirlTorque, blowDown):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_dynamics_attached_body.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_dynamics_attached_body.py
@@ -64,7 +64,6 @@ def test_unitThrusters(show_plots, long_angle, lat_angle, location, rate):
 
 # Run the test
 def unitThrusters(show_plots, long_angle, lat_angle, location, rate):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py
@@ -38,11 +38,6 @@ def test_thrusterIntegratedTest(show_plots):
 
 def thrusterIntegratedTest(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
@@ -131,7 +131,6 @@ def test_unitThrusters(testFixture, show_plots, thrustNumber, initialConditions,
 
 # Run the test
 def unitThrusters(testFixture, show_plots, thrustNumber, initialConditions, duration, long_angle, lat_angle, location, swirlTorque, rate, attachBody):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages

--- a/src/simulation/dynamics/VSCMGs/_UnitTest/test_VSCMGStateEffector_integrated.py
+++ b/src/simulation/dynamics/VSCMGs/_UnitTest/test_VSCMGStateEffector_integrated.py
@@ -119,11 +119,6 @@ def test_VSCMGIntegratedTest(show_plots,useFlag,testCase):
     assert testResults < 1, testMessage
 
 def VSCMGIntegratedTest(show_plots,useFlag,testCase):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/extForceTorque/_UnitTest/test_extForceTorqueIntegrated.py
+++ b/src/simulation/dynamics/extForceTorque/_UnitTest/test_extForceTorqueIntegrated.py
@@ -42,11 +42,6 @@ def test_ForceBodyAndTorqueAllTest(show_plots, function):
 
 def extForceBodyAndTorque():
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -135,11 +130,6 @@ def extForceBodyAndTorque():
     return [testFailCount, ''.join(testMessages)]
 
 def extForceInertialAndTorque():
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravityDynEffector.py
+++ b/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravityDynEffector.py
@@ -155,11 +155,6 @@ def test_gravityEffectorAllTest(show_plots):
 
 def independentSphericalHarmonics(show_plots):
     testCase = "independentCheck"
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -211,11 +206,6 @@ def independentSphericalHarmonics(show_plots):
 
 def sphericalHarmonics(show_plots):
     testCase = 'sphericalHarmonics'
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -283,11 +273,6 @@ def sphericalHarmonics(show_plots):
 
 def singleGravityBody(show_plots):
     testCase = 'singleBody'
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -437,12 +422,7 @@ def register(manager):
     return
 
 def multiBodyGravity(show_plots):
-    testCase = 'multiBody' #for AutoTeX stuff
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
+    testCase = 'multiBody' #for AutoTeX stuf
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
     #

--- a/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravitySpacecraft.py
+++ b/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravitySpacecraft.py
@@ -55,11 +55,6 @@ def test_gravityEffectorAllTest(show_plots, function):
 
 def singleGravityBody(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -182,11 +177,6 @@ def singleGravityBody(show_plots):
     return [testFailCount, ''.join(testMessages)]
 
 def multiBodyGravity(show_plots):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -307,11 +297,6 @@ def multiBodyGravity(show_plots):
 
 def polyGravityBody(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/_UnitTest/test_linearTranslationOneDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/_UnitTest/test_linearTranslationOneDOFStateEffector.py
@@ -81,7 +81,6 @@ def test_translatingBody(show_plots, function):
 
 # rho ref and cmd force are zero, no lock flag
 def translatingBodyNoInput(show_plots):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
@@ -260,7 +259,6 @@ def translatingBodyNoInput(show_plots):
 
 # rho ref and cmd force are zero, lock flag is enabled
 def translatingBodyLockFlag(show_plots):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
@@ -445,7 +443,6 @@ def translatingBodyLockFlag(show_plots):
 
 # cmd force is nonzero, rho ref is zero, no lock flag
 def translatingBodyCommandedForce(show_plots, cmdForce):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
@@ -619,7 +616,6 @@ def translatingBodyCommandedForce(show_plots, cmdForce):
 
 # rho ref is nonzero, cmd force is zero and lock flag is false
 def translatingBodyRhoReference(show_plots, rhoRef):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -70,7 +70,6 @@ def test_PrescribedMotionStateEffector_Rotation(show_plots, theta_init, theta_re
     and the spacecraft rotational angular momentum match the final simulation values to a reasonable extent.
     """
 
-    __tracebackhide__ = True
 
     unit_task_name = "unitTask"
     unit_process_name = "testProcess"
@@ -242,7 +241,6 @@ def test_PrescribedMotionStateEffector_Translation(show_plots, trans_pos_init, t
     and the spacecraft rotational angular momentum match the final simulation values to a reasonable extent.
     """
 
-    __tracebackhide__ = True
 
     unit_task_name = "unitTask"
     unit_process_name = "test_processess"

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
@@ -59,11 +59,6 @@ def test_reactionWheelIntegratedTest(show_plots,useFlag,testCase):
     assert testResults < 1, testMessage
 
 def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraft.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraft.py
@@ -70,11 +70,6 @@ def test_spacecraftAllTest(show_plots, function):
 
 def SCTranslation(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -202,11 +197,6 @@ def SCTranslation(show_plots):
 
 def SCTransAndRotation(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -381,11 +371,6 @@ def SCTransAndRotation(show_plots):
 
 def SCRotation(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -606,11 +591,6 @@ def SCRotation(show_plots):
 
 def SCTransBOE(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -753,11 +733,6 @@ def SCTransBOE(show_plots):
 
 def SCPointBVsPointC(show_plots):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -917,11 +892,6 @@ def SCPointBVsPointC(show_plots):
 @pytest.mark.parametrize("accuracy", [1e-3])
 def scOptionalRef(show_plots, accuracy):
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -1023,11 +993,6 @@ def scOptionalRef(show_plots, accuracy):
 
 def scAccumDV():
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -1106,11 +1071,6 @@ def scAccumDV():
 
 def scAccumDVExtForce():
     """Module Unit Test"""
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
@@ -75,7 +75,6 @@ def test_spinningBody(show_plots, cmdTorque, lock, thetaRef):
 
 
 def spinningBody(show_plots, cmdTorque, lock, thetaRef):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
@@ -78,7 +78,6 @@ def test_spinningBody(show_plots, cmdTorque1, lock1, theta1Ref, cmdTorque2, lock
 
 
 def spinningBody(show_plots, cmdTorque1, lock1, theta1Ref, cmdTorque2, lock2, theta2Ref):
-    __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages

--- a/src/simulation/dynamics/stateArchitecture/_UnitTest/test_stateArchitecture.py
+++ b/src/simulation/dynamics/stateArchitecture/_UnitTest/test_stateArchitecture.py
@@ -21,7 +21,6 @@ from xmera.simulation import stateArchitecture
 
 
 def test_stateData(show_plots):
-    __tracebackhide__ = True
 
     stateUse = [[10.0], [20.0]]
     stateName = "position"
@@ -68,7 +67,6 @@ def test_stateData(show_plots):
 
 
 def test_stateProperties(show_plots):
-    __tracebackhide__ = True
 
     newManager = stateArchitecture.DynParamManager()
 
@@ -102,7 +100,6 @@ def test_stateProperties(show_plots):
 
 
 def test_stateArchitecture(show_plots):
-    __tracebackhide__ = True
 
     newManager = stateArchitecture.DynParamManager()
 

--- a/src/simulation/environment/albedo/_UnitTest/test_albedo.py
+++ b/src/simulation/environment/albedo/_UnitTest/test_albedo.py
@@ -75,7 +75,6 @@ def test_unitAlbedo(show_plots, planetCase, modelType, useEclipse):
 
 
 def unitAlbedo(show_plots, planetCase, modelType, useEclipse):
-    __tracebackhide__ = True
     testFailCount = 0
     testMessages = []
     testTaskName = "unitTestTask"

--- a/src/simulation/environment/eclipse/_UnitTest/test_eclipse.py
+++ b/src/simulation/environment/eclipse/_UnitTest/test_eclipse.py
@@ -127,8 +127,6 @@ is pulled from the log data and compared to the expected truth value.
 
 
 def unitEclipse(show_plots, eclipseCondition, planet):
-    __tracebackhide__ = True
-
     testFailCount = 0
     testMessages = []
     testTaskName = "unitTestTask"
@@ -318,7 +316,6 @@ def unitEclipse(show_plots, eclipseCondition, planet):
     return [testFailCount, ''.join(testMessages)]
 
 def unitEclipseCustom(show_plots):
-    __tracebackhide__ = True
 
     testFailCount = 0
     testMessages = []

--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
@@ -71,8 +71,6 @@ def test_coarseSunSensor(show_plots, useConstellation, visibilityFactor, fov, ke
                                      noiseStd, albedoValue, sunDistInput, minIn, maxIn, errTol, name, zLevel, lineWide)
     assert testResults < 1, testMessage
 
-    __tracebackhide__ = True
-
 
 def run(show_plots, useConstellation, visibilityFactor, fov, kelly, scaleFactor, bias, noiseStd, albedoValue,
         sunDistInput, minIn, maxIn, errTol, name, zLevel, lineWide):

--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensorFaults.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensorFaults.py
@@ -58,8 +58,6 @@ def test_coarseSunSensor(cssFault):
     # each test method requires a single assert method to be called
     [testResults, testMessage] = run(cssFault)
     assert testResults < 1, testMessage
-    __tracebackhide__ = True
-
 
 def run(cssFault):
     # np.random.seed(10)

--- a/src/tests/test_pythonVariableLogger.py
+++ b/src/tests/test_pythonVariableLogger.py
@@ -40,7 +40,6 @@ def test_times():
 
 
 def test_logging():
-    __tracebackhide__ = True
 
     simulation = SimulationBaseClass.SimBaseClass()
     simTime = 2.0

--- a/src/tests/test_utilitiesUKF.py
+++ b/src/tests/test_utilitiesUKF.py
@@ -40,11 +40,6 @@ def test_all_utilities_ukf(show_plots, filterModule):
     assert testResults < 1, testMessage
 
 def utilities_nominal(filterModule):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -297,11 +292,6 @@ def utilities_nominal(filterModule):
 
 
 def utilities_fault(filterModule):
-    # The __tracebackhide__ setting influences pytest showing of tracebacks:
-    # the mrp_steering_tracking() function will not be shown unless the
-    # --fulltrace command line option is specified.
-    __tracebackhide__ = True
-
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 

--- a/src/utilities/tests/test_legacyVariableLogging.py
+++ b/src/utilities/tests/test_legacyVariableLogging.py
@@ -23,7 +23,6 @@ import warnings
 from xmera.utilities import deprecated
 
 def test_legacy_variable_logging(show_plots):
-    __tracebackhide__ = True
 
     warnings.filterwarnings("ignore", category=deprecated.BSKDeprecationWarning)
 


### PR DESCRIPTION
* **Tickets addressed:** #536 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR removes any traceback hiding in python test files.

Hiding tracebacks hinders viewing execution failure information. Hiding tracebacks is typically only done for helper functions within a test. In other cases, pytest gives options to control output and output from general stdout/stderr can be routed appropriately.

## Verification
All tests and examples run as normal.

## Documentation
NA

## Future work
None
