### PR TITLE
FIx:uses strict weak ordering for roi sorting

### DIFF
--- a/src/fswAlgorithms/imageProcessing/regionsOfInterest/regionsOfInterestAlgorithm.cpp
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterest/regionsOfInterestAlgorithm.cpp
@@ -81,7 +81,7 @@ std::array<RegionOfInterest, MAX_NUMBER_REGIONS> RegionsOfInterestAlgorithm::ord
     const std::array<RegionOfInterest, MAX_NUMBER_REGIONS>& regions) {
     std::array<RegionOfInterest, MAX_NUMBER_REGIONS> sorted = regions;
     std::ranges::sort(sorted.begin(), sorted.end(), [](const RegionOfInterest& a, const RegionOfInterest& b) {
-        return a.numberOfPixels >= b.numberOfPixels;
+        return a.numberOfPixels > b.numberOfPixels;
     });
     return sorted;
 }


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR changes the ROI list sorting predicate to use strict weak ordering of `<` rather than `<=` which has undefined behavior.

## Verification
CI runs successfully. Fuzz tests are run successfully. 

## Documentation
None invalidated. None added.

## Future work
None
