### PR TITLE
Add array of bools as swig type map

### DIFF
--- a/src/architecture/_GeneralModuleFiles/swig_conly_data.i
+++ b/src/architecture/_GeneralModuleFiles/swig_conly_data.i
@@ -69,6 +69,38 @@ ARRAYASLIST(int)
 ARRAYASLIST(float)
 ARRAYASLIST(unsigned int)
 
+%typemap(in) bool [ANY] (bool temp[$1_dim0]) {
+    if (!PySequence_Check($input)) {
+        PyErr_SetString(PyExc_ValueError, "Expected a sequence");
+        return NULL;
+    }
+    if (PySequence_Length($input) > $1_dim0) {
+        PyErr_SetString(PyExc_ValueError, "Size mismatch. Expected $1_dim0 elements");
+        return NULL;
+    }
+    memset(temp, 0, $1_dim0 * sizeof(bool));
+    for (int i = 0; i < PySequence_Length($input); i++) {
+        PyObject *o = PySequence_GetItem($input, i);
+        temp[i] = PyObject_IsTrue(o) ? true : false;
+        Py_DECREF(o);
+    }
+    $1 = temp;
+}
+
+%typemap(memberin) bool [ANY] {
+    for (int i = 0; i < $1_dim0; i++) {
+        $1[i] = $input[i];
+    }
+}
+
+%typemap(out) bool [ANY] {
+    $result = PyList_New($1_dim0);
+    for (int i = 0; i < $1_dim0; i++) {
+        PyObject *o = PyBool_FromLong((long)$1[i]);
+        PyList_SetItem($result, i, o);
+    }
+}
+
 %define ARRAYINTASLIST(type)
 %typemap(in) type [ANY] (type temp[$1_dim0]) {
     int i;


### PR DESCRIPTION
* **Tickets addressed:** xmera-2084
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds a swig type map for `bool[]` in C/C++. 

## Verification
Currently this typemap is tested implicitly through use.

## Documentation
None added.

## Future work
None
