### PR TITLE
Feature/2059 add boolean array for swig

### DIFF
--- a/src/architecture/_GeneralModuleFiles/swig_conly_data.i
+++ b/src/architecture/_GeneralModuleFiles/swig_conly_data.i
@@ -126,6 +126,7 @@ ARRAYASLIST(float)
 }
 
 %enddef
+ARRAYINTASLIST(bool)
 ARRAYINTASLIST(int)
 ARRAYINTASLIST(unsigned int)
 

--- a/src/architecture/_GeneralModuleFiles/swig_conly_data.i
+++ b/src/architecture/_GeneralModuleFiles/swig_conly_data.i
@@ -65,9 +65,7 @@
 
 %enddef
 ARRAYASLIST(double)
-ARRAYASLIST(int)
 ARRAYASLIST(float)
-ARRAYASLIST(unsigned int)
 
 %define ARRAYINTASLIST(type)
 %typemap(in) type [ANY] (type temp[$1_dim0]) {


### PR DESCRIPTION
* **Tickets addressed:** 2059
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR is necessary to add boolean array to the swig_conly_data.i to allow us to access boolean arrays from the python layer. However, this PR also removes redundant ARRAYASLIST(int) and ARRAYASLIST(unsigned int). From Claude: "These were already overridden by ARRAYINTASLIST, which correctly uses integer conversion (PyInt_AsLong/PyInt_FromLong) instead of float conversion (PyFloat_AsDouble/PyFloat_FromDouble)."
The redundant use of ARRAYASLIST(int) and ARRAYASLIST(unsigned int) was found by a conservation with Claude explaining why ARRAYINTASLIST should be used for the boolean case.

This was the conversation:
Why is there int and unsigned int in these then: ARRAYASLIST(int) and ARRAYASLIST(unsigned int)                                                                                                                                                                                                                                                                                                                                                                                                                                                                       

"Good catch — that's redundant and arguably incorrect. int and unsigned int appear in both ARRAYASLIST (which converts through PyFloat_AsDouble/PyFloat_FromDouble) and ARRAYINTASLIST (which converts through PyInt_AsLong/PyInt_FromLong).

Since SWIG applies typemaps in order and the last definition wins, the ARRAYINTASLIST versions on lines 132-133 override the ARRAYASLIST versions on lines 68/70 for int and unsigned int. So the float-based conversions for those types are effectively dead code.

It looks like ARRAYINTASLIST was added later to fix the issue of integer types being round-tripped through floats (which can lose precision for large integers), but the original ARRAYASLIST(int) and ARRAYASLIST(unsigned int) were never cleaned up. They could be removed without changing behavior."

## Verification
No tests were added because the current testing suite should be sufficient. This is being added so that a test on the fp32 repo can run without having access issues from the python layer. 

## Documentation
None

## Future work
None
