### PR TITLE
Feature/1840 oe state ephem float support

### DIFF
--- a/src/architecture/utilities/orbitalMotion.cpp
+++ b/src/architecture/utilities/orbitalMotion.cpp
@@ -495,3 +495,215 @@ EquinoctialElements OrbitalMotion::mapClassicalToEquinoctialElements(const Class
 
     return equinoctial;
 }
+
+/**
+ * @brief Converts eccentric anomaly to true anomaly.
+ * @param E Eccentric anomaly in radians.
+ * @param e Orbital eccentricity.
+ * @return True anomaly in radians.
+ */
+float OrbitalMotion::eccentricToTrueAnomalyF32(float E, float e) {
+    assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
+    return 2.0 * std::atan2(std::sqrt(1 + e) * std::sin(E / 2), std::sqrt(1 - e) * std::cos(E / 2));
+}
+
+/**
+ * @brief Converts eccentric anomaly to mean anomaly.
+ * @param E Eccentric anomaly in radians.
+ * @param e Orbital eccentricity.
+ * @return Mean anomaly in radians.
+ */
+float OrbitalMotion::eccentricToMeanAnomalyF32(float E, float e) {
+    assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
+    return E - e * std::sin(E);
+}
+
+/**
+ * @brief Converts true anomaly to eccentric anomaly.
+ * @param f True anomaly in radians.
+ * @param e Orbital eccentricity.
+ * @return Eccentric anomaly in radians.
+ */
+float OrbitalMotion::trueToEccentricAnomalyF32(float f, float e) {
+    assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
+    return 2.0 * std::atan2(std::sqrt(1 - e) * std::sin(f / 2), std::sqrt(1 + e) * std::cos(f / 2));
+}
+
+/**
+ * @brief Convert true anomaly to mean anomaly
+ * @param f True anomaly in radians
+ * @param e Orbital eccentricity (0 <= e < 1).
+ * @return Mean anomaly in radians.
+ */
+float OrbitalMotion::trueToMeanAnomalyF32(float f, float e) {
+    assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
+    float eccentric = trueToEccentricAnomalyF32(f, e);
+    return eccentricToMeanAnomalyF32(eccentric, e);
+}
+
+/**
+ * @brief Converts true anomaly to hyperbolic anomaly.
+ * @param f True anomaly in radians.
+ * @param e Orbital eccentricity (> 1).
+ * @return Hyperbolic anomaly in radians.
+ */
+float OrbitalMotion::trueToHyperbolicAnomalyF32(float f, float e) {
+    assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
+    return 2.0 * std::atanh(std::sqrt((e - 1) / (e + 1)) * std::tan(f / 2));
+}
+
+/**
+ * @brief Converts hyperbolic anomaly to true anomaly.
+ * @param H Hyperbolic anomaly in radians.
+ * @param e Orbital eccentricity (> 1).
+ * @return True anomaly in radians.
+ */
+float OrbitalMotion::hyperbolicToTrueAnomalyF32(float H, float e) {
+    assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
+    return 2.0 * std::atan(std::sqrt((e + 1) / (e - 1)) * std::tanh(H / 2));
+}
+
+/**
+ * @brief Converts hyperbolic anomaly to mean hyperbolic anomaly.
+ * @param H Hyperbolic anomaly in radians.
+ * @param e Orbital eccentricity (> 1).
+ * @return Mean hyperbolic anomaly in radians.
+ */
+float OrbitalMotion::hyperbolicToMeanAnomalyF32(float H, float e) {
+    assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
+    return e * std::sinh(H) - H;
+}
+
+/**
+ * @brief Convert mean anomaly to eccentric anomaly
+ * @param M Mean anomaly in radians.
+ * @param e Orbital eccentricity (0 <= e < 1).
+ * @return Eccentric anomaly in radians.
+ */
+float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
+    assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
+    float E = M;
+    for (int i = 0; i < 200; ++i) {
+        float dE = (E - e * std::sin(E) - M) / (1 - e * std::cos(E));
+        E -= dE;
+        if (std::abs(dE) < tolerance) break;
+    }
+    return E;
+}
+
+/**
+ * @brief Convert mean anomaly to true anomaly
+ * @param M Mean anomaly in radians.
+ * @param e Orbital eccentricity (0 <= e < 1).
+ * @return True anomaly in radians.
+ */
+float OrbitalMotion::meanToTrueAnomalyF32(float M, float e) {
+    assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
+    float eccentric = meanToEccentricAnomalyF32(M, e);
+    return eccentricToTrueAnomalyF32(eccentric, e);
+}
+
+/**
+ * @brief Mean hyperbolic anomaly to hyperbolic anomaly
+ * @param N Mean hyperbolic anomaly in radians.
+ * @param e Orbital eccentricity (> 1).
+ * @return Hyperbolic anomaly in radians.
+ */
+float OrbitalMotion::meanToHyperbolicAnomalyF32(float N, float e) {
+    assert(e > 1.0 && "Eccentricity must be > 1");
+    float H = std::abs(N) > 7.0 ? 7.0 * (N > 0 ? 1 : -1) : N;
+    for (int i = 0; i < 200; ++i) {
+        float dH = (e * std::sinh(H) - H - N) / (e * std::cosh(H) - 1);
+        H -= dH;
+        if (std::abs(dH) < tolerance) break;
+    }
+    return H;
+}
+
+/**
+ * @brief Converts orbital elements to position and velocity vectors.
+ * @param mu Gravitational parameter (km^3/s^2).
+ * @param elements Classical orbital elements (a, e, i, Omega, omega, f).
+ * @param CartesianState Output: position and velocity vectors in km and km/s.
+ */
+CartesianState OrbitalMotion::elementsToCartesianStateF32(double mu, const ClassicalElementsF32& elements) {
+    double a = elements.semiMajorAxis;
+    float e = elements.eccentricity;
+    float i = elements.inclination;
+    float Omega = elements.rightAscensionAscendingNode;
+    float omega = elements.argPeriapsis;
+    float f = elements.trueAnomaly;
+
+    double p = a * (1 - e * e);
+    double r = p / (1 + e * std::cos(f));
+    double h = std::sqrt(mu * p);
+
+    float cos_O = std::cos(Omega);
+    float sin_O = std::sin(Omega);
+    float cos_o = std::cos(omega);
+    float sin_o = std::sin(omega);
+    float cos_i = std::cos(i);
+    float sin_i = std::sin(i);
+    float cos_f = std::cos(f);
+    float sin_f = std::sin(f);
+
+    float cos_theta = cos_o * cos_f - sin_o * sin_f;
+    float sin_theta = sin_o * cos_f + cos_o * sin_f;
+
+    Eigen::Vector3d rVec{};
+    rVec(0) = r * (cos_O * cos_theta - sin_O * sin_theta * cos_i);
+    rVec(1) = r * (sin_O * cos_theta + cos_O * sin_theta * cos_i);
+    rVec(2) = r * (sin_theta * sin_i);
+
+    double vx = -mu / h * (cos_O * (sin_theta + e * sin_o) + sin_O * (cos_theta + e * cos_o) * cos_i);
+    double vy = -mu / h * (sin_O * (sin_theta + e * sin_o) - cos_O * (cos_theta + e * cos_o) * cos_i);
+    double vz = mu / h * (cos_theta + e * cos_o) * sin_i;
+
+    const Eigen::Vector3d vVec = Eigen::Vector3d(vx, vy, vz);
+
+    CartesianState state{};
+    state.position = rVec;
+    state.velocity = vVec;
+
+    return state;
+}
+
+/**
+ * @brief Converts position and velocity vectors to classical orbital elements.
+ * @param mu Gravitational parameter (km^3/s^2).
+ * @param rVec Position vector in km.
+ * @param vVec Velocity vector in km/s.
+ * @return elements : classical orbital elements (a, e, i, Omega, omega, f).
+ */
+ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(double mu,
+                                                                const Eigen::Vector3d& rVec,
+                                                                const Eigen::Vector3d& vVec) {
+    double r = rVec.norm();
+    double v = vVec.norm();
+    const Eigen::Vector3d hVec = rVec.cross(vVec);
+    double h = hVec.norm();
+    const Eigen::Vector3d nVec = Eigen::Vector3d::UnitZ().cross(hVec);
+    const Eigen::Vector3d eVec = ((v * v - mu / r) * rVec - (rVec.dot(vVec)) * vVec) / mu;
+
+    ClassicalElementsF32 elements{};
+
+    elements.radiusMagnitude = r;
+    elements.alpha = static_cast<float>(2.0 / r - v * v / mu);
+    elements.semiMajorAxis = std::abs(elements.alpha) > 1e-10 ? 1.0 / elements.alpha : 0.0;
+    elements.eccentricity = static_cast<float>(eVec.norm());
+    elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
+
+    auto Omega = static_cast<float>(std::atan2(nVec(1), nVec(0)));
+    elements.rightAscensionAscendingNode = Omega < 0 ? static_cast<float>(Omega + 2 * M_PI) : Omega;
+
+    auto omega = static_cast<float>(std::atan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec)));
+    elements.argPeriapsis = omega < 0 ? static_cast<float>(omega + 2 * M_PI) : omega;
+
+    auto f = static_cast<float>(std::atan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec)));
+    elements.trueAnomaly = f < 0 ? static_cast<float>(f + 2 * M_PI) : f;
+
+    elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);
+    elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);
+
+    return elements;
+}

