### PR TITLE
Add missing std_vector.i

### DIFF
--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020, Autonomous Vehicle Systems Lab, Univeristy of Colorado at Boulder
+Copyright (c) 2020, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -24,6 +24,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 #include <vector>
 %}
+
+%include <std_vector.i>
 
 %define INSTANTIATE_TEMPLATES(messageType, messageTypePayload, folder)
 %{


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR adds the <std_vector.i> include into `newMessaging.ih`. The interface header relies on this inclusion and was previously working because the include was available transitively via the `msgInterfacePy.i.in` which includes `newMessaging.ih`. 

## Verification
All tests pass

## Documentation
NA

## Future work
None
