### PR TITLE
Fix eigenSupport const correctness

### DIFF
--- a/src/architecture/utilities/eigenSupport.h
+++ b/src/architecture/utilities/eigenSupport.h
@@ -211,8 +211,8 @@ void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* out
  * @return Eigen matrix populated with the values from `inArray`.
  */
 template <typename ScalarT, int rows, int cols>
-Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(ScalarT* inArray) {
-    return Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray);
+Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(const ScalarT* inArray) {
+    return Eigen::Map<const Eigen::Matrix<ScalarT, rows, cols>>(inArray);
 }
 
 /**
@@ -225,9 +225,9 @@ Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(ScalarT* inArray) {
  * @return Eigen dynamic matrix containing the mapped values.
  */
 template <typename ScalarT>
-Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
+Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(const ScalarT* inArray, int nRows, int nCols) {
     Eigen::MatrixX<ScalarT> outMat(nRows, nCols);
-    outMat = Eigen::Map<Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
+    outMat = Eigen::Map<const Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
     return outMat;
 }
 
@@ -240,8 +240,8 @@ Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(ScalarT* inArray, int nRows, int nC
  * @return Eigen vector whose contents match the input array.
  */
 template <typename ScalarT, int size>
-Eigen::Vector<ScalarT, size> cArrayToEigenVector(ScalarT (&inArray)[size]) {
-    return Eigen::Map<Eigen::Vector<ScalarT, size>>(inArray);
+Eigen::Vector<ScalarT, size> cArrayToEigenVector(const ScalarT (&inArray)[size]) {
+    return Eigen::Map<const Eigen::Vector<ScalarT, size>>(inArray);
 }
 
 /**
@@ -252,8 +252,8 @@ Eigen::Vector<ScalarT, size> cArrayToEigenVector(ScalarT (&inArray)[size]) {
  * @return Eigen::Vector3 populated from the input data.
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> cArrayToEigenVector3(ScalarT* inArray) {
-    return Eigen::Map<Eigen::Vector3<ScalarT>>(inArray);
+Eigen::Vector3<ScalarT> cArrayToEigenVector3(const ScalarT* inArray) {
+    return Eigen::Map<const Eigen::Vector3<ScalarT>>(inArray);
 }
 
 /**
@@ -264,9 +264,9 @@ Eigen::Vector3<ScalarT> cArrayToEigenVector3(ScalarT* inArray) {
  * @return Eigen::MRP constructed from the input.
  */
 template <typename ScalarT>
-Eigen::MRP<ScalarT> cArrayToEigenMrp(ScalarT* inArray) {
+Eigen::MRP<ScalarT> cArrayToEigenMrp(const ScalarT* inArray) {
     Eigen::MRP<ScalarT> sigma_Eigen;
-    sigma_Eigen = Eigen::Map<Eigen::Vector<ScalarT, 3>>(inArray);
+    sigma_Eigen = Eigen::Map<const Eigen::Vector<ScalarT, 3>>(inArray);
 
     return sigma_Eigen;
 }
@@ -279,8 +279,8 @@ Eigen::MRP<ScalarT> cArrayToEigenMrp(ScalarT* inArray) {
  * @return Eigen::Matrix3 with the copied values.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(ScalarT* inArray) {
-    return Eigen::Map<Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
+Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(const ScalarT* inArray) {
+    return Eigen::Map<const Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
 }
 
 /**

--- a/src/architecture/utilities/tests/test_eigenSupport.cpp
+++ b/src/architecture/utilities/tests/test_eigenSupport.cpp
@@ -173,10 +173,28 @@ TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenVectorCopiesElements) {
     }
 }
 
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenVectorAcceptsConstInput) {
+    using Scalar = TypeParam;
+    const Scalar raw[3] = {static_cast<Scalar>(1.0), static_cast<Scalar>(2.0), static_cast<Scalar>(3.0)};
+    auto vec = cArrayToEigenVector(raw);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(vec(i), raw[i]);
+    }
+}
+
 TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenVector3CreatesMatchingVector) {
     using Scalar = TypeParam;
     Scalar raw[3] = {static_cast<Scalar>(1.0), static_cast<Scalar>(-2.0), static_cast<Scalar>(0.5)};
 
+    Eigen::Vector3<Scalar> vec = cArrayToEigenVector3(raw);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(vec(i), raw[i]);
+    }
+}
+
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenVector3AcceptsConstInput) {
+    using Scalar = TypeParam;
+    const Scalar raw[3] = {static_cast<Scalar>(4.0), static_cast<Scalar>(-5.0), static_cast<Scalar>(6.0)};
     Eigen::Vector3<Scalar> vec = cArrayToEigenVector3(raw);
     for (int i = 0; i < 3; ++i) {
         EXPECT_EQ(vec(i), raw[i]);
@@ -191,6 +209,38 @@ TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMrpCopiesCoefficients) {
     EXPECT_EQ(mrp.x(), raw[0]);
     EXPECT_EQ(mrp.y(), raw[1]);
     EXPECT_EQ(mrp.z(), raw[2]);
+}
+
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMrpAcceptsConstInput) {
+    using Scalar = TypeParam;
+    const Scalar raw[3] = {static_cast<Scalar>(0.1), static_cast<Scalar>(-0.2), static_cast<Scalar>(0.3)};
+    Eigen::MRP<Scalar> mrp = cArrayToEigenMrp(raw);
+    EXPECT_EQ(mrp.x(), raw[0]);
+    EXPECT_EQ(mrp.y(), raw[1]);
+    EXPECT_EQ(mrp.z(), raw[2]);
+}
+
+TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMatrix3AcceptsConstInput) {
+    using Scalar = TypeParam;
+    const std::array<Scalar, 9> raw = {static_cast<Scalar>(1),
+                                       static_cast<Scalar>(2),
+                                       static_cast<Scalar>(3),
+                                       static_cast<Scalar>(4),
+                                       static_cast<Scalar>(5),
+                                       static_cast<Scalar>(6),
+                                       static_cast<Scalar>(7),
+                                       static_cast<Scalar>(8),
+                                       static_cast<Scalar>(9)};
+
+    Eigen::Matrix3<Scalar> expected;
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            expected(i, j) = static_cast<Scalar>(i * 3 + j + 1);
+        }
+    }
+
+    Eigen::Matrix3<Scalar> reconstructed = cArrayToEigenMatrix3(raw.data());
+    ExpectMatricesApproxEqual(expected, reconstructed, GetTolerance<Scalar>());
 }
 
 TYPED_TEST(EigenSupportConversionsTest, CArrayToEigenMatrix3ReadsRowMajorDataCorrectly) {


### PR DESCRIPTION
* **Tickets addressed:** #595 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR changes the `cArrayTo...` function parameters to accept `const` input and use `Eigen::Map<const ...>` internally. This is the idiomatic Eigen pattern for read-only mapped data, and is already used by `c2DArrayToEigenMatrix3`.

## Verification
CI runs successfully. Four new test are added. They test that `const` parameter compiles (if `ScalarT` were still deduced as `const float`, the test wouldn't build), and that the returned Eigen type contains the correct values (the `Eigen::Map<const ...>` correctly reads the data).

## Documentation
NA

## Future work
None
