### PR TITLE
Create regionsOfInterestPrune module

### DIFF
--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -29,7 +29,6 @@
 ARRAYINTASLIST(FSWdeviceAvailability)
 STRUCTASLIST(CSSUnitConfigMsgPayload)
 STRUCTASLIST(AccPktDataMsgPayload)
-STRUCTASLIST(RegionOfInterestMsgPayload)
 STRUCTASLIST(RWConfigElementMsgPayload)
 STRUCTASLIST(CSSArraySensorMsgPayload)
 STRUCTASLIST(THRConfigMsgPayload)

--- a/src/architecture/msgPayloadDef/RegionsIdentifiedMsgPayload.h
+++ b/src/architecture/msgPayloadDef/RegionsIdentifiedMsgPayload.h
@@ -1,12 +1,16 @@
 #ifndef REGIONS_IDENTIFIED_H
 #define REGIONS_IDENTIFIED_H
 
-#include "RegionOfInterestMsgPayload.h"
 #include "definitions.h"
 
 /*! @brief Regions of interest extracted by camera */
 typedef struct {
-    RegionOfInterestMsgPayload regions[MAX_NUMBER_REGIONS];  //!< [ROI] array of regions
+    double timeTag[MAX_NUMBER_REGIONS];      //!< [sec] time tag of the image which provided the region(s)
+    int centerX[MAX_NUMBER_REGIONS];         //!< [pix] center pixel coordinate x
+    int centerY[MAX_NUMBER_REGIONS];         //!< [pix] center pixel coordinate y
+    int width[MAX_NUMBER_REGIONS];           //!< [pix] region width
+    int height[MAX_NUMBER_REGIONS];          //!< [pix] region height
+    int numberOfPixels[MAX_NUMBER_REGIONS];  //!< [-] number of pixels in the region
 } RegionsIdentifiedMsgPayload;
 
 #endif

--- a/src/fswAlgorithms/CMakeLists.txt
+++ b/src/fswAlgorithms/CMakeLists.txt
@@ -105,6 +105,7 @@ add_subdirectory(imageProcessing/houghCircles)
 add_subdirectory(imageProcessing/limbFinding)
 add_subdirectory(imageProcessing/opticalFlow)
 add_subdirectory(imageProcessing/regionsOfInterest)