--- a/src/architecture/utilities/orbitalMotion.hpp
+++ b/src/architecture/utilities/orbitalMotion.hpp
@@ -41,6 +41,31 @@ class EquinoctialElements {
     double a = 0, P1 = 0, P2 = 0, Q1 = 0, Q2 = 0, l = 0, L = 0;
 };
 
+class ClassicalElementsF32 {
+   public:
+    double semiMajorAxis = 0;
+    float eccentricity = 0;
+    float inclination = 0;
+    float rightAscensionAscendingNode = 0;
+    float argPeriapsis = 0;
+    float trueAnomaly = 0;
+    double radiusMagnitude = 0;
+    float alpha = 0;
+    double radiusPeriapsis = 0;
+    double radiusApoapsis = 0;
+};
+
+class EquinoctialElementsF32 {
+   public:
+    double a = 0;
+    float P1 = 0;
+    float P2 = 0;
+    float Q1 = 0;
+    float Q2 = 0;
+    float l = 0;
+    float L = 0;
+};
+
 class OrbitalMotion {
    public:
     static Eigen::Matrix3d hillFrameDCM(const Eigen::Vector3d& rc_N, const Eigen::Vector3d& vc_N);
@@ -84,6 +109,21 @@ class OrbitalMotion {
     static Eigen::Vector3d zonalHarmonicPerturbation(const Eigen::Vector3d& positionKm, int maxJ, CelestialObject body);
 
     static EquinoctialElements mapClassicalToEquinoctialElements(const ClassicalElements& classicals);
+
+    static float eccentricToTrueAnomalyF32(float E, float e);
+    static float eccentricToMeanAnomalyF32(float E, float e);
+    static float trueToEccentricAnomalyF32(float f, float e);
+    static float trueToHyperbolicAnomalyF32(float f, float e);
+    static float trueToMeanAnomalyF32(float f, float e);
+    static float hyperbolicToTrueAnomalyF32(float H, float e);
+    static float hyperbolicToMeanAnomalyF32(float H, float e);
+    static float meanToEccentricAnomalyF32(float M, float e);
+    static float meanToTrueAnomalyF32(float M, float e);
+    static float meanToHyperbolicAnomalyF32(float N, float e);
+    static CartesianState elementsToCartesianStateF32(double mu, const ClassicalElementsF32& elements);
+    static ClassicalElementsF32 cartesianStateToElementsF32(double mu,
+                                                            const Eigen::Vector3d& rVec,
+                                                            const Eigen::Vector3d& vVec);
 };
 
 #endif

--- a/src/fswAlgorithms/transDetermination/_GeneralModuleFiles/ephemerisUtilities.cpp
+++ b/src/fswAlgorithms/transDetermination/_GeneralModuleFiles/ephemerisUtilities.cpp
@@ -43,3 +43,29 @@ double calculateChebyValue(const double *coefficients,
 
     return estValue;
 }
+
+/*
+ * Function to evaluate a set of chebyshev polynomials (first argument) to a certain degree (second argument) at
+ * a specific point (evaluationPoint)
+ */
+float calculateChebyValueF32(const float *coefficients,
+                             const signed int numberOfCoefficients,
+                             const double evaluationPoint) {
+    float chebyPrev = 1.0;
+    float chebyNow = evaluationPoint;
+    const float valueMult = 2.0 * evaluationPoint;
+
+    float estValue = coefficients[0] * chebyPrev;
+    if (numberOfCoefficients <= 1) {
+        return estValue;
+    }
+    estValue += coefficients[1] * chebyNow;
+    for (int i = 2; i < numberOfCoefficients; ++i) {
+        const float chebyLocalPrev = chebyNow;
+        chebyNow = valueMult * chebyNow - chebyPrev;
+        chebyPrev = chebyLocalPrev;
+        estValue += coefficients[i] * chebyNow;
+    }
+
+    return estValue;
+}

--- a/src/fswAlgorithms/transDetermination/_GeneralModuleFiles/ephemerisUtilities.h
+++ b/src/fswAlgorithms/transDetermination/_GeneralModuleFiles/ephemerisUtilities.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif
 /*! Calculate Chebychev Polynominal */
 double calculateChebyValue(const double *chebyCoeff, const signed int nCoeff, const double evalValue);
+float calculateChebyValueF32(const float *chebyCoeff, const signed int nCoeff, const double evalValue);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-1840
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
Various functions inside `orbitalMotion` and `ephemerisUtilities` are duplicated to work with float inputs instead of doubles. For quantities such as position and time, doubles are still used because higher precision is needed for the possibly large values. However, for angular quantities, floats are used instead. This set of functions is needed on the external fp32 repo.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->
Tested on the external repo.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The functions inside `orbitalMotion` and `ephemerisUtilities` may be templated in the near future to work with both doubles or floats.
