### PR TITLE
Fix: fuzztest macro to add address sanitizer compiler flags

### DIFF
--- a/src/cmake/XmeraGoogleTest.cmake
+++ b/src/cmake/XmeraGoogleTest.cmake
@@ -1,5 +1,4 @@
 option(XMERA_ENABLE_FUZZTESTS "Fetch and build fuzz targets with Google FuzzTest" OFF)
-#option(XMERA_ENABLE_SANITIZERS "Build Xmera with ASan/UBSan instrumentation" OFF)
 
 if(XMERA_ENABLE_FUZZTESTS)
   include(FetchContent)
@@ -25,6 +24,8 @@ if(XMERA_ENABLE_FUZZTESTS)
   set(ANTLR_BUILD_SHARED OFF CACHE BOOL "Disable building ANTLR4 shared library" FORCE)
 
   FetchContent_MakeAvailable(fuzztest)
+
+  fuzztest_setup_fuzzing_flags()
 endif()
 
 find_package(GTest REQUIRED)


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
I erroneously deleted the line which configures address sanitization when building with the `fuzz-test` preset.

## Verification
All tests run.

## Documentation
None

## Future work
None