+add_subdirectory(imageProcessing/regionsOfInterestPrune)
 
 add_subdirectory(opticalNavigation/cobConverter)
 add_subdirectory(opticalNavigation/faultDetection)

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterest/regionsOfInterest.cpp
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterest/regionsOfInterest.cpp
@@ -33,27 +33,17 @@ void RegionsOfInterest::reset(uint64_t currentSimNanos) { this->algorithm.reset(
 void RegionsOfInterest::updateState(uint64_t currentSimNanos) {
     // Read input message containing detected regions
     auto regionsMsgPayload = this->roisInMsg();
-    auto regions = std::to_array(regionsMsgPayload.regions);
 
     // Convert message payload to algorithm structures
     std::array<RegionOfInterest, MAX_NUMBER_REGIONS> regionsInput{};
-    size_t index = 0;
-    for (const auto& [timeTag,
-                      centerX,
-                      centerY,
-                      width,
-                      height,
-                      numberOfPixels,
-                      centerOfBrightnessX,
-                      centerOfBrightnessY] : regions) {
+    for (size_t index = 0; index < MAX_NUMBER_REGIONS; ++index) {
         RegionOfInterest regionInput{};
-        regionInput.timeTag = timeTag;
-        regionInput.regionCenter << centerX, centerY;
-        regionInput.regionSize << width, height;
-        regionInput.centerOfBrightness << centerOfBrightnessX, centerOfBrightnessY;
-        regionInput.numberOfPixels = numberOfPixels;
+        regionInput.timeTag = regionsMsgPayload.timeTag[index];
+        regionInput.regionCenter << regionsMsgPayload.centerX[index], regionsMsgPayload.centerY[index];
+        regionInput.regionSize << regionsMsgPayload.width[index], regionsMsgPayload.height[index];
+        regionInput.centerOfBrightness << regionsMsgPayload.centerX[index], regionsMsgPayload.centerY[index];
+        regionInput.numberOfPixels = regionsMsgPayload.numberOfPixels[index];
         regionsInput.at(index) = regionInput;
-        ++index;
     }
 
     // Process regions through algorithm

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterest/regionsOfInterest.h
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterest/regionsOfInterest.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <Eigen/Core>
 
+#include <architecture/msgPayloadDef/RegionOfInterestMsgPayload.h>
 #include <architecture/msgPayloadDef/RegionsIdentifiedMsgPayload.h>
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterest/tests/test_regionsOfInterest.py
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterest/tests/test_regionsOfInterest.py
@@ -76,23 +76,16 @@ def test_single_region_basic(show_plots):
     # Configure module
     roi_module.setMaxRoiSeparation(100)
 
-    # Create input message with single region
+    # Create input message with single region (slot 1; slots 0 and 2 are empty)
     regions_msg_payload = messaging.RegionsIdentifiedMsgPayload()
-    region1 = messaging.RegionOfInterestMsgPayload()
-    region1.numberOfPixels = 250
-    region1.centerOfBrightnessX = 512
-    region1.centerOfBrightnessY = 384
-    region1.centerX = 512
-    region1.centerY = 384
-    region1.width = 20
-    region1.height = 20
-    region1.timeTag = 0.0
-
-    region2 = messaging.RegionOfInterestMsgPayload()
-    region3 = messaging.RegionOfInterestMsgPayload()
-
-    # regions_msg_payload.regions[0].numberOfPixels = 250
-    regions_msg_payload.regions = [region2, region1, region3]
+    regions_msg_payload.numberOfPixels      = [0,   250, 0]
+    regions_msg_payload.centerOfBrightnessX = [0,   512, 0]
+    regions_msg_payload.centerOfBrightnessY = [0,   384, 0]
+    regions_msg_payload.centerX             = [0,   512, 0]
+    regions_msg_payload.centerY             = [0,   384, 0]
+    regions_msg_payload.width               = [0,    20, 0]
+    regions_msg_payload.height              = [0,    20, 0]
+    regions_msg_payload.timeTag             = [0.0, 0.0, 0.0]
 
     regions_input_msg = messaging.RegionsIdentifiedMsg().write(regions_msg_payload)
     roi_module.roisInMsg.subscribeTo(regions_input_msg)
@@ -170,23 +163,11 @@ def test_region_merging(show_plots):
 
     # Create two close regions
     regions_msg_payload = messaging.RegionsIdentifiedMsgPayload()
-
-    # Create input message with single region
-    region1 = messaging.RegionOfInterestMsgPayload()
-    region1.numberOfPixels = 100
-    region1.centerOfBrightnessX = 500
-    region1.centerOfBrightnessY = 400
-    region1.centerX = 500
-    region1.centerY = 400
-    region2 = messaging.RegionOfInterestMsgPayload()
-    region2.numberOfPixels = 80
-    region2.centerOfBrightnessX = 510
-    region2.centerOfBrightnessY = 405
-    region2.centerX = 510
-    region2.centerY = 405
-    region3 = messaging.RegionOfInterestMsgPayload()
-
-    regions_msg_payload.regions = [region1, region2, region3]
+    regions_msg_payload.numberOfPixels      = [100, 80, 0]
+    regions_msg_payload.centerOfBrightnessX = [500, 510, 0]
+    regions_msg_payload.centerOfBrightnessY = [400, 405, 0]
+    regions_msg_payload.centerX             = [500, 510, 0]
+    regions_msg_payload.centerY             = [400, 405, 0]
 
     regions_input_msg = messaging.RegionsIdentifiedMsg().write(regions_msg_payload)
     roi_module.roisInMsg.subscribeTo(regions_input_msg)
@@ -235,23 +216,11 @@ def test_windowing(show_plots):
 
     # Create regions: one inside window, one outside
     regions_msg_payload = messaging.RegionsIdentifiedMsgPayload()
-
-    # Create input message with single region
-    region1 = messaging.RegionOfInterestMsgPayload()
-    region1.numberOfPixels = 100
-    region1.centerOfBrightnessX = 500
-    region1.centerOfBrightnessY = 380
-    region1.centerX = 500
-    region1.centerY = 380
-    region2 = messaging.RegionOfInterestMsgPayload()
-    region2.numberOfPixels = 200
-    region2.centerOfBrightnessX = 100
-    region2.centerOfBrightnessY = 100
-    region2.centerX = 100
-    region2.centerY = 100
-    region3 = messaging.RegionOfInterestMsgPayload()
-
-    regions_msg_payload.regions = [region1, region2, region3]
+    regions_msg_payload.numberOfPixels      = [100, 200, 0]
+    regions_msg_payload.centerOfBrightnessX = [500, 100, 0]
+    regions_msg_payload.centerOfBrightnessY = [380, 100, 0]
+    regions_msg_payload.centerX             = [500, 100, 0]
+    regions_msg_payload.centerY             = [380, 100, 0]
 
     regions_input_msg = messaging.RegionsIdentifiedMsg().write(regions_msg_payload)
     roi_module.roisInMsg.subscribeTo(regions_input_msg)
@@ -310,24 +279,15 @@ def region_identification(show_plots, num_regions, use_windowing):
         {'pixels': 180, 'x': 600, 'y': 300},
     ]
 
-    region_list = []
-    for i in range(min(num_regions, len(test_regions))):
-        region = messaging.RegionOfInterestMsgPayload()
-        region.numberOfPixels = test_regions[i]['pixels']
-        region.centerOfBrightnessX =  test_regions[i]['x']
-        region.centerOfBrightnessY =  test_regions[i]['y']
-        region.centerX = test_regions[i]['x']
-        region.centerY = test_regions[i]['y']
-        region.width = 15
-        region.height = 15
-        region.timeTag = i * 0.1
-        region_list.append(region)
-
-    for i in range(num_regions, 3):
-        region = messaging.RegionOfInterestMsgPayload()
-        region_list.append(region)
-
-    regions_msg_payload.regions = region_list
+    n = min(num_regions, len(test_regions))
+    regions_msg_payload.numberOfPixels      = [test_regions[i]['pixels'] if i < n else 0   for i in range(3)]
+    regions_msg_payload.centerOfBrightnessX = [test_regions[i]['x']      if i < n else 0   for i in range(3)]
+    regions_msg_payload.centerOfBrightnessY = [test_regions[i]['y']      if i < n else 0   for i in range(3)]
+    regions_msg_payload.centerX             = [test_regions[i]['x']      if i < n else 0   for i in range(3)]
+    regions_msg_payload.centerY             = [test_regions[i]['y']      if i < n else 0   for i in range(3)]
+    regions_msg_payload.width               = [15                         if i < n else 0   for i in range(3)]
+    regions_msg_payload.height              = [15                         if i < n else 0   for i in range(3)]
+    regions_msg_payload.timeTag             = [i * 0.1                   if i < n else 0.0 for i in range(3)]
     regions_input_msg = messaging.RegionsIdentifiedMsg().write(regions_msg_payload)
     roi_module.roisInMsg.subscribeTo(regions_input_msg)
 

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/CMakeLists.txt
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(module "fswAlgorithms.imageProcessing.regionsOfInterestPrune")
+xmera_is_module_enabled("${module}" _is_enabled)
+if(NOT _is_enabled)
+  return()
+endif()
+
+find_package(OpenCV REQUIRED)
+
+xmera_add_swig_module("${module}")
+target_sources("${module}" PRIVATE
+  regionsOfInterestPrune.cpp
+  regionsOfInterestPruneAlgorithm.cpp
+)
+
+target_link_libraries("${module}" PRIVATE
+  opencv_imgcodecs
+  opencv_imgproc
+)
+
+# Suppress duplicate library warnings from OpenCV's vcpkg distribution on macOS
+target_link_options("${module}" PRIVATE
+  "$<$<PLATFORM_ID:Darwin>:-Wl,-no_warn_duplicate_libraries>"
+)

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/_UnitTest/test_regionsOfInterestPrune.py
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/_UnitTest/test_regionsOfInterestPrune.py
@@ -65,19 +65,18 @@ def _run_once(sim):
 
 def _regions_from_log(roi_log, timestep=-1):
     """Return valid regions at timestep as SimpleNamespace objects with field attribute access."""
-    regions = roi_log.regions[timestep]
-    regions_dict = []
-    for k in range(0, 3):
-        numberOfPixels = regions[f"regions[{k}].numberOfPixels"]
+    regions = []
+    for k in range(MAX_NUMBER_REGIONS):
+        numberOfPixels = roi_log.numberOfPixels[timestep][k]
         if numberOfPixels > 0:
-            regions_dict.append(types.SimpleNamespace(
+            regions.append(types.SimpleNamespace(
                 numberOfPixels=numberOfPixels,
-                centerX=regions[f"regions[{k}].centerX"],
-                centerY=regions[f"regions[{k}].centerY"],
-                width=regions[f"regions[{k}].width"],
-                height=regions[f"regions[{k}].height"],
+                centerX=roi_log.centerX[timestep][k],
+                centerY=roi_log.centerY[timestep][k],
+                width=roi_log.width[timestep][k],
+                height=roi_log.height[timestep][k],
             ))
-    return regions_dict
+    return regions
 
 
 # ---------------------------------------------------------------------------

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/_UnitTest/test_regionsOfInterestPrune.py
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/_UnitTest/test_regionsOfInterestPrune.py
@@ -1,0 +1,424 @@
+"""
+Unit tests for regionsOfInterestPrune.
+
+    test_message_connection  — verifies rowColSumInMsg links to fpgaImagePipeline.rowColSumOutMsg
+                               and that regionsIdentifiedOutMsg is written after one step.
+    test_step2_*             — verify bounding-box identification and the center-coordinate
+                               conversion published to regionsIdentifiedOutMsg.
+    test_pruning             — end-to-end integration on a real image; writes an annotated
+                               PNG using center coordinates (matching saveVisualization).
+"""
+
+import inspect
+import os
+import tempfile
+import types
+
+import numpy as np
+import pytest
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+IMAGE_PATH = os.path.abspath(
+    os.path.join(path, "..", "..", "fpgaImagePipeline", "_UnitTest", "pia_958_830.tiff")
+)
+
+importErr = False
+reasonErr = ""
+try:
+    import cv2
+    from xmera.fswAlgorithms import fpgaImagePipeline
+    from xmera.fswAlgorithms import regionsOfInterestPrune
+except ImportError as e:
+    importErr = True
+    reasonErr = f"Required module not built: {e}"
+
+# Synthetic image parameters (uniform 500, kernel=5)
+# Interior blur = (500 × 5 × 5) >> 1 = 6250; blurShift(5) = 1
+# Interior region starts at HALF = (5-1)//2 = 2
+HALF = 2
+INTERIOR_BLUR = (500 * 5 * 5) >> 1  # 6250
+
+from xmera.architecture import messaging
+MAX_NUMBER_REGIONS = messaging.MAX_NUMBER_REGIONS
+from xmera.utilities import SimulationBaseClass, macros
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sim(*modules):
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("testProcess")
+    proc.addTask(sim.CreateNewTask("testTask", macros.sec2nano(1.0)))
+    for mod in modules:
+        sim.AddModelToTask("testTask", mod)
+    return sim
+
+
+def _run_once(sim):
+    sim.InitializeSimulation()
+    sim.TotalSim.singleStepProcesses()
+
+
+def _regions_from_log(roi_log, timestep=-1):
+    """Return valid regions at timestep as SimpleNamespace objects with field attribute access."""
+    regions = roi_log.regions[timestep]
+    regions_dict = []
+    for k in range(0, 3):
+        numberOfPixels = regions[f"regions[{k}].numberOfPixels"]
+        if numberOfPixels > 0:
+            regions_dict.append(types.SimpleNamespace(
+                numberOfPixels=numberOfPixels,
+                centerX=regions[f"regions[{k}].centerX"],
+                centerY=regions[f"regions[{k}].centerY"],
+                width=regions[f"regions[{k}].width"],
+                height=regions[f"regions[{k}].height"],
+            ))
+    return regions_dict
+
+
+# ---------------------------------------------------------------------------
+# Test — message connection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_message_connection():
+    """Verify rowColSumInMsg connects to fpgaImagePipeline.rowColSumOutMsg and
+    that regionsIdentifiedOutMsg is written with correct image dimensions.
+
+    Assertions
+    ----------
+    1. rowColSumInMsg.isLinked() is True after subscribeTo.
+    2. rowColSumOutMsg carries the correct image dimensions after one step.
+    3. regionsIdentifiedOutMsg is written; any valid region has centre coordinates
+       within the image bounds.
+    """
+    assert os.path.isfile(IMAGE_PATH), f"Test image not found: {IMAGE_PATH}"
+
+    img_info = cv2.imread(IMAGE_PATH, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_GRAYSCALE)
+    assert img_info is not None, f"cv2 could not read: {IMAGE_PATH}"
+    img_h, img_w = img_info.shape
+
+    pipeline = fpgaImagePipeline.FpgaImagePipeline()
+    pipeline.ModelTag = "fpgaPipeline"
+    pipeline.setImageWidth(img_w)
+    pipeline.setImageHeight(img_h)
+    pipeline.setImageFileName(IMAGE_PATH)
+
+    pruner = regionsOfInterestPrune.RegionsOfInterestPrune()
+    pruner.ModelTag = "roiPrune"
+    pruner.rowColSumInMsg.subscribeTo(pipeline.rowColSumOutMsg)
+
+    assert pruner.rowColSumInMsg.isLinked(), \
+        "rowColSumInMsg should be linked after subscribeTo()"
+
+    rc_log  = pipeline.rowColSumOutMsg.recorder()
+    roi_log = pruner.regionsIdentifiedOutMsg.recorder()
+    _run_once(_make_sim(pipeline, pruner, rc_log, roi_log))
+
+    assert rc_log.numRows[-1] == img_h, \
+        f"Expected numRows={img_h}, got {rc_log.numRows[-1]}"
+    assert rc_log.numCols[-1] == img_w, \
+        f"Expected numCols={img_w}, got {rc_log.numCols[-1]}"
+
+    # regionsIdentifiedOutMsg must be written; any valid region must be in-bounds
+    for reg in _regions_from_log(roi_log):
+        assert 0 <= reg.centerX < img_w, \
+            f"centerX={reg.centerX} out of bounds [0, {img_w})"
+        assert 0 <= reg.centerY < img_h, \
+            f"centerY={reg.centerY} out of bounds [0, {img_h})"
+
+
+# ---------------------------------------------------------------------------
+# Tests — rank-1/rank-2 identification
+# ---------------------------------------------------------------------------
+#
+# Synthetic image building blocks: bright blocks of pixel value 500 separated
+# by at least one dark pixel so each block produces a distinct row/col span.
+#
+# A 5×5 block at value 500 with kernel=5:
+#   interior blur = (500×5×5)>>1 = 6250 > threshold=6249  → 1 above-threshold pixel
+#   border pixels: ≤4 full rows/cols in kernel → blur ≤ 5000 < 6249
+#
+# Internal (corner-based) representation: row, col, height, width, count
+# Published output (RegionsIdentifiedMsgPayload): centerX, centerY, width, height,
+#   numberOfPixels  where centerX = col + width//2, centerY = row + height//2.
+
+BLOCK  = 5          # 5×5 bright block
+GAP    = 1          # dark gap between blocks
+STRIDE = BLOCK + GAP
+
+LARGE_BLOCK  = 13   # 13×13 block → 9×9 = 81 interior above-threshold pixels
+MEDIUM_BLOCK = 9    # 9×9  block → 5×5 = 25 interior above-threshold pixels
+
+
+def _write_tmp_image(img):
+    with tempfile.NamedTemporaryFile(suffix=".tiff", delete=False) as f:
+        path = f.name
+    cv2.imwrite(path, img)
+    return path
+
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_step2_rank1_only():
+    """M=1: single object — one above-threshold pixel at the block interior.
+
+    Published output:  regions[0].numberOfPixels==1, center at (col+0, row+0)
+                       since width==height==1.
+    """
+    H = 2 * HALF + STRIDE
+    W = 2 * HALF + STRIDE
+    img = np.zeros((H, W), dtype=np.uint16)
+    img[HALF:HALF + BLOCK, HALF:HALF + BLOCK] = 500
+
+    # Single above-threshold pixel: interior corner (row=HALF+HALF, col=HALF+HALF) = (4, 4)
+    exp_col, exp_row, exp_w, exp_h = HALF + HALF, HALF + HALF, 1, 1
+    exp_cx = exp_col + exp_w // 2   # = 4
+    exp_cy = exp_row + exp_h // 2   # = 4
+
+    img_path = _write_tmp_image(img)
+    try:
+        pipeline = fpgaImagePipeline.FpgaImagePipeline()
+        pipeline.ModelTag = "fpga"
+        pipeline.setImageWidth(W)
+        pipeline.setImageHeight(H)
+        pipeline.setImageFileName(img_path)
+        pipeline.setKernelSize(5)
+        pipeline.setThreshold(INTERIOR_BLUR - 1)
+
+        pruner = regionsOfInterestPrune.RegionsOfInterestPrune()
+        pruner.ModelTag = "pruner"
+        pruner.rowColSumInMsg.subscribeTo(pipeline.rowColSumOutMsg)
+
+        roi_log = pruner.regionsIdentifiedOutMsg.recorder()
+        _run_once(_make_sim(pipeline, pruner, roi_log))
+
+        # --- published message checks (center coordinates) ---
+        regions = _regions_from_log(roi_log)
+        assert len(regions) == 1, \
+            f"Expected 1 valid region in regionsIdentifiedOutMsg, got {len(regions)}"
+        r = regions[0]
+        assert r.numberOfPixels == 1, \
+            f"Expected numberOfPixels=1, got {r.numberOfPixels}"
+        assert r.centerX == exp_cx and r.centerY == exp_cy, \
+            f"Expected center=({exp_cx},{exp_cy}), got ({r.centerX},{r.centerY})"
+        assert r.width == exp_w and r.height == exp_h, \
+            f"Expected size={exp_w}×{exp_h}, got {r.width}×{r.height}"
+    finally:
+        os.unlink(img_path)
+
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_step2_rank1_and_rank2():
+    """Two real objects; both appear in regionsIdentifiedOutMsg with correct
+    center coordinates.
+
+    Image layout (160×160):
+      13×13 block at (3, 3)  → rank-1; bounding box row=5,col=5,h=9,w=9
+                               → centerX=9, centerY=9
+       5×5 block at (100, 5) → rank-2; bounding box row=102,col=5,h=1,w=9
+                               → centerX=9, centerY=102
+    """
+    H, W = 160, 160
+    img = np.zeros((H, W), dtype=np.uint16)
+    img[3:3 + LARGE_BLOCK, 3:3 + LARGE_BLOCK] = 500   # large block → rank-1
+    img[100:100 + BLOCK, 5:5 + BLOCK] = 500            # small block → rank-2
+
+    img_path = _write_tmp_image(img)
+    try:
+        pipeline = fpgaImagePipeline.FpgaImagePipeline()
+        pipeline.ModelTag = "fpga"
+        pipeline.setImageWidth(W)
+        pipeline.setImageHeight(H)
+        pipeline.setImageFileName(img_path)
+        pipeline.setKernelSize(5)
+        pipeline.setThreshold(INTERIOR_BLUR - 1)
+
+        pruner = regionsOfInterestPrune.RegionsOfInterestPrune()
+        pruner.ModelTag = "pruner"
+        pruner.rowColSumInMsg.subscribeTo(pipeline.rowColSumOutMsg)
+
+        roi_log = pruner.regionsIdentifiedOutMsg.recorder()
+        _run_once(_make_sim(pipeline, pruner, roi_log))
+
+        # --- published message checks (center coordinates) ---
+        regions = _regions_from_log(roi_log)
+        assert len(regions) == 2, \
+            f"Expected 2 valid regions in regionsIdentifiedOutMsg, got {len(regions)}"
+
+        r1 = regions[0]
+        assert r1.centerX == 9 and r1.centerY == 9, \
+            f"rank-1 center: expected (9,9), got ({r1.centerX},{r1.centerY})"
+        assert r1.width == 9 and r1.height == 9, \
+            f"rank-1 size: expected 9×9, got {r1.width}×{r1.height}"
+        r2 = regions[1]
+        assert r2.centerX == 9 and r2.centerY == 102, \
+            f"rank-2 center: expected (9,102), got ({r2.centerX},{r2.centerY})"
+        assert r2.width == 9 and r2.height == 1, \
+            f"rank-2 size: expected 9×1, got {r2.width}×{r2.height}"
+    finally:
+        os.unlink(img_path)
+
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_step2_rank2_by_count():
+    """Three objects sorted by pixel count; all three fit in MAX_NUMBER_REGIONS=3
+    and appear in regionsIdentifiedOutMsg in the correct order.
+
+    Image layout (H=100, W=30):
+      13×13 block at (3, 3)   → rank-1; bbox row=5,col=5,h=9,w=9   → center (9,9)
+       9×9  block at (50, 5)  → rank-2; bbox row=52,col=5,h=5,w=9  → center (9,54)
+       5×5  block at (80, 7)  → rank-3; bbox row=82,col=5,h=1,w=9  → center (9,82)
+    """
+    H, W = 100, 30
+    img = np.zeros((H, W), dtype=np.uint16)
+    img[3:3 + LARGE_BLOCK,   3:3 + LARGE_BLOCK]   = 500   # 13×13 → rank-1
+    img[50:50 + MEDIUM_BLOCK, 5:5 + MEDIUM_BLOCK]  = 500   # 9×9  → rank-2
+    img[80:80 + BLOCK,        7:7 + BLOCK]          = 500   # 5×5  → rank-3
+
+    img_path = _write_tmp_image(img)
+    try:
+        pipeline = fpgaImagePipeline.FpgaImagePipeline()
+        pipeline.ModelTag = "fpga"
+        pipeline.setImageWidth(W)
+        pipeline.setImageHeight(H)
+        pipeline.setImageFileName(img_path)
+        pipeline.setKernelSize(5)
+        pipeline.setThreshold(INTERIOR_BLUR - 1)
+
+        pruner = regionsOfInterestPrune.RegionsOfInterestPrune()
+        pruner.ModelTag = "pruner"
+        pruner.rowColSumInMsg.subscribeTo(pipeline.rowColSumOutMsg)
+
+        roi_log = pruner.regionsIdentifiedOutMsg.recorder()
+        _run_once(_make_sim(pipeline, pruner, roi_log))
+
+        # --- published message checks (center coordinates, all 3 fit in MAX_NUMBER_REGIONS) ---
+        regions = _regions_from_log(roi_log)
+        assert len(regions) == 3, \
+            f"Expected 3 valid regions in regionsIdentifiedOutMsg, got {len(regions)}"
+
+        expected_centers = [(9, 9), (9, 54), (9, 82)]
+        for k, (exp_cx, exp_cy) in enumerate(expected_centers):
+            r = regions[k]
+            assert r.centerX == exp_cx and r.centerY == exp_cy, \
+                f"rank-{k+1} center: expected ({exp_cx},{exp_cy}), got ({r.centerX},{r.centerY})"
+        # Verify descending order by pixel count
+        counts = [r.numberOfPixels for r in regions]
+        assert counts == sorted(counts, reverse=True), \
+            f"Regions not sorted by numberOfPixels (descending): {counts}"
+    finally:
+        os.unlink(img_path)
+
+
+# ---------------------------------------------------------------------------
+# Test — end-to-end pipeline on real image
+# ---------------------------------------------------------------------------
+
+OUTPUT_PATH = os.path.join(path, "test_pruning_output.png")
+THRESH_PATH = os.path.join(path, "test_pruning_threshold.png")
+
+PIPELINE_KERNEL = 5
+
+
+def _auto_threshold(image_path, kernel_size, percentile=95.0):
+    """Detect image dimensions and compute a threshold from the image's blur distribution.
+
+    Mirrors _detect_image_info() in run_pipeline_reference.py exactly:
+    applies the same ×16 scaling for 8-bit images, same blurShift lookup,
+    and same percentile default (95.0) so thresholds are consistent across
+    both tools regardless of which pia_ image is used.
+
+    Returns
+    -------
+    (width : int, height : int, threshold : int)
+    """
+    img = cv2.imread(image_path, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_GRAYSCALE)
+    assert img is not None, f"cv2 could not read: {image_path}"
+    h, w = img.shape
+    pixels = img.astype(np.float32) * (16.0 if img.dtype == np.uint8 else 1.0)
+    blur = cv2.boxFilter(pixels, -1, (kernel_size, kernel_size), normalize=False)
+    shift = {5: 1, 7: 2, 9: 3}.get(int(kernel_size), 1)
+    blur_shifted = blur / float(1 << shift)
+    return w, h, max(1, int(np.percentile(blur_shifted.ravel(), percentile)))
+
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+@pytest.mark.parametrize("test_image_path", [
+    os.path.abspath(
+        os.path.join(path, "..", "..", "fpgaImagePipeline", "_UnitTest", "pia_958_830.tiff")
+    ),
+    # os.path.abspath(
+    #     os.path.join(path, "..", "..", "fpgaImagePipeline", "_UnitTest", "pia_616_592.tiff")
+    # ),
+    # os.path.abspath(
+    #     os.path.join(path, "..", "..", "fpgaImagePipeline", "_UnitTest", "bennu_1024_1024.tiff")
+    # ),
+    # os.path.abspath(
+    #     os.path.join(path, "..", "..", "fpgaImagePipeline", "_UnitTest", "jupiter_3000_3000.tiff")
+    # ),
+])
+@pytest.mark.parametrize("row_col_span", [2, 3, 4])
+def test_pruning(test_image_path, row_col_span, threshold=None):
+    """End-to-end integration test: real pia_ image through the full
+    fpgaImagePipeline → regionsOfInterestPrune chain.
+
+    Checks at least one candidate is identified and verifies the published
+    regionsIdentifiedOutMsg contains valid center-coordinate regions.
+
+    Writes two diagnostic PNGs to the _UnitTest directory:
+
+        test_pruning_output.png
+            All published regions (up to MAX_NUMBER_REGIONS) drawn in thin yellow
+            from centre coordinates, matching the production saveVisualization style.
+            Rank-1 in RED with filled centre dot and label "R1 (<numberOfPixels>)".
+            Rank-2 in BLUE with filled centre dot (if present).
+
+        test_pruning_threshold.png
+            Above-threshold pixels → 255, below → 0.
+    """
+    if not os.path.isfile(test_image_path):
+        pytest.skip(f"Test image not found: {test_image_path}")
+
+    img_w, img_h, auto_t = _auto_threshold(test_image_path, PIPELINE_KERNEL)
+    if threshold is None:
+        threshold = auto_t
+    print(f"\ntest_pruning: {img_w}×{img_h}, threshold={threshold}")
+
+    pipeline = fpgaImagePipeline.FpgaImagePipeline()
+    pipeline.ModelTag = "fpga"
+    pipeline.setImageWidth(img_w)
+    pipeline.setImageHeight(img_h)
+    pipeline.setImageFileName(test_image_path)
+    pipeline.setKernelSize(PIPELINE_KERNEL)
+    pipeline.setThreshold(threshold)
+
+    pruner = regionsOfInterestPrune.RegionsOfInterestPrune()
+    pruner.ModelTag = "pruner"
+    pruner.rowColSumInMsg.subscribeTo(pipeline.rowColSumOutMsg)
+    pruner.threshImageInMsg.subscribeTo(pipeline.threshImageOutMsg)
+    pruner.setMaxRowSpans(row_col_span)
+    pruner.setMaxColSpans(row_col_span)
+    pruner.setSaveImages(True)
+    pruner.setSaveDir(path)
+
+    roi_log = pruner.regionsIdentifiedOutMsg.recorder()
+    _run_once(_make_sim(pipeline, pruner, roi_log))
+
+    regions = _regions_from_log(roi_log)
+    assert len(regions) >= 1, \
+        f"Expected at least 1 candidate, got {len(regions)}"
+
+    for k, reg in enumerate(regions):
+        assert 0 <= reg.centerX < img_w and 0 <= reg.centerY < img_h, \
+            f"Region {k} center ({reg.centerX},{reg.centerY}) out of image bounds {img_w}×{img_h}"
+
+    r1 = regions[0]
+    count_str = f"R1 pixel count (approx): {r1.numberOfPixels}"
+    if len(regions) >= 2:
+        count_str += f"  |  R2 pixel count (approx): {regions[1].numberOfPixels}"
+    print(count_str)
+    print(f"test_pruning: {len(regions)} candidate(s); visualisation saved by module to {path}")

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.cpp
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.cpp
@@ -1,0 +1,149 @@
+#include "regionsOfInterestPrune.h"
+
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Free helper — converts a single internal candidate (corner-based) to the
+// center-coordinate form expected by RegionsIdentifiedMsgPayload.
+// ---------------------------------------------------------------------------
+static RegionOfInterestMsgPayload toRegionOfInterest(const RoiCandidateEntry& cand, double timeTagSec) {
+    RegionOfInterestMsgPayload reg{};
+    reg.timeTag = timeTagSec;
+    reg.centerX = static_cast<int>(cand.col + cand.width / 2);
+    reg.centerY = static_cast<int>(cand.row + cand.height / 2);
+    reg.width = static_cast<int>(cand.width);
+    reg.height = static_cast<int>(cand.height);
+    reg.numberOfPixels = static_cast<int>(cand.count);
+    reg.centerOfBrightnessX = reg.centerX;  // best estimate without full pixel data
+    reg.centerOfBrightnessY = reg.centerY;
+    return reg;
+}
+
+// ---------------------------------------------------------------------------
+// BSK adapter interface
+// ---------------------------------------------------------------------------
+
+void RegionsOfInterestPrune::reset(uint64_t /*callTime*/) {
+    if (!rowColSumInMsg.isLinked())
+        bskLogger.bskLog(BSK_WARNING, "RegionsOfInterestPrune: rowColSumInMsg is not linked");
+    numPublished = 0;
+    lastRegionsOutput = {};
+}
+
+void RegionsOfInterestPrune::updateState(uint64_t callTime) {
+    if (!rowColSumInMsg.isLinked()) return;
+
+    const FpgaRowColSumMsgPayload rcMsg = rowColSumInMsg();
+    const auto* rowSums = reinterpret_cast<const uint16_t*>(rcMsg.rowSumPointer);
+    const auto* colSums = reinterpret_cast<const uint16_t*>(rcMsg.colSumPointer);
+
+    const RoiCandidates candidates = algorithm.update(rowSums, rcMsg.numRows, colSums, rcMsg.numCols);
+
+    lastRegionsOutput = {};
+    numPublished = std::min(candidates.numCandidates, static_cast<uint32_t>(MAX_NUMBER_REGIONS));
+    const double timeTagSec = static_cast<double>(callTime) * NANO2SEC;
+    for (uint32_t k = 0; k < numPublished; ++k)
+        lastRegionsOutput.regions[k] = toRegionOfInterest(candidates.candidates[k], timeTagSec);
+    regionsIdentifiedOutMsg.write(&lastRegionsOutput, moduleID, callTime);
+
+    if (saveImages && !saveDir.empty()) saveVisualization(rcMsg);
+}
+
+// ---------------------------------------------------------------------------
+// Visualization helpers
+// ---------------------------------------------------------------------------
+
+/*! Builds a BGR background image for the current frame.
+ *  Prefers the packed 1-bit threshold image; falls back to a synthetic image
+ *  whose brightness at (r,c) is min(rowSum[r], colSum[c]).
+ @return BGR cv::Mat of size H×W, or an empty Mat on failure.
+ @param rcMsg  Row/col sum message (carries dimensions and fallback data).
+*/
+cv::Mat RegionsOfInterestPrune::buildBackground(const FpgaRowColSumMsgPayload& rcMsg) {
+    const auto H = static_cast<int>(rcMsg.numRows);
+    const auto W = static_cast<int>(rcMsg.numCols);
+
+    if (threshImageInMsg.isLinked()) {
+        const FpgaThreshImageMsgPayload thMsg = threshImageInMsg();
+        const auto* bits = reinterpret_cast<const uint8_t*>(thMsg.imagePointer);
+        if (bits && thMsg.width == static_cast<uint32_t>(W) && thMsg.height == static_cast<uint32_t>(H)) {
+            // Unpack 1-bit-per-pixel (MSB-first) → 8-bit grayscale → BGR.
+            cv::Mat gray(H, W, CV_8UC1);
+            const int nPix = H * W;
+            for (int i = 0; i < nPix; ++i)
+                gray.at<uint8_t>(i / W, i % W) = static_cast<uint8_t>(((bits[i / 8] >> (7 - i % 8)) & 1) * 255);
+            cv::Mat bgr;
+            cv::cvtColor(gray, bgr, cv::COLOR_GRAY2BGR);
+            return bgr;
+        }
+    }
+
+    // Fallback: synthesize from 1-D sums.
+    const auto* rowSums = reinterpret_cast<const uint16_t*>(rcMsg.rowSumPointer);
+    const auto* colSums = reinterpret_cast<const uint16_t*>(rcMsg.colSumPointer);
+    if (!rowSums || !colSums) return {};
+
+    uint32_t maxVal = 0;
+    for (int r = 0; r < H; ++r) maxVal = std::max(maxVal, static_cast<uint32_t>(rowSums[r]));
+    for (int c = 0; c < W; ++c) maxVal = std::max(maxVal, static_cast<uint32_t>(colSums[c]));
+
+    cv::Mat gray(H, W, CV_8UC1, cv::Scalar(0));
+    if (maxVal > 0) {
+        for (int r = 0; r < H; ++r)
+            for (int c = 0; c < W; ++c)
+                gray.at<uint8_t>(r, c) =
+                    static_cast<uint8_t>(std::min<uint32_t>(rowSums[r], colSums[c]) * 255u / maxVal);
+    }
+    cv::Mat bgr;
+    cv::cvtColor(gray, bgr, cv::COLOR_GRAY2BGR);
+    return bgr;
+}
+
+/*! Annotates one ranked region on vis: thick bounding box + filled center dot + label.
+ @param vis        BGR image to annotate in-place.
+ @param reg        Region in center-coordinate form.
+ @param color      BGR annotation color.
+ @param thickness  Bounding-box line thickness.
+ @param label      Text label drawn above the box.
+*/
+void RegionsOfInterestPrune::drawRegion(cv::Mat& vis,
+                                        const RegionOfInterestMsgPayload& reg,
+                                        const cv::Scalar& color,
+                                        int thickness,
+                                        const std::string& label) {
+    const int x = reg.centerX - reg.width / 2;
+    const int y = reg.centerY - reg.height / 2;
+    cv::rectangle(vis, cv::Point(x, y), cv::Point(x + reg.width, y + reg.height), color, thickness);
+    cv::circle(vis, cv::Point(reg.centerX, reg.centerY), 3, color, -1);
+    cv::putText(vis, label, cv::Point(x, std::max(y - 6, 12)), cv::FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv::LINE_AA);
+}
+
+void RegionsOfInterestPrune::saveVisualization(const FpgaRowColSumMsgPayload& rcMsg) {
+    if (rcMsg.numRows == 0 || rcMsg.numCols == 0) return;
+
+    cv::Mat vis = buildBackground(rcMsg);
+    if (vis.empty()) return;
+
+    const uint32_t nDraw = numPublished;
+
+    // All published regions: thin cyan outline for context.
+    for (uint32_t k = 0; k < nDraw; ++k) {
+        const auto& reg = lastRegionsOutput.regions[k];
+        const int x = reg.centerX - reg.width / 2;
+        const int y = reg.centerY - reg.height / 2;
+        cv::rectangle(vis, cv::Point(x, y), cv::Point(x + reg.width, y + reg.height), cv::Scalar(0, 255, 255), 1);
+    }
+    // Rank-1 (red) and rank-2 (blue): thicker box + center dot + pixel-count label.
+    static const cv::Scalar kRed(0, 0, 255);
+    static const cv::Scalar kBlue(255, 0, 0);
+    if (nDraw >= 1) {
+        const auto& r1 = lastRegionsOutput.regions[0];
+        drawRegion(vis, r1, kRed, 2, "R1 (" + std::to_string(r1.numberOfPixels) + ")");
+    }
+    if (nDraw >= 2) {
+        const auto& r2 = lastRegionsOutput.regions[1];
+        drawRegion(vis, r2, kBlue, 2, "R2 (" + std::to_string(r2.numberOfPixels) + ")");
+    }
+
+    cv::imwrite(saveDir + "/" + std::to_string(rcMsg.timeTag) + "_pruning_output.png", vis);
+}

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.cpp
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.cpp
@@ -3,20 +3,19 @@
 #include <string>
 
 // ---------------------------------------------------------------------------
-// Free helper — converts a single internal candidate (corner-based) to the
-// center-coordinate form expected by RegionsIdentifiedMsgPayload.
+// Free helpers
 // ---------------------------------------------------------------------------
-static RegionOfInterestMsgPayload toRegionOfInterest(const RoiCandidateEntry& cand, double timeTagSec) {
-    RegionOfInterestMsgPayload reg{};
-    reg.timeTag = timeTagSec;
-    reg.centerX = static_cast<int>(cand.col + cand.width / 2);
-    reg.centerY = static_cast<int>(cand.row + cand.height / 2);
-    reg.width = static_cast<int>(cand.width);
-    reg.height = static_cast<int>(cand.height);
-    reg.numberOfPixels = static_cast<int>(cand.count);
-    reg.centerOfBrightnessX = reg.centerX;  // best estimate without full pixel data
-    reg.centerOfBrightnessY = reg.centerY;
-    return reg;
+
+// Converts a flat-array slot back to RegionOfInterestMsgPayload for visualization.
+static RegionOfInterestMsgPayload regionAt(const RegionsIdentifiedMsgPayload& msg, uint32_t k) {
+    return {.timeTag = msg.timeTag[k],
+            .centerX = msg.centerX[k],
+            .centerY = msg.centerY[k],
+            .width = msg.width[k],
+            .height = msg.height[k],
+            .numberOfPixels = msg.numberOfPixels[k],
+            .centerOfBrightnessX = msg.centerX[k],
+            .centerOfBrightnessY = msg.centerY[k]};
 }
 
 // ---------------------------------------------------------------------------
@@ -24,29 +23,36 @@ static RegionOfInterestMsgPayload toRegionOfInterest(const RoiCandidateEntry& ca
 // ---------------------------------------------------------------------------
 
 void RegionsOfInterestPrune::reset(uint64_t /*callTime*/) {
-    if (!rowColSumInMsg.isLinked())
-        bskLogger.bskLog(BSK_WARNING, "RegionsOfInterestPrune: rowColSumInMsg is not linked");
-    numPublished = 0;
-    lastRegionsOutput = {};
+    if (!this->rowColSumInMsg.isLinked())
+        this->bskLogger.bskLog(BSK_WARNING, "RegionsOfInterestPrune: rowColSumInMsg is not linked");
+    this->numPublished = 0;
+    this->lastRegionsOutput = {};
 }
 
 void RegionsOfInterestPrune::updateState(uint64_t callTime) {
-    if (!rowColSumInMsg.isLinked()) return;
+    if (!this->rowColSumInMsg.isLinked()) return;
 
-    const FpgaRowColSumMsgPayload rcMsg = rowColSumInMsg();
-    const auto* rowSums = reinterpret_cast<const uint16_t*>(rcMsg.rowSumPointer);
-    const auto* colSums = reinterpret_cast<const uint16_t*>(rcMsg.colSumPointer);
+    const FpgaRowColSumMsgPayload rcMsg = this->rowColSumInMsg();
+    const auto* rowSums = static_cast<const uint16_t*>(rcMsg.rowSumPointer);
+    const auto* colSums = static_cast<const uint16_t*>(rcMsg.colSumPointer);
 
-    const RoiCandidates candidates = algorithm.update(rowSums, rcMsg.numRows, colSums, rcMsg.numCols);
+    const RoiCandidates candidates = this->algorithm.update(rowSums, rcMsg.numRows, colSums, rcMsg.numCols);
 
-    lastRegionsOutput = {};
-    numPublished = std::min(candidates.numCandidates, static_cast<uint32_t>(MAX_NUMBER_REGIONS));
+    this->lastRegionsOutput = {};
+    this->numPublished = std::min(candidates.numCandidates, static_cast<uint32_t>(MAX_NUMBER_REGIONS));
     const double timeTagSec = static_cast<double>(callTime) * NANO2SEC;
-    for (uint32_t k = 0; k < numPublished; ++k)
-        lastRegionsOutput.regions[k] = toRegionOfInterest(candidates.candidates[k], timeTagSec);
-    regionsIdentifiedOutMsg.write(&lastRegionsOutput, moduleID, callTime);
+    for (uint32_t k = 0; k < this->numPublished; ++k) {
+        const auto& cand = candidates.candidates[k];
+        this->lastRegionsOutput.timeTag[k] = timeTagSec;
+        this->lastRegionsOutput.centerX[k] = static_cast<int>(cand.col + cand.width / 2);
+        this->lastRegionsOutput.centerY[k] = static_cast<int>(cand.row + cand.height / 2);
+        this->lastRegionsOutput.width[k] = static_cast<int>(cand.width);
+        this->lastRegionsOutput.height[k] = static_cast<int>(cand.height);
+        this->lastRegionsOutput.numberOfPixels[k] = static_cast<int>(cand.count);
+    }
+    this->regionsIdentifiedOutMsg.write(&this->lastRegionsOutput, moduleID, callTime);
 
-    if (saveImages && !saveDir.empty()) saveVisualization(rcMsg);
+    if (this->saveImages && !this->saveDir.empty()) saveVisualization(rcMsg);
 }
 
 // ---------------------------------------------------------------------------
@@ -63,8 +69,8 @@ cv::Mat RegionsOfInterestPrune::buildBackground(const FpgaRowColSumMsgPayload& r
     const auto H = static_cast<int>(rcMsg.numRows);
     const auto W = static_cast<int>(rcMsg.numCols);
 
-    if (threshImageInMsg.isLinked()) {
-        const FpgaThreshImageMsgPayload thMsg = threshImageInMsg();
+    if (this->threshImageInMsg.isLinked()) {
+        const FpgaThreshImageMsgPayload thMsg = this->threshImageInMsg();
         const auto* bits = reinterpret_cast<const uint8_t*>(thMsg.imagePointer);
         if (bits && thMsg.width == static_cast<uint32_t>(W) && thMsg.height == static_cast<uint32_t>(H)) {
             // Unpack 1-bit-per-pixel (MSB-first) → 8-bit grayscale → BGR.
@@ -79,8 +85,8 @@ cv::Mat RegionsOfInterestPrune::buildBackground(const FpgaRowColSumMsgPayload& r
     }
 
     // Fallback: synthesize from 1-D sums.
-    const auto* rowSums = reinterpret_cast<const uint16_t*>(rcMsg.rowSumPointer);
-    const auto* colSums = reinterpret_cast<const uint16_t*>(rcMsg.colSumPointer);
+    const auto* rowSums = static_cast<const uint16_t*>(rcMsg.rowSumPointer);
+    const auto* colSums = static_cast<const uint16_t*>(rcMsg.colSumPointer);
     if (!rowSums || !colSums) return {};
 
     uint32_t maxVal = 0;
@@ -124,26 +130,29 @@ void RegionsOfInterestPrune::saveVisualization(const FpgaRowColSumMsgPayload& rc
     cv::Mat vis = buildBackground(rcMsg);
     if (vis.empty()) return;
 
-    const uint32_t nDraw = numPublished;
+    const uint32_t nDraw = this->numPublished;
 
     // All published regions: thin cyan outline for context.
     for (uint32_t k = 0; k < nDraw; ++k) {
-        const auto& reg = lastRegionsOutput.regions[k];
-        const int x = reg.centerX - reg.width / 2;
-        const int y = reg.centerY - reg.height / 2;
-        cv::rectangle(vis, cv::Point(x, y), cv::Point(x + reg.width, y + reg.height), cv::Scalar(0, 255, 255), 1);
+        const int x = this->lastRegionsOutput.centerX[k] - this->lastRegionsOutput.width[k] / 2;
+        const int y = this->lastRegionsOutput.centerY[k] - this->lastRegionsOutput.height[k] / 2;
+        cv::rectangle(vis,
+                      cv::Point(x, y),
+                      cv::Point(x + this->lastRegionsOutput.width[k], y + this->lastRegionsOutput.height[k]),
+                      cv::Scalar(0, 255, 255),
+                      1);
     }
     // Rank-1 (red) and rank-2 (blue): thicker box + center dot + pixel-count label.
     static const cv::Scalar kRed(0, 0, 255);
     static const cv::Scalar kBlue(255, 0, 0);
     if (nDraw >= 1) {
-        const auto& r1 = lastRegionsOutput.regions[0];
+        const auto r1 = regionAt(this->lastRegionsOutput, 0);
         drawRegion(vis, r1, kRed, 2, "R1 (" + std::to_string(r1.numberOfPixels) + ")");
     }
     if (nDraw >= 2) {
-        const auto& r2 = lastRegionsOutput.regions[1];
+        const auto r2 = regionAt(this->lastRegionsOutput, 1);
         drawRegion(vis, r2, kBlue, 2, "R2 (" + std::to_string(r2.numberOfPixels) + ")");
     }
 
-    cv::imwrite(saveDir + "/" + std::to_string(rcMsg.timeTag) + "_pruning_output.png", vis);
+    cv::imwrite(this->saveDir + "/" + std::to_string(rcMsg.timeTag) + "_pruning_output.png", vis);
 }

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.h
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.h
@@ -1,0 +1,67 @@
+#ifndef REGIONS_OF_INTEREST_PRUNE_H
+#define REGIONS_OF_INTEREST_PRUNE_H
+
+#include <string>
+
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <architecture/_GeneralModuleFiles/sys_model.h>
+#include <architecture/messaging/messaging.h>
+#include <architecture/msgPayloadDef/FpgaRowColSumMsgPayload.h>
+#include <architecture/msgPayloadDef/FpgaThreshImageMsgPayload.h>
+#include <architecture/msgPayloadDef/RegionsIdentifiedMsgPayload.h>
+#include <architecture/utilities/bskLogging.h>
+#include <architecture/utilities/macroDefinitions.h>
+
+#include "regionsOfInterestPruneAlgorithm.h"
+
+/*! @brief Basilisk adapter for the regions-of-interest pruning module.
+ *
+ *  Reads FpgaRowColSumMsgPayload, delegates computation to RegionsOfInterestPruneAlgorithm,
+ *  and publishes up to MAX_NUMBER_REGIONS candidates sorted by estimated above-threshold
+ *  pixel count to regionsIdentifiedOutMsg (RegionsIdentifiedMsgPayload).
+ */
+class RegionsOfInterestPrune : public SysModel {
+   public:
+    void reset(uint64_t callTime) override;
+    void updateState(uint64_t callTime) override;
+
+    // --- Pre-filter configuration (forwarded to algorithm) ---
+    void setMaxRowSpans(uint32_t n) { algorithm.setMaxRowSpans(n); }
+    uint32_t getMaxRowSpans() const { return algorithm.getMaxRowSpans(); }
+    void setMaxColSpans(uint32_t n) { algorithm.setMaxColSpans(n); }
+    uint32_t getMaxColSpans() const { return algorithm.getMaxColSpans(); }
+
+    // --- Save configuration ---
+    void setSaveImages(bool save) { saveImages = save; }
+    bool getSaveImages() const { return saveImages; }
+    void setSaveDir(const std::string& dir) { saveDir = dir; }
+    std::string getSaveDir() const { return saveDir; }
+
+    // --- Message interfaces ---
+    ReadFunctor<FpgaRowColSumMsgPayload> rowColSumInMsg;           //!< Row/col accumulators from fpgaImagePipeline
+    ReadFunctor<FpgaThreshImageMsgPayload> threshImageInMsg;       //!< Optional: threshold image for visualization
+    Message<RegionsIdentifiedMsgPayload> regionsIdentifiedOutMsg;  //!< Pruned candidates as RegionsIdentifiedMsg
+
+    BSKLogger bskLogger = {};
+
+   private:
+    // Build the BGR background image from the threshold msg (preferred) or the 1-D sums (fallback).
+    cv::Mat buildBackground(const FpgaRowColSumMsgPayload& rcMsg);
+    // Draw a thick bounding-box + filled center dot + label for one ranked region.
+    static void drawRegion(cv::Mat& vis,
+                           const RegionOfInterestMsgPayload& reg,
+                           const cv::Scalar& color,
+                           int thickness,
+                           const std::string& label);
+    void saveVisualization(const FpgaRowColSumMsgPayload& rcMsg);
+
+    RegionsOfInterestPruneAlgorithm algorithm{};
+    uint32_t numPublished{};                          //!< Number of valid entries in lastRegionsOutput
+    RegionsIdentifiedMsgPayload lastRegionsOutput{};  //!< Published center-coordinate form
+    bool saveImages{false};
+    std::string saveDir{};
+};
+
+#endif

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.h
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.h
@@ -10,6 +10,7 @@
 #include <architecture/messaging/messaging.h>
 #include <architecture/msgPayloadDef/FpgaRowColSumMsgPayload.h>
 #include <architecture/msgPayloadDef/FpgaThreshImageMsgPayload.h>
+#include <architecture/msgPayloadDef/RegionOfInterestMsgPayload.h>
 #include <architecture/msgPayloadDef/RegionsIdentifiedMsgPayload.h>
 #include <architecture/utilities/bskLogging.h>
 #include <architecture/utilities/macroDefinitions.h>

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.i
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.i
@@ -1,0 +1,17 @@
+%module regionsOfInterestPrune
+%{
+   #include "regionsOfInterestPrune.h"
+%}
+
+%include <stdint.i>
+%include <std_string.i>
+%include <architecture/_GeneralModuleFiles/swig_eigen.i>
+%include <architecture/_GeneralModuleFiles/sys_model.i>
+%include <architecture/_GeneralModuleFiles/swig_conly_data.i>
+
+%include "regionsOfInterestPrune.h"
+
+%include <architecture/msgPayloadDef/FpgaRowColSumMsgPayload.h>
+%include <architecture/msgPayloadDef/FpgaThreshImageMsgPayload.h>
+%include <architecture/msgPayloadDef/RegionOfInterestMsgPayload.h>
+%include <architecture/msgPayloadDef/RegionsIdentifiedMsgPayload.h>

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.rst
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPrune.rst
@@ -1,0 +1,160 @@
+Executive Summary
+-----------------
+
+``RegionsOfInterestPrune`` consumes the row/column above-threshold pixel sums produced by
+``fpgaImagePipeline`` and outputs up to ``ROI_CANDIDATES_MAX`` bounding-box candidates sorted
+by estimated pixel count.  It sits immediately downstream of ``fpgaImagePipeline`` and feeds
+downstream tracking or centroiding stages.
+
+The module is split into two classes:
+
+* ``RegionsOfInterestPruneAlgorithm`` — pure C++, no Basilisk dependencies.  Accepts raw
+  ``uint16_t`` row/col sum arrays and returns a ``RoiCandidatesMsgPayload``.
+* ``RegionsOfInterestPrune`` — thin Basilisk adapter.  Reads ``FpgaRowColSumMsgPayload``,
+  delegates computation to ``RegionsOfInterestPruneAlgorithm``, and writes the result to
+  ``candidatesOutMsg``.
+
+Pipeline stages::
+
+    rowColSumInMsg
+         │
+         ▼
+    1. Find spans   ──  contiguous non-zero runs in rowSums / colSums; accumulate per-span sums
+         │
+         ▼
+    2. Pre-filter   ──  top maxRowSpans row spans, top maxColSpans col spans (by accumulator)
+         │
+         ▼
+    3. Cross-product ─  bounding boxes; count = min(R[k], C[l]) per box
+         │
+         ▼
+    4. Sort & truncate  sort by count desc, keep ≤ ROI_CANDIDATES_MAX
+         │
+         ▼
+    candidatesOutMsg
+
+
+Algorithm Details
+-----------------
+
+**Step 1 — span detection and accumulation**
+
+A *span* is a maximal contiguous run of non-zero entries in a 1-D sum array.  Each row span
+``(r, h)`` and col span ``(c, w)`` defines the start and length of a group of image rows or
+columns that contain at least one above-threshold pixel.  The per-span accumulator sum ``R[k]``
+(or ``C[l]``) is computed in the same forward pass as span detection.
+
+**Step 2 — pre-filter safeguard**
+
+In the worst case the cross-product of all row spans and all col spans is unbounded.  To cap
+computation, the module keeps only the top ``maxRowSpans`` row spans (by their row-sum
+accumulator ``R[k]``) and the top ``maxColSpans`` col spans (by ``C[l]``).  The cross-product
+is then at most ``maxRowSpans × maxColSpans`` candidates regardless of image size.
+
+Because the true rank-1 candidate lies at the intersection of ``argmax(R)`` and ``argmax(C)``,
+it is always preserved by this filter.
+
+**Step 3 — cross-product and pixel count estimation**
+
+Every combination of a filtered row span ``k`` and a filtered col span ``l`` defines a
+bounding box candidate ``(r, h, c, w)`` where ``r`` / ``h`` are the start row and height from
+span ``k``, and ``c`` / ``w`` are the start column and width from span ``l``.  The estimated
+pixel count for each box is:
+
+* ``R[k]`` = sum of ``rowSums`` over row span ``k`` — overcounts pixels outside col span ``l``
+* ``C[l]`` = sum of ``colSums`` over col span ``l`` — overcounts pixels outside row span ``k``
+* ``count = min(R[k], C[l])`` — tightest upper bound obtainable from 1-D projections alone
+
+**Step 4 — sort and truncate**
+
+All candidates from Step 3 are sorted by ``count`` in descending order.  If the number of
+candidates exceeds ``ROI_CANDIDATES_MAX`` the tail is dropped.  The final list is packed into
+``RoiCandidatesMsgPayload`` with ``candidates[0]`` as rank-1 (highest count).
+
+
+Message Connection Descriptions
+--------------------------------
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - rowColSumInMsg
+      - :ref:`FpgaRowColSumMsgPayload`
+      - Per-row and per-column above-threshold pixel counts from ``fpgaImagePipeline``.
+    * - candidatesOutMsg
+      - :ref:`RoiCandidatesMsgPayload`
+      - Up to ``ROI_CANDIDATES_MAX`` bounding-box candidates sorted by estimated pixel count.
+        ``candidates[0]`` is rank-1 (highest count), ``candidates[1]`` is rank-2, etc.
+
+
+User Guide
+----------
+
+#. Import the module::
+
+    from xmera.fswAlgorithms import regionsOfInterestPrune
+
+#. Instantiate and configure::
+
+    pruner = regionsOfInterestPrune.RegionsOfInterestPrune()
+    pruner.ModelTag = "roiPrune"
+
+    # Optional: tune the pre-filter safeguard (defaults: 3 each)
+    pruner.setMaxRowSpans(10)
+    pruner.setMaxColSpans(10)
+
+#. Connect to the upstream pipeline::
+
+    pruner.rowColSumInMsg.subscribeTo(pipeline.rowColSumOutMsg)
+
+#. Add to simulation task::
+
+    sim.AddModelToTask(taskName, pruner)
+
+#. Read results::
+
+    n     = pruner.getNumCandidates()        # number of candidates returned (≤ ROI_CANDIDATES_MAX)
+    row   = pruner.getCandidateRow(0)        # top-ranked candidate
+    col   = pruner.getCandidateCol(0)
+    h     = pruner.getCandidateHeight(0)
+    w     = pruner.getCandidateWidth(0)
+    count = pruner.getCandidateCount(0)      # estimated above-threshold pixel count
+
+
+Unit Tests
+----------
+
+All tests reside in ``_UnitTest/test_regionsOfInterestPrune.py``.
+
+.. list-table::
+    :widths: 30 70
+    :header-rows: 1
+
+    * - Test
+      - Description
+    * - ``test_message_connection``
+      - Verifies ``rowColSumInMsg`` links correctly and the received payload carries the
+        expected image dimensions after one simulation step.
+    * - ``test_step2_rank1_only``
+      - Single 5×5 bright block (M=1): checks exactly one candidate is output with count=1.
+    * - ``test_step2_rank1_and_rank2``
+      - 13×13 and 5×5 blocks sharing a col span: verifies rank-1 and rank-2 bounding boxes
+        and positions.
+    * - ``test_step2_rank2_by_count``
+      - Three col-aligned blocks (13×13, 9×9, 5×5): confirms candidates are sorted by
+        estimated count (81, 25, 1) so rank-2 is the 9×9 block, not the 5×5 block.
+    * - ``test_pruning``
+      - End-to-end integration on ``pia_958_830.tiff`` through the full
+        ``fpgaImagePipeline`` → ``regionsOfInterestPrune`` chain.  Parametrized over
+        ``row_col_span`` ∈ {2, 3, 4} (passed to ``setMaxRowSpans`` / ``setMaxColSpans``).
+        The threshold is auto-computed from the 95th percentile of the image blur map.
+        Skipped if the test image is not found.  Writes two output files:
+
+        * ``test_pruning_output.png`` — colour-annotated image with all candidates in yellow,
+          rank-1 in red labelled ``R1 (<count>)``, rank-2 in blue labelled ``R2 (<count>)``.
+        * ``test_pruning_threshold.png`` — binary mask of above-threshold pixels output by
+          ``fpgaImagePipeline`` (above-threshold → 255, below → 0).

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPruneAlgorithm.cpp
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPruneAlgorithm.cpp
@@ -1,0 +1,111 @@
+#include "regionsOfInterestPruneAlgorithm.h"
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+
+/*! Update method for the regions-of-interest pruning algorithm.  Orchestrates
+ *  the four pipeline steps and returns a fully populated RoiCandidates.
+ @return RoiCandidates  Candidates sorted by estimated pixel count (descending).
+ @param rowSums   Pointer to the per-row above-threshold pixel sums.
+ @param numRows   Number of rows in the sum array.
+ @param colSums   Pointer to the per-column above-threshold pixel sums.
+ @param numCols   Number of columns in the sum array.
+*/
+RoiCandidates RegionsOfInterestPruneAlgorithm::update(const uint16_t* rowSums,
+                                                      uint32_t numRows,
+                                                      const uint16_t* colSums,
+                                                      uint32_t numCols) const {
+    // Step 1: locate contiguous non-zero spans and accumulate per-span pixel sums.
+    const auto [rowSpans, rowAccum] = findSpans(rowSums, numRows);
+    const auto [colSpans, colAccum] = findSpans(colSums, numCols);
+
+    // Step 2: keep only the highest-sum spans to bound the cross-product size.
+    const auto topRows = topIndices(rowAccum, this->maxRowSpans);
+    const auto topCols = topIndices(colAccum, this->maxColSpans);
+
+    // Steps 3–4: form bounding boxes, sort by estimated pixel count, truncate.
+    return packOutput(buildCandidates(rowSpans, rowAccum, topRows, colSpans, colAccum, topCols));
+}
+
+/*! Scans a 1-D sum array and returns all contiguous non-zero spans together
+ *  with the accumulated sum for each span.  A single forward pass produces both.
+ @return Pair of (spans, accum) where spans[i] = (start, length) and accum[i] = sum over that span.
+ @param s  Pointer to the 1-D sum array.
+ @param n  Length of the array.
+*/
+std::pair<RegionsOfInterestPruneAlgorithm::SpanVec, RegionsOfInterestPruneAlgorithm::AccumVec>
+RegionsOfInterestPruneAlgorithm::findSpans(const uint16_t* s, uint32_t n) {
+    SpanVec spans;
+    AccumVec accum;
+    for (uint32_t i = 0; i < n;) {
+        if (s[i]) {
+            uint32_t j = i;
+            uint32_t sum = 0;
+            while (j < n && s[j]) sum += s[j++];
+            spans.emplace_back(i, j - i);
+            accum.push_back(sum);
+            i = j;
+        } else
+            ++i;
+    }
+    return {spans, accum};
+}
+
+/*! Returns the indices of the top-keep entries of vals ordered by descending value.
+ *  Uses std::partial_sort so only the retained portion is fully sorted (O(N log keep)).
+ @return Vector of at most keep indices into vals, sorted by vals[i] descending.
+ @param vals  Accumulator values to rank.
+ @param keep  Maximum number of top entries to retain.
+*/
+RegionsOfInterestPruneAlgorithm::AccumVec RegionsOfInterestPruneAlgorithm::topIndices(const AccumVec& vals,
+                                                                                      uint32_t keep) {
+    AccumVec idx(vals.size());
+    std::iota(idx.begin(), idx.end(), 0);
+    keep = std::min(keep, static_cast<uint32_t>(vals.size()));
+    std::ranges::partial_sort(idx, idx.begin() + keep, std::greater{}, [&vals](uint32_t i) { return vals[i]; });
+    idx.resize(keep);
+    return idx;
+}
+
+/*! Forms bounding-box candidates from the cross-product of the filtered row and col spans.
+ *  The estimated pixel count for each box is min(R[k], C[l]) — the tightest upper bound
+ *  obtainable from 1-D projections alone.
+ @return Vector of RoiCandidateEntry, one per (rowIdx × colIdx) pair.
+ @param rowSpans  All detected row spans.
+ @param R         Per-row-span accumulator sums.
+ @param rowIdx    Indices into rowSpans / R selected by the pre-filter (Step 2).
+ @param colSpans  All detected col spans.
+ @param C         Per-col-span accumulator sums.
+ @param colIdx    Indices into colSpans / C selected by the pre-filter (Step 2).
+*/
+std::vector<RoiCandidateEntry> RegionsOfInterestPruneAlgorithm::buildCandidates(const SpanVec& rowSpans,
+                                                                                const AccumVec& R,
+                                                                                const AccumVec& rowIdx,
+                                                                                const SpanVec& colSpans,
+                                                                                const AccumVec& C,
+                                                                                const AccumVec& colIdx) {
+    std::vector<RoiCandidateEntry> candidates;
+    for (uint32_t ki : rowIdx)
+        for (uint32_t li : colIdx) {
+            const auto [r, h] = rowSpans[ki];
+            const auto [c, w] = colSpans[li];
+            candidates.push_back({r, c, h, w, std::min(R[ki], C[li])});
+        }
+    return candidates;
+}
+
+/*! Sorts candidates by estimated pixel count (descending), truncates to ROI_CANDIDATES_MAX,
+ *  and packs the result into a RoiCandidates ready for publication.
+ @return RoiCandidates with numCandidates set and candidates[0] = rank-1.
+ @param candidates  Unsorted candidate list (taken by value; sorted in-place).
+*/
+RoiCandidates RegionsOfInterestPruneAlgorithm::packOutput(std::vector<RoiCandidateEntry> candidates) {
+    std::ranges::sort(candidates, std::greater{}, &RoiCandidateEntry::count);
+    if (candidates.size() > ROI_CANDIDATES_MAX) candidates.resize(ROI_CANDIDATES_MAX);
+
+    RoiCandidates outRoi{};
+    outRoi.numCandidates = static_cast<uint32_t>(candidates.size());
+    for (uint32_t i = 0; i < outRoi.numCandidates; ++i) outRoi.candidates[i] = candidates[i];
+    return outRoi;
+}

--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPruneAlgorithm.h
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPruneAlgorithm.h
@@ -1,0 +1,69 @@
+#ifndef REGIONS_OF_INTEREST_PRUNE_ALGORITHM_H
+#define REGIONS_OF_INTEREST_PRUNE_ALGORITHM_H
+
+#include <array>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+/*! @brief Internal bounding-box candidate (corner coordinates + pixel count). */
+static constexpr uint32_t ROI_CANDIDATES_MAX = 16;
+
+struct RoiCandidateEntry {
+    uint32_t row{};     //!< [px] Top-left row of the bounding box
+    uint32_t col{};     //!< [px] Top-left column of the bounding box
+    uint32_t height{};  //!< [px] Height of the bounding box
+    uint32_t width{};   //!< [px] Width of the bounding box
+    uint32_t count{};   //!< [-] Estimated above-threshold pixel count
+};
+
+struct RoiCandidates {
+    uint32_t numCandidates{};                                      //!< [-] Number of valid entries
+    std::array<RoiCandidateEntry, ROI_CANDIDATES_MAX> candidates;  //!< [-] Sorted by count descending
+};
+
+/*! @brief algorithm for the regions-of-interest pruning stage.
+ *
+ *  Accepts raw row/col sum arrays and returns a
+ *  RoiCandidates.  Pipeline stages:
+ *    1. Find contiguous non-zero spans in rowSums / colSums; accumulate per-span sums.
+ *    2. Pre-filter to top maxRowSpans / maxColSpans spans by accumulator value.
+ *    3. Cross-product of filtered spans → bounding boxes with count = min(R[k], C[l]).
+ *    4. Sort by count descending, return top ROI_CANDIDATES_MAX entries.
+ */
+class RegionsOfInterestPruneAlgorithm {
+   public:
+    RoiCandidates update(const uint16_t* rowSums, uint32_t numRows, const uint16_t* colSums, uint32_t numCols) const;
+
+    void setMaxRowSpans(uint32_t n) { this->maxRowSpans = n; }
+    uint32_t getMaxRowSpans() const { return this->maxRowSpans; }
+    void setMaxColSpans(uint32_t n) { this->maxColSpans = n; }
+    uint32_t getMaxColSpans() const { return this->maxColSpans; }
+
+   private:
+    uint32_t maxRowSpans{3};  //!< Pre-filter: keep this many top row spans before cross-product
+    uint32_t maxColSpans{3};  //!< Pre-filter: keep this many top col spans before cross-product
+
+    using Span = std::pair<uint32_t, uint32_t>;
+    using SpanVec = std::vector<Span>;
+    using AccumVec = std::vector<uint32_t>;
+
+    // Step 1: find contiguous non-zero spans and accumulate per-span sums.
+    static std::pair<SpanVec, AccumVec> findSpans(const uint16_t* s, uint32_t n);
+
+    // Step 2: return indices of the top-keep entries in vals (by descending value).
+    static AccumVec topIndices(const AccumVec& vals, uint32_t keep);
+
+    // Step 3: cross-product of filtered row/col spans → bounding-box candidates.
+    static std::vector<RoiCandidateEntry> buildCandidates(const SpanVec& rowSpans,
+                                                          const AccumVec& R,
+                                                          const AccumVec& rowIdx,
+                                                          const SpanVec& colSpans,
+                                                          const AccumVec& C,
+                                                          const AccumVec& colIdx);
+
+    // Step 4: sort candidates by count descending, truncate, and pack into a message.
+    static RoiCandidates packOutput(std::vector<RoiCandidateEntry> candidates);
+};
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** xmera-2145
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
Add regionsOfInterestPrune module. This module takes the row/col sums of the fpgaImagePipeline module and identify rank-1 and rank-2 regions of interest. It also estimates the above-threshold pixel counts per region. I refactor the message RegionsIdentifiedMsgPayload to avoid nested message definition, which prevents pytest to fail.

## Verification
Pass the python unit test

## Documentation
See .rst

## Future work
- Better approach to identify the rank-2 region
- Better approach to estimate the pixel count in rank-1 and rank-2 regions.
