### PR TITLE
Build only python 3.9 and 3.14

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,6 +65,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-14]
         python-version: ["3.9", "3.14"]
+        exclude:
+          - os: macos-14
+            python-version: "3.9"
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.14"]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR removes python 3.10-3.13 from the CI build matrix. The assumption is that if the bounds work, the inside versions do also. 

## Verification
CI tests to run.

## Documentation
NA

## Future work
None
