### PR TITLE
Custom message template interface

### DIFF
--- a/src/architecture/messaging/msgAutoSource/generateSWIGModules.py
+++ b/src/architecture/messaging/msgAutoSource/generateSWIGModules.py
@@ -1,12 +1,11 @@
+#!/usr/bin/env python3
 import sys
 
 if __name__ == "__main__":
      moduleOutputPath = sys.argv[1]
-     headerinputPath = sys.argv[2]
+     swigTemplateFile = sys.argv[2]
      structType = sys.argv[3].split('Payload')[0]
      baseDir = sys.argv[4]
-
-     swigTemplateFile = 'msgInterfacePy.i.in'
 
      swigFid = open(swigTemplateFile, 'r')
      swigTemplateData = swigFid.read()

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -3,27 +3,27 @@
 %module {type}Payload
 %{{
     #include "{baseDir}/{type}Payload.h"
-    #include "architecture/messaging/messaging.h"
-    #include "architecture/msgPayloadDef/ReconfigBurnInfoMsgPayload.h"
-    #include "architecture/msgPayloadDef/RWConfigElementMsgPayload.h"
-    #include "architecture/msgPayloadDef/THRConfigMsgPayload.h"
-    #include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
+    #include <architecture/messaging/messaging.h>
+    #include <architecture/msgPayloadDef/ReconfigBurnInfoMsgPayload.h>
+    #include <architecture/msgPayloadDef/RWConfigElementMsgPayload.h>
+    #include <architecture/msgPayloadDef/THRConfigMsgPayload.h>
+    #include <simulation/dynamics/reactionWheels/reactionWheelSupport.h>
     #include <stdint.h>
     #include <vector>
     #include <string>
 %}}
 %include "architecture/messaging/newMessaging.ih"
 
-%include "std_vector.i"
-%include "std_string.i"
-%include "architecture/_GeneralModuleFiles/swig_eigen.i"
-%include "architecture/_GeneralModuleFiles/swig_conly_data.i"
-%include "stdint.i"
+%include <std_vector.i>
+%include <std_string.i>
+%include <architecture/_GeneralModuleFiles/swig_eigen.i>
+%include <architecture/_GeneralModuleFiles/swig_conly_data.i>
+%include <stdint.i>
 %template(TimeVector) std::vector<unsigned long long, std::allocator<unsigned long long>>;
 %template(DoubleVector) std::vector<double, std::allocator<double>>;
 %template(StringVector) std::vector<std::string, std::allocator<std::string>>;
 
-%include "architecture/msgPayloadDef/definitions.h"
+%include <architecture/msgPayloadDef/definitions.h>
 %include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 %include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
 ARRAYINTASLIST(FSWdeviceAvailability)
@@ -34,8 +34,8 @@ STRUCTASLIST(CSSArraySensorMsgPayload)
 STRUCTASLIST(THRConfigMsgPayload)
 STRUCTASLIST(ReconfigBurnInfoMsgPayload)
 
-%include "architecture/messaging/messaging.h"
-%include "architecture/_GeneralModuleFiles/sys_model.h"
+%include <architecture/messaging/messaging.h>
+%include <architecture/_GeneralModuleFiles/sys_model.h>
 
 %rename(__subscribe_to) subscribeTo;  // we want the users to have a unified "subscribeTo" interface
 %rename(__is_subscribed_to) isSubscribedTo;  // we want the users to have a unified "isSubscribedTo" interface
@@ -43,9 +43,6 @@ STRUCTASLIST(ReconfigBurnInfoMsgPayload)
 %rename(__timeWritten_vector) timesWritten;
 %rename(__record_vector) record;
 
-%pythoncode %{{
-import numpy as np
-%}};
 %include "{baseDir}/{type}Payload.h"
 INSTANTIATE_TEMPLATES({type}, {type}Payload, {baseDir})
 %template({type}OutMsgsVector) std::vector<Message<{type}Payload>, std::allocator<Message<{type}Payload>> >;

--- a/src/cmake/XmeraFramework.cmake
+++ b/src/cmake/XmeraFramework.cmake
@@ -145,6 +145,12 @@ function(xmera_add_swig_module module)
 endfunction()
 
 function(xmera_add_swig_message message)
+  cmake_parse_arguments(PARSE_ARGV 1 arg "" "TEMPLATE" "")
+
+  if(NOT (DEFINED arg_TEMPLATE))
+    set(arg_TEMPLATE "${CMAKE_SOURCE_DIR}/architecture/messaging/msgAutoSource/msgInterfacePy.i.in")
+  endif()
+
   set_property(GLOBAL APPEND PROPERTY XMERA_REGISTERED_MESSAGES "${message}")
 
   add_custom_command(
@@ -155,7 +161,7 @@ function(xmera_add_swig_message message)
       "${Python3_EXECUTABLE}"
       "${CMAKE_SOURCE_DIR}/architecture/messaging/msgAutoSource/generateSWIGModules.py"
       "${CMAKE_CURRENT_BINARY_DIR}/${message}.i"
-      "${CMAKE_CURRENT_SOURCE_DIR}/${message}.h"
+      "${arg_TEMPLATE}"
       "${message}"
       "${CMAKE_CURRENT_SOURCE_DIR}"
     WORKING_DIRECTORY
@@ -164,7 +170,7 @@ function(xmera_add_swig_message message)
       "${CMAKE_CURRENT_SOURCE_DIR}/${message}.h"
     DEPENDS
       "${CMAKE_SOURCE_DIR}/architecture/messaging/msgAutoSource/generateSWIGModules.py"
-      "${CMAKE_SOURCE_DIR}/architecture/messaging/msgAutoSource/msgInterfacePy.i.in"
+      "${arg_TEMPLATE}"
     VERBATIM
     DEPENDS_EXPLICIT_ONLY
   )


### PR DESCRIPTION
* **Tickets addressed:** #555
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR introduces the facility to supply a custom SWIG interface file template alongside the registration of a message in CMake via `xmera_add_swig_message`. 

The current message template msgInterfacePy.i.in provides a catch all mechanism for the generation of a SWIG interface file for each message added to the build. Xmera supports the addition of multiple contrib projects/module roots (and their message definitions) to the build. These contrib messages may only make use of those SWIG definitions that exist in the msgInterfacePy.i.in. To make customizations to the generated SWIG interface one would need to edit the core msgInterfacePy.i.in. This is an unacceptable coupling, therefore, this PR.

## Verification
This has been manually verified against other contrib repositories. A formal continuous integration of this feature is being setup with an example contrib repository.

## Documentation
Will be updated when rebuilt/written.

## Future work
None
