### PR TITLE
Add Google fuzztest to Xmera

### DIFF
--- a/.github/scripts/run_long_fuzzers.sh
+++ b/.github/scripts/run_long_fuzzers.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <build_dir> <log_dir> [--fuzz-for <duration>] [--corpus <path>]" >&2
+  exit 2
+fi
+
+BUILD_DIR="$1"
+LOG_DIR="$2"
+shift 2
+
+FUZZ_DURATION="30s"
+CORPUS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fuzz-for)
+      [[ $# -ge 2 ]] || { echo "--fuzz-for requires a value" >&2; exit 2; }
+      FUZZ_DURATION="$2"
+      shift 2
+      ;;
+    --corpus)
+      [[ $# -ge 2 ]] || { echo "--corpus requires a path" >&2; exit 2; }
+      CORPUS_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR"
+if [[ -n "$CORPUS_DIR" ]]; then
+  mkdir -p "$CORPUS_DIR"
+fi
+
+FUZZ_BINS=$(BUILD_DIR="$BUILD_DIR" python - <<'PY'
+import json, os, subprocess
+build_dir = os.environ["BUILD_DIR"]
+proc = subprocess.run(
+    ["ctest", "--show-only=json-v1", "-L", "fuzz"],
+    capture_output=True, text=True, check=True,
+    cwd=build_dir
+)
+data = json.loads(proc.stdout or "{}")
+seen = []
+for test in data.get("tests", []):
+    cmd = test.get("command", [])
+    if cmd:
+        exe = cmd[0]
+        if exe not in seen:
+            seen.append(exe)
+print("\n".join(seen))
+PY
+)
+if [[ -z "$FUZZ_BINS" ]]; then
+  echo "No fuzz executables discovered via CTest labels." >&2
+  exit 1
+fi
+while IFS= read -r fuzz_bin; do
+  [[ -z "$fuzz_bin" ]] && continue
+  fuzz_name="$(basename "$fuzz_bin")"
+  echo ">>> Running long fuzz session for ${fuzz_name}"
+  cmd=("$fuzz_bin")
+  if [[ -n "$FUZZ_DURATION" ]]; then
+    cmd+=("--fuzz_for=${FUZZ_DURATION}")
+  fi
+  if [[ -n "$CORPUS_DIR" ]]; then
+    cmd+=("--corpus_database=${CORPUS_DIR}")
+  fi
+  "${cmd[@]}" | tee "$LOG_DIR/${fuzz_name}.log"
+done <<< "$FUZZ_BINS"

--- a/.github/workflows/nightly-long-tests.yml
+++ b/.github/workflows/nightly-long-tests.yml
@@ -1,0 +1,154 @@
+name: Nightly Long Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  USERNAME: ${{ github.repository_owner }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+  VCPKG_FEATURE_FLAGS: "manifests,registries,binarycaching"
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_OUTPUT_ON_FAILURE: 1
+  XMERA_FUZZTEST_CORPUS_DIR: ${{ github.workspace }}/.fuzztest_corpus
+
+jobs:
+  nightly-long:
+    name: Long tests & fuzzing (ubuntu-24.04 / Clang)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore fuzz corpus cache
+        id: fuzz-corpus-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .fuzztest_corpus
+          key: fuzz-corpus-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ runner.os }}-
+
+      - name: Ensure fuzz corpus directory exists
+        run: mkdir -p .fuzztest_corpus
+
+      - name: Install Clang 18
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-18 lld-18
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 180
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 180
+          sudo update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-18 180
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build build-essential \
+            pkg-config autoconf automake libtool \
+            zip unzip \
+            bison swig \
+            mono-complete
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.28.3'
+
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+          vcpkgJsonGlob: "src/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "src/vcpkg-configuration.json"
+
+      - name: Add NuGet sources for vcpkg binary cache (portable)
+        env:
+          VCPKG_EXE: ${{ runner.workspace }}/b/vcpkg/vcpkg
+        run: |
+          set -euo pipefail
+          NUGET="$(${VCPKG_EXE} fetch nuget | tail -n 1)"
+
+          # Build the command invocation safely (handles paths with spaces)
+          if [[ "$NUGET" == *.exe ]]; then
+            NUGET_CMD=(mono "$NUGET")
+          else
+            # e.g., "nuget" shim from Mono on macOS, or a native path
+            NUGET_CMD=("$NUGET")
+          fi
+
+          echo "Using NuGet CLI: ${NUGET_CMD[*]}"
+
+          "${NUGET_CMD[@]}" sources add \
+            -Source "${FEED_URL}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${USERNAME}" \
+            -Password "${{ secrets.GH_VCPKG_PACKAGES_TOKEN }}"
+
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.GH_VCPKG_PACKAGES_TOKEN }}" \
+            -Source "${FEED_URL}"
+
+      - name: Configure long-test preset (ASan/UBSan fuzzing)
+        working-directory: src
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,${{ env.FEED_URL }},readwrite"
+          CC: clang
+          CXX: clang++
+        run: cmake --preset fuzz-test
+
+      - name: Build targets
+        working-directory: src
+        env:
+          CC: clang
+          CXX: clang++
+        run: cmake --build ../build --parallel
+
+      - name: Run C/C++ tests (includes fuzz smoke)
+        working-directory: build
+        env:
+          XMERA_FUZZTEST_REPLAY_CORPUS: __ALL__
+          XMERA_FUZZTEST_REPLAY_FOR: inf
+        run: ctest --output-on-failure
+
+      - name: Run long fuzzers
+        working-directory: build
+        env:
+          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:check_initialization_order=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:suppressions=/dev/null
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/run_long_fuzzers.sh" "$(pwd)" "${GITHUB_WORKSPACE}/fuzz-logs" \
+            --fuzz-for 600s \
+            --corpus "${XMERA_FUZZTEST_CORPUS_DIR}"
+
+      - name: Archive fuzz logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-logs
+          path: fuzz-logs
+          retention-days: 7
+
+      - name: Upload fuzz corpus artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-corpus-${{ github.run_id }}
+          path: .fuzztest_corpus
+          retention-days: 7
+
+      - name: Save fuzz corpus cache
+        if: ${{ always() }}
+        uses: actions/cache/save@v4
+        with:
+          path: .fuzztest_corpus
+          key: fuzz-corpus-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -175,7 +175,7 @@ jobs:
         working-directory: src
         env:
           VCPKG_BINARY_SOURCES: "clear;nuget,${{ env.FEED_URL }},readwrite"
