### PR TITLE
Resolve eigenSupport.h static analysis warnings

### DIFF
--- a/examples/BskSim/models/BSK_FormationFsw.py
+++ b/examples/BskSim/models/BSK_FormationFsw.py
@@ -178,9 +178,9 @@ class BSKFswModels():
 
     def SetRWMotorTorque(self):
         controlAxes_B = [
-          1.0, 0.0, 0.0,
-          0.0, 1.0, 0.0,
-          0.0, 0.0, 1.0]
+          [1.0, 0.0, 0.0],
+          [0.0, 1.0, 0.0],
+          [0.0, 0.0, 1.0]]
 
         self.rwMotorTorque.controlAxes_B = controlAxes_B
         self.rwMotorTorque.vehControlInMsg.subscribeTo(self.cmdTorqueMsg)

--- a/examples/BskSim/models/BSK_Fsw.py
+++ b/examples/BskSim/models/BSK_Fsw.py
@@ -415,9 +415,9 @@ class BSKFswModels:
     def SetRWMotorTorque(self):
         """Set the RW motor torque information"""
         controlAxes_B = [
-            1.0, 0.0, 0.0
-            , 0.0, 1.0, 0.0
-            , 0.0, 0.0, 1.0
+            [1.0, 0.0, 0.0]
+            , [0.0, 1.0, 0.0]
+            , [0.0, 0.0, 1.0]
         ]
         self.rwMotorTorque.controlAxes_B = controlAxes_B
         self.rwMotorTorque.vehControlInMsg.subscribeTo(self.cmdTorqueMsg)

--- a/examples/BskSim/models/BSK_SEPFsw.py
+++ b/examples/BskSim/models/BSK_SEPFsw.py
@@ -491,9 +491,9 @@ class BSKFswModels:
         """
         Defines the motor torque from the control law
         """
-        controlAxes_B = [1.0, 0.0, 0.0,
-                         0.0, 1.0, 0.0,
-                         0.0, 0.0, 1.0]
+        controlAxes_B = [[1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0],
+                         [0.0, 0.0, 1.0]]
 
         self.rwMotorTorqueData.controlAxes_B = controlAxes_B
         self.rwMotorTorqueData.vehControlInMsg.subscribeTo(self.mrpFeedbackRWsData.cmdTorqueOutMsg)

--- a/examples/MultiSatBskSim/modelsMultiSat/BSK_MultiSatFsw.py
+++ b/examples/MultiSatBskSim/modelsMultiSat/BSK_MultiSatFsw.py
@@ -236,9 +236,9 @@ class BSKFswModels:
         """
         Defines the motor torque from the control law.
         """
-        controlAxes_B = [1.0, 0.0, 0.0,
-                         0.0, 1.0, 0.0,
-                         0.0, 0.0, 1.0]
+        controlAxes_B = [[1.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0],
+                         [0.0, 0.0, 1.0]]
 
         self.rwMotorTorque.controlAxes_B = controlAxes_B
         self.rwMotorTorque.vehControlInMsg.subscribeTo(self.mrpFeedbackRWs.cmdTorqueOutMsg)

--- a/examples/OpNavScenarios/modelsOpNav/BSK_OpNavFsw.py
+++ b/examples/OpNavScenarios/modelsOpNav/BSK_OpNavFsw.py
@@ -392,10 +392,9 @@ class BSKFswModels():
         self.fswRwConfigMsg = fswSetupRW.writeConfigMessage()
 
     def SetRWMotorTorque(self, SimBase):
-        controlAxes_B = [
-                        1.0, 0.0, 0.0
-                        , 0.0, 1.0, 0.0
-                        , 0.0, 0.0, 1.0
+        controlAxes_B = [[1.0, 0.0, 0.0]
+                        , [0.0, 1.0, 0.0]
+                        , [0.0, 0.0, 1.0]
                         ]
         self.rwMotorTorque.controlAxes_B = controlAxes_B
         self.rwMotorTorque.vehControlInMsg.subscribeTo(self.mrpFeedbackRWs.cmdTorqueOutMsg)

--- a/examples/scenarioAttitudeConstrainedManeuver.py
+++ b/examples/scenarioAttitudeConstrainedManeuver.py
@@ -265,7 +265,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     scSim.AddModelToTask(simTaskName, rwMotorTorqueObj)
 
     # Make the RW control all three body axes
-    controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 
     # Boresight vector modules.

--- a/examples/scenarioAttitudeConstraintViolation.py
+++ b/examples/scenarioAttitudeConstraintViolation.py
@@ -308,7 +308,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     scSim.AddModelToTask(simTaskName, rwMotorTorqueObj)
 
     # Make the RW control all three body axes
-    controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 
     # Boresight vector modules.

--- a/examples/scenarioAttitudeFeedbackRW.py
+++ b/examples/scenarioAttitudeFeedbackRW.py
@@ -492,7 +492,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioAttitudeFeedbackRWPower.py
+++ b/examples/scenarioAttitudeFeedbackRWPower.py
@@ -289,7 +289,7 @@ def run(show_plots, useRwPowerGeneration):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioAttitudeSteering.py
+++ b/examples/scenarioAttitudeSteering.py
@@ -388,9 +388,9 @@ def run(show_plots, simCase):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0,
-        0, 1, 0,
-        0, 0, 1
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioCielimAttitudeFeedbackRW.py
+++ b/examples/scenarioCielimAttitudeFeedbackRW.py
@@ -242,7 +242,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueConfig.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioEarthPoint.py
+++ b/examples/scenarioEarthPoint.py
@@ -307,7 +307,7 @@ def run( showPlots):
     # add module that maps the Lr control torque into the RW motor torques
     rwMotorTorqueObj = rwMotorTorque.RwMotorTorque()
     rwMotorTorqueObj.modelTag = "rwMotorTorque"
-    rwMotorTorqueObj.controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    rwMotorTorqueObj.controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     scSim.AddModelToTask(fswTask, rwMotorTorqueObj, 20)
 
     # Connect messages

--- a/examples/scenarioFlybyPoint.py
+++ b/examples/scenarioFlybyPoint.py
@@ -204,7 +204,7 @@ def run(show_plots, zeroEarthGravity, dtFilterData):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueConfig.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -359,7 +359,7 @@ def run(show_plots):
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioHohmann.py
+++ b/examples/scenarioHohmann.py
@@ -280,7 +280,7 @@ def run(show_plots, rFirst, rSecond):
     # Add module that maps the Lr control torque into the RW motor torques
     rwMotorTorqueObj = rwMotorTorque.RwMotorTorque()
     rwMotorTorqueObj.modelTag = "rwMotorTorque"
-    controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
     scSim.AddModelToTask(fswTaskName, rwMotorTorqueObj)
 

--- a/examples/scenarioHohmann.py
+++ b/examples/scenarioHohmann.py
@@ -232,8 +232,7 @@ def run(show_plots, rFirst, rSecond):
 
     firstBurnMRPRotation = mrpRotation.MrpRotation()
     firstBurnMRPRotation.modelTag = "mrpRotation"
-    sigma_RR0 = np.array([np.tan(- np.pi / 8), 0, 0])
-    firstBurnMRPRotation.setSigmaRR0(sigma_RR0)
+    firstBurnMRPRotation.sigma_RR0 = np.array([np.tan(- np.pi / 8), 0, 0])
     scSim.AddModelToTask("firstBurnTask", firstBurnMRPRotation)
     firstBurnMRPRotation.attRefOutMsg = attRefMsg
 
@@ -247,8 +246,7 @@ def run(show_plots, rFirst, rSecond):
     # Need to get this reference attitude to rotate 180
     secondBurnMRPRotation = mrpRotation.MrpRotation()
     secondBurnMRPRotation.modelTag = "mrpRotation"
-    sigma_RR0 = np.array([np.tan(np.pi / 8), 0, 0])
-    secondBurnMRPRotation.setSigmaRR0(sigma_RR0)
+    secondBurnMRPRotation.sigma_RR0 = np.array([np.tan(np.pi / 8), 0, 0])
     scSim.AddModelToTask("secondBurnTask", secondBurnMRPRotation)
     secondBurnMRPRotation.attRefOutMsg = attRefMsg
 

--- a/examples/scenarioMomentumDumping.py
+++ b/examples/scenarioMomentumDumping.py
@@ -275,7 +275,7 @@ def run(show_plots):
     mrpControl.setK((mrpControl.getP()/xi)*(mrpControl.getP()/xi)/np.max(I))
     mrpControl.setIntegralLimit(2. / mrpControl.getKi() * 0.1)
 
-    controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
     # add module that maps the Lr control torque into the RW motor torques
     rwMotorTorqueObj = rwMotorTorque.RwMotorTorque()

--- a/examples/scenarioMomentumDumpingZeroNetForce.py
+++ b/examples/scenarioMomentumDumpingZeroNetForce.py
@@ -284,7 +284,7 @@ def run(show_plots):
     mrpControl.setK((mrpControl.getP()/xi)*(mrpControl.getP()/xi)/np.max(I))
     mrpControl.setIntegralLimit(2. / mrpControl.getKi() * 0.1)
 
-    controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
     # add module that maps the Lr control torque into the RW motor torques
     rwMotorTorqueObj = rwMotorTorque.RwMotorTorque()

--- a/examples/scenarioMonteCarloAttRW.py
+++ b/examples/scenarioMonteCarloAttRW.py
@@ -534,11 +534,7 @@ def createScenarioAttitudeFeedbackRW():
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mrpControl.cmdTorqueOutMsg)
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(fswRwConfMsg)
     # Make the RW control all three body axes
-    controlAxes_B = [
-             1,0,0
-            ,0,1,0
-            ,0,0,1
-        ]
+    controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 
     fswRWVoltage = rwMotorVoltage.RwMotorVoltage(0.0, 10.0)

