### PR TITLE
Prevent infinite recursion in python variable logger

### DIFF
--- a/src/utilities/pythonVariableLogger.py
+++ b/src/utilities/pythonVariableLogger.py
@@ -44,13 +44,12 @@ class PythonVariableLogger(sim_model.SysModel):
             min_log_period (int, optional): The minimum interval between data recordings
                 Defaults to 0.
         """
-        super().__init__()
-
         self.logging_functions = logging_functions
-
         self.min_log_period = min_log_period
         self._next_update_time = 0
         self.clear()
+
+        super().__init__()
 
     def clear(self):
         """Called to clear the internal data storages"""

--- a/src/utilities/pythonVariableLogger.py
+++ b/src/utilities/pythonVariableLogger.py
@@ -91,7 +91,11 @@ class PythonVariableLogger(sim_model.SysModel):
         return np.column_stack([self.times(), self.__getattr__(name)])
 
     def __getattr__(self, __name: str) -> Any:
-        if __name in self._variables:
-            return np.array(self._variables[__name])
+        try:
+            variables = self.__dict__["_variables"]
+        except KeyError:
+            raise AttributeError(__name)
+        if __name in variables:
+            return np.array(variables[__name])
         raise AttributeError(f"Logger is not logging '{__name}'. "
-                             f"Must be one of: {', '.join(self._variables)}")
+                             f"Must be one of: {', '.join(variables)}")


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2110
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When setting a break point after the addition of a `pythonVariableLogger`, that break point is never hit. The issue is infinite recursion on the `__getattr__` function in the python variable logger. Using `__getattr__` needs to be defensive about partially-initialized state. Using `self.__dict__["_variables"]` avoids re-entering `__getattr__` and raises a clean KeyError/AttributeError when the attribute doesn't exist yet.
                                                                                                                                                                                                                                                 
## Verification
Scenarios and tests that suffered from this error no longer do. CI runs.

## Documentation
NA

## Future work
None