-        run: cmake --preset ci-test
+        run: cmake --preset fuzz-smoke-test
 
       - name: Build
         working-directory: src
@@ -201,9 +201,11 @@ jobs:
           path: junit/test-results-${{ matrix.python-version }}.xml
           retention-days: 7
 
-      - name: Run C/C++ tests
+      - name: Run C/C++ unit tests (include fuzz-smoke)
         working-directory: ./build
-        run: ctest --output-on-failure
+        env:
+          CTEST_PARALLEL_LEVEL: 1
+        run: ctest --output-on-failure -LE fuzz
 
       - name: Upload CMake & test logs on failure
         if: ${{ failure() }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,7 @@ endif()
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 find_package(SWIG REQUIRED)
 find_package(Eigen3 CONFIG REQUIRED)
-find_package(GTest REQUIRED)
-enable_testing()
+include(XmeraGoogleTest)
 
 # Patch the Python3::Module interface link options to be more selective,
 # so that all symbols must be resolved at link time *except* those that we know

--- a/src/CMakePresets.json
+++ b/src/CMakePresets.json
@@ -16,8 +16,6 @@
           "${sourceDir}/cmake/",
         "CMAKE_BUILD_TYPE":
           "Debug",
-        "CMAKE_INSTALL_MODE":
-          "SYMLINK_OR_COPY",
         "CMAKE_INSTALL_PREFIX":
           "${sourceDir}/../dist",
         "XMERA_MODULE_ROOTS":
@@ -25,7 +23,9 @@
         "XMERA_ENABLE_GROUPS":
           "simulation;fswAlgorithms;moduleTemplates",
         "XMERA_ENABLE_INTERNAL":
-          "YES"
+          "YES",
+        "XMERA_ENABLE_FUZZTESTS":
+          "OFF"
       }
     },
     {
@@ -34,6 +34,22 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE":
           "Release"
+      }
+    },
+    {
+      "name": "fuzz-smoke-test",
+      "inherits": "ci-test",
+      "cacheVariables": {
+        "XMERA_ENABLE_FUZZTESTS":
+          "ON"
+      }
+    },
+    {
+      "name": "fuzz-test",
+      "inherits": "fuzz-smoke-test",
+      "cacheVariables": {
+        "FUZZTEST_FUZZING_MODE":
+          "ON"
       }
     }
   ],