--- a/examples/scenarioMtbMomentumManagement.py
+++ b/examples/scenarioMtbMomentumManagement.py
@@ -367,7 +367,7 @@ def run(show_plots):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioMtbMomentumManagementSimple.py
+++ b/examples/scenarioMtbMomentumManagementSimple.py
@@ -429,7 +429,7 @@ def run(show_plots):
 
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -354,7 +354,7 @@ def run(show_plots):
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
     # Make the RW control all three body axes
     controlAxes_B = [
-        1, 0, 0, 0, 1, 0, 0, 0, 1
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -412,7 +412,7 @@ def run(show_plots):
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(rwConfigMsg)
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mrpFeedbackControl.cmdTorqueOutMsg)
-    rwMotorTorqueObj.controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    rwMotorTorqueObj.controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
 
     # Connect the smallBodyEKF output messages to the relevant modules

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -630,7 +630,7 @@ def run(show_plots):
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(rwConfigMsg)
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mrpFeedbackControl.cmdTorqueOutMsg)
-    rwMotorTorqueObj.controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    rwMotorTorqueObj.controlAxes_B = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
 
     # Create the Lyapunov feedback controller

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -312,15 +312,11 @@ Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT>& mrp) {
  * @return Eigen::Matrix3 representing the rotation.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> eigenM1(const ScalarT angle) {
-    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+Eigen::Matrix3<ScalarT> eigenM1(ScalarT angle) {
+    const ScalarT c = std::cos(angle);
+    const ScalarT s = std::sin(angle);
 
-    mOut(1, 1) = std::cos(angle);
-    mOut(1, 2) = std::sin(angle);
-    mOut(2, 1) = -std::sin(angle);
-    mOut(2, 2) = std::cos(angle);
-
-    return mOut;
+    return Eigen::Matrix3<ScalarT>{{ScalarT{1}, ScalarT{0}, ScalarT{0}}, {ScalarT{0}, c, s}, {ScalarT{0}, -s, c}};
 }
 
 /**
@@ -331,15 +327,11 @@ Eigen::Matrix3<ScalarT> eigenM1(const ScalarT angle) {
  * @return Eigen::Matrix3 representing the rotation.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> eigenM2(const ScalarT angle) {
-    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+Eigen::Matrix3<ScalarT> eigenM2(ScalarT angle) {
+    const ScalarT c = std::cos(angle);
+    const ScalarT s = std::sin(angle);
 
-    mOut(0, 0) = std::cos(angle);
-    mOut(0, 2) = -std::sin(angle);
-    mOut(2, 0) = std::sin(angle);
-    mOut(2, 2) = std::cos(angle);
-
-    return mOut;
+    return Eigen::Matrix3<ScalarT>{{c, ScalarT{0}, -s}, {ScalarT{0}, ScalarT{1}, ScalarT{0}}, {s, ScalarT{0}, c}};
 }
 
 /**
@@ -350,15 +342,11 @@ Eigen::Matrix3<ScalarT> eigenM2(const ScalarT angle) {
  * @return Eigen::Matrix3 representing the rotation.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> eigenM3(const ScalarT angle) {
-    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+Eigen::Matrix3<ScalarT> eigenM3(ScalarT angle) {
+    const ScalarT c = std::cos(angle);
+    const ScalarT s = std::sin(angle);
 
-    mOut(0, 0) = std::cos(angle);
-    mOut(0, 1) = std::sin(angle);
-    mOut(1, 0) = -std::sin(angle);
-    mOut(1, 1) = std::cos(angle);
-
-    return mOut;
+    return Eigen::Matrix3<ScalarT>{{c, s, ScalarT{0}}, {-s, c, ScalarT{0}}, {ScalarT{0}, ScalarT{0}, ScalarT{1}}};
 }
 
 /**
@@ -370,18 +358,13 @@ Eigen::Matrix3<ScalarT> eigenM3(const ScalarT angle) {
  */
 template <typename Derived>
 Eigen::Matrix3<typename Eigen::MatrixBase<Derived>::Scalar> eigenTilde(const Eigen::MatrixBase<Derived>& vec) {
-    using Scalar = typename Eigen::MatrixBase<Derived>::Scalar;
+    using Scalar = Eigen::MatrixBase<Derived>::Scalar;
 
-    Eigen::Matrix3<Scalar> mOut = Eigen::Matrix3<Scalar>::Zero();
+    const Scalar vx = vec(0);
+    const Scalar vy = vec(1);
+    const Scalar vz = vec(2);
 
-    mOut(0, 1) = -vec(2);
-    mOut(1, 0) = vec(2);
-    mOut(0, 2) = vec(1);
-    mOut(2, 0) = -vec(1);
-    mOut(1, 2) = -vec(0);
-    mOut(2, 1) = vec(0);
-
-    return mOut;
+    return Eigen::Matrix3<Scalar>{{Scalar{0}, -vz, vy}, {vz, Scalar{0}, -vx}, {-vy, vx, Scalar{0}}};
 }
 
 #endif  // EIGEN_SUPPORT

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -207,7 +207,7 @@ void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* out
  * @return Eigen matrix populated with the values from `inArray`.
  */
 template <typename ScalarT, int rows, int cols>
-Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
+Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(ScalarT* inArray) {
     return Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray);
 }
 
@@ -221,7 +221,7 @@ Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
  * @return Eigen dynamic matrix containing the mapped values.
  */
 template <typename ScalarT>
-Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
+Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
     Eigen::MatrixX<ScalarT> outMat(nRows, nCols);
     outMat = Eigen::Map<Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
     return outMat;
@@ -236,7 +236,7 @@ Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nC
  * @return Eigen vector whose contents match the input array.
  */
 template <typename ScalarT, int size>
-Eigen::Vector<ScalarT, size> cArrayAsEigenVector(ScalarT (&inArray)[size]) {
+Eigen::Vector<ScalarT, size> cArrayToEigenVector(ScalarT (&inArray)[size]) {
     return Eigen::Map<Eigen::Vector<ScalarT, size>>(inArray);
 }
 
@@ -248,7 +248,7 @@ Eigen::Vector<ScalarT, size> cArrayAsEigenVector(ScalarT (&inArray)[size]) {
  * @return Eigen::Vector3 populated from the input data.
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> cArrayAsEigenVector3(ScalarT* inArray) {
+Eigen::Vector3<ScalarT> cArrayToEigenVector3(ScalarT* inArray) {
     return Eigen::Map<Eigen::Vector3<ScalarT>>(inArray);
 }
 
@@ -260,7 +260,7 @@ Eigen::Vector3<ScalarT> cArrayAsEigenVector3(ScalarT* inArray) {
  * @return Eigen::MRP constructed from the input.
  */
 template <typename ScalarT>
-Eigen::MRP<ScalarT> cArrayAsEigenMrp(ScalarT* inArray) {
+Eigen::MRP<ScalarT> cArrayToEigenMrp(ScalarT* inArray) {
     Eigen::MRP<ScalarT> sigma_Eigen;
     sigma_Eigen = Eigen::Map<Eigen::Vector<ScalarT, 3>>(inArray);
 
@@ -275,7 +275,7 @@ Eigen::MRP<ScalarT> cArrayAsEigenMrp(ScalarT* inArray) {
  * @return Eigen::Matrix3 with the copied values.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> cArrayAsEigenMatrix3(ScalarT* inArray) {
+Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(ScalarT* inArray) {
     return Eigen::Map<Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
 }
 
@@ -287,7 +287,7 @@ Eigen::Matrix3<ScalarT> cArrayAsEigenMatrix3(ScalarT* inArray) {
  * @return Eigen::Matrix3 containing the same entries.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> c2DArrayAsEigenMatrix3(ScalarT in2DArray[3][3]) {
+Eigen::Matrix3<ScalarT> c2DArrayToEigenMatrix3(ScalarT in2DArray[3][3]) {
     Eigen::Matrix3<ScalarT> outMat = Eigen::Map<const Eigen::Matrix<ScalarT, 3, 3, Eigen::RowMajor>>(&in2DArray[0][0]);
     return outMat;
 }

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -208,9 +208,7 @@ void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* out
  */
 template <typename ScalarT, int rows, int cols>
 Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
-    Eigen::Matrix<ScalarT, rows, cols> outMat;
-    outMat = Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray, outMat.rows(), outMat.cols());
-    return outMat;
+    return Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray);
 }
 
 /**
@@ -224,8 +222,7 @@ Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
  */
 template <typename ScalarT>
 Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
-    Eigen::MatrixX<ScalarT> outMat;
-    outMat.resize(nRows, nCols);
+    Eigen::MatrixX<ScalarT> outMat(nRows, nCols);
     outMat = Eigen::Map<Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
     return outMat;
 }
@@ -291,13 +288,7 @@ Eigen::Matrix3<ScalarT> cArrayAsEigenMatrix3(ScalarT* inArray) {
  */
 template <typename ScalarT>
 Eigen::Matrix3<ScalarT> c2DArrayAsEigenMatrix3(ScalarT in2DArray[3][3]) {
-    Eigen::Matrix3<ScalarT> outMat;
-    for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 3; j++) {
-            outMat(i, j) = in2DArray[i][j];
-        }
-    }
-
+    Eigen::Matrix3<ScalarT> outMat = Eigen::Map<const Eigen::Matrix<ScalarT, 3, 3, Eigen::RowMajor>>(&in2DArray[0][0]);
     return outMat;
 }
 
@@ -309,14 +300,8 @@ Eigen::Matrix3<ScalarT> c2DArrayAsEigenMatrix3(ScalarT in2DArray[3][3]) {
  * @return Eigen::Vector3 containing the MRP coefficients.
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT> mrp) {
-    Eigen::Vector3<ScalarT> vec3;
-
-    vec3[0] = mrp.x();
-    vec3[1] = mrp.y();
-    vec3[2] = mrp.z();
-
-    return vec3;
+Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT>& mrp) {
+    return Eigen::Vector3<ScalarT>(mrp.x(), mrp.y(), mrp.z());
 }
 
 /**

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -152,31 +152,32 @@ template <class Derived, std::size_t Size>
 void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
                               typename Derived::Scalar (&out)[Size],
                               std::size_t offset,
-                              const std::size_t stride = 1) {
+                              const std::size_t stride = 1U) {
     using Scalar = Derived::Scalar;
 
     const auto count = static_cast<std::size_t>(inMat.size());
-    if (count == 0) return;
+    if (count == 0U) {
+        return;
+    }
 
-    if (stride == 0 && count > 1) {
+    if (stride == 0U && count > 1U) {
         std::terminate();
     }
 
     // Capacity check: last index must be < N
-    const std::size_t last_index = offset + (count - 1) * stride;
-    if (last_index >= Size) {
+    if (const std::size_t last_index = offset + (count - 1U) * stride; last_index >= Size) {
         std::terminate();
     }
 
     // Make a contiguous row-major buffer regardless of input layout
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
 
-    if (stride == 1) {
+    if (stride == 1U) {
         std::copy(rm.data(), rm.data() + rm.size(), out + offset);
     } else {
         const Scalar* src = rm.data();
         std::size_t idx = offset;
-        for (std::size_t i = 0; i < count; ++i) {
+        for (std::size_t i = 0U; i < count; ++i) {
             out[idx] = src[i];
             idx += stride;
         }

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -26,8 +26,8 @@ inline constexpr bool is_fixed_v =
  * @param inMat Matrix to copy from.
  * @param out Destination array that receives the flattened entries.
  */
-template <class Derived, std::size_t Size>
-void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
+template <class Derived, std::size_t size>
+void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[size]) {
     static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
                   "Input must be a fixed-size Eigen type.");
 
@@ -35,7 +35,7 @@ void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deriv
     constexpr int Rows = Derived::RowsAtCompileTime;
     constexpr int Cols = Derived::ColsAtCompileTime;
 
-    static_assert(static_cast<std::size_t>(Rows) * static_cast<std::size_t>(Cols) == Size,
+    static_assert(static_cast<std::size_t>(Rows) * static_cast<std::size_t>(Cols) == size,
                   "Output array size must equal rows*cols of input.");
 
     if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
@@ -59,12 +59,12 @@ void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deriv
  * @param inMat Matrix to copy from.
  * @param out Destination array that must hold at least `inMat.size()` values.
  */
-template <class Derived, std::size_t Size>
-void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
+template <class Derived, std::size_t size>
+void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[size]) {
     using Scalar = Derived::Scalar;
 
     // Runtime capacity check against compile-time size
-    if (static_cast<std::size_t>(inMat.size()) > Size) {
+    if (static_cast<std::size_t>(inMat.size()) > size) {
         std::terminate();
     }
 
@@ -120,12 +120,12 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
  * @param inMat Matrix to copy from.
  * @param out Destination 2-D array `out[Rows][Cols]`.
  */
-template <class Derived, std::size_t Rows, std::size_t Cols>
-void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Rows][Cols]) {
+template <class Derived, std::size_t rows, std::size_t cols>
+void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[rows][cols]) {
     using Scalar = Derived::Scalar;
 
     // Enforce shape at runtime (safer for 2-D indexing)
-    if (inMat.rows() != static_cast<int>(Rows) || inMat.cols() != static_cast<int>(Cols)) {
+    if (inMat.rows() != static_cast<int>(rows) || inMat.cols() != static_cast<int>(cols)) {
         std::terminate();
     }
 
@@ -148,9 +148,9 @@ void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename De
  * @param offset Starting index in `out` for the first element.
  * @param stride Number of indices to skip between elements (default 1).
  */
-template <class Derived, std::size_t Size>
+template <class Derived, std::size_t size>
 void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
-                              typename Derived::Scalar (&out)[Size],
+                              typename Derived::Scalar (&out)[size],
                               std::size_t offset,
                               const std::size_t stride = 1U) {
     using Scalar = Derived::Scalar;
@@ -165,7 +165,7 @@ void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
     }
 
     // Capacity check: last index must be < N
-    if (const std::size_t last_index = offset + (count - 1U) * stride; last_index >= Size) {
+    if (const std::size_t last_index = offset + ((count - 1U) * stride); last_index >= size) {
         std::terminate();
     }
 

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -1,5 +1,5 @@
-#ifndef EIGENSUPPORT
-#define EIGENSUPPORT
+#ifndef EIGEN_SUPPORT
+#define EIGEN_SUPPORT
 
 #include <architecture/utilities/eigenMRP.h>
 
@@ -399,4 +399,4 @@ Eigen::Matrix3<typename Eigen::MatrixBase<Derived>::Scalar> eigenTilde(const Eig
     return mOut;
 }
 
-#endif  // EIGENSUPPORT
+#endif  // EIGEN_SUPPORT

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -8,7 +8,7 @@
 #include <exception>
 
 template <class Derived>
-constexpr bool is_row_major_v = (Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0;
+inline constexpr bool is_row_major_v = (Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0;
 
 template <class Derived>
 inline constexpr bool is_fixed_v =

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -31,7 +31,7 @@ void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deriv
     static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
                   "Input must be a fixed-size Eigen type.");
 
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
     constexpr int Rows = Derived::RowsAtCompileTime;
     constexpr int Cols = Derived::ColsAtCompileTime;
 
@@ -61,7 +61,7 @@ void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deriv
  */
 template <class Derived, std::size_t Size>
 void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
 
     // Runtime capacity check against compile-time size
     if (static_cast<std::size_t>(inMat.size()) > Size) {
@@ -92,7 +92,7 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
     static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
                   "Input must be a fixed-size Eigen type.");
 
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
     constexpr int R = Derived::RowsAtCompileTime;
     constexpr int C = Derived::ColsAtCompileTime;
 
@@ -123,7 +123,7 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
  */
 template <class Derived, std::size_t Rows, std::size_t Cols>
 void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Rows][Cols]) {
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
 
     // Enforce shape at runtime (safer for 2-D indexing)
     if (inMat.rows() != static_cast<int>(Rows) || inMat.cols() != static_cast<int>(Cols)) {
@@ -154,7 +154,7 @@ void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
                               typename Derived::Scalar (&out)[Size],
                               std::size_t offset,
                               const std::size_t stride = 1) {
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
 
     const auto count = static_cast<std::size_t>(inMat.size());
     if (count == 0) return;

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -40,10 +40,10 @@ void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deriv
 
     if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
         Eigen::Matrix<Scalar, Rows, Cols, Eigen::RowMajor> tmp = inMat;
-        std::memcpy(out, tmp.data(), Size * sizeof(Scalar));
+        std::copy(tmp.data(), tmp.data() + tmp.size(), out);
     } else {
         Eigen::Matrix<Scalar, Cols, Rows> tmpT = inMat.transpose();
-        std::memcpy(out, tmpT.data(), Size * sizeof(Scalar));
+        std::copy(tmpT.data(), tmpT.data() + tmpT.size(), out);
     }
 }
 
@@ -70,8 +70,7 @@ void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deri
 
     // Make a contiguous row-major buffer regardless of input layout
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
-    const auto count = static_cast<std::size_t>(inMat.size());
-    std::memcpy(out, rm.data(), count * sizeof(Scalar));
+    std::copy(rm.data(), rm.data() + rm.size(), out);
 }
 
 /**
@@ -101,10 +100,10 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
 
     if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
         Eigen::Matrix<Scalar, R, C, Eigen::RowMajor> tmp = inMat;
-        std::memcpy(out, tmp.data(), N * M * sizeof(Scalar));
+        std::copy(tmp.data(), tmp.data() + tmp.size(), &out[0][0]);
     } else {
         Eigen::Matrix<Scalar, C, R> tmpT = inMat.transpose();
-        std::memcpy(out, tmpT.data(), N * M * sizeof(Scalar));
+        std::copy(tmpT.data(), tmpT.data() + tmpT.size(), &out[0][0]);
     }
 }
 
@@ -131,7 +130,7 @@ void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename De
     }
 
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
-    std::memcpy(&out[0][0], rm.data(), Rows * Cols * sizeof(Scalar));
+    std::copy(rm.data(), rm.data() + rm.size(), &out[0][0]);
 }
 
 /**
@@ -173,7 +172,7 @@ void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
 
     if (stride == 1) {
-        std::memcpy(out + offset, rm.data(), count * sizeof(Scalar));
+        std::copy(rm.data(), rm.data() + rm.size(), out + offset);
     } else {
         const Scalar* src = rm.data();
         std::size_t idx = offset;
@@ -194,7 +193,7 @@ void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
  */
 template <typename ScalarT, int size>
 void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* outArray) {
-    memcpy(outArray, inVec.data(), size * sizeof(ScalarT));
+    std::copy(inVec.data(), inVec.data() + size, outArray);
 }
 
 /**

--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -238,7 +238,7 @@ Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nC
  * @param inArray Reference to the C array holding the coefficients.
  * @return Eigen vector whose contents match the input array.
  */
-template <typename ScalarT, std::size_t size>
+template <typename ScalarT, int size>
 Eigen::Vector<ScalarT, size> cArrayAsEigenVector(ScalarT (&inArray)[size]) {
     return Eigen::Map<Eigen::Vector<ScalarT, size>>(inArray);
 }

--- a/src/architecture/utilities/geodeticConversion.cpp
+++ b/src/architecture/utilities/geodeticConversion.cpp
@@ -9,7 +9,7 @@ given a rotation matrix.
 @return pcpfPosition: [m] Position vector in PCPF coordinates
 */
 Eigen::Vector3d PCI2PCPF(Eigen::Vector3d pciPosition, double J20002Pfix[3][3]) {
-    Eigen::Matrix3d dcm_PN = cArrayAsEigenMatrix3(*J20002Pfix);
+    Eigen::Matrix3d dcm_PN = cArrayToEigenMatrix3(*J20002Pfix);
     Eigen::Vector3d pcpfPosition = dcm_PN * pciPosition;
 
     return pcpfPosition;
@@ -107,7 +107,7 @@ rotation matrix.
 @return pciPosition: [m] Final position in the planet-centered inertial frame.
 */
 Eigen::Vector3d PCPF2PCI(Eigen::Vector3d pcpfPosition, double J20002Pfix[3][3]) {
-    Eigen::Matrix3d dcm_NP = cArrayAsEigenMatrix3(*J20002Pfix).transpose();
+    Eigen::Matrix3d dcm_NP = cArrayToEigenMatrix3(*J20002Pfix).transpose();
     Eigen::Vector3d pciPosition = dcm_NP * pcpfPosition;
 
     return pciPosition;
@@ -136,7 +136,7 @@ Eigen::Matrix3d C_PCPF2SEZ(double lat, double longitude) {
     Euler2(M_PI_2 - lat, m1);
     Euler3(longitude, m2);
 
-    Eigen::MatrixXd rot2 = cArrayAsEigenMatrix3(*m1);
-    Eigen::MatrixXd rot3 = cArrayAsEigenMatrix3(*m2);
+    Eigen::MatrixXd rot2 = cArrayToEigenMatrix3(*m1);
+    Eigen::MatrixXd rot3 = cArrayToEigenMatrix3(*m2);
     return rot2 * rot3;
 }

--- a/src/architecture/utilities/keplerianOrbit.cpp
+++ b/src/architecture/utilities/keplerianOrbit.cpp
@@ -159,8 +159,8 @@ void KeplerianOrbit::change_f() {
     double v[3];
     ClassicElements oe = this->oe();                                                                               //
     elem2rv(this->mu, &oe, r, v);                                                                                  //
-    this->position_BP_P = cArrayAsEigenVector(r);                                                                  //
-    this->velocity_BP_P = cArrayAsEigenVector(v);                                                                  //
+    this->position_BP_P = cArrayToEigenVector(r);                                                                  //
+    this->velocity_BP_P = cArrayToEigenVector(v);                                                                  //
     this->true_anomaly_rate = this->n() * pow(this->a(), 2) * sqrt(1 - pow(this->e(), 2)) / pow(this->r(), 2);     //
     this->radial_rate = this->r() * this->fDot() * this->e() * sin(this->f()) / (1 + this->e() * cos(this->f()));  //
     this->eccentric_anomaly = safeAcos(this->e() + cos(this->f()) / (1 + this->e() * cos(this->f())));             //

--- a/src/architecture/utilities/tests/test_eigenSupport.cpp
+++ b/src/architecture/utilities/tests/test_eigenSupport.cpp
@@ -126,7 +126,7 @@ TYPED_TEST(EigenSupportConversionsTest, EigenVectorToCArrayCopiesElements) {
     }
 }
 
-TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMatrixPreservesColumnMajorOrdering) {
+TYPED_TEST(EigenSupportConversionsTest, cArrayToEigenMatrixPreservesColumnMajorOrdering) {
     using Scalar = TypeParam;
     constexpr int rows = 3;
     constexpr int cols = 2;
@@ -137,11 +137,11 @@ TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMatrixPreservesColumnMajorO
         }
     }
 
-    Eigen::Matrix<Scalar, rows, cols> reconstructed = cArrayAsEigenMatrix<Scalar, rows, cols>(original.data());
+    Eigen::Matrix<Scalar, rows, cols> reconstructed = cArrayToEigenMatrix<Scalar, rows, cols>(original.data());
     ExpectMatricesApproxEqual(original, reconstructed, GetTolerance<Scalar>());
 }
 
-TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMatrixXPreservesColumnMajorOrdering) {
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMatrixXPreservesColumnMajorOrdering) {
     using Scalar = TypeParam;
     const int rows = 4;
     const int cols = 1;
@@ -152,11 +152,11 @@ TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMatrixXPreservesColumnMajor
         }
     }
 
-    auto reconstructed = cArrayAsEigenMatrixX(original.data(), rows, cols);
+    auto reconstructed = cArrayToEigenMatrixX(original.data(), rows, cols);
     ExpectMatricesApproxEqual(original, reconstructed, GetTolerance<Scalar>());
 }
 
-TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenVectorCopiesElements) {
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenVectorCopiesElements) {
     using Scalar = TypeParam;
     constexpr std::size_t size = 5;
     Scalar raw[size] = {};
@@ -164,33 +164,33 @@ TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenVectorCopiesElements) {
         raw[i] = static_cast<Scalar>(i * 2 - 3);
     }
 
-    auto vec = cArrayAsEigenVector(raw);
+    auto vec = cArrayToEigenVector(raw);
     for (std::size_t i = 0; i < size; ++i) {
         EXPECT_EQ(vec(static_cast<int>(i)), raw[i]);
     }
 }
 
-TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenVector3CreatesMatchingVector) {
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenVector3CreatesMatchingVector) {
     using Scalar = TypeParam;
     Scalar raw[3] = {static_cast<Scalar>(1.0), static_cast<Scalar>(-2.0), static_cast<Scalar>(0.5)};
 
-    Eigen::Vector3<Scalar> vec = cArrayAsEigenVector3(raw);
+    Eigen::Vector3<Scalar> vec = cArrayToEigenVector3(raw);
     for (int i = 0; i < 3; ++i) {
         EXPECT_EQ(vec(i), raw[i]);
     }
 }
 
-TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMrpCopiesCoefficients) {
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMrpCopiesCoefficients) {
     using Scalar = TypeParam;
     Scalar raw[3] = {static_cast<Scalar>(0.1), static_cast<Scalar>(-0.2), static_cast<Scalar>(0.3)};
 
-    Eigen::MRP<Scalar> mrp = cArrayAsEigenMrp(raw);
+    Eigen::MRP<Scalar> mrp = cArrayToEigenMrp(raw);
     EXPECT_EQ(mrp.x(), raw[0]);
     EXPECT_EQ(mrp.y(), raw[1]);
     EXPECT_EQ(mrp.z(), raw[2]);
 }
 
-TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMatrix3ReadsRowMajorDataCorrectly) {
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMatrix3ReadsRowMajorDataCorrectly) {
     using Scalar = TypeParam;
     std::array<Scalar, 9> raw = {static_cast<Scalar>(1),
                                  static_cast<Scalar>(2),
@@ -209,17 +209,17 @@ TYPED_TEST(EigenSupportConversionsTest, CArrayAsEigenMatrix3ReadsRowMajorDataCor
         }
     }
 
-    Eigen::Matrix3<Scalar> reconstructed = cArrayAsEigenMatrix3(raw.data());
+    Eigen::Matrix3<Scalar> reconstructed = cArrayToEigenMatrix3(raw.data());
     ExpectMatricesApproxEqual(expected, reconstructed, GetTolerance<Scalar>());
 }
 
