### PR TITLE
Feature/getter access for mrp rotation

### DIFF
--- a/src/fswAlgorithms/attGuidance/mrpRotation/_UnitTest/test_mrpRotation.py
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/_UnitTest/test_mrpRotation.py
@@ -140,9 +140,9 @@ def test_mrp_rotation(show_plots, cmd_state_flag, test_reset):
 
     # Initialize the test module configuration data
     sigma_RR0 = np.array([0.3, .5, 0.0])
-    module.setSigmaRR0(sigma_RR0)
+    module.sigma_RR0 = sigma_RR0
     omega_RR0_R = np.array([0.1, 0.0, 0.0]) * mc.D2R
-    module.setOmegaRR0(omega_RR0_R)
+    module.omega_RR0_R = omega_RR0_R
 
     if cmd_state_flag:
         desired_att = messaging.AttStateMsgPayload()

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.cpp
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.cpp
@@ -47,7 +47,7 @@ void MrpRotation::setSigmaRR0(const Eigen::Vector3d& sigma) { this->algorithm.se
 /*! Getter method for the current MRP attitude coordinate set with respect to the input reference
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d& MrpRotation::getSigmaRR0() const { return this->algorithm.getSigmaRR0(); }
+const Eigen::Vector3d MrpRotation::getSigmaRR0() const { return this->algorithm.getSigmaRR0(); }
 
 /*! Setter method for the angular velocity vector relative to input reference
  @return void
@@ -58,4 +58,4 @@ void MrpRotation::setOmegaRR0(const Eigen::Vector3d& omega) { this->algorithm.se
 /*! Getter method for the angular velocity vector relative to input reference
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d& MrpRotation::getOmegaRR0() const { return this->algorithm.getOmegaRR0(); }
+const Eigen::Vector3d MrpRotation::getOmegaRR0() const { return this->algorithm.getOmegaRR0(); }

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.h
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.h
@@ -20,9 +20,9 @@ class MrpRotation : public SysModel {
     void updateState(uint64_t callTime) override;
 
     void setSigmaRR0(const Eigen::Vector3d& sigma);
-    const Eigen::Vector3d& getSigmaRR0() const;
+    const Eigen::Vector3d getSigmaRR0() const;
     void setOmegaRR0(const Eigen::Vector3d& omega);
-    const Eigen::Vector3d& getOmegaRR0() const;
+    const Eigen::Vector3d getOmegaRR0() const;
 
     Message<AttRefMsgPayload> attRefOutMsg;           //!< output message containing the Reference
     ReadFunctor<AttRefMsgPayload> attRefInMsg;        //!< guidance reference input message

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.i
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.i
@@ -3,6 +3,10 @@
    #include "mrpRotation.h"
 %}
 
+%include <attribute.i>
+%attribute(MrpRotation, Eigen::Vector3d, sigma_RR0, getSigmaRR0, setSigmaRR0)
+%attribute(MrpRotation, Eigen::Vector3d, omega_RR0_R, getOmegaRR0, setOmegaRR0)
+
 %include <architecture/_GeneralModuleFiles/sys_model.i>
 %include <architecture/_GeneralModuleFiles/swig_conly_data.i>
 %include <architecture/_GeneralModuleFiles/swig_eigen.i>

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotationAlgorithm.cpp
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotationAlgorithm.cpp
@@ -124,7 +124,7 @@ void MrpRotationAlgorithm::setSigmaRR0(const Eigen::Vector3d& sigma) { this->sig
 /*! Getter method for the current MRP attitude coordinate set with respect to the input reference
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d& MrpRotationAlgorithm::getSigmaRR0() const { return this->sigma_RR0; }
+const Eigen::Vector3d MrpRotationAlgorithm::getSigmaRR0() const { return this->sigma_RR0; }
 
 /*! Setter method for the angular velocity vector relative to input reference
  @return void
@@ -135,7 +135,7 @@ void MrpRotationAlgorithm::setOmegaRR0(const Eigen::Vector3d& omega) { this->ome
 /*! Getter method for the angular velocity vector relative to input reference
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d& MrpRotationAlgorithm::getOmegaRR0() const { return this->omega_RR0_R; }
+const Eigen::Vector3d MrpRotationAlgorithm::getOmegaRR0() const { return this->omega_RR0_R; }
 
 /*! Enable dynamic reference input
  @return void

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotationAlgorithm.h
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotationAlgorithm.h
@@ -20,9 +20,9 @@ class MrpRotationAlgorithm {
                                                  Eigen::Vector3d domega_R0N_N);
 
     void setSigmaRR0(const Eigen::Vector3d& sigma);
-    const Eigen::Vector3d& getSigmaRR0() const;
+    const Eigen::Vector3d getSigmaRR0() const;
     void setOmegaRR0(const Eigen::Vector3d& omega);
-    const Eigen::Vector3d& getOmegaRR0() const;
+    const Eigen::Vector3d getOmegaRR0() const;
     void enableDynamicReference();
     const bool isDynamicReferenceEnabled() const;
 


### PR DESCRIPTION
* **Tickets addressed:** xmera-562
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description
Currently for mrpRotation, the getter methods are not accessible from python. To fix this, I removed the pass by reference for the getter methods. Addionally, I added the attribute call in the .i file for the setter and getter so that we can access the class variables just like we normally would for a python class.

## Verification
All of the tests pass

## Documentation
None

## Future work
None