--- a/src/cmake/XmeraGoogleTest.cmake
+++ b/src/cmake/XmeraGoogleTest.cmake
@@ -1,0 +1,31 @@
+option(XMERA_ENABLE_FUZZTESTS "Fetch and build fuzz targets with Google FuzzTest" OFF)
+#option(XMERA_ENABLE_SANITIZERS "Build Xmera with ASan/UBSan instrumentation" OFF)
+
+if(XMERA_ENABLE_FUZZTESTS)
+  include(FetchContent)
+
+  set(XMERA_FUZZTEST_GIT_TAG "2025-08-05"
+    CACHE STRING
+    "Git tag or commit to use for the Google FuzzTest dependency"
+  )
+
+  FetchContent_Declare(
+    fuzztest
+    GIT_REPOSITORY https://github.com/google/fuzztest.git
+    GIT_TAG main   # or a specific commit/tag
+  )
+
+  # Make fuzztest's own stuff quiet and out of 'all'
+  set(FETCHCONTENT_FUZZTEST_EXCLUDE_FROM_ALL ON)
+
+  # Turn off fuzztest's own tests / gtest download
+  set(FUZZTEST_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  set(FUZZTEST_DOWNLOAD_GTEST OFF CACHE BOOL "" FORCE)
+  set(ANTLR_BUILD_CPP_TESTS OFF CACHE BOOL "Disable building ANTLR4 tests" FORCE)
+  set(ANTLR_BUILD_SHARED OFF CACHE BOOL "Disable building ANTLR4 shared library" FORCE)
+
+  FetchContent_MakeAvailable(fuzztest)
+endif()
+
+find_package(GTest REQUIRED)
+enable_testing()


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR adds the C/C++ test fuzzing infrastructure google/fuzztest. This allows the Xmera and other root repositories to develop and run fuzz tests. A new github workflow is add to run fuzz tests nightly. The project CMake presets have been updated as follows. A preset named `fuzz-smoke-test` is added which enables the CMake option `XMERA_ENABLE_FUZZTESTS` which controls the download and build of the fuzztest infrastructure from github, and controls the compilation of the project's fuzztest targets. With this preset the tests will run as if they are normal C/C++ tests with no fuzzing. A further preset named `fuzz-test` sets the fuzztest cmake option `FUZZTEST_FUZZING_MODE` which allows for fuzztests to be run with a fuzzer.  

## Verification
The `fuzz-smoke-test` is now the CI's default CMake preset. This runs successfully. The `fuzz-test` preset is used in the new github workflow and has been tested manually with the development of this PR.

## Documentation
The new documentation is almost finished and the details of how to use test fuzzing will be added also.

## Future work
A subsequent PR will make additions which store the corpora of fuzzed parameters so that future fuzzing runs can continue to search the test domain and range.