-TYPED_TEST(EigenSupportConversionsTest, C2DArrayAsEigenMatrix3CopiesEntries) {
+TYPED_TEST(EigenSupportConversionsTest, C2DArrayToEigenMatrix3CopiesEntries) {
     using Scalar = TypeParam;
     Scalar raw[3][3] = {{static_cast<Scalar>(1), static_cast<Scalar>(2), static_cast<Scalar>(3)},
                         {static_cast<Scalar>(4), static_cast<Scalar>(5), static_cast<Scalar>(6)},
                         {static_cast<Scalar>(7), static_cast<Scalar>(8), static_cast<Scalar>(9)}};
 
-    Eigen::Matrix3<Scalar> reconstructed = c2DArrayAsEigenMatrix3(raw);
+    Eigen::Matrix3<Scalar> reconstructed = c2DArrayToEigenMatrix3(raw);
 
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedbackAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedbackAlgorithm.cpp
@@ -16,7 +16,7 @@ void MrpFeedbackAlgorithm::reset(VehicleConfigMsgPayload vehConfigMsg,
                                  RWArrayConfigMsgPayload rwConfigMsg,
                                  bool rwIsLinked) {
     /*! - copy over spacecraft inertia tensor */
-    this->ISCPntB_B = cArrayAsEigenMatrix3(vehConfigMsg.ISCPntB_B);
+    this->ISCPntB_B = cArrayToEigenMatrix3(vehConfigMsg.ISCPntB_B);
 
     /*! - zero the number of RW by default */
     this->rwConfigParams.numRW = 0;
@@ -86,7 +86,7 @@ MrpFeedbackOutput MrpFeedbackAlgorithm::update(uint64_t callTime,
     Eigen::Vector3d Lr = this->K * sigma_BR + this->P * omega_BR_B + this->P * this->Ki * z;
 
     Eigen::Matrix<double, 3, RW_EFF_CNT> G_s_B =
-        cArrayAsEigenMatrix<double, 3, RW_EFF_CNT>(this->rwConfigParams.GsMatrix_B);
+        cArrayToEigenMatrix<double, 3, RW_EFF_CNT>(this->rwConfigParams.GsMatrix_B);
 
     Eigen::Vector3d H_B = this->ISCPntB_B * omega_BN_B;
     for (uint32_t i = 0; i < this->rwConfigParams.numRW; i++) {

--- a/src/fswAlgorithms/attControl/mrpPD/mrpPDAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/mrpPD/mrpPDAlgorithm.cpp
@@ -10,12 +10,12 @@
 */
 CmdTorqueBodyMsgPayload MrpPDAlgorithm::update(uint64_t callTime, AttGuidMsgPayload guidInMsg) {
     // Compute hub inertial angular velocity in B-frame components
-    Eigen::Vector3d omega_BR_B = cArrayAsEigenVector(guidInMsg.omega_BR_B);
-    Eigen::Vector3d omega_RN_B = cArrayAsEigenVector(guidInMsg.omega_RN_B);
+    Eigen::Vector3d omega_BR_B = cArrayToEigenVector(guidInMsg.omega_BR_B);
+    Eigen::Vector3d omega_RN_B = cArrayToEigenVector(guidInMsg.omega_RN_B);
     Eigen::Vector3d omega_BN_B = omega_BR_B + omega_RN_B;
 
-    Eigen::Vector3d sigma_BR = cArrayAsEigenVector(guidInMsg.sigma_BR);
-    Eigen::Vector3d domega_RN_B = cArrayAsEigenVector(guidInMsg.domega_RN_B);
+    Eigen::Vector3d sigma_BR = cArrayToEigenVector(guidInMsg.sigma_BR);
+    Eigen::Vector3d domega_RN_B = cArrayToEigenVector(guidInMsg.domega_RN_B);
 
     // Compute required attitude control torque vector
     Eigen::Vector3d Lr = -this->K * sigma_BR - this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
@@ -34,7 +34,7 @@ CmdTorqueBodyMsgPayload MrpPDAlgorithm::update(uint64_t callTime, AttGuidMsgPayl
  @param vehicleConfigIn Vehicle config input
 */
 void MrpPDAlgorithm::setSpacecraftInertia(VehicleConfigMsgPayload vehicleConfigIn) {
-    this->ISCPntB_B = cArrayAsEigenMatrix3(vehicleConfigIn.ISCPntB_B);
+    this->ISCPntB_B = cArrayToEigenMatrix3(vehicleConfigIn.ISCPntB_B);
 }
 
 /*! Setter method for the derivative gain P.

--- a/src/fswAlgorithms/attControl/rateControl/rateControlAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateControl/rateControlAlgorithm.cpp
@@ -11,10 +11,10 @@ CmdTorqueBodyMsgPayload RateControlAlgorithm::update(AttGuidMsgPayload attGuidIn
     CmdTorqueBodyMsgPayload torqueCmdOut{};
 
     // Compute required attitude control torque vector
-    Eigen::Vector3d omega_BR_B = cArrayAsEigenVector(attGuidIn.omega_BR_B);
-    Eigen::Vector3d omega_RN_B = cArrayAsEigenVector(attGuidIn.omega_RN_B);
+    Eigen::Vector3d omega_BR_B = cArrayToEigenVector(attGuidIn.omega_BR_B);
+    Eigen::Vector3d omega_RN_B = cArrayToEigenVector(attGuidIn.omega_RN_B);
     Eigen::Vector3d omega_BN_B = omega_BR_B + omega_RN_B;
-    Eigen::Vector3d domega_RN_B = cArrayAsEigenVector(attGuidIn.domega_RN_B);
+    Eigen::Vector3d domega_RN_B = cArrayToEigenVector(attGuidIn.domega_RN_B);
     Eigen::Vector3d Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
                          this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
                          this->knownTorquePntB_B;  // [Nm]
@@ -29,7 +29,7 @@ CmdTorqueBodyMsgPayload RateControlAlgorithm::update(AttGuidMsgPayload attGuidIn
  @param vehicleConfigIn Vehicle config input
 */
 void RateControlAlgorithm::setSpacecraftInertia(VehicleConfigMsgPayload vehicleConfigIn) {
-    this->ISCPntB_B = cArrayAsEigenMatrix3(vehicleConfigIn.ISCPntB_B);
+    this->ISCPntB_B = cArrayToEigenMatrix3(vehicleConfigIn.ISCPntB_B);
 }
 
 /*! Setter method for the derivative gain P.

--- a/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinearAlgorithm.cpp
+++ b/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinearAlgorithm.cpp
@@ -16,7 +16,7 @@
 void RateServoFullNonlinearAlgorithm::reset(VehicleConfigMsgPayload vehConfigMsg,
                                             RWArrayConfigMsgPayload rwConfigMsg,
                                             bool rwIsLinked) {
-    this->ISCPntB_B = cArrayAsEigenMatrix3(vehConfigMsg.ISCPntB_B);
+    this->ISCPntB_B = cArrayToEigenMatrix3(vehConfigMsg.ISCPntB_B);
 
     this->rwConfigParams.numRW = 0;
     if (rwIsLinked) {
@@ -88,7 +88,7 @@ CmdTorqueBodyMsgPayload RateServoFullNonlinearAlgorithm::update(uint64_t callTim
     Eigen::Vector3d Lr = this->P * omega_BBast_B + this->Ki * this->z;
 
     Eigen::Matrix<double, 3, RW_EFF_CNT> G_s_B =
-        cArrayAsEigenMatrix<double, 3, RW_EFF_CNT>(this->rwConfigParams.GsMatrix_B);
+        cArrayToEigenMatrix<double, 3, RW_EFF_CNT>(this->rwConfigParams.GsMatrix_B);
 
     Eigen::Vector3d H_B = this->ISCPntB_B * omega_BN_B;
     for (uint32_t i = 0; i < this->rwConfigParams.numRW; i++) {

--- a/src/fswAlgorithms/attControl/thrMomentumManagementCpp/thrMomentumManagementCpp.cpp
+++ b/src/fswAlgorithms/attControl/thrMomentumManagementCpp/thrMomentumManagementCpp.cpp
@@ -26,7 +26,7 @@ void ThrMomentumManagementCpp::updateState(uint64_t currentSimNanos) {
         Eigen::Vector3d hs_B = Eigen::Vector3d::Zero();
         for (int i = 0; i < this->rwConfigParams.numRW; i++) {
             hs_B += this->rwConfigParams.JsList[i] * rwSpeedMsg.wheelSpeeds[i] *
-                    cArrayAsEigenVector3(&this->rwConfigParams.GsMatrix_B[i * 3]);
+                    cArrayToEigenVector3(&this->rwConfigParams.GsMatrix_B[i * 3]);
         }
 
         if (this->hd_B.norm() > 0) {

--- a/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
+++ b/src/fswAlgorithms/attDetermination/inertialAttitudeUkf/inertialAttitudeUkf.cpp
@@ -126,13 +126,13 @@ void InertialAttitudeUkf::readRWSpeedData() {
     if (this->firstFilterPass) {
         this->wheelAccelerations = Eigen::VectorXd::Zero(this->rwArrayConfigPayload.numRW);
         Eigen::MatrixXd wheelSpeed =
-            cArrayAsEigenMatrixX(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
+            cArrayToEigenMatrixX(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
         this->previousWheelSpeeds = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
         this->previousWheelSpeedTime = wheelSpeedTime * NANO2SEC;
     } else {
         double dt = wheelSpeedTime * NANO2SEC - this->previousWheelSpeedTime;
         Eigen::MatrixXd wheelSpeed =
-            cArrayAsEigenMatrixX(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
+            cArrayToEigenMatrixX(rwSpeedPayload.wheelSpeeds, this->rwArrayConfigPayload.numRW, 1);
         Eigen::VectorXd currentWheelSpeed = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
         this->wheelAccelerations = (currentWheelSpeed - this->previousWheelSpeeds) / dt;
         this->previousWheelSpeeds = Eigen::Map<Eigen::VectorXd>(wheelSpeed.data(), wheelSpeed.size());
@@ -154,7 +154,7 @@ void InertialAttitudeUkf::readStarTrackerData() {
             starTrackerMeasurement.setValidity(true);
 
             /*! - Get the mapping from camera frame to inertial for the noise matrix */
-            Eigen::Matrix3d dcm_CB = cArrayAsEigenMatrix3(starTracker.dcm_CB);
+            Eigen::Matrix3d dcm_CB = cArrayToEigenMatrix3(starTracker.dcm_CB);
 
             starTrackerMeasurement.setMeasurementNoise(this->measNoiseScaling * dcm_CB.transpose() *
                                                        this->starTrackerMessages[index].measurementNoise_C * dcm_CB);
@@ -204,7 +204,7 @@ void InertialAttitudeUkf::readGyroData() {
 
         gyroMeasurement.setMeasurementNoise(this->measNoiseScaling * this->gyroNoise /
                                             gyroBuffer.numberOfValidGyroMeasurements);
-        gyroMeasurement.setObservation(cArrayAsEigenVector(gyroBuffer.AngVelPlatform));
+        gyroMeasurement.setObservation(cArrayToEigenVector(gyroBuffer.AngVelPlatform));
         gyroMeasurement.setMeasurementModel(MeasurementModel::velocityStatesWithBias);
         this->measurements[this->measurementIndex] = gyroMeasurement;
         this->measurementIndex += 1;
@@ -221,7 +221,7 @@ void InertialAttitudeUkf::readFilterMeasurements() {
         this->rwArrayConfigPayload = this->rwArrayConfigMsg();
         auto vehicleConfigPayload = this->vehicleConfigMsg();
 
-        this->spacecraftInertia = cArrayAsEigenMatrix3(vehicleConfigPayload.ISCPntB_B);
+        this->spacecraftInertia = cArrayToEigenMatrix3(vehicleConfigPayload.ISCPntB_B);
         this->spacecraftInertiaInverse = this->spacecraftInertia.inverse();
     }
 

--- a/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
+++ b/src/fswAlgorithms/attDetermination/sunlineSRuKF/sunlineSRuKF.cpp
@@ -104,7 +104,7 @@ void SunlineSRuKF::readGyroMeasurements() {
         gyroMeasurements.setValidity(true);
         gyroMeasurements.setMeasurementName("gyro");
         gyroMeasurements.setTimeTag(navAttInputBuffer.timeTag);
-        gyroMeasurements.setObservation(cArrayAsEigenVector(navAttInputBuffer.omega_BN_B));
+        gyroMeasurements.setObservation(cArrayToEigenVector(navAttInputBuffer.omega_BN_B));
         gyroMeasurements.setMeasurementModel(MeasurementModel::velocityStates);
         Eigen::MatrixXd I = Eigen::Matrix3d::Identity();
         gyroMeasurements.setMeasurementNoise(this->measNoiseScaling * pow(this->gyroMeasNoiseStd, 2) * I);

--- a/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
+++ b/src/fswAlgorithms/attGuidance/attRefCorrection/attRefCorrection.cpp
@@ -24,7 +24,7 @@ void AttRefCorrection::reset(uint64_t callTime) {
 void AttRefCorrection::updateState(uint64_t const callTime) {
     // read in the input messages
     AttRefMsgPayload attRefMsgBuffer = this->attRefInMsg();
-    Eigen::Vector3d sigma_RN_local = cArrayAsEigenVector3(attRefMsgBuffer.sigma_RN);
+    Eigen::Vector3d sigma_RN_local = cArrayToEigenVector3(attRefMsgBuffer.sigma_RN);
 
     // compute corrected reference orientation
     sigma_RN_local = addMrp(sigma_RN_local, this->sigma_RR0);

--- a/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.cpp
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/attTrackingErrorAlgorithm.cpp
@@ -26,24 +26,24 @@ AttGuidMsgPayload AttTrackingErrorAlgorithm::update(uint64_t callTime,
     Eigen::Vector3d sigma_RR0 = -1 * this->sigma_R0R;
 
     // Compute MRP from inertial to updated reference frame sigma_RN
-    Eigen::Vector3d sigma_RN = cArrayAsEigenVector(attRefInMsg.sigma_RN);
+    Eigen::Vector3d sigma_RN = cArrayToEigenVector(attRefInMsg.sigma_RN);
     sigma_RN = addMrp(sigma_RN, sigma_RR0);
 
     // Compute attitude error sigma_BR
-    Eigen::Vector3d sigma_BN = cArrayAsEigenVector(attNavInMsg.sigma_BN);
+    Eigen::Vector3d sigma_BN = cArrayToEigenVector(attNavInMsg.sigma_BN);
     Eigen::Vector3d sigma_BR = subMrp(sigma_BN, sigma_RN);
 
     // Compute angular velocity reference body frame components omega_RN_B
     Eigen::Matrix3d dcm_BN = mrpToDcm(sigma_BN);
-    Eigen::Vector3d omega_RN_N = cArrayAsEigenVector(attRefInMsg.omega_RN_N);
+    Eigen::Vector3d omega_RN_N = cArrayToEigenVector(attRefInMsg.omega_RN_N);
     Eigen::Vector3d omega_RN_B = dcm_BN * omega_RN_N;
 
     // Compute angular velocity error omega_BR
-    Eigen::Vector3d omega_BN_B = cArrayAsEigenVector(attNavInMsg.omega_BN_B);
+    Eigen::Vector3d omega_BN_B = cArrayToEigenVector(attNavInMsg.omega_BN_B);
     Eigen::Vector3d omega_BR_B = omega_BN_B - omega_RN_B;
 
     // Compute reference angular velocity rate in body frame components domega_RN_B
-    Eigen::Vector3d domega_RN_N = cArrayAsEigenVector(attRefInMsg.domega_RN_N);
+    Eigen::Vector3d domega_RN_N = cArrayToEigenVector(attRefInMsg.domega_RN_N);
     Eigen::Vector3d domega_RN_B = dcm_BN * domega_RN_N;
 
     // Write attitude guidance output message

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.cpp
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePointAlgorithm.cpp
@@ -35,7 +35,7 @@ AttGuidMsgPayload SunSafePointAlgorithm::update(uint64_t callTime,
     this->sunDirectionInBuffer = sunDirectionInMsg;
 
     // Determine norm of measured Sun-direction vector
-    const double sHatNorm = cArrayAsEigenVector(this->sunDirectionInBuffer.vehSunPntBdy).norm();
+    const double sHatNorm = cArrayToEigenVector(this->sunDirectionInBuffer.vehSunPntBdy).norm();
 
     // Zero the attitude guidance output buffer message
     this->attGuidanceOutBuffer = AttGuidMsgPayload();
@@ -65,7 +65,7 @@ AttGuidMsgPayload SunSafePointAlgorithm::update(uint64_t callTime,
 void SunSafePointAlgorithm::computeAttGuidanceStates(double sHatNorm) {
     // Compute the current sun angle error
     double dotProductNormalized =
-        this->sHatBdyCmd.dot(cArrayAsEigenVector(this->sunDirectionInBuffer.vehSunPntBdy)) / sHatNorm;
+        this->sHatBdyCmd.dot(cArrayToEigenVector(this->sunDirectionInBuffer.vehSunPntBdy)) / sHatNorm;
     dotProductNormalized = std::abs(dotProductNormalized) > 1.0 ? dotProductNormalized / std::abs(dotProductNormalized)
                                                                 : dotProductNormalized;
     double sunAngleErr = safeAcos(dotProductNormalized);
@@ -82,7 +82,7 @@ void SunSafePointAlgorithm::computeAttGuidanceStates(double sHatNorm) {
             e_hat = this->eHat180_B;
             // Normal case where sun and commanded body vectors are not aligned
         } else {
-            e_hat = cArrayAsEigenVector(this->sunDirectionInBuffer.vehSunPntBdy).cross(this->sHatBdyCmd);
+            e_hat = cArrayToEigenVector(this->sunDirectionInBuffer.vehSunPntBdy).cross(this->sHatBdyCmd);
         }
         Eigen::Vector3d sunMnvrVec = e_hat / e_hat.norm();
         Eigen::Vector3d sigma_BR = std::tan(sunAngleErr * 0.25) * sunMnvrVec;
@@ -92,14 +92,14 @@ void SunSafePointAlgorithm::computeAttGuidanceStates(double sHatNorm) {
 
     // Rate tracking error is the body rate to bring spacecraft to rest
     this->omega_RN_B =
-        (this->sunAxisSpinRate / sHatNorm) * cArrayAsEigenVector(this->sunDirectionInBuffer.vehSunPntBdy);
+        (this->sunAxisSpinRate / sHatNorm) * cArrayToEigenVector(this->sunDirectionInBuffer.vehSunPntBdy);
 }
 
 /*! Method for computing the hub angular rate error omega_BR_B.
  @return void
 */
 void SunSafePointAlgorithm::computeHubAngularRateError(NavAttMsgPayload imuInMsg) {
-    const Eigen::Vector3d omega_BN_B = cArrayAsEigenVector(imuInMsg.omega_BN_B);  // [rad/s]
+    const Eigen::Vector3d omega_BN_B = cArrayToEigenVector(imuInMsg.omega_BN_B);  // [rad/s]
     Eigen::Vector3d omega_BR_B = omega_BN_B - this->omega_RN_B;                   // [rad/s]
 
     eigenVectorToCArray(omega_BR_B, this->attGuidanceOutBuffer.omega_BR_B);

--- a/src/fswAlgorithms/attGuidance/triad/triad.cpp
+++ b/src/fswAlgorithms/attGuidance/triad/triad.cpp
@@ -89,12 +89,12 @@ void Triad::updateState(uint64_t callTime) {
         hReqHat_N = this->hHat_N.normalized();
     } else if (this->inertialAxisInput == InertialAxisInput::inputInertialHeadingMsg) {
         InertialHeadingMsgPayload inertialHeadingIn = this->inertialHeadingInMsg();
-        hReqHat_N = cArrayAsEigenVector(inertialHeadingIn.rHat_XN_N).normalized();
+        hReqHat_N = cArrayToEigenVector(inertialHeadingIn.rHat_XN_N).normalized();
     } else if (this->inertialAxisInput == InertialAxisInput::inputEphemerisMsg) {
         EphemerisMsgPayload ephemerisIn = this->ephemerisInMsg();
         NavTransMsgPayload transNavIn = this->transNavInMsg();
         hReqHat_N =
-            (cArrayAsEigenVector(ephemerisIn.r_BdyZero_N) - cArrayAsEigenVector(transNavIn.r_BN_N)).normalized();
+            (cArrayToEigenVector(ephemerisIn.r_BdyZero_N) - cArrayToEigenVector(transNavIn.r_BN_N)).normalized();
     }
 
     /*! get body frame heading */
@@ -103,10 +103,10 @@ void Triad::updateState(uint64_t callTime) {
         hRefHat_B = this->h1Hat_B.normalized();
     } else if (this->bodyAxisInput == BodyAxisInput::inputBodyHeadingMsg) {
         BodyHeadingMsgPayload bodyHeadingIn = this->bodyHeadingInMsg();
-        hRefHat_B = cArrayAsEigenVector(bodyHeadingIn.rHat_XB_B).normalized();
+        hRefHat_B = cArrayToEigenVector(bodyHeadingIn.rHat_XB_B).normalized();
     }
 
-    Eigen::MRPd sigma_BN(cArrayAsEigenVector(attNavIn.sigma_BN));
+    Eigen::MRPd sigma_BN(cArrayToEigenVector(attNavIn.sigma_BN));
     /*! define the body frame orientation DCM BN */
     Eigen::Matrix3d BN = sigma_BN.toRotationMatrix().transpose();
 
@@ -114,7 +114,7 @@ void Triad::updateState(uint64_t callTime) {
     Eigen::Vector3d a1Hat_B = this->a1Hat_B.normalized();
 
     /*! read Sun direction in B frame from the attNav message */
-    Eigen::Vector3d rHat_SB_B = cArrayAsEigenVector(attNavIn.vehSunPntBdy).normalized();
+    Eigen::Vector3d rHat_SB_B = cArrayToEigenVector(attNavIn.vehSunPntBdy).normalized();
 
     Eigen::Vector3d rHat_SB_N;
     rHat_SB_N = BN.transpose() * rHat_SB_B;

--- a/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/forceTorqueThrForceMappingAlgorithm.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/forceTorqueThrForceMappingAlgorithm.cpp
@@ -34,7 +34,7 @@ void ForceTorqueThrForceMappingAlgorithm::reset(VehicleConfigMsgPayload& vehConf
                                                 THRArrayConfigMsgPayload& thrConfigMsg) {
     /*! - copy the thruster position and thruster force heading information into the module configuration data */
     this->numThrusters = thrConfigMsg.numThrusters;
-    this->CoM_B = cArrayAsEigenVector(vehConfigMsg.CoM_B);
+    this->CoM_B = cArrayToEigenVector(vehConfigMsg.CoM_B);
     if (this->numThrusters > MAX_EFF_CNT) {
         throw std::invalid_argument(
             "forceTorqueThrForceMapping thruster configuration input message has a number of "
@@ -43,8 +43,8 @@ void ForceTorqueThrForceMappingAlgorithm::reset(VehicleConfigMsgPayload& vehConf
 
     /*! - copy the thruster position and thruster force heading information into the module configuration data */
     for (uint32_t i = 0; i < this->numThrusters; ++i) {
-        this->rThruster_B.col(i) = cArrayAsEigenVector(thrConfigMsg.thrusters[i].rThrust_B);
-        this->gtThruster_B.col(i) = cArrayAsEigenVector(thrConfigMsg.thrusters[i].tHatThrust_B);
+        this->rThruster_B.col(i) = cArrayToEigenVector(thrConfigMsg.thrusters[i].rThrust_B);
+        this->gtThruster_B.col(i) = cArrayToEigenVector(thrConfigMsg.thrusters[i].tHatThrust_B);
         if (thrConfigMsg.thrusters[i].maxThrust <= 0.0) {
             throw std::invalid_argument(
                 "forceTorqueThrForceMapping: A configured thruster has a non-sensible "
@@ -64,8 +64,8 @@ THRArrayCmdForceMsgPayload ForceTorqueThrForceMappingAlgorithm::update(CmdTorque
 
     /* Create the torque and force vector */
     Eigen::Vector<double, 6> forceTorque_B{};
-    forceTorque_B.head(3) = cArrayAsEigenVector(cmdTorqueMsg.torqueRequestBody);
-    forceTorque_B.tail(3) = cArrayAsEigenVector(cmdForceMsg.forceRequestBody);
+    forceTorque_B.head(3) = cArrayToEigenVector(cmdTorqueMsg.torqueRequestBody);
+    forceTorque_B.tail(3) = cArrayToEigenVector(cmdForceMsg.forceRequestBody);
 
     /* - compute thruster locations relative to COM */
     Eigen::Matrix<double, 3, MAX_EFF_CNT> rThrusterRelCOM_B{Eigen::Matrix<double, 3, MAX_EFF_CNT>::Zero()};

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorqueAlgorithm.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/rwMotorTorqueAlgorithm.cpp
@@ -54,7 +54,7 @@ void RwMotorTorqueAlgorithm::reset(RWArrayConfigMsgPayload& rwParamsInMsg, bool 
      and create the [Gs] projection matrix once */
     if (!rwAvailIsLinked) {
         this->numAvailRW = this->rwConfigParams.numRW;
-        this->G_s_B = cArrayAsEigenMatrix<double, 3, RW_EFF_CNT>(this->rwConfigParams.GsMatrix_B);
+        this->G_s_B = cArrayToEigenMatrix<double, 3, RW_EFF_CNT>(this->rwConfigParams.GsMatrix_B);
     }
 }
 
@@ -76,11 +76,11 @@ RwMotorTorqueMsgPayload RwMotorTorqueAlgorithm::update(CmdTorqueBodyMsgPayload& 
     /*! - zero control torque and RW motor torque variables */
     Eigen::Vector<double, RW_EFF_CNT> us = Eigen::Vector<double, RW_EFF_CNT>::Zero();
 
-    Eigen::Vector3d Lr_B = cArrayAsEigenVector(LrInputMsg.torqueRequestBody);
+    Eigen::Vector3d Lr_B = cArrayToEigenVector(LrInputMsg.torqueRequestBody);
 
     /*! - Check if the optional second message is provided */
     if (cmdTorque2IsLinked) {
-        Lr_B += cArrayAsEigenVector(LrInput2Msg.torqueRequestBody);
+        Lr_B += cArrayToEigenVector(LrInput2Msg.torqueRequestBody);
     }
 
     /*! - Check if RW availability message is available */
@@ -91,7 +91,7 @@ RwMotorTorqueMsgPayload RwMotorTorqueAlgorithm::update(CmdTorqueBodyMsgPayload& 
         /*! - create the current [Gs] projection matrix with the available RWs */
         for (uint32_t i = 0; i < this->rwConfigParams.numRW; ++i) {
             if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) {
-                this->G_s_B.col(numAvailWheels) = cArrayAsEigenVector3(&this->rwConfigParams.GsMatrix_B[i * 3]);
+                this->G_s_B.col(numAvailWheels) = cArrayToEigenVector3(&this->rwConfigParams.GsMatrix_B[i * 3]);
                 numAvailWheels += 1;
             }
         }

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpaceAlgorithm.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/rwNullSpaceAlgorithm.cpp
@@ -14,7 +14,7 @@ void RwNullSpaceAlgorithm::reset(RWConstellationMsgPayload& rwConfigInMsg) {
     Eigen::Matrix<double, 3, RW_EFF_CNT> G_s_B{};
     G_s_B.setZero();
     for (uint32_t i = 0; i < this->numWheels; i = i + 1) {
-        G_s_B.col(i) = cArrayAsEigenVector(rwConfigInMsg.reactionWheels[i].gsHat_B);
+        G_s_B.col(i) = cArrayToEigenVector(rwConfigInMsg.reactionWheels[i].gsHat_B);
     }
 
     /* find the [tau] null space projection matrix [tau] = ([I] - [Gs]^T.([Gs].[Gs]^T)^-1.[Gs]) */
@@ -37,15 +37,15 @@ RwMotorTorqueMsgPayload RwNullSpaceAlgorithm::update(RwMotorTorqueMsgPayload& co
                                             the control and null motion torques */
 
     /* compute the wheel speed control vector d = -K.DeltaOmega */
-    Eigen::Vector<double, MAX_EFF_CNT> d = -this->omegaGain * (cArrayAsEigenVector(rwSpeeds.wheelSpeeds) -
-                                                               cArrayAsEigenVector(rwDesiredSpeeds.wheelSpeeds));
+    Eigen::Vector<double, MAX_EFF_CNT> d = -this->omegaGain * (cArrayToEigenVector(rwSpeeds.wheelSpeeds) -
+                                                               cArrayToEigenVector(rwDesiredSpeeds.wheelSpeeds));
 
     /* compute the RW null space motor torque solution to reduce the wheel speeds */
     Eigen::Vector<double, MAX_EFF_CNT> motorTorqueNullSpace = this->tau * d;
 
     /* add the null motion RW torque solution to the RW feedback control torque solution */
     Eigen::Vector<double, MAX_EFF_CNT> motorTorque =
-        motorTorqueNullSpace + cArrayAsEigenVector(controlRequest.motorTorque);
+        motorTorqueNullSpace + cArrayToEigenVector(controlRequest.motorTorque);
 
     eigenVectorToCArray(motorTorque, finalControl.motorTorque);
 

--- a/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverterAlgorithm.cpp
+++ b/src/fswAlgorithms/opticalNavigation/cobConverter/cobConverterAlgorithm.cpp
@@ -54,7 +54,7 @@ CobConverterAlgorithm::~CobConverterAlgorithm() = default;
 void CobConverterAlgorithm::computeCameraParameters(const CameraModelMsgPayload& cameraSpecs) {
     double sigma_camera[3];
     std::ranges::copy(cameraSpecs.bodyToCameraMrp, std::begin(sigma_camera));
-    this->dcm_CB = mrpToDcm(cArrayAsEigenVector3(sigma_camera));
+    this->dcm_CB = mrpToDcm(cArrayToEigenVector3(sigma_camera));
 
     // Camera parameters
     double alpha = 0;
@@ -92,7 +92,7 @@ void CobConverterAlgorithm::computeRotations(const NavAttMsgPayload& navAttBuffe
     double sigma_BN[3];
     std::ranges::copy(navAttBuffer.sigma_BN, std::begin(sigma_BN));
     // Extract rotations from relevant messages
-    this->dcm_BN = mrpToDcm(cArrayAsEigenVector3(sigma_BN));
+    this->dcm_BN = mrpToDcm(cArrayToEigenVector3(sigma_BN));
     this->dcm_NC = this->dcm_BN.transpose() * this->dcm_CB.transpose();
 }
 
@@ -114,9 +114,9 @@ void CobConverterAlgorithm::computePhaseAngleCorrection(const FilterMsgPayload& 
     std::ranges::copy(filterMsgBuffer.state, std::begin(filter_state));
     std::ranges::copy(sunBuffer.vehSunPntBdy, std::begin(sun_B));
 
-    this->sc_position = cArrayAsEigenMatrix<double, 6, 1>(filter_state).col(0).head(3);
+    this->sc_position = cArrayToEigenMatrix<double, 6, 1>(filter_state).col(0).head(3);
     Eigen::Vector3d rhat_N = this->sc_position.normalized();
-    Eigen::Vector3d shat_B = cArrayAsEigenVector3(sun_B).normalized();
+    Eigen::Vector3d shat_B = cArrayToEigenVector3(sun_B).normalized();
     this->shat_N = dcm_BN.transpose() * shat_B;
     Eigen::Vector3d shat_C = dcm_CB * shat_B;
 
@@ -214,7 +214,7 @@ void CobConverterAlgorithm::computeCameraFrameUncertainty(const FilterMsgPayload
 
         // Compute COM uncertainty direction
         const Eigen::Matrix<double, 6, 6> Covariance =
-            cArrayAsEigenMatrixX(covariance, filterMsgBuffer.numberOfStates, filterMsgBuffer.numberOfStates);
+            cArrayToEigenMatrixX(covariance, filterMsgBuffer.numberOfStates, filterMsgBuffer.numberOfStates);
         const Eigen::Matrix3d positionCovariance = Covariance.topLeftCorner(3, 3);
 
         const Eigen::RowVector3d deltaBinary_r = deltaBinary_delta_r + (deltaBinary_deltaAlpha * deltaAlpha_delta_R);
@@ -381,10 +381,10 @@ void CobConverterAlgorithm::cobOutlierDetection(const FilterMsgPayload& filterMs
     std::ranges::copy(filterMsgBuffer.covar, std::begin(covariance));
 
     int numberOfStates = filterMsgBuffer.numberOfStates;
-    Eigen::VectorXd filterState = cArrayAsEigenMatrixX(state, numberOfStates, 1);
+    Eigen::VectorXd filterState = cArrayToEigenMatrixX(state, numberOfStates, 1);
     Eigen::Vector3d rNav_BN_N = filterState.segment(0, 3);
     Eigen::Vector3d rhatNav_N = rNav_BN_N.normalized();
-    Eigen::MatrixXd filterCovariance = cArrayAsEigenMatrixX(covariance, numberOfStates, numberOfStates);
+    Eigen::MatrixXd filterCovariance = cArrayToEigenMatrixX(covariance, numberOfStates, numberOfStates);
     Eigen::Matrix3d covarNav_N = filterCovariance.block(0, 0, 3, 3) / pow(rNav_BN_N.norm(), 2);
 
     Eigen::Vector3d rhatCOB_C =

--- a/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/flybyODuKF/flybyODuKF.cpp
@@ -82,10 +82,10 @@ void FlybyODuKF::readFilterMeasurements() {
 
     if (headingMeasurement.getValidity() && headingMeasurement.getTimeTag() >= this->previousFilterTimeTag) {
         /*! - Read measurement and cholesky decomposition its noise*/
-        headingMeasurement.setObservation(cArrayAsEigenVector(this->opNavHeadingBuffer.rhat_BN_N));
+        headingMeasurement.setObservation(cArrayToEigenVector(this->opNavHeadingBuffer.rhat_BN_N));
         headingMeasurement.getObservation().normalize();
         headingMeasurement.setMeasurementNoise(this->measNoiseScaling *
-                                               cArrayAsEigenMatrixX(this->opNavHeadingBuffer.covar_N,
+                                               cArrayToEigenMatrixX(this->opNavHeadingBuffer.covar_N,
                                                                     (int)headingMeasurement.size(),
                                                                     (int)headingMeasurement.size()));
         headingMeasurement.setMeasurementModel(MeasurementModel::normalizedPositionStates);

--- a/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/linearODeKF/linearODeKF.cpp
@@ -106,9 +106,9 @@ void LinearODeKF::readFilterMeasurements() {
 
     if (headingMeasurement.getValidity() && headingMeasurement.getTimeTag() >= this->previousFilterTimeTag) {
         /*! - Read measurement and cholesky decomposition its noise*/
-        headingMeasurement.setObservation(cArrayAsEigenVector(this->opNavHeadingBuffer.rhat_BN_N).normalized());
+        headingMeasurement.setObservation(cArrayToEigenVector(this->opNavHeadingBuffer.rhat_BN_N).normalized());
         headingMeasurement.setMeasurementNoise(this->measNoiseScaling *
-                                               cArrayAsEigenMatrixX(this->opNavHeadingBuffer.covar_N,
+                                               cArrayToEigenMatrixX(this->opNavHeadingBuffer.covar_N,
                                                                     (int)headingMeasurement.size(),
                                                                     (int)headingMeasurement.size()));
         headingMeasurement.setMeasurementModel(MeasurementModel::normalizedPositionStates);

--- a/src/fswAlgorithms/opticalNavigation/positionODuKF/positionODuKF.cpp
+++ b/src/fswAlgorithms/opticalNavigation/positionODuKF/positionODuKF.cpp
@@ -173,7 +173,7 @@ void PositionODuKF::readFilterMeasurements() {
     this->measurementRead = false;
     if (this->cameraPosBuffer.valid) {
         /*! - Read measurement and cholesky decomposition its noise*/
-        this->obs = cArrayAsEigenVector(this->cameraPosBuffer.cameraPos_N) * 1E-3;  // Change units to km
+        this->obs = cArrayToEigenVector(this->cameraPosBuffer.cameraPos_N) * 1E-3;  // Change units to km
         this->measurementNoise.resize(this->obs.size(), this->obs.size());
         this->measurementNoise << this->measNoiseSD * this->measNoiseSD, 0, 0, 0, this->measNoiseSD * this->measNoiseSD,
             0, 0, 0, this->measNoiseSD * this->measNoiseSD;

--- a/src/fswAlgorithms/opticalNavigation/timeClosestApproach/timeClosestApproach.cpp
+++ b/src/fswAlgorithms/opticalNavigation/timeClosestApproach/timeClosestApproach.cpp
@@ -15,9 +15,9 @@ void TimeClosestApproach::readMessages() {
     auto navFilterMsgPayload = this->navFilterMsg();
 
     this->numberOfStates = filterStatePayload.numberOfStates;
-    this->r_BN_N = cArrayAsEigenVector(navFilterMsgPayload.r_BN_N);
-    this->v_BN_N = cArrayAsEigenVector(navFilterMsgPayload.v_BN_N);
-    this->filterCovariance = cArrayAsEigenMatrixX(filterStatePayload.covar, this->numberOfStates, this->numberOfStates);
+    this->r_BN_N = cArrayToEigenVector(navFilterMsgPayload.r_BN_N);
+    this->v_BN_N = cArrayToEigenVector(navFilterMsgPayload.v_BN_N);
+    this->filterCovariance = cArrayToEigenMatrixX(filterStatePayload.covar, this->numberOfStates, this->numberOfStates);
 }
 
 /*! Write output messages.

--- a/src/fswAlgorithms/opticalNavigation/visualOdometry/visualOdometry.cpp
+++ b/src/fswAlgorithms/opticalNavigation/visualOdometry/visualOdometry.cpp
@@ -97,23 +97,23 @@ void VisualOdometry::computeCameraMatrix() {
 void VisualOdometry::computeAframeDCM() {
     double CB_temp[3][3];
     MRP2C(this->cameraBuffer.sigma_CB, CB_temp);
-    Eigen::Matrix3d CB = cArrayAsEigenMatrix3(*CB_temp);
+    Eigen::Matrix3d CB = cArrayToEigenMatrix3(*CB_temp);
 
     double Bkmin1N_temp[3][3];
     MRP2C(this->keyPointBuffer.sigma_BN_firstImage, Bkmin1N_temp);
-    Eigen::Matrix3d Bkmin1N = cArrayAsEigenMatrix3(*Bkmin1N_temp);
+    Eigen::Matrix3d Bkmin1N = cArrayToEigenMatrix3(*Bkmin1N_temp);
 
     double NTkmin1_temp[3][3];
     MRP2C(this->keyPointBuffer.sigma_TN_firstImage, NTkmin1_temp);
-    Eigen::Matrix3d NTkmin1 = cArrayAsEigenMatrix3(*NTkmin1_temp).transpose();
+    Eigen::Matrix3d NTkmin1 = cArrayToEigenMatrix3(*NTkmin1_temp).transpose();
 
     double BkmN_temp[3][3];
     MRP2C(this->keyPointBuffer.sigma_BN_secondImage, BkmN_temp);
-    Eigen::Matrix3d BkN = cArrayAsEigenMatrix3(*BkmN_temp);
+    Eigen::Matrix3d BkN = cArrayToEigenMatrix3(*BkmN_temp);
 
     double NTk_temp[3][3];
     MRP2C(this->keyPointBuffer.sigma_TN_secondImage, NTk_temp);
-    Eigen::Matrix3d NTk = cArrayAsEigenMatrix3(*NTk_temp).transpose();
+    Eigen::Matrix3d NTk = cArrayToEigenMatrix3(*NTk_temp).transpose();
 
     this->CkCkmin1 = CB * BkN * NTk * (CB * Bkmin1N * NTkmin1).transpose();
 }

--- a/src/fswAlgorithms/orbitControl/lambertPlanner/lambertPlanner.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertPlanner/lambertPlanner.cpp
@@ -85,8 +85,8 @@ void LambertPlanner::readMessages() {
     } else {
         this->time = navTransInMsgBuffer.timeTag;
     }
-    this->r_N = cArrayAsEigenVector(navTransInMsgBuffer.r_BN_N);
-    this->v_N = cArrayAsEigenVector(navTransInMsgBuffer.v_BN_N);
+    this->r_N = cArrayToEigenVector(navTransInMsgBuffer.r_BN_N);
+    this->v_N = cArrayToEigenVector(navTransInMsgBuffer.v_BN_N);
 }
 
 /*! This method writes the output messages each call of updateState

--- a/src/fswAlgorithms/orbitControl/lambertSecondDV/lambertSecondDV.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertSecondDV/lambertSecondDV.cpp
@@ -50,10 +50,10 @@ void LambertSecondDV::readMessages() {
 
     // lambert solution content
     if (this->lambertSolutionSpecifier == 1) {
-        this->vExpected_N = cArrayAsEigenVector(lambertSolutionInMsgBuffer.v2);
+        this->vExpected_N = cArrayToEigenVector(lambertSolutionInMsgBuffer.v2);
         this->validLambert = lambertSolutionInMsgBuffer.valid;
     } else if (this->lambertSolutionSpecifier == 2) {
-        this->vExpected_N = cArrayAsEigenVector(lambertSolutionInMsgBuffer.v2Sol2);
+        this->vExpected_N = cArrayToEigenVector(lambertSolutionInMsgBuffer.v2Sol2);
         this->validLambert = lambertSolutionInMsgBuffer.validSol2;
     } else {
         bskLogger.bskLog(BSK_ERROR,
@@ -62,7 +62,7 @@ void LambertSecondDV::readMessages() {
     }
 
     // desired velocity
-    this->vDesired_N = cArrayAsEigenVector(desiredVelocityInMsgBuffer.vDesired_N);
+    this->vDesired_N = cArrayToEigenVector(desiredVelocityInMsgBuffer.vDesired_N);
     this->maneuverTime = desiredVelocityInMsgBuffer.maneuverTime;
 }
 

--- a/src/fswAlgorithms/orbitControl/lambertSolver/lambertSolver.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertSolver/lambertSolver.cpp
@@ -68,8 +68,8 @@ void LambertSolver::readMessages() {
         this->numberOfRevolutions = lambertProblemInMsgBuffer.numRevolutions;
     }
     this->solverMethod = lambertProblemInMsgBuffer.solverMethod;
-    this->r1vec = cArrayAsEigenVector(lambertProblemInMsgBuffer.r1vec);
-    this->r2vec = cArrayAsEigenVector(lambertProblemInMsgBuffer.r2vec);
+    this->r1vec = cArrayToEigenVector(lambertProblemInMsgBuffer.r1vec);
+    this->r2vec = cArrayToEigenVector(lambertProblemInMsgBuffer.r2vec);
 }
 
 /*! This method writes the output messages each call of updateState

--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/lambertSurfaceRelativeVelocity.cpp
@@ -53,11 +53,11 @@ void LambertSurfaceRelativeVelocity::readMessages() {
     LambertProblemMsgPayload lambertProblemInMsgBuffer = this->lambertProblemInMsg();
     EphemerisMsgPayload ephemerisInMsgBuffer = this->ephemerisInMsg();
 
-    this->r_BN_N = cArrayAsEigenVector(lambertProblemInMsgBuffer.r2vec);
+    this->r_BN_N = cArrayToEigenVector(lambertProblemInMsgBuffer.r2vec);
 
-    Eigen::MRPd sigma_PN = cArrayAsEigenMrp(ephemerisInMsgBuffer.sigma_BN);
+    Eigen::MRPd sigma_PN = cArrayToEigenMrp(ephemerisInMsgBuffer.sigma_BN);
     this->dcm_PN = sigma_PN.toRotationMatrix().transpose();
-    Eigen::Vector3d omega_PN_P = cArrayAsEigenVector(ephemerisInMsgBuffer.omega_BN_B);
+    Eigen::Vector3d omega_PN_P = cArrayToEigenVector(ephemerisInMsgBuffer.omega_BN_B);
     this->omega_PN_N = this->dcm_PN.transpose() * omega_PN_P;
 }
 

--- a/src/fswAlgorithms/orbitControl/lambertValidator/lambertValidator.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertValidator/lambertValidator.cpp
@@ -114,21 +114,21 @@ void LambertValidator::readMessages() {
     }
 
     // current spacecraft state
-    this->r_N = cArrayAsEigenVector(navTransInMsgBuffer.r_BN_N);
-    this->v_N = cArrayAsEigenVector(navTransInMsgBuffer.v_BN_N);
+    this->r_N = cArrayToEigenVector(navTransInMsgBuffer.r_BN_N);
+    this->v_N = cArrayToEigenVector(navTransInMsgBuffer.v_BN_N);
 
     // targeted position
-    this->r_TN_N = cArrayAsEigenVector(lambertProblemInMsgBuffer.r2vec);
+    this->r_TN_N = cArrayToEigenVector(lambertProblemInMsgBuffer.r2vec);
 
     // lambert solution and performance message content
     if (this->lambertSolutionSpecifier == 1) {
-        this->vLambert_N = cArrayAsEigenVector(lambertSolutionInMsgBuffer.v1);
+        this->vLambert_N = cArrayToEigenVector(lambertSolutionInMsgBuffer.v1);
         this->validLambert = lambertSolutionInMsgBuffer.valid;
         this->xLambert = lambertPerformanceInMsgBuffer.x;
         this->numIterLambert = lambertPerformanceInMsgBuffer.numIter;
         this->errXLambert = lambertPerformanceInMsgBuffer.errX;
     } else if (this->lambertSolutionSpecifier == 2) {
-        this->vLambert_N = cArrayAsEigenVector(lambertSolutionInMsgBuffer.v1Sol2);
+        this->vLambert_N = cArrayToEigenVector(lambertSolutionInMsgBuffer.v1Sol2);
         this->validLambert = lambertSolutionInMsgBuffer.validSol2;
         this->xLambert = lambertPerformanceInMsgBuffer.xSol2;
         this->numIterLambert = lambertPerformanceInMsgBuffer.numIterSol2;
@@ -219,7 +219,7 @@ std::array<Eigen::VectorXd, NUM_INITIALSTATES> LambertValidator::getInitialState
     eigenVectorToCArray(this->rm_N, rc_N);
     eigenVectorToCArray(this->vm_N, vc_N);
     hillFrame(rc_N, vc_N, HN);
-    this->dcm_HN = c2DArrayAsEigenMatrix3(HN);
+    this->dcm_HN = c2DArrayToEigenMatrix3(HN);
 
     // vectors expressed in Hill frame
     Eigen::Vector3d rm_H = this->dcm_HN * this->rm_N;

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
@@ -65,19 +65,19 @@ void SmallBodyWaypointFeedback::computeControl(uint64_t currentSimNanos) {
     /* Compute the hill frame DCM of the small body */
     double dcm_ON_array[3][3];
     hillFrame(asteroidEphemerisInMsgBuffer.r_BdyZero_N, asteroidEphemerisInMsgBuffer.v_BdyZero_N, dcm_ON_array);
-    dcm_ON = cArrayAsEigenMatrix3(*dcm_ON_array);
+    dcm_ON = cArrayToEigenMatrix3(*dcm_ON_array);
 
     /* Compute the direction of the sun from the asteroid in the small body's hill frame, assumes heliocentric frame
      * centered at the origin of the sun, not the solar system's barycenter */
-    r_ON_N = cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N);
-    r_SN_N = cArrayAsEigenVector(sunEphemerisInMsgBuffer.r_BdyZero_N);
+    r_ON_N = cArrayToEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N);
+    r_SN_N = cArrayToEigenVector(sunEphemerisInMsgBuffer.r_BdyZero_N);
     r_SO_O = dcm_ON * (r_SN_N - r_ON_N);  // small body to sun pos vector
 
     /* Compute the dcm from the body frame to the body's hill frame */
     double dcm_BN[3][3];
     MRP2C(navAttInMsgBuffer.sigma_BN, dcm_BN);
     Eigen::Matrix3d dcm_OB;
-    dcm_OB = dcm_ON * cArrayAsEigenMatrix3(*dcm_BN).transpose();
+    dcm_OB = dcm_ON * cArrayToEigenMatrix3(*dcm_BN).transpose();
 
     /* Compute x1, x2 from the input messages */
     double r_BO_O[3];
@@ -88,8 +88,8 @@ void SmallBodyWaypointFeedback::computeControl(uint64_t currentSimNanos) {
             navTransInMsgBuffer.v_BN_N,
             r_BO_O,
             v_BO_O);
-    x1 = cArrayAsEigenVector(r_BO_O);
-    x2 = cArrayAsEigenVector(v_BO_O);
+    x1 = cArrayToEigenVector(r_BO_O);
+    x2 = cArrayToEigenVector(v_BO_O);
 
     /* Compute dx1 and dx2 */
     dx1 = x1 - x1_ref;

--- a/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/SICP/scalingIterativeClosestPoint.cpp
@@ -178,7 +178,7 @@ void ScalingIterativeClosestPoint::updateState(uint64_t currentSimNanos) {
     //! - If initial condition message exists populate the initial conditions, otherwise use defaults
     if (initicalConditionValidity) {
         this->R_init =
-            cArrayAsEigenMatrixX(this->initialConditionBuffer.rotationMatrix, SICP_POINT_DIM, SICP_POINT_DIM);
+            cArrayToEigenMatrixX(this->initialConditionBuffer.rotationMatrix, SICP_POINT_DIM, SICP_POINT_DIM);
         this->t_init = Eigen::Map<Eigen::VectorXd>(this->initialConditionBuffer.translation, SICP_POINT_DIM, 1);
         this->s_init = this->initialConditionBuffer.scaleFactor[0];
     } else {
@@ -193,9 +193,9 @@ void ScalingIterativeClosestPoint::updateState(uint64_t currentSimNanos) {
         this->outputSICPData.write(&this->sicpBuffer, this->moduleID, currentSimNanos);
         this->outputPointCloud.write(&this->outputCloudBuffer, this->moduleID, currentSimNanos);
     } else {
-        Eigen::MatrixXd measuredPoints = cArrayAsEigenMatrixX(
+        Eigen::MatrixXd measuredPoints = cArrayToEigenMatrixX(
             this->measuredCloudBuffer.points, SICP_POINT_DIM, this->measuredCloudBuffer.numberOfPoints);
-        Eigen::MatrixXd referencePoints = cArrayAsEigenMatrixX(
+        Eigen::MatrixXd referencePoints = cArrayToEigenMatrixX(
             this->referenceCloudBuffer.points, SICP_POINT_DIM, this->referenceCloudBuffer.numberOfPoints);
         //! - Initialize R (rotation matrix), t (translation vector) and s (scale factor).
         //! k and kmin1 refer to the iteration

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/cameraTriangulation.cpp
@@ -61,7 +61,7 @@ void CameraTriangulation::readMessages() {
     /* point cloud message */
     bool validPointCloud = pointCloudInMsgBuffer.valid;
     int pointCloudSize = pointCloudInMsgBuffer.numberOfPoints;
-    this->pointCloud = cArrayAsEigenMatrixX(pointCloudInMsgBuffer.points, SICP_POINT_DIM, pointCloudSize);
+    this->pointCloud = cArrayToEigenMatrixX(pointCloudInMsgBuffer.points, SICP_POINT_DIM, pointCloudSize);
     uint64_t timeTagPointCloud = pointCloudInMsgBuffer.timeTag;
 
     /* key points message */
@@ -70,7 +70,7 @@ void CameraTriangulation::readMessages() {
     int cameraIDkeyPoints = keyPointsInMsgBuffer.cameraID;
     // stacked vector with all pixel locations of key points
     Eigen::VectorXd keyPointsStacked(2 * numberKeyPoints);
-    keyPointsStacked = cArrayAsEigenMatrixX(keyPointsInMsgBuffer.keyPoints_secondImage, 2 * numberKeyPoints, 1);
+    keyPointsStacked = cArrayToEigenMatrixX(keyPointsInMsgBuffer.keyPoints_secondImage, 2 * numberKeyPoints, 1);
     // convert to std vector that includes all key point pixel locations
     this->keyPoints.clear();
     for (int c = 0; c < numberKeyPoints; c++) {
@@ -79,13 +79,13 @@ void CameraTriangulation::readMessages() {
     }
     uint64_t timeTagKeyPoints = keyPointsInMsgBuffer.timeTag_secondImage;
     // dcm from inertial frame N to body frame B
-    this->sigma_BN = cArrayAsEigenMrp(keyPointsInMsgBuffer.sigma_BN_secondImage);
+    this->sigma_BN = cArrayToEigenMrp(keyPointsInMsgBuffer.sigma_BN_secondImage);
     Eigen::Matrix3d dcm_BN = this->sigma_BN.toRotationMatrix().transpose();
 
     /* camera config message */
     int cameraIDconfig = cameraConfigInMsgBuffer.cameraID;
     // dcm from body frame B to camera frame C
-    Eigen::MRPd sigma_CB = cArrayAsEigenMrp(cameraConfigInMsgBuffer.sigma_CB);
+    Eigen::MRPd sigma_CB = cArrayToEigenMrp(cameraConfigInMsgBuffer.sigma_CB);
     Eigen::Matrix3d dcm_CB = sigma_CB.toRotationMatrix().transpose();
     // camera parameters
     double alpha = 0;

--- a/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/initializeICP/initializeICP.cpp
@@ -31,7 +31,7 @@ void InitializeICP::normalizePointCloud() {
     PointCloudMsgPayload measuredCloudBuffer = this->inputMeasuredPointCloud();
     this->normalizedCloudBuffer = PointCloudMsgPayload{};
     Eigen::MatrixXd measuredPoints =
-        cArrayAsEigenMatrixX(measuredCloudBuffer.points, SICP_POINT_DIM, measuredCloudBuffer.numberOfPoints);
+        cArrayToEigenMatrixX(measuredCloudBuffer.points, SICP_POINT_DIM, measuredCloudBuffer.numberOfPoints);
     Eigen::MatrixXd normalizedPoints = Eigen::MatrixXd::Zero(SICP_POINT_DIM, measuredCloudBuffer.numberOfPoints);
     //! If there is a valid point cloud present, average the point norms to normalize each point
     if (measuredCloudBuffer.valid && measuredCloudBuffer.numberOfPoints > 0) {
@@ -69,11 +69,11 @@ void InitializeICP::setInitialConditions(uint64_t currentSimNanos) {
 
     //!< When a valid ICP solution has been computed, use that instead of ephemeris information as a priority
     if (sicpBuffer.valid) {
-        this->R_logged = cArrayAsEigenMatrixX(
+        this->R_logged = cArrayToEigenMatrixX(
             &sicpBuffer.rotationMatrix[(sicpBuffer.numberOfIteration - 1) * SICP_POINT_DIM * SICP_POINT_DIM],
             SICP_POINT_DIM,
             SICP_POINT_DIM);
-        this->t_logged = cArrayAsEigenMatrixX(
+        this->t_logged = cArrayToEigenMatrixX(
             &sicpBuffer.translation[(sicpBuffer.numberOfIteration - 1) * SICP_POINT_DIM], 1, SICP_POINT_DIM);
         this->s_logged = sicpBuffer.scaleFactor[sicpBuffer.numberOfIteration - 1];
         this->initialPhase = false;
@@ -85,12 +85,12 @@ void InitializeICP::setInitialConditions(uint64_t currentSimNanos) {
     if (this->normalizedCloudBuffer.valid) {
         if (this->initialPhase || timeSinceICPSolution > this->maxTimeBetweenMeasurements) {
             EphemerisMsgPayload ephemerisInMsgBuffer = this->ephemerisInMsg();
-            Eigen::Vector3d r_BN_N = cArrayAsEigenVector(ephemerisInMsgBuffer.r_BdyZero_N);
+            Eigen::Vector3d r_BN_N = cArrayToEigenVector(ephemerisInMsgBuffer.r_BdyZero_N);
 
-            Eigen::MRPd sigma_CB = cArrayAsEigenMrp(cameraBuffer.sigma_CB);
+            Eigen::MRPd sigma_CB = cArrayToEigenMrp(cameraBuffer.sigma_CB);
             Eigen::Matrix3d dcm_CB = sigma_CB.toRotationMatrix().transpose();
 
-            Eigen::MRPd sigma_BN = cArrayAsEigenMrp(ephemerisInMsgBuffer.sigma_BN);
+            Eigen::MRPd sigma_BN = cArrayToEigenMrp(ephemerisInMsgBuffer.sigma_BN);
             Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
 
             R_prev = (dcm_CB * dcm_BN);

--- a/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.cpp
+++ b/src/fswAlgorithms/pointCloudProcessing/pointCloudTriangulation/pointCloudTriangulation.cpp
@@ -76,15 +76,15 @@ void PointCloudTriangulation::readMessages() {
 
     /* velocity information either from ephemeris message or nav message */
     if (this->initialPhase) {
-        this->vScaleFactor = cArrayAsEigenVector(ephemerisInMsgBuffer.v_BdyZero_N).norm();
+        this->vScaleFactor = cArrayToEigenVector(ephemerisInMsgBuffer.v_BdyZero_N).norm();
     } else {
-        this->vScaleFactor = cArrayAsEigenVector(navTransInMsgBuffer.v_BN_N).norm();
+        this->vScaleFactor = cArrayToEigenVector(navTransInMsgBuffer.v_BN_N).norm();
     }
 
     /* direction of motion message */
     bool validDOM = directionOfMotionInMsgBuffer.valid;
     uint64_t timeTagDOM = directionOfMotionInMsgBuffer.timeOfDirectionEstimate;
-    this->v_C1_hat = cArrayAsEigenVector(directionOfMotionInMsgBuffer.v_C_hat);
+    this->v_C1_hat = cArrayToEigenVector(directionOfMotionInMsgBuffer.v_C_hat);
 
     /* key points message */
     bool validKeyPoints = keyPointsInMsgBuffer.valid;
@@ -93,7 +93,7 @@ void PointCloudTriangulation::readMessages() {
 
     // stacked vector with all pixel locations of key points for 1st camera location
     Eigen::VectorXd keyPointsStacked1(2 * this->numberKeyPoints);
-    keyPointsStacked1 = cArrayAsEigenMatrixX(keyPointsInMsgBuffer.keyPoints_firstImage, 2 * this->numberKeyPoints, 1);
+    keyPointsStacked1 = cArrayToEigenMatrixX(keyPointsInMsgBuffer.keyPoints_firstImage, 2 * this->numberKeyPoints, 1);
     // convert to std vector that includes all key point pixel locations
     this->keyPoints1.clear();
     for (int c = 0; c < this->numberKeyPoints; c++) {
@@ -102,12 +102,12 @@ void PointCloudTriangulation::readMessages() {
     }
     this->timeTag1 = keyPointsInMsgBuffer.timeTag_firstImage;
     // dcm from inertial frame N to body frame B
-    Eigen::MRPd sigma_B1N = cArrayAsEigenMrp(keyPointsInMsgBuffer.sigma_BN_firstImage);
+    Eigen::MRPd sigma_B1N = cArrayToEigenMrp(keyPointsInMsgBuffer.sigma_BN_firstImage);
     Eigen::Matrix3d dcm_B1N = sigma_B1N.toRotationMatrix().transpose();
 
     // stacked vector with all pixel locations of key points for 2nd camera location
     Eigen::VectorXd keyPointsStacked2(2 * this->numberKeyPoints);
-    keyPointsStacked2 = cArrayAsEigenMatrixX(keyPointsInMsgBuffer.keyPoints_secondImage, 2 * this->numberKeyPoints, 1);
+    keyPointsStacked2 = cArrayToEigenMatrixX(keyPointsInMsgBuffer.keyPoints_secondImage, 2 * this->numberKeyPoints, 1);
     // convert to std vector that includes all key point pixel locations
     this->keyPoints2.clear();
     for (int c = 0; c < this->numberKeyPoints; c++) {
@@ -116,13 +116,13 @@ void PointCloudTriangulation::readMessages() {
     }
     this->timeTag2 = keyPointsInMsgBuffer.timeTag_secondImage;
     // dcm from inertial frame N to body frame B
-    Eigen::MRPd sigma_B2N = cArrayAsEigenMrp(keyPointsInMsgBuffer.sigma_BN_secondImage);
+    Eigen::MRPd sigma_B2N = cArrayToEigenMrp(keyPointsInMsgBuffer.sigma_BN_secondImage);
     Eigen::Matrix3d dcm_B2N = sigma_B2N.toRotationMatrix().transpose();
 
     /* camera config message */
     int64_t cameraIDconfig = cameraConfigInMsgBuffer.cameraID;
     // dcm from body frame B to camera frame C
-    Eigen::MRPd sigma_CB = cArrayAsEigenMrp(cameraConfigInMsgBuffer.sigma_CB);
+    Eigen::MRPd sigma_CB = cArrayToEigenMrp(cameraConfigInMsgBuffer.sigma_CB);
     Eigen::Matrix3d dcm_CB = sigma_CB.toRotationMatrix().transpose();
     // camera parameters
     double alpha = 0;

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
@@ -123,25 +123,25 @@ void SmallBodyNavEKF::predict(uint64_t currentSimNanos) {
     /* Compute the hill frame DCM of the small body */
     double dcm_ON_array[3][3];
     hillFrame(asteroidEphemerisInMsgBuffer.r_BdyZero_N, asteroidEphemerisInMsgBuffer.v_BdyZero_N, dcm_ON_array);
-    dcm_ON = cArrayAsEigenMatrix3(*dcm_ON_array);
+    dcm_ON = cArrayToEigenMatrix3(*dcm_ON_array);
 
     /* Compute the direction of the sun from the asteroid in the small body's hill frame, assumes heliocentric frame
      * centered at the origin of the sun, not the solar system's barycenter*/
     Eigen::Vector3d r_ON_N;  // inertial to small body pos. vector
     Eigen::Vector3d r_SN_N;  // inertial to sun pos. vector
-    r_ON_N = cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N);
-    r_SN_N = cArrayAsEigenVector(sunEphemerisInMsgBuffer.r_BdyZero_N);
+    r_ON_N = cArrayToEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N);
+    r_SN_N = cArrayToEigenVector(sunEphemerisInMsgBuffer.r_BdyZero_N);
     r_SO_O = dcm_ON * (r_SN_N - r_ON_N);  // small body to sun pos vector
 
     /* Compute the total thrust and torque from the thrusters */
     thrust_B.setZero();  // Set to zero in case no thrusters are used
     for (long unsigned int c = 0; c < thrusterInMsgBuffer.size(); c++) {
-        thrust_B += cArrayAsEigenVector(thrusterInMsgBuffer[c].thrustForce_B);
+        thrust_B += cArrayToEigenVector(thrusterInMsgBuffer[c].thrustForce_B);
     }
 
     /* Add the commanded force */
     if (this->cmdForceBodyInMsg.isLinked()) {
-        cmdForce_B = cArrayAsEigenVector(cmdForceBodyInMsgBuffer.forceRequestBody);
+        cmdForce_B = cArrayToEigenVector(cmdForceBodyInMsgBuffer.forceRequestBody);
     }
 
     /* Compute aprior state estimate */
@@ -206,7 +206,7 @@ void SmallBodyNavEKF::computeEquationsOfMotion(Eigen::VectorXd x_hat, Eigen::Mat
     double dcm_BN_meas[3][3];
     MRP2C(this->navAttInMsgBuffer.sigma_BN, dcm_BN_meas);
     Eigen::Matrix3d dcm_OB;
-    dcm_OB = dcm_ON * cArrayAsEigenMatrix3(*dcm_BN_meas).transpose();
+    dcm_OB = dcm_ON * cArrayToEigenMatrix3(*dcm_BN_meas).transpose();
     /* Now compute x2_dot */
     x_hat_dot_k.segment(3, 3) = -F_ddot * o_hat_3_tilde * x_1 - 2 * F_dot * o_hat_3_tilde * x_2 -
                                 pow(F_dot, 2) * o_hat_3_tilde * o_hat_3_tilde * x_1 -
@@ -285,15 +285,15 @@ void SmallBodyNavEKF::measurementUpdate() {
     /* Subtract the asteroid position from the spacecraft position and rotate it into the small body's hill frame*/
     Eigen::VectorXd y_k1;
     y_k1.setZero(this->numStates);
-    y_k1.segment(0, 3) = dcm_ON * (cArrayAsEigenVector(navTransInMsgBuffer.r_BN_N) -
-                                   cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
+    y_k1.segment(0, 3) = dcm_ON * (cArrayToEigenVector(navTransInMsgBuffer.r_BN_N) -
+                                   cArrayToEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
 
     /* Perform a similar operation for the relative velocity */
-    y_k1.segment(3, 3) = dcm_ON * (cArrayAsEigenVector(navTransInMsgBuffer.v_BN_N) -
-                                   cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.v_BdyZero_N));
+    y_k1.segment(3, 3) = dcm_ON * (cArrayToEigenVector(navTransInMsgBuffer.v_BN_N) -
+                                   cArrayToEigenVector(asteroidEphemerisInMsgBuffer.v_BdyZero_N));
 
     /* Small body attitude from the ephemeris msg */
-    y_k1.segment(6, 3) = cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.sigma_BN);
+    y_k1.segment(6, 3) = cArrayToEigenVector(asteroidEphemerisInMsgBuffer.sigma_BN);
 
     /* Check if the shadow set measurement must be considered, i.e. |sigma| > 1/3 */
     if (y_k1.segment(6, 3).norm() > 1.0 / 3.0) {
@@ -306,7 +306,7 @@ void SmallBodyNavEKF::measurementUpdate() {
     }
 
     /* Small body attitude rate from the ephemeris msg */
-    y_k1.segment(9, 3) = cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.omega_BN_B);
+    y_k1.segment(9, 3) = cArrayToEigenVector(asteroidEphemerisInMsgBuffer.omega_BN_B);
 
     /* Update the state estimate */
     x_hat_k1 = x_hat_k1_ + K_k1 * (y_k1 - x_hat_k1_);
@@ -385,10 +385,10 @@ void SmallBodyNavEKF::writeMessages(uint64_t currentSimNanos) {
     /* Assign values to the nav trans output message */
     navTransOutMsgBuffer.timeTag = navTransInMsgBuffer.timeTag;
     eigenMatrixXToCArray(
-        cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N) + dcm_ON.transpose() * x_hat_k.segment(0, 3),
+        cArrayToEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N) + dcm_ON.transpose() * x_hat_k.segment(0, 3),
         navTransOutMsgBuffer.r_BN_N);
     eigenMatrixXToCArray(
-        cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.v_BdyZero_N) + dcm_ON.transpose() * x_hat_k.segment(3, 3),
+        cArrayToEigenVector(asteroidEphemerisInMsgBuffer.v_BdyZero_N) + dcm_ON.transpose() * x_hat_k.segment(3, 3),
         navTransOutMsgBuffer.v_BN_N);
     v3Copy(navTransOutMsgBuffer.vehAccumDV,
            navTransInMsgBuffer.vehAccumDV);  // Not an estimated parameter, pass through

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
@@ -69,7 +69,7 @@ void SmallBodyNavUKF::readMessages() {
 */
 void SmallBodyNavUKF::processUT(uint64_t currentSimNanos) {
     /* Read angular velocity of the small body fixed frame */
-    this->omega_AN_A = cArrayAsEigenVector(this->asteroidEphemerisInMsgBuffer.omega_BN_B);
+    this->omega_AN_A = cArrayToEigenVector(this->asteroidEphemerisInMsgBuffer.omega_BN_B);
 
     /* Declare matrix to store sigma points spread */
     Eigen::MatrixXd X_sigma_k;
@@ -192,7 +192,7 @@ void SmallBodyNavUKF::measurementUT() {
     /* Extract dcm of the small body, it transforms from inertial to small body fixed frame */
     double dcm_AN_array[3][3];
     MRP2C(asteroidEphemerisInMsgBuffer.sigma_BN, dcm_AN_array);
-    this->dcm_AN = cArrayAsEigenMatrix3(*dcm_AN_array);
+    this->dcm_AN = cArrayToEigenMatrix3(*dcm_AN_array);
 
     /* Add process noise covariance */
     this->R_k1_ = this->R_k1_ + this->dcm_AN * this->R_meas * this->dcm_AN.transpose();
@@ -204,13 +204,13 @@ void SmallBodyNavUKF::measurementUT() {
 void SmallBodyNavUKF::kalmanUpdate() {
     /* Read attitude MRP of the small body fixed frame w.r.t. inertial */
     Eigen::Vector3d sigma_AN;
-    sigma_AN = cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.sigma_BN);
+    sigma_AN = cArrayToEigenVector(asteroidEphemerisInMsgBuffer.sigma_BN);
 
     /* Subtract the asteroid position from the spacecraft position */
     Eigen::VectorXd y_k1;
     y_k1.setZero(this->numMeas);
-    y_k1.segment(0, 3) = this->dcm_AN * (cArrayAsEigenVector(navTransInMsgBuffer.r_BN_N) -
-                                         cArrayAsEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
+    y_k1.segment(0, 3) = this->dcm_AN * (cArrayToEigenVector(navTransInMsgBuffer.r_BN_N) -
+                                         cArrayToEigenVector(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
 
     /* Compute Kalman gain */
     this->K = this->H * this->R_k1_.inverse();

--- a/src/fswAlgorithms/stateEstimation/thrustCMEstimation/thrustCMEstimation.cpp
+++ b/src/fswAlgorithms/stateEstimation/thrustCMEstimation/thrustCMEstimation.cpp
@@ -49,18 +49,18 @@ void ThrustCMEstimation::updateState(uint64_t currentSimNanos) {
     THRConfigMsgPayload thrConfigBuffer = this->thrusterConfigBInMsg();
 
     /*! compute thruster information in B-frame coordinates */
-    Eigen::Vector3d r_TB_B = cArrayAsEigenVector(thrConfigBuffer.rThrust_B);
-    Eigen::Vector3d T_B = thrConfigBuffer.maxThrust * cArrayAsEigenVector(thrConfigBuffer.tHatThrust_B);
+    Eigen::Vector3d r_TB_B = cArrayToEigenVector(thrConfigBuffer.rThrust_B);
+    Eigen::Vector3d T_B = thrConfigBuffer.maxThrust * cArrayToEigenVector(thrConfigBuffer.tHatThrust_B);
 
     /*! compute error w.r.t. target attitude */
     AttGuidMsgPayload attGuidBuffer = this->attGuidInMsg();
-    Eigen::Vector3d sigma_BR = cArrayAsEigenVector(attGuidBuffer.sigma_BR);
-    Eigen::Vector3d omega_BR_B = cArrayAsEigenVector(attGuidBuffer.omega_BR_B);
+    Eigen::Vector3d sigma_BR = cArrayToEigenVector(attGuidBuffer.sigma_BR);
+    Eigen::Vector3d omega_BR_B = cArrayToEigenVector(attGuidBuffer.omega_BR_B);
     double attError = pow(sigma_BR.squaredNorm() + omega_BR_B.squaredNorm(), 0.5);
 
     /*! read commanded torque msg */
     CmdTorqueBodyMsgPayload cmdTorqueBuffer = this->intFeedbackTorqueInMsg();
-    Eigen::Vector3d L_B = -cArrayAsEigenVector(cmdTorqueBuffer.torqueRequestBody);
+    Eigen::Vector3d L_B = -cArrayToEigenVector(cmdTorqueBuffer.torqueRequestBody);
 
     Eigen::Vector3d y;        // measurement
     Eigen::Vector3d preFit;   // pre-fit residual
@@ -110,7 +110,7 @@ void ThrustCMEstimation::updateState(uint64_t currentSimNanos) {
     Eigen::Vector3d r_CB_error;
     if (this->cmKnowledge) {
         VehicleConfigMsgPayload vehConfigBuffer = this->vehConfigInMsg();
-        Eigen::Vector3d r_CB_B_true = cArrayAsEigenVector(vehConfigBuffer.CoM_B);
+        Eigen::Vector3d r_CB_B_true = cArrayToEigenVector(vehConfigBuffer.CoM_B);
         r_CB_error = this->r_CB_est - r_CB_B_true;
         eigenVectorToCArray(r_CB_error, cmEstDataBuffer.stateError);
     } else {

--- a/src/fswAlgorithms/transDetermination/ephemDifferenceWithUncertainty/ephemDifferenceWithUncertaintyAlgorithm.cpp
+++ b/src/fswAlgorithms/transDetermination/ephemDifferenceWithUncertainty/ephemDifferenceWithUncertaintyAlgorithm.cpp
@@ -12,10 +12,10 @@ std::tuple<NavTransMsgPayload, FilterMsgPayload> EphemDifferenceWithUncertaintyA
     double timeTag = ephemSecondaryInBuffer.timeTag;
 
     /*! - compute relative states */
-    Eigen::Vector3d r_1_N = cArrayAsEigenVector(ephemBaseInBuffer.r_BdyZero_N);
-    Eigen::Vector3d v_1_N = cArrayAsEigenVector(ephemBaseInBuffer.v_BdyZero_N);
-    Eigen::Vector3d r_2_N = cArrayAsEigenVector(ephemSecondaryInBuffer.r_BdyZero_N);
-    Eigen::Vector3d v_2_N = cArrayAsEigenVector(ephemSecondaryInBuffer.v_BdyZero_N);
+    Eigen::Vector3d r_1_N = cArrayToEigenVector(ephemBaseInBuffer.r_BdyZero_N);
+    Eigen::Vector3d v_1_N = cArrayToEigenVector(ephemBaseInBuffer.v_BdyZero_N);
+    Eigen::Vector3d r_2_N = cArrayToEigenVector(ephemSecondaryInBuffer.r_BdyZero_N);
+    Eigen::Vector3d v_2_N = cArrayToEigenVector(ephemSecondaryInBuffer.v_BdyZero_N);
 
     Eigen::Vector3d r_21_N = r_2_N - r_1_N;
     Eigen::Vector3d v_21_N = v_2_N - v_1_N;

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -665,7 +665,7 @@ Eigen::Vector3d PrescribedRotation1DOF::computeSigma_FM() {
     // Compute the MRP sigma_FM representing the current spinning body attitude relative to the mount frame
     double sigma_FM_array[3];
     C2MRP(dcm_FM, sigma_FM_array);
-    return cArrayAsEigenVector(sigma_FM_array);
+    return cArrayToEigenVector(sigma_FM_array);
 }
 
 /*! Setter method for the coast option bang duration.

--- a/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.cpp
+++ b/src/simulation/deviceInterface/singleAxisProfiler/singleAxisProfiler.cpp
@@ -63,7 +63,7 @@ Eigen::Vector3d SingleAxisProfiler::computeSigma_FM(double theta) {
     // Compute the MRP sigma_FM representing the current spinning body attitude relative to the mount frame
     double sigma_FM_array[3];
     C2MRP(dcm_FM, sigma_FM_array);
-    return cArrayAsEigenVector(sigma_FM_array);
+    return cArrayToEigenVector(sigma_FM_array);
 }
 
 /*! Setter method for the spinning body rotation axis.

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.cpp
@@ -69,10 +69,10 @@ void BoreAngCalc::ReadInputs() {
 */
 void BoreAngCalc::computeCelestialAxisPoint() {
     // Convert planet and body data to Eigen variables
-    Eigen::Vector3d r_BN_N = cArrayAsEigenVector(this->localState.r_BN_N);           // spacecraft's inertial position
-    Eigen::Vector3d v_BN_N = cArrayAsEigenVector(this->localState.v_BN_N);           // spacecraft''s inertial velocity
-    Eigen::Vector3d r_PN_N = cArrayAsEigenVector(this->localPlanet.PositionVector);  // planet's inertial position
-    Eigen::Vector3d v_PN_N = cArrayAsEigenVector(this->localPlanet.VelocityVector);  // planet's inertial velocity
+    Eigen::Vector3d r_BN_N = cArrayToEigenVector(this->localState.r_BN_N);           // spacecraft's inertial position
+    Eigen::Vector3d v_BN_N = cArrayToEigenVector(this->localState.v_BN_N);           // spacecraft''s inertial velocity
+    Eigen::Vector3d r_PN_N = cArrayToEigenVector(this->localPlanet.PositionVector);  // planet's inertial position
+    Eigen::Vector3d v_PN_N = cArrayToEigenVector(this->localPlanet.VelocityVector);  // planet's inertial velocity
 
     // Compute the relative vectors
     Eigen::Vector3d r_PB_N = r_PN_N - r_BN_N;                      // relative position vector
@@ -87,7 +87,7 @@ void BoreAngCalc::computeCelestialAxisPoint() {
     dcm_PoN.row(1) = dcm_PoN.row(2).cross(dcm_PoN.row(0));
 
     // Compute the point to body frame DCM and convert the boresight vector to the Po frame
-    Eigen::MRPd sigma_BN = cArrayAsEigenMrp(this->localState.sigma_BN);  // mrp, inertial to body frame
+    Eigen::MRPd sigma_BN = cArrayToEigenMrp(this->localState.sigma_BN);  // mrp, inertial to body frame
     Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();    // dcm, inertial to body frame
     Eigen::Matrix3d dcm_BPo = dcm_BN * dcm_PoN.transpose();              // dcm, point to body frame
     this->boreVec_Po = dcm_BPo.transpose() * this->boreVec_B;
@@ -119,7 +119,7 @@ void BoreAngCalc::computeCelestialOutputData() {
 */
 void BoreAngCalc::computeInertialOutputData() {
     // Compute the DCM from inertial do body frame
-    Eigen::MRPd sigma_BN = cArrayAsEigenMrp(this->localState.sigma_BN);  // mrp, inertial to body frame
+    Eigen::MRPd sigma_BN = cArrayToEigenMrp(this->localState.sigma_BN);  // mrp, inertial to body frame
     Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();    // dcm, inertial to body frame
 
     // Calculate the inertial heading vector

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.cpp
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.cpp
@@ -94,19 +94,19 @@ void MtbEffector::computeForceTorque(double integTime, double timeStep) {
      */
     sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
     dcm_BN = sigmaBN.toRotationMatrix().transpose();
-    magField_N = cArrayAsEigenVector(this->magInMsgBuffer.magField_N);
+    magField_N = cArrayToEigenVector(this->magInMsgBuffer.magField_N);
     magField_B = dcm_BN * magField_N;
     bTilde = eigenTilde(magField_B);
 
     /*
      * Compute torque produced by magnetic torque bars in body frame components.
-     * Since cArrayAsEigenMatrix expects a column major input, we need to
+     * Since cArrayToEigenMatrix expects a column major input, we need to
      * transpose GtMatrix_B.
      */
     double GtColMajor[3 * MAX_EFF_CNT];
     mSetZero(GtColMajor, 3, this->mtbConfigParams.numMTB);
     mTranspose(this->mtbConfigParams.GtMatrix_B, 3, this->mtbConfigParams.numMTB, GtColMajor);
-    GtMatrix_B = cArrayAsEigenMatrixX(GtColMajor, 3, this->mtbConfigParams.numMTB);
+    GtMatrix_B = cArrayToEigenMatrixX(GtColMajor, 3, this->mtbConfigParams.numMTB);
 
     /* check if dipole commands are saturating the effector */
     for (int i = 0; i < this->mtbConfigParams.numMTB; i++) {

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -162,9 +162,9 @@ void ThrusterDynamicEffector::UpdateThrusterProperties() {
             this->attachedBodyBuffer = this->attachedBodyInMsgs.at(index)();
 
             // Grab attached body variables
-            sigma_FN = cArrayAsEigenMrp(attachedBodyBuffer.sigma_BN);
-            omega_FN_F = cArrayAsEigenVector(attachedBodyBuffer.omega_BN_B);
-            r_FN_N = cArrayAsEigenVector(attachedBodyBuffer.r_BN_N);
+            sigma_FN = cArrayToEigenMrp(attachedBodyBuffer.sigma_BN);
+            omega_FN_F = cArrayToEigenVector(attachedBodyBuffer.omega_BN_B);
+            r_FN_N = cArrayToEigenVector(attachedBodyBuffer.r_BN_N);
 
             // Compute the DCM between the attached body and the hub
             dcm_FN = (sigma_FN.toRotationMatrix()).transpose();

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -184,9 +184,9 @@ void ThrusterStateEffector::UpdateThrusterProperties() {
             this->attachedBodyBuffer = this->attachedBodyInMsgs.at(index)();
 
             // Grab attached body variables
-            sigma_FN = cArrayAsEigenMrp(attachedBodyBuffer.sigma_BN);
-            omega_FN_F = cArrayAsEigenVector(attachedBodyBuffer.omega_BN_B);
-            r_FN_N = cArrayAsEigenVector(attachedBodyBuffer.r_BN_N);
+            sigma_FN = cArrayToEigenMrp(attachedBodyBuffer.sigma_BN);
+            omega_FN_F = cArrayToEigenVector(attachedBodyBuffer.omega_BN_B);
+            r_FN_N = cArrayToEigenVector(attachedBodyBuffer.r_BN_N);
 
             // Compute the DCM between the attached body and the hub
             dcm_FN = (sigma_FN.toRotationMatrix()).transpose();

--- a/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
@@ -40,12 +40,12 @@ void GravBodyData::initBody(int64_t moduleID) {
 
 Eigen::Vector3d GravBodyData::computeGravityInertial(Eigen::Vector3d r_I, uint64_t simTimeNanos) {
     double dt = computeDtInSeconds(simTimeNanos, this->timeWritten);
-    Eigen::Matrix3d dcm_PfixN = c2DArrayAsEigenMatrix3(this->localPlanet.J20002Pfix).transpose();
+    Eigen::Matrix3d dcm_PfixN = c2DArrayToEigenMatrix3(this->localPlanet.J20002Pfix).transpose();
     if (dcm_PfixN.isZero()) {  // Sanity check for connected messages that do not initialize J20002Pfix
         dcm_PfixN = Eigen::Matrix3d::Identity();
     }
 
-    Eigen::Matrix3d dcm_PfixN_dot = c2DArrayAsEigenMatrix3(this->localPlanet.J20002Pfix_dot).transpose();
+    Eigen::Matrix3d dcm_PfixN_dot = c2DArrayToEigenMatrix3(this->localPlanet.J20002Pfix_dot).transpose();
     dcm_PfixN += dcm_PfixN_dot * dt;
 
     // store the current planet orientation and rates
@@ -86,9 +86,9 @@ void GravBodyData::registerProperties(DynParamManager& statesIn) {
     this->muPlanet = statesIn.createProperty(this->planetName + ".mu", muInit);
 
     this->J20002Pfix =
-        statesIn.createProperty(this->planetName + ".J20002Pfix", c2DArrayAsEigenMatrix3(this->localPlanet.J20002Pfix));
+        statesIn.createProperty(this->planetName + ".J20002Pfix", c2DArrayToEigenMatrix3(this->localPlanet.J20002Pfix));
     this->J20002Pfix_dot = statesIn.createProperty(this->planetName + ".J20002Pfix_dot",
-                                                   c2DArrayAsEigenMatrix3(this->localPlanet.J20002Pfix_dot));
+                                                   c2DArrayToEigenMatrix3(this->localPlanet.J20002Pfix_dot));
 }
 
 void GravityEffector::reset(uint64_t currentSimNanos) {
@@ -185,7 +185,7 @@ void GravityEffector::computeGravityField(Eigen::Vector3d r_cF_N, Eigen::Vector3
 
         // store planet states in the state engine parameters
         *(body->r_PN_N) = r_PN_N;
-        *(body->v_PN_N) = cArrayAsEigenVector(body->localPlanet.VelocityVector);
+        *(body->v_PN_N) = cArrayToEigenVector(body->localPlanet.VelocityVector);
         (*(body->muPlanet))(0, 0) = body->mu;
     }
 
@@ -201,7 +201,7 @@ void GravityEffector::updateInertialPosAndVel(Eigen::Vector3d r_BF_N, Eigen::Vec
         Eigen::Vector3d r_CN_N = getEulerSteppedGravBodyPosition(this->centralBody);
         *this->inertialPositionProperty = r_CN_N + r_BF_N;
         *this->inertialVelocityProperty =
-            cArrayAsEigenMatrixX(this->centralBody->localPlanet.VelocityVector, 3, 1) + rDot_BF_N;
+            cArrayToEigenMatrixX(this->centralBody->localPlanet.VelocityVector, 3, 1) + rDot_BF_N;
     } else {
         *this->inertialPositionProperty = r_BF_N;
         *this->inertialVelocityProperty = rDot_BF_N;
@@ -211,8 +211,8 @@ void GravityEffector::updateInertialPosAndVel(Eigen::Vector3d r_BF_N, Eigen::Vec
 Eigen::Vector3d GravityEffector::getEulerSteppedGravBodyPosition(std::shared_ptr<GravBodyData> bodyData) {
     uint64_t systemClock = (uint64_t)this->timeCorr->data()[0];
     double dt = computeDtInSeconds(systemClock, bodyData->timeWritten);
-    Eigen::Vector3d r_PN_N = cArrayAsEigenVector(bodyData->localPlanet.PositionVector);
-    r_PN_N += cArrayAsEigenVector(bodyData->localPlanet.VelocityVector) * dt;
+    Eigen::Vector3d r_PN_N = cArrayToEigenVector(bodyData->localPlanet.PositionVector);
+    r_PN_N += cArrayToEigenVector(bodyData->localPlanet.VelocityVector) * dt;
     return r_PN_N;
 }
 

--- a/src/simulation/dynamics/extForceTorque/extForceTorque.cpp
+++ b/src/simulation/dynamics/extForceTorque/extForceTorque.cpp
@@ -63,7 +63,7 @@ void ExtForceTorque::computeForceTorque(double integTime, double timeStep) {
     this->forceExternal_N = this->extForce_N;
     /* add the cmd force in inertial frame components set via FSW communication */
     if (this->cmdForceInertialInMsg.isLinked()) {
-        cmdVec = cArrayAsEigenVector(this->incomingCmdForceInertialBuffer.forceRequestInertial);
+        cmdVec = cArrayToEigenVector(this->incomingCmdForceInertialBuffer.forceRequestInertial);
         this->forceExternal_N += cmdVec;
     }
 
@@ -71,7 +71,7 @@ void ExtForceTorque::computeForceTorque(double integTime, double timeStep) {
     this->forceExternal_B = this->extForce_B;
     /* add the cmd force in body frame components set via FSW communication */
     if (this->cmdForceBodyInMsg.isLinked()) {
-        cmdVec = cArrayAsEigenVector(this->incomingCmdForceBodyBuffer.forceRequestBody);
+        cmdVec = cArrayToEigenVector(this->incomingCmdForceBodyBuffer.forceRequestBody);
         this->forceExternal_B += cmdVec;
     }
 
@@ -79,7 +79,7 @@ void ExtForceTorque::computeForceTorque(double integTime, double timeStep) {
     this->torqueExternalPntB_B = this->extTorquePntB_B;
     /* add the cmd torque about Point B in body frame components set via FSW communication */
     if (this->cmdTorqueInMsg.isLinked()) {
-        cmdVec = cArrayAsEigenVector(this->incomingCmdTorqueBuffer.torqueRequestBody);
+        cmdVec = cArrayToEigenVector(this->incomingCmdTorqueBuffer.torqueRequestBody);
         this->torqueExternalPntB_B += cmdVec;
     }
 

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -83,7 +83,7 @@ void FacetSRPDynamicEffector::ReadMessages() {
         SpicePlanetStateMsgPayload sunMsgBuffer;
         sunMsgBuffer = SpicePlanetStateMsgPayload{};
         sunMsgBuffer = this->sunInMsg();
-        this->r_SN_N = cArrayAsEigenVector(sunMsgBuffer.PositionVector);
+        this->r_SN_N = cArrayToEigenVector(sunMsgBuffer.PositionVector);
     }
 
     // Read the facet articulation angle data
@@ -155,7 +155,7 @@ void FacetSRPDynamicEffector::computeForceTorque(double callTime, double timeSte
                                  -articulationAngle * scGeometry.facetRotAxes_B[i][2]};
             double dcmBB0[3][3];
             PRV2C(prv_BB0, dcmBB0);
-            dcm_BB0 = c2DArrayAsEigenMatrix3(dcmBB0);
+            dcm_BB0 = c2DArrayToEigenMatrix3(dcmBB0);
 
             // Rotate the facet normal vector through the current articulation angle
             this->scGeometry.facetNormals_B[i] = dcm_BB0 * this->scGeometry.facetNormals_B[i];

--- a/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
+++ b/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
@@ -111,8 +111,8 @@ void MsmForceTorque::readMessages() {
         this->volt.at(c) = voltInMsgBuffer.voltage;
 
         scStateInMsgsBuffer = this->scStateInMsgs.at(c)();
-        this->r_BN_NList.at(c) = cArrayAsEigenVector(scStateInMsgsBuffer.r_BN_N);
-        this->sigma_BNList.at(c) = cArrayAsEigenVector(scStateInMsgsBuffer.sigma_BN);
+        this->r_BN_NList.at(c) = cArrayToEigenVector(scStateInMsgsBuffer.r_BN_N);
+        this->sigma_BNList.at(c) = cArrayToEigenVector(scStateInMsgsBuffer.sigma_BN);
     }
 }
 

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -295,25 +295,25 @@ void PrescribedMotionStateEffector::updateState(uint64_t callTime) {
     // Read the translational input message if it is linked and written
     if (this->prescribedTranslationInMsg.isLinked() && this->prescribedTranslationInMsg.isWritten()) {
         PrescribedTranslationMsgPayload incomingPrescribedTransStates = this->prescribedTranslationInMsg();
-        this->r_FM_M = cArrayAsEigenVector(incomingPrescribedTransStates.r_FM_M);
-        this->rPrime_FM_M = cArrayAsEigenVector(incomingPrescribedTransStates.rPrime_FM_M);
-        this->rPrimePrime_FM_M = cArrayAsEigenVector(incomingPrescribedTransStates.rPrimePrime_FM_M);
+        this->r_FM_M = cArrayToEigenVector(incomingPrescribedTransStates.r_FM_M);
+        this->rPrime_FM_M = cArrayToEigenVector(incomingPrescribedTransStates.rPrime_FM_M);
+        this->rPrimePrime_FM_M = cArrayToEigenVector(incomingPrescribedTransStates.rPrimePrime_FM_M);
 
         // Save off the prescribed translational states at each dynamics time step
-        this->rEpoch_FM_M = cArrayAsEigenVector(incomingPrescribedTransStates.r_FM_M);
-        this->rPrimeEpoch_FM_M = cArrayAsEigenVector(incomingPrescribedTransStates.rPrime_FM_M);
+        this->rEpoch_FM_M = cArrayToEigenVector(incomingPrescribedTransStates.r_FM_M);
+        this->rPrimeEpoch_FM_M = cArrayToEigenVector(incomingPrescribedTransStates.rPrime_FM_M);
     }
 
     // Read the rotational input message if it is linked and written
     if (this->prescribedRotationInMsg.isLinked() && this->prescribedRotationInMsg.isWritten()) {
         PrescribedRotationMsgPayload incomingPrescribedRotStates = this->prescribedRotationInMsg();
-        this->omega_FM_F = cArrayAsEigenVector(incomingPrescribedRotStates.omega_FM_F);
-        this->omegaPrime_FM_F = cArrayAsEigenVector(incomingPrescribedRotStates.omegaPrime_FM_F);
-        this->sigma_FM = cArrayAsEigenVector(incomingPrescribedRotStates.sigma_FM);
+        this->omega_FM_F = cArrayToEigenVector(incomingPrescribedRotStates.omega_FM_F);
+        this->omegaPrime_FM_F = cArrayToEigenVector(incomingPrescribedRotStates.omegaPrime_FM_F);
+        this->sigma_FM = cArrayToEigenVector(incomingPrescribedRotStates.sigma_FM);
 
         // Save off the prescribed rotational states at each dynamics time step
-        this->omegaEpoch_FM_F = cArrayAsEigenVector(incomingPrescribedRotStates.omega_FM_F);
-        Eigen::Vector3d sigma_FM_loc = cArrayAsEigenVector(incomingPrescribedRotStates.sigma_FM);
+        this->omegaEpoch_FM_F = cArrayToEigenVector(incomingPrescribedRotStates.omega_FM_F);
+        Eigen::Vector3d sigma_FM_loc = cArrayToEigenVector(incomingPrescribedRotStates.sigma_FM);
         this->sigma_FMState->setState(sigma_FM_loc);
     }
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -93,8 +93,8 @@ void Spacecraft::readOptionalRefMsg() {
         Eigen::Vector3d omega_BN_B;
         AttRefMsgPayload attRefMsgBuffer;
         attRefMsgBuffer = this->attRefInMsg();
-        Eigen::MRPd sigma_BN = cArrayAsEigenMrp(attRefMsgBuffer.sigma_RN);
-        Eigen::Vector3d omega_BN_N = cArrayAsEigenVector(attRefMsgBuffer.omega_RN_N);
+        Eigen::MRPd sigma_BN = cArrayToEigenMrp(attRefMsgBuffer.sigma_RN);
+        Eigen::Vector3d omega_BN_N = cArrayToEigenVector(attRefMsgBuffer.omega_RN_N);
         Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
         omega_BN_B = dcm_BN * omega_BN_N;
 
@@ -108,8 +108,8 @@ void Spacecraft::readOptionalRefMsg() {
         TransRefMsgPayload transRefMsgBuffer;
         transRefMsgBuffer = this->transRefInMsg();
 
-        r_RN_N = cArrayAsEigenVector(transRefMsgBuffer.r_RN_N);
-        v_RN_N = cArrayAsEigenVector(transRefMsgBuffer.v_RN_N);
+        r_RN_N = cArrayToEigenVector(transRefMsgBuffer.r_RN_N);
+        v_RN_N = cArrayToEigenVector(transRefMsgBuffer.v_RN_N);
 
         this->hubR_N->setState(r_RN_N);
         this->hubV_N->setState(v_RN_N);

--- a/src/simulation/environment/albedo/albedo.cpp
+++ b/src/simulation/environment/albedo/albedo.cpp
@@ -224,7 +224,7 @@ void Albedo::updateState(uint64_t currentSimNanos) {
             tmpTot[3] += outData[3];
             idx++;
         }
-        this->albOutData.push_back(cArrayAsEigenVector(tmpTot));
+        this->albOutData.push_back(cArrayToEigenVector(tmpTot));
     }
     this->writeMessages(currentSimNanos);
 }
@@ -635,8 +635,8 @@ void Albedo::computeAlbedo(size_t idx,
             num1[i] = albLon1[i];
             num2[i] = albLat1[i];
         }
-        this->albLon = cArrayAsEigenMatrixX(num1, 1, IIdx);
-        this->albLat = cArrayAsEigenMatrixX(num2, 1, IIdx);
+        this->albLon = cArrayToEigenMatrixX(num1, 1, IIdx);
+        this->albLat = cArrayToEigenMatrixX(num2, 1, IIdx);
         //! - Total albedo flux ratio [-]
         auto albedoAtInstrumentMax = alb_Imax;
         auto albedoAtInstrument = alb_I;

--- a/src/simulation/environment/eclipse/eclipse.cpp
+++ b/src/simulation/environment/eclipse/eclipse.cpp
@@ -95,12 +95,12 @@ void Eclipse::updateState(uint64_t currentSimNanos) {
         double tmpShadowFactor = 1.0;  // 1.0 means 100% illumination (no eclipse)
         double eclipsePlanetDistance = 0.0;
         int64_t eclipsePlanetKey = -1;
-        r_BN_N = cArrayAsEigenVector(scIt->r_BN_N);
+        r_BN_N = cArrayToEigenVector(scIt->r_BN_N);
 
         // Find the closest planet if there is one
         int idx = 0;
         for (planetIt = this->planetBuffer.begin(); planetIt != this->planetBuffer.end(); planetIt++) {
-            r_PN_N = cArrayAsEigenVector(planetIt->PositionVector);
+            r_PN_N = cArrayToEigenVector(planetIt->PositionVector);
             s_HP_N = r_HN_N - r_PN_N;
             r_HB_N = r_HN_N - r_BN_N;
             s_BP_N = r_BN_N - r_PN_N;
@@ -123,7 +123,7 @@ void Eclipse::updateState(uint64_t currentSimNanos) {
         // If planetkey is not -1 then we have a planet for which
         // we compute the eclipse conditions
         if (eclipsePlanetKey >= 0) {
-            r_PN_N = cArrayAsEigenVector(this->planetBuffer[eclipsePlanetKey].PositionVector);
+            r_PN_N = cArrayToEigenVector(this->planetBuffer[eclipsePlanetKey].PositionVector);
             s_BP_N = r_BN_N - r_PN_N;
             r_HB_N = r_HN_N - r_BN_N;
             s_HP_N = r_HN_N - r_PN_N;

--- a/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
+++ b/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
@@ -61,12 +61,12 @@ void EphemerisConverter::convertEphemData(uint64_t clockNow) {
         this->ephemOutBuffers.at(c).timeTag = this->spiceInMsgs.at(c).timeWritten() * 1.0E-9;
 
         /* Compute sigma_BN */
-        dcm_BN = cArrayAsEigenMatrix3(*this->spiceInBuffers.at(c).J20002Pfix);
+        dcm_BN = cArrayToEigenMatrix3(*this->spiceInBuffers.at(c).J20002Pfix);
         sigma_BN = dcmToMrp(dcm_BN);
         eigenVectorToCArray(sigma_BN, this->ephemOutBuffers.at(c).sigma_BN);  // sigma_BN
 
         /* Compute omega_BN_B */
-        dcm_BN_dot = cArrayAsEigenMatrix3(*this->spiceInBuffers.at(c).J20002Pfix_dot);
+        dcm_BN_dot = cArrayToEigenMatrix3(*this->spiceInBuffers.at(c).J20002Pfix_dot);
         omega_tilde_BN_B_eigen = -dcm_BN_dot * dcm_BN.transpose();
         eigenMatrixToCArray(omega_tilde_BN_B_eigen, omega_tilde_BN_B_array);
         m33Copy(RECAST3X3 omega_tilde_BN_B_array, omega_tilde_BN_B);

--- a/src/simulation/environment/groundLocation/groundLocation.cpp
+++ b/src/simulation/environment/groundLocation/groundLocation.cpp
@@ -137,9 +137,9 @@ void GroundLocation::WriteMessages(uint64_t CurrentClock) {
 
 void GroundLocation::updateInertialPositions() {
     // First, get the rotation matrix from the inertial to planet frame from SPICE:
-    this->dcm_PN = cArrayAsEigenMatrix3(*this->planetState.J20002Pfix);
-    this->dcm_PN_dot = cArrayAsEigenMatrix3(*this->planetState.J20002Pfix_dot);
-    this->r_PN_N = cArrayAsEigenVector(this->planetState.PositionVector);
+    this->dcm_PN = cArrayToEigenMatrix3(*this->planetState.J20002Pfix);
+    this->dcm_PN_dot = cArrayToEigenMatrix3(*this->planetState.J20002Pfix_dot);
+    this->r_PN_N = cArrayToEigenVector(this->planetState.PositionVector);
     // Then, transpose it to get the planet to inertial frame
     this->r_LP_N = this->dcm_PN.transpose() * this->r_LP_P_Init;
     this->rhat_LP_N = this->r_LP_N / this->r_LP_N.norm();
@@ -163,7 +163,7 @@ void GroundLocation::computeAccess() {
          scStatesMsgIt != scStatesBuffer.end();
          scStatesMsgIt++, accessMsgIt++) {
         //! Compute the relative position of each spacecraft to the site in the planet-centered inertial frame
-        Eigen::Vector3d r_BP_N = cArrayAsEigenVector(scStatesMsgIt->r_BN_N) - this->r_PN_N;
+        Eigen::Vector3d r_BP_N = cArrayToEigenVector(scStatesMsgIt->r_BN_N) - this->r_PN_N;
         Eigen::Vector3d r_BL_N = r_BP_N - this->r_LP_N;
         auto r_BL_mag = r_BL_N.norm();
         Eigen::Vector3d relativeHeading_N = r_BL_N / r_BL_mag;
@@ -180,7 +180,7 @@ void GroundLocation::computeAccess() {
 
         Eigen::Vector3d v_BL_L =
             this->dcm_LP * this->dcm_PN *
-            (cArrayAsEigenVector(scStatesMsgIt->v_BN_N) -
+            (cArrayToEigenVector(scStatesMsgIt->v_BN_N) -
              this->w_PN.cross(r_BP_N));  // V observed from gL wrt P frame, expressed in L frame coords (SEZ)
         eigenVectorToCArray(v_BL_L, accessMsgIt->v_BL_L);
         accessMsgIt->range_dot = v_BL_L.dot(r_BL_L) / r_BL_mag;

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -118,7 +118,7 @@ void GroundMapping::computeAccess(uint64_t c) {
 
     Eigen::Vector3d v_BL_L =
         this->dcm_LP * this->dcm_PN *
-        (cArrayAsEigenVector(scStateInMsgBuffer.v_BN_N) -
+        (cArrayToEigenVector(scStateInMsgBuffer.v_BN_N) -
          this->w_PN.cross(r_BP_N));  // V observed from gL wrt P frame, expressed in L frame coords (SEZ)
     eigenVectorToCArray(v_BL_L, this->accessMsgBuffer.at(c).v_BL_L);
     this->accessMsgBuffer.at(c).range_dot = v_BL_L.dot(r_BL_L) / r_BL_mag;
@@ -142,15 +142,15 @@ void GroundMapping::computeAccess(uint64_t c) {
  */
 void GroundMapping::updateInertialPositions() {
     // First, get the rotation matrix from the inertial to planet frame from SPICE:
-    this->dcm_PN = cArrayAsEigenMatrix3(*this->planetInMsgBuffer.J20002Pfix);
-    this->dcm_PN_dot = cArrayAsEigenMatrix3(*this->planetInMsgBuffer.J20002Pfix_dot);
-    this->r_PN_N = cArrayAsEigenVector(this->planetInMsgBuffer.PositionVector);
+    this->dcm_PN = cArrayToEigenMatrix3(*this->planetInMsgBuffer.J20002Pfix);
+    this->dcm_PN_dot = cArrayToEigenMatrix3(*this->planetInMsgBuffer.J20002Pfix_dot);
+    this->r_PN_N = cArrayToEigenVector(this->planetInMsgBuffer.PositionVector);
 
     // Compute the position of the body frame to the planet in the inertial frame
-    this->r_BP_N = cArrayAsEigenVector(scStateInMsgBuffer.r_BN_N) - this->r_PN_N;
+    this->r_BP_N = cArrayToEigenVector(scStateInMsgBuffer.r_BN_N) - this->r_PN_N;
     double dcm_BN[3][3];
     MRP2C(scStateInMsgBuffer.sigma_BN, dcm_BN);
-    this->dcm_NB = cArrayAsEigenMatrix3(*dcm_BN).transpose();
+    this->dcm_NB = cArrayToEigenMatrix3(*dcm_BN).transpose();
 
     // Get planet frame angular velocity vector
     Eigen::Matrix3d w_tilde_PN = -this->dcm_PN_dot * this->dcm_PN.transpose();

--- a/src/simulation/environment/spacecraftLocation/spacecraftLocation.cpp
+++ b/src/simulation/environment/spacecraftLocation/spacecraftLocation.cpp
@@ -87,7 +87,7 @@ bool SpacecraftLocation::ReadMessages() {
 
     // read in primary spacecraft states
     this->primaryScStatesBuffer = this->primaryScStateInMsg();
-    this->r_BN_N = cArrayAsEigenVector(this->primaryScStatesBuffer.r_BN_N);
+    this->r_BN_N = cArrayToEigenVector(this->primaryScStatesBuffer.r_BN_N);
 
     // read in the spacecraft state messages
     bool scRead;
@@ -128,11 +128,11 @@ void SpacecraftLocation::computeAccess() {
     Eigen::Vector3d r_LP_P;  //!< [m] spacecraft Location relative to planet origin vector
 
     // get planet position and orientation relative to inertial frame
-    this->dcm_PN = cArrayAsEigenMatrix3(*this->planetState.J20002Pfix);
-    this->r_PN_N = cArrayAsEigenVector(this->planetState.PositionVector);
+    this->dcm_PN = cArrayToEigenMatrix3(*this->planetState.J20002Pfix);
+    this->r_PN_N = cArrayToEigenVector(this->planetState.PositionVector);
 
     // compute primary spacecraft relative to planet
-    Eigen::MRPd sigma_BN = cArrayAsEigenMrp(this->primaryScStatesBuffer.sigma_BN);
+    Eigen::MRPd sigma_BN = cArrayToEigenMrp(this->primaryScStatesBuffer.sigma_BN);
     Eigen::Matrix3d dcm_NB = sigma_BN.toRotationMatrix();
     r_LP_P = this->dcm_PN * (this->r_BN_N + dcm_NB * this->r_LB_B - this->r_PN_N);
 
@@ -145,7 +145,7 @@ void SpacecraftLocation::computeAccess() {
         Eigen::Vector3d r_SP_P;  // other satellite position relative to planet
         Eigen::Vector3d r_SL_P;  // other satellite position relative to primary spacecraft location L
 
-        r_SN_N = cArrayAsEigenVector(this->scStatesBuffer.at(c).r_BN_N);
+        r_SN_N = cArrayToEigenVector(this->scStatesBuffer.at(c).r_BN_N);
         r_SP_P = this->dcm_PN * (r_SN_N - this->r_PN_N);
 
         // do affine scaling to map ellipsoid to sphere

--- a/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
+++ b/src/simulation/navigation/pinholeCamera/pinholeCamera.cpp
@@ -189,21 +189,21 @@ void PinholeCamera::processInputs() {
     /* Extract planet dcm */
     double dcm_PN_array[3][3];
     MRP2C(this->ephemerisPlanet.sigma_BN, dcm_PN_array);
-    this->dcm_PN = cArrayAsEigenMatrix3(*dcm_PN_array);
+    this->dcm_PN = cArrayToEigenMatrix3(*dcm_PN_array);
 
     /* Compute planet to Sun line e_SP on the planet rotating frame P */
     Eigen::Vector3d r_PS_N;
-    r_PS_N = cArrayAsEigenVector(this->ephemerisPlanet.r_BdyZero_N);
+    r_PS_N = cArrayToEigenVector(this->ephemerisPlanet.r_BdyZero_N);
     this->e_SP_P = this->dcm_PN * (-r_PS_N / r_PS_N.norm());
 
     /* Compute spacecraft position in the planet rotating frame P */
-    this->r_BP_P = this->dcm_PN * (cArrayAsEigenVector(this->spacecraftState.r_BN_N) -
-                                   cArrayAsEigenVector(this->ephemerisPlanet.r_BdyZero_N));
+    this->r_BP_P = this->dcm_PN * (cArrayToEigenVector(this->spacecraftState.r_BN_N) -
+                                   cArrayToEigenVector(this->ephemerisPlanet.r_BdyZero_N));
 
     /* Compute spacecraft dcm with respect to planet rotating frame */
     double dcm_BN_array[3][3];
     MRP2C(this->spacecraftState.sigma_BN, dcm_BN_array);
-    this->dcm_BP = cArrayAsEigenMatrix3(*dcm_BN_array) * this->dcm_PN.transpose();
+    this->dcm_BP = cArrayToEigenMatrix3(*dcm_BN_array) * this->dcm_PN.transpose();
 
     /* Camera focal direction in planet frame */
     this->eC_P = (this->dcm_CB * this->dcm_BP).transpose() * this->eC_C;
@@ -297,7 +297,7 @@ void PinholeCamera::processBatch(Eigen::MatrixXd rBatch_BP_P,
         /* Compute spacecraft dcm w.r.t. planet frame */
         eigenMatrixXToCArray(mrpBatch_BP.row(i).transpose(), mrp_BP);
         MRP2C(mrp_BP, dcm_BP_array);
-        this->dcm_BP = cArrayAsEigenMatrix3(*dcm_BP_array);
+        this->dcm_BP = cArrayToEigenMatrix3(*dcm_BP_array);
 
         /* Compute camera focal direction in planet frame */
         this->eC_P = (this->dcm_CB * this->dcm_BP).transpose() * this->eC_C;

--- a/src/simulation/power/simpleSolarPanel/simpleSolarPanel.cpp
+++ b/src/simulation/power/simpleSolarPanel/simpleSolarPanel.cpp
@@ -99,9 +99,9 @@ void SimpleSolarPanel::computeSunData() {
     Eigen::Vector3d sHat_B;  //!< [] unit Sun heading vector relative to the spacecraft in B frame.
 
     //! - Read Message data to eigen
-    r_BN_N = cArrayAsEigenVector(this->stateCurrent.r_BN_N);
-    r_SN_N = cArrayAsEigenVector(this->sunData.PositionVector);
-    sigma_BN = cArrayAsEigenMrp(this->stateCurrent.sigma_BN);
+    r_BN_N = cArrayToEigenVector(this->stateCurrent.r_BN_N);
+    r_SN_N = cArrayToEigenVector(this->sunData.PositionVector);
+    sigma_BN = cArrayToEigenMrp(this->stateCurrent.sigma_BN);
 
     //! - Find sun heading unit vector
     r_SB_N = r_SN_N - r_BN_N;

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
@@ -82,7 +82,7 @@ void CoarseSunSensor::setBodyToPlatformDCM(double yaw, double pitch, double roll
     double q[3] = {yaw, pitch, roll};
     double dcm_PBcArray[9];
     Euler3212C(q, RECAST3X3 dcm_PBcArray);
-    this->dcm_PB = cArrayAsEigenMatrix3(dcm_PBcArray);
+    this->dcm_PB = cArrayToEigenMatrix3(dcm_PBcArray);
 }
 
 /*! This method is used to reset the module.
@@ -180,9 +180,9 @@ void CoarseSunSensor::computeSunData() {
     //! - Get the position from spacecraft to Sun
 
     //! - Read Message data to eigen
-    r_BN_N_eigen = cArrayAsEigenVector(this->stateCurrent.r_BN_N);
-    sunPos = cArrayAsEigenVector(this->sunData.PositionVector);
-    sigma_BN_eigen = cArrayAsEigenMrp(this->stateCurrent.sigma_BN);
+    r_BN_N_eigen = cArrayToEigenVector(this->stateCurrent.r_BN_N);
+    sunPos = cArrayToEigenVector(this->sunData.PositionVector);
+    sigma_BN_eigen = cArrayToEigenMrp(this->stateCurrent.sigma_BN);
 
     //! - Find sun heading unit vector
     Sc2Sun_Inrtl = sunPos - r_BN_N_eigen;

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -125,11 +125,11 @@ void ImuSensor::readInputMessages() {
     if (this->scStateInMsg.isLinked()) {
         this->StateCurrent = this->scStateInMsg();
     }
-    this->current_sigma_BN = cArrayAsEigenVector(this->StateCurrent.sigma_BN);
-    this->current_omega_BN_B = cArrayAsEigenVector(this->StateCurrent.omega_BN_B);
-    this->current_nonConservativeAccelpntB_B = cArrayAsEigenVector(this->StateCurrent.nonConservativeAccelpntB_B);
-    this->current_omegaDot_BN_B = cArrayAsEigenVector(this->StateCurrent.omegaDot_BN_B);
-    this->current_TotalAccumDV_BN_B = cArrayAsEigenVector(this->StateCurrent.TotalAccumDV_BN_B);
+    this->current_sigma_BN = cArrayToEigenVector(this->StateCurrent.sigma_BN);
+    this->current_omega_BN_B = cArrayToEigenVector(this->StateCurrent.omega_BN_B);
+    this->current_nonConservativeAccelpntB_B = cArrayToEigenVector(this->StateCurrent.nonConservativeAccelpntB_B);
+    this->current_omegaDot_BN_B = cArrayToEigenVector(this->StateCurrent.omegaDot_BN_B);
+    this->current_TotalAccumDV_BN_B = cArrayToEigenVector(this->StateCurrent.TotalAccumDV_BN_B);
 }
 
 /*!
@@ -282,7 +282,7 @@ void ImuSensor::computePlatformDR() {
                (this->dcm_PB * this->previous_sigma_BN.toRotationMatrix().transpose()).transpose();
     eigenMatrixToCArray(dcm_P2P1, dcm_P2P1_cArray);         // makes a 9x1
     C2PRV(RECAST3X3 dcm_P2P1_cArray, prv_PN_cArray);        // makes it back into a 3x3
-    this->prv_PN_out = cArrayAsEigenVector(prv_PN_cArray);  // writes it back to the variable to be passed along.
+    this->prv_PN_out = cArrayToEigenVector(prv_PN_cArray);  // writes it back to the variable to be passed along.
 
     // calculate "instantaneous" angular rate
     this->omega_PN_P_out = this->dcm_PB * this->current_omega_BN_B;

--- a/src/simulation/sensors/magnetometer/magnetometer.cpp
+++ b/src/simulation/sensors/magnetometer/magnetometer.cpp
@@ -72,8 +72,8 @@ void Magnetometer::computeMagData() {
     Eigen::Matrix3d dcm_BN;
     Eigen::MRPd sigma_BN;
     //! - Magnetic field vector in inertial frame using a magnetic field model (WMM, Dipole, etc.)
-    tam_N = cArrayAsEigenVector(this->magData.magField_N);
-    sigma_BN = cArrayAsEigenMrp(this->stateCurrent.sigma_BN);
+    tam_N = cArrayToEigenVector(this->magData.magField_N);
+    sigma_BN = cArrayToEigenMrp(this->stateCurrent.sigma_BN);
     //! - Get the inertial to sensor frame transformation information and convert tam_N to tam_S
     dcm_BN = sigma_BN.toRotationMatrix().transpose();
     this->tam_S = this->dcm_SB * dcm_BN * tam_N;

--- a/src/simulation/sensors/starTracker/starTracker.cpp
+++ b/src/simulation/sensors/starTracker/starTracker.cpp
@@ -67,10 +67,10 @@ void StarTracker::applySensorErrors() {
     this->mrpErrors = prvToMrp(this->navErrors);
 
     Eigen::Vector3d sigmaSensed;
-    sigmaSensed = addMrp(cArrayAsEigenVector(this->scState.sigma_BN), this->mrpErrors);
+    sigmaSensed = addMrp(cArrayToEigenVector(this->scState.sigma_BN), this->mrpErrors);
 
     // Save the previous sensed quaternion before computing the current sensed quaternion
-    this->betaPrevious_CN = cArrayAsEigenVector(this->sensedValues.qInrtl2Case);
+    this->betaPrevious_CN = cArrayToEigenVector(this->sensedValues.qInrtl2Case);
 
     this->computeQuaternion(&sigmaSensed, &this->sensedValues);
     this->sensedValues.timeTag = this->sensorTimeTag;
@@ -96,7 +96,7 @@ void StarTracker::computeQuaternion(Eigen::Vector3d* sigma, STSensorMsgPayload* 
     compute platform angular velocity from sensed quaternions
  */
 void StarTracker::computeAngularVelocity(uint64_t currentSimNanos) {
-    Eigen::Vector4d beta_CN = cArrayAsEigenVector(this->sensedValues.qInrtl2Case);
+    Eigen::Vector4d beta_CN = cArrayToEigenVector(this->sensedValues.qInrtl2Case);
 
     // Determine betaDot_CN
     Eigen::Vector4d betaDot_CN = Eigen::Vector4d::Zero();
@@ -116,7 +116,7 @@ void StarTracker::computeAngularVelocity(uint64_t currentSimNanos) {
  */
 void StarTracker::computeTrueOutput() {
     this->trueValues.timeTag = this->sensorTimeTag;
-    Eigen::Vector3d sigma_BN = cArrayAsEigenVector(this->scState.sigma_BN);
+    Eigen::Vector3d sigma_BN = cArrayToEigenVector(this->scState.sigma_BN);
     this->computeQuaternion(&sigma_BN, &this->trueValues);
 }
 

--- a/src/simulation/thermal/sensorThermal/sensorThermal.cpp
+++ b/src/simulation/thermal/sensorThermal/sensorThermal.cpp
@@ -131,9 +131,9 @@ void SensorThermal::computeSunData() {
     Eigen::Vector3d sHat_B;  //!< [] unit Sun heading vector relative to the spacecraft in B frame.
 
     //! - Read Message data to eigen
-    r_BN_N = cArrayAsEigenVector(this->stateCurrent.r_BN_N);
-    r_SN_N = cArrayAsEigenVector(this->sunData.PositionVector);
-    sigma_BN = cArrayAsEigenVector(this->stateCurrent.sigma_BN);
+    r_BN_N = cArrayToEigenVector(this->stateCurrent.r_BN_N);
+    r_SN_N = cArrayToEigenVector(this->sunData.PositionVector);
+    sigma_BN = cArrayToEigenVector(this->stateCurrent.sigma_BN);
 
     //! - Find sun heading unit vector
     r_SB_N = r_SN_N - r_BN_N;

--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
@@ -132,14 +132,14 @@ void DataFileToViz::setNumOfSatellites(int numSat) {
 /*!
  Add a thruster 3d position vector to the list of thruster locations
  */
-void DataFileToViz::appendThrPos(double pos_B[3]) { this->thrPosList.push_back(cArrayAsEigenVector3(pos_B)); }
+void DataFileToViz::appendThrPos(double pos_B[3]) { this->thrPosList.push_back(cArrayToEigenVector3(pos_B)); }
 
 /*!
  Add a thruster 3d unit direction vector to the list.  The input vectors gets normalized before being added to the list.
  */
 void DataFileToViz::appendThrDir(double dir_B[3]) {
     v3Normalize(dir_B, dir_B);
-    this->thrDirList.push_back(cArrayAsEigenVector3(dir_B));
+    this->thrDirList.push_back(cArrayToEigenVector3(dir_B));
 }
 
 /*!
@@ -204,7 +204,7 @@ void DataFileToViz::appendOmegaMax(double OmegaMax) { this->rwOmegaMaxList.push_
 /*!
  Add a thruster 3d position vector to the list of thruster locations
  */
-void DataFileToViz::appendRwPos(double pos_B[3]) { this->rwPosList.push_back(cArrayAsEigenVector3(pos_B)); }
+void DataFileToViz::appendRwPos(double pos_B[3]) { this->rwPosList.push_back(cArrayToEigenVector3(pos_B)); }
 
 /*!
  Add a RW spin axis unit direction vector to the list.  The input vectors gets normalized before being added to the
@@ -212,7 +212,7 @@ void DataFileToViz::appendRwPos(double pos_B[3]) { this->rwPosList.push_back(cAr
  */
 void DataFileToViz::appendRwDir(double dir_B[3]) {
     v3Normalize(dir_B, dir_B);
-    this->rwDirList.push_back(cArrayAsEigenVector3(dir_B));
+    this->rwDirList.push_back(cArrayToEigenVector3(dir_B));
 }
 
 /*! Update this module at the task rate


### PR DESCRIPTION
* **Tickets addressed:** #567 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds minor refactoring to eigenSupport.h to resolve the issues listed below. The penultimate commit fixes a change I made in that should not have been made. Specifically, returning function calls to use "To" preposition. These functions were previously renamed under the false expectation that they would return views on memory (`Eigen:Map`). This is not the case and they are correctly returning copies. They should remain as copies because the size of the returned vector/matrix values are small in memory terms. Finally, a small fix is added to the hohmann example scenario using the incorrect `sigma_RR0` property.

- ensure scalar type on literals
- declare and initialize variables in single expression
- template type to correct signed-ness MISRA 5-0-4
- literal integer types to prevent possible signed promotion MISRA 5-0-4
- replace memcopy with std::copy resolving MISRA 24.5.2
- resolve MISRA 6.2.4 warning

## Verification
CI and tests to run.

## Documentation
None

## Future work
<!-- What next steps can we anticipate from here, if any? -->
