### PR TITLE
Feature/1540 add binary asteroid

### DIFF
--- a/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
@@ -8,20 +8,14 @@ import os
 
 import pytest
 
-#
 # Spice Unit Test
-#
-# Purpose:  Test the proper function of the Spice Ephemeris module.
-#           Proper function is tested by comparing Spice Ephemeris to
-#           JPL Horizons Database for different planets and times of year
-# Author:   Thibaud Teil
-# Creation Date:  Dec. 20, 2016
-#
+# Purpose: Validate SpiceInterface ephemeris output against the JPL Horizons
+#          database for several planets across multiple times of year.
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 from xmera import __path__
-bskPath = __path__[0]
+bsk_path = __path__[0]
 
 
 import datetime
@@ -34,348 +28,246 @@ from xmera.utilities import macros
 import matplotlib.pyplot as plt
 
 
-# Class in order to plot using data across the different parameterized scenarios
+# Stores per-parameterized-run errors so we can plot them all together at module teardown.
 class DataStore:
     def __init__(self):
-        self.Date = []  # replace these with appropriate containers for the data to be stored for plotting
-        self.MarsPosErr = []
-        self.EarthPosErr = []
-        self.SunPosErr = []
+        self.date = []
+        self.mars_pos_err = []
+        self.earth_pos_err = []
+        self.sun_pos_err = []
 
-    def plotData(self):
+    def plot_data(self):
         fig1 = plt.figure(1)
         rect = fig1.patch
-        rect.set_facecolor('white')
+        rect.set_facecolor("white")
 
-        plt.xticks(numpy.arange(len(self.Date)), self.Date)
-        plt.plot(self.MarsPosErr, 'r', label='Mars')
-        plt.plot(self.EarthPosErr, 'bs', label='Earth')
-        plt.plot(self.SunPosErr, 'yo', label='Sun')
+        plt.xticks(numpy.arange(len(self.date)), self.date)
+        plt.plot(self.mars_pos_err, "r", label="Mars")
+        plt.plot(self.earth_pos_err, "bs", label="Earth")
+        plt.plot(self.sun_pos_err, "yo", label="Sun")
 
-        plt.rc('font', size=50)
-        plt.legend(loc='upper left')
+        plt.rc("font", size=50)
+        plt.legend(loc="upper left")
         fig1.autofmt_xdate()
-        plt.xlabel('Date of test')
-        plt.ylabel('Position Error [m]')
+        plt.xlabel("Date of test")
+        plt.ylabel("Position Error [m]")
         plt.show()
 
-    def giveData(self):
+    def give_data(self):
         plt.figure(1)
         plt.close(1)
-        fig1 = plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
+        fig1 = plt.figure(1, figsize=(7, 5), dpi=80, facecolor="w", edgecolor="k")
 
-        plt.xticks(numpy.arange(len(self.Date)), self.Date)
-        plt.plot(self.MarsPosErr, 'r', label='Mars')
-        plt.plot(self.EarthPosErr, 'b', label='Earth')
-        plt.plot(self.SunPosErr, 'y', label='Sun')
+        plt.xticks(numpy.arange(len(self.date)), self.date)
+        plt.plot(self.mars_pos_err, "r", label="Mars")
+        plt.plot(self.earth_pos_err, "b", label="Earth")
+        plt.plot(self.sun_pos_err, "y", label="Sun")
 
-        plt.legend(loc='upper left')
+        plt.legend(loc="upper left")
         fig1.autofmt_xdate()
-        plt.xlabel('Date of test')
-        plt.ylabel('Position Error [m]')
-
+        plt.xlabel("Date of test")
+        plt.ylabel("Position Error [m]")
         return plt
 
 
-# Py.test fixture in order to plot
 @pytest.fixture(scope="module")
-def testPlottingFixture(show_plots):
-    dataStore = DataStore()
-    yield dataStore
+def test_plotting_fixture(show_plots):
+    data_store = DataStore()
+    yield data_store
 
-    plt = dataStore.giveData()
-    unitTestSupport.writeFigureLaTeX('EphemMars', 'Ephemeris Error on Mars', plt, 'height=0.7\\textwidth, keepaspectratio', path)
+    plt = data_store.give_data()
+    unitTestSupport.writeFigureLaTeX("EphemMars", "Ephemeris Error on Mars", plt,
+                                     "height=0.7\\textwidth, keepaspectratio", path)
     plt.ylim(0, 2E-2)
-    unitTestSupport.writeFigureLaTeX('EphemEarth', 'Ephemeris Error on Earth', plt, 'height=0.7\\textwidth, keepaspectratio', path)
+    unitTestSupport.writeFigureLaTeX("EphemEarth", "Ephemeris Error on Earth", plt,
+                                     "height=0.7\\textwidth, keepaspectratio", path)
     plt.ylim(0, 5E-6)
-    unitTestSupport.writeFigureLaTeX('EphemSun', 'Ephemeris Error on Sun', plt, 'height=0.7\\textwidth, keepaspectratio', path)
+    unitTestSupport.writeFigureLaTeX("EphemSun", "Ephemeris Error on Sun", plt,
+                                     "height=0.7\\textwidth, keepaspectratio", path)
     if show_plots:
-        dataStore.plotData()
+        data_store.plot_data()
 
 
-# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
-# @pytest.mark.skipif(conditionstring)
-# uncomment this line if this test has an expected failure, adjust message as needed
-# @pytest.mark.xfail(True)
-
-# The following 'parametrize' function decorator provides the parameters and expected results for each
-#   of the multiple test runs for this test.
-@pytest.mark.parametrize("DateSpice, DatePlot , MarsTruthPos , EarthTruthPos, SunTruthPos, useMsg", [
-    ("2015 February 10, 00:00:00.0 TDB", "02/10/15" ,[2.049283795042291E+08, 4.654550957513031E+07, 1.580778617009296E+07] ,[-1.137790671899544E+08, 8.569008401822130E+07, 3.712507705247846E+07],[4.480338216752146E+05, -7.947764237588293E+04, -5.745748832696378E+04], False),
-    ("2015 February 20, 00:00:00.0 TDB", "02/20/15" ,[ 1.997780190793433E+08, 6.636509140613769E+07, 2.503734390917690E+07], [-1.286636391244711E+08, 6.611156946652703E+07, 2.863736192793162E+07],[4.535258225415821E+05, -7.180260790174162E+04, -5.428151563919459E+04], False),
-    ("2015 April 10, 00:00:00.0 TDB", "04/10/15" ,[1.468463828343225E+08, 1.502909016357645E+08, 6.495986693265321E+07],[-1.406808744055921E+08, -4.614996219219251E+07, -2.003047222725225E+07],[4.786772771370058E+05, -3.283487082146838E+04, -3.809690999538498E+04], False),
-    ("2015 April 20, 00:00:00.0 TDB", "04/20/15" ,[1.313859463489376E+08, 1.637422864185919E+08, 7.154683454681394E+07], [-1.304372112275012E+08, -6.769916175223185E+07, -2.937179538983412E+07],[4.834188130324496E+05, -2.461799304268214E+04, -3.467083541217462E+04], False),
-    ("2015 June 10, 00:00:00.0 TDB", "06/10/15" , [3.777078276008123E+07, 2.080046702252371E+08, 9.437503998071109E+07],[-2.946784585692780E+07, -1.365779215199542E+08, -5.923299652516938E+07],[5.052070933145228E+05, 1.837038638578682E+04, -1.665575509449521E+04], False),
-    ("2015 June 20, 00:00:00.0 TDB", "06/20/15" , [1.778745850655047E+07, 2.116712756672253E+08, 9.659608128589308E+07], [-4.338053580692466E+06, -1.393743714818930E+08, -6.044500073550620E+07],[5.090137386469169E+05, 2.694272566092012E+04, -1.304862690440150E+04], False),
-    ("2015 August 10, 00:00:00.0 TDB", "08/10/15" , [-8.302866300591002E+07, 2.053384243312354E+08, 9.641192179982041E+07],[1.111973130587749E+08, -9.507060674145325E+07, -4.123957889640842E+07],[5.263951240980130E+05, 7.113788303899391E+04, 5.601415938789949E+03], False),
-    ("2015 August 20, 00:00:00.0 TDB", "08/20/15" , [-1.015602120938274E+08, 1.994877113707506E+08, 9.422840996376510E+07], [1.267319535735967E+08, -7.664279872369213E+07, -3.325170492059625E+07],[5.294368386862668E+05, 7.989635630604146E+04, 9.307380417148834E+03], False),
-    ("2015 October 10, 00:00:00.0 TDB", "10/10/15" , [-1.828944464171771E+08, 1.498117608528323E+08, 7.363786404040858E+07],[1.440636517249971E+08, 3.827074461651713E+07, 1.656440704503509E+07],[5.433268959250135E+05, 1.251717566539142E+05, 2.849999378507032E+04], False),
-    ("2015 October 20, 00:00:00.0 TDB", "10/20/15" , [-1.955685835661002E+08, 1.367530082668284E+08, 6.799006120628108E+07],[1.343849818314204E+08, 6.019977403127116E+07, 2.607024615553362E+07],[5.457339294611338E+05, 1.342148834831663E+05, 3.234185290692726E+04], False),
-    ("2015 December 10, 00:00:00.0 TDB", "12/10/15" , [-2.392022492203017E+08, 5.847873056287902E+07, 3.326431285934674E+07],[3.277145427626925E+07, 1.320956053465003E+08, 5.723804900679157E+07],[5.559607335969181E+05, 1.813263443761486E+05, 5.242991145066972E+04], False),
-    ("2015 December 20, 00:00:00.0 TDB", "12/20/15" , [-2.432532635321551E+08, 4.156075241419497E+07, 2.561357000250468E+07], [6.866134677340530E+06, 1.351080593806486E+08, 5.854460725992832E+07],[5.575179227151767E+05, 1.907337298309725E+05, 5.645553733620559E+04], False),
-    ("2016 February 10, 00:00:00.0 TDB", "02/10/16" , [-2.385499316808322E+08, -4.818711325555268E+07, -1.567983931044450E+07],[-1.132504603146183E+08, 8.647183658089657E+07, 3.746046979137553E+07],[5.630027736619673E+05, 2.402590276126245E+05, 7.772804647512530E+04], False),
-    ("2016 February 20, 00:00:00.0 TDB", "02/20/16" , [-2.326189626865872E+08, -6.493600278878165E+07,-2.352250994262638E+07], [-1.282197228963156E+08, 6.695033443521750E+07, 2.899822684259482E+07],[5.635403728358555E+05, 2.498445036007692E+05, 8.185973180152237E+04], False),
-    ("2016 April 10, 00:00:00.0 TDB", "04/10/16" , [-1.795928090776869E+08, -1.395102817786797E+08, -5.916067235603344E+07],[-1.399773606371217E+08, -4.749126225182984E+07, -2.061331784067504E+07],[5.639699901756521E+05, 2.977755140828988E+05, 1.025609223621660E+05], False),
-    ("2016 April 20, 00:00:00.0 TDB", "04/20/16" , [-1.646488222290798E+08, -1.517361128528306E+08, -6.517204439842616E+07], [-1.294310199316289E+08, -6.890085351639988E+07, -2.989515576444890E+07],[5.636348418836893E+05, 3.073681895822543E+05, 1.067117713233756E+05], False),
-    ("2016 June 10, 00:00:00.0 TDB", "06/10/16" , [-7.085675304355654E+07, -1.933788289169757E+08, -8.680583098365544E+07],[-2.756178030784301E+07, -1.365892814324490E+08, -5.923888961370525E+07],[5.597493293268962E+05, 3.563312003229167E+05, 1.279448896916322E+05], False),
-    ("2016 June 20, 00:00:00.0 TDB", "06/20/16" , [-4.994076874358515E+07, -1.967336617729592E+08, -8.890950206156498E+07], [-2.413995783152328E+06, -1.390828611356292E+08, -6.032062925759617E+07],[5.585605124166313E+05, 3.659402953599973E+05, 1.321213212542782E+05], False),
-    ("2016 August 10, 00:00:00.0 TDB", "08/10/16" , [5.965895856067932E+07, -1.851251207911916E+08, -8.654489416392270E+07],[1.124873641861596E+08, -9.344410235679612E+07, -4.053621796412993E+07],[5.501477436262188E+05, 4.149525682073312E+05, 1.534983234437988E+05], False),
-    ("2016 August 20, 00:00:00.0 TDB", "08/20/16" , [8.021899957229958E+07, -1.770523551156136E+08, -8.339737954004113E+07] , [1.277516713236801E+08, -7.484361731649198E+07, -3.247232896320245E+07],[5.480148786547601E+05, 4.245199573757614E+05, 1.576874582857746E+05], False),
-    ("2016 October 10, 00:00:00.0 TDB", "10/10/16" , [1.674991232418756E+08, -1.090427183510760E+08, -5.456038490399034E+07],[ 1.434719792031415E+08, 4.029387436854774E+07, 1.744057129058395E+07],[5.348794087050703E+05, 4.727986075510736E+05, 1.788947974297997E+05], False),
-    ("2016 October 20, 00:00:00.0 TDB", "10/20/16" , [1.797014954219412E+08, -9.133803506487390E+07, -4.676932170648168E+07] , [ 1.334883617893556E+08, 6.209917895944476E+07, 2.689423661839254E+07],[5.318931290166953E+05, 4.821605725626923E+05, 1.830201949404063E+05], False),
-    ("2016 December 10, 00:00:00.0 TDB", "12/10/16" , [2.087370835407280E+08, 1.035903131428964E+07, -9.084001492689754E+05] ,[3.082308903715757E+07, 1.328026978502711E+08, 5.754559376449955E+07],[5.147792796720199E+05, 5.293951386498961E+05, 2.038816823549219E+05], False),
-    ("2016 December 20, 00:00:00.0 TDB", "12/20/16" , [2.075411186038260E+08, 3.092173198610598E+07, 8.555251204561792E+06], [4.885421269793877E+06, 1.355125217382336E+08, 5.872015978003684E+07],[5.110736843893399E+05, 5.385860060393942E+05, 2.079481168492821E+05], True)
+@pytest.mark.parametrize("date_spice, date_plot, mars_truth_pos, earth_truth_pos, sun_truth_pos, use_msg", [
+    ("2015 February 10, 00:00:00.0 TDB", "02/10/15", [2.049283795042291E+08, 4.654550957513031E+07, 1.580778617009296E+07], [-1.137790671899544E+08, 8.569008401822130E+07, 3.712507705247846E+07], [4.480338216752146E+05, -7.947764237588293E+04, -5.745748832696378E+04], False),
+    ("2015 February 20, 00:00:00.0 TDB", "02/20/15", [1.997780190793433E+08, 6.636509140613769E+07, 2.503734390917690E+07], [-1.286636391244711E+08, 6.611156946652703E+07, 2.863736192793162E+07], [4.535258225415821E+05, -7.180260790174162E+04, -5.428151563919459E+04], False),
+    ("2015 April 10, 00:00:00.0 TDB", "04/10/15", [1.468463828343225E+08, 1.502909016357645E+08, 6.495986693265321E+07], [-1.406808744055921E+08, -4.614996219219251E+07, -2.003047222725225E+07], [4.786772771370058E+05, -3.283487082146838E+04, -3.809690999538498E+04], False),
+    ("2015 April 20, 00:00:00.0 TDB", "04/20/15", [1.313859463489376E+08, 1.637422864185919E+08, 7.154683454681394E+07], [-1.304372112275012E+08, -6.769916175223185E+07, -2.937179538983412E+07], [4.834188130324496E+05, -2.461799304268214E+04, -3.467083541217462E+04], False),
+    ("2015 June 10, 00:00:00.0 TDB", "06/10/15", [3.777078276008123E+07, 2.080046702252371E+08, 9.437503998071109E+07], [-2.946784585692780E+07, -1.365779215199542E+08, -5.923299652516938E+07], [5.052070933145228E+05, 1.837038638578682E+04, -1.665575509449521E+04], False),
+    ("2015 June 20, 00:00:00.0 TDB", "06/20/15", [1.778745850655047E+07, 2.116712756672253E+08, 9.659608128589308E+07], [-4.338053580692466E+06, -1.393743714818930E+08, -6.044500073550620E+07], [5.090137386469169E+05, 2.694272566092012E+04, -1.304862690440150E+04], False),
+    ("2015 August 10, 00:00:00.0 TDB", "08/10/15", [-8.302866300591002E+07, 2.053384243312354E+08, 9.641192179982041E+07], [1.111973130587749E+08, -9.507060674145325E+07, -4.123957889640842E+07], [5.263951240980130E+05, 7.113788303899391E+04, 5.601415938789949E+03], False),
+    ("2015 August 20, 00:00:00.0 TDB", "08/20/15", [-1.015602120938274E+08, 1.994877113707506E+08, 9.422840996376510E+07], [1.267319535735967E+08, -7.664279872369213E+07, -3.325170492059625E+07], [5.294368386862668E+05, 7.989635630604146E+04, 9.307380417148834E+03], False),
+    ("2015 October 10, 00:00:00.0 TDB", "10/10/15", [-1.828944464171771E+08, 1.498117608528323E+08, 7.363786404040858E+07], [1.440636517249971E+08, 3.827074461651713E+07, 1.656440704503509E+07], [5.433268959250135E+05, 1.251717566539142E+05, 2.849999378507032E+04], False),
+    ("2015 October 20, 00:00:00.0 TDB", "10/20/15", [-1.955685835661002E+08, 1.367530082668284E+08, 6.799006120628108E+07], [1.343849818314204E+08, 6.019977403127116E+07, 2.607024615553362E+07], [5.457339294611338E+05, 1.342148834831663E+05, 3.234185290692726E+04], False),
+    ("2015 December 10, 00:00:00.0 TDB", "12/10/15", [-2.392022492203017E+08, 5.847873056287902E+07, 3.326431285934674E+07], [3.277145427626925E+07, 1.320956053465003E+08, 5.723804900679157E+07], [5.559607335969181E+05, 1.813263443761486E+05, 5.242991145066972E+04], False),
+    ("2015 December 20, 00:00:00.0 TDB", "12/20/15", [-2.432532635321551E+08, 4.156075241419497E+07, 2.561357000250468E+07], [6.866134677340530E+06, 1.351080593806486E+08, 5.854460725992832E+07], [5.575179227151767E+05, 1.907337298309725E+05, 5.645553733620559E+04], False),
+    ("2016 February 10, 00:00:00.0 TDB", "02/10/16", [-2.385499316808322E+08, -4.818711325555268E+07, -1.567983931044450E+07], [-1.132504603146183E+08, 8.647183658089657E+07, 3.746046979137553E+07], [5.630027736619673E+05, 2.402590276126245E+05, 7.772804647512530E+04], False),
+    ("2016 February 20, 00:00:00.0 TDB", "02/20/16", [-2.326189626865872E+08, -6.493600278878165E+07, -2.352250994262638E+07], [-1.282197228963156E+08, 6.695033443521750E+07, 2.899822684259482E+07], [5.635403728358555E+05, 2.498445036007692E+05, 8.185973180152237E+04], False),
+    ("2016 April 10, 00:00:00.0 TDB", "04/10/16", [-1.795928090776869E+08, -1.395102817786797E+08, -5.916067235603344E+07], [-1.399773606371217E+08, -4.749126225182984E+07, -2.061331784067504E+07], [5.639699901756521E+05, 2.977755140828988E+05, 1.025609223621660E+05], False),
+    ("2016 April 20, 00:00:00.0 TDB", "04/20/16", [-1.646488222290798E+08, -1.517361128528306E+08, -6.517204439842616E+07], [-1.294310199316289E+08, -6.890085351639988E+07, -2.989515576444890E+07], [5.636348418836893E+05, 3.073681895822543E+05, 1.067117713233756E+05], False),
+    ("2016 June 10, 00:00:00.0 TDB", "06/10/16", [-7.085675304355654E+07, -1.933788289169757E+08, -8.680583098365544E+07], [-2.756178030784301E+07, -1.365892814324490E+08, -5.923888961370525E+07], [5.597493293268962E+05, 3.563312003229167E+05, 1.279448896916322E+05], False),
+    ("2016 June 20, 00:00:00.0 TDB", "06/20/16", [-4.994076874358515E+07, -1.967336617729592E+08, -8.890950206156498E+07], [-2.413995783152328E+06, -1.390828611356292E+08, -6.032062925759617E+07], [5.585605124166313E+05, 3.659402953599973E+05, 1.321213212542782E+05], False),
+    ("2016 August 10, 00:00:00.0 TDB", "08/10/16", [5.965895856067932E+07, -1.851251207911916E+08, -8.654489416392270E+07], [1.124873641861596E+08, -9.344410235679612E+07, -4.053621796412993E+07], [5.501477436262188E+05, 4.149525682073312E+05, 1.534983234437988E+05], False),
+    ("2016 August 20, 00:00:00.0 TDB", "08/20/16", [8.021899957229958E+07, -1.770523551156136E+08, -8.339737954004113E+07], [1.277516713236801E+08, -7.484361731649198E+07, -3.247232896320245E+07], [5.480148786547601E+05, 4.245199573757614E+05, 1.576874582857746E+05], False),
+    ("2016 October 10, 00:00:00.0 TDB", "10/10/16", [1.674991232418756E+08, -1.090427183510760E+08, -5.456038490399034E+07], [1.434719792031415E+08, 4.029387436854774E+07, 1.744057129058395E+07], [5.348794087050703E+05, 4.727986075510736E+05, 1.788947974297997E+05], False),
+    ("2016 October 20, 00:00:00.0 TDB", "10/20/16", [1.797014954219412E+08, -9.133803506487390E+07, -4.676932170648168E+07], [1.334883617893556E+08, 6.209917895944476E+07, 2.689423661839254E+07], [5.318931290166953E+05, 4.821605725626923E+05, 1.830201949404063E+05], False),
+    ("2016 December 10, 00:00:00.0 TDB", "12/10/16", [2.087370835407280E+08, 1.035903131428964E+07, -9.084001492689754E+05], [3.082308903715757E+07, 1.328026978502711E+08, 5.754559376449955E+07], [5.147792796720199E+05, 5.293951386498961E+05, 2.038816823549219E+05], False),
+    ("2016 December 20, 00:00:00.0 TDB", "12/20/16", [2.075411186038260E+08, 3.092173198610598E+07, 8.555251204561792E+06], [4.885421269793877E+06, 1.355125217382336E+08, 5.872015978003684E+07], [5.110736843893399E+05, 5.385860060393942E+05, 2.079481168492821E+05], True),
 ])
-
-
-
-# provide a unique test method name, starting with test_
-def test_unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos, EarthTruthPos,
-                   SunTruthPos, useMsg):
+def test_unitSpice(test_plotting_fixture, show_plots, date_spice, date_plot,
+                   mars_truth_pos, earth_truth_pos, sun_truth_pos, use_msg):
     """Module Unit Test"""
-    # each test method requires a single assert method to be called
-    [testResults, testMessage] = unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos,
-                                           EarthTruthPos, SunTruthPos, useMsg)
-    assert testResults < 1, testMessage
+    [test_fail_count, test_message] = unit_spice(test_plotting_fixture, show_plots, date_spice, date_plot,
+                                                 mars_truth_pos, earth_truth_pos, sun_truth_pos, use_msg)
+    assert test_fail_count < 1, test_message
 
 
-# Run unit test
-def unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos, EarthTruthPos, SunTruthPos, useMsg):
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty array to store test log messages
+def unit_spice(test_plotting_fixture, show_plots, date_spice, date_plot,
+               mars_truth_pos, earth_truth_pos, sun_truth_pos, use_msg):
+    test_fail_count = 0
+    test_messages = []
 
-    # Create a sim module as an empty container
-    unitTaskName = "unitTask"  # arbitrary name (don't change)
-    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
 
-    # Create a sim module as an empty container
-    TotalSim = SimulationBaseClass.SimBaseClass()
+    total_sim = SimulationBaseClass.SimBaseClass()
+    dyn_unit_test_proc = total_sim.CreateNewProcess(unit_process_name)
+    dyn_unit_test_proc.addTask(total_sim.CreateNewTask(unit_task_name, macros.sec2nano(0.1)))
 
-    DynUnitTestProc = TotalSim.CreateNewProcess(unitProcessName)
-    # create the dynamics task and specify the integration update time
-    DynUnitTestProc.addTask(TotalSim.CreateNewTask(unitTaskName, macros.sec2nano(0.1)))
+    spice_object = spiceInterface.SpiceInterface()
+    spice_object.modelTag = "SpiceInterfaceData"
+    spice_object.SPICEDataPath = bsk_path + "/supportData/EphemerisData/"
+    planet_names = ["earth", "mars barycenter", "sun"]
+    spice_object.addPlanetNames(planet_names)
+    spice_object.UTCCalInit = date_spice
 
-    # Initialize the spice modules that we are using.
-    SpiceObject = spiceInterface.SpiceInterface()
-    SpiceObject.modelTag = "SpiceInterfaceData"
-    SpiceObject.SPICEDataPath = bskPath + '/supportData/EphemerisData/'
-    planetNames = ["earth", "mars barycenter", "sun"]
-    SpiceObject.addPlanetNames(planetNames)
-    SpiceObject.UTCCalInit = DateSpice
+    if use_msg:
+        # Verify custom planet frame names are honored, and that "" falls back to the IAU default.
+        planet_frames = ["IAU_" + p for p in planet_names]
+        planet_frames[1] = ""
+        spice_object.planetFrames = planet_frames
 
-    if useMsg:      # in this case check that the planet frame names can be set as well
-        planetFrames = []
-        for planet in planetNames:
-            planetFrames.append("IAU_" + planet)
-        planetFrames[1] = ""    # testing that default IAU values are used here
-        SpiceObject.planetFrames = planetFrames
+    total_sim.AddModelToTask(unit_task_name, spice_object)
 
-    TotalSim.AddModelToTask(unitTaskName, SpiceObject)
+    if use_msg:
+        epoch_msg = spice_utilities.timeStringToGregorianUTCMsg(date_spice)
+        spice_object.epochInMsg.subscribeTo(epoch_msg)
 
-    if useMsg:
-        epochMsg = spice_utilities.timeStringToGregorianUTCMsg(DateSpice)
-        SpiceObject.epochInMsg.subscribeTo(epochMsg)
+        # The epoch input message must override any UTCCalInit set on the object.
+        spice_object.UTCCalInit = "1990 February 10, 00:00:00.0 TDB"
 
-        # The following value is set, but should not be used by the module.  This checks that the above
-        # epoch message over-rules any info set in this variable.
-        SpiceObject.UTCCalInit = "1990 February 10, 00:00:00.0 TDB"
+    spice_object_log = spice_object.logger(["GPSSeconds", "J2000Current", "julianDateCurrent", "GPSWeek"])
+    total_sim.AddModelToTask(unit_task_name, spice_object_log)
 
-    spiceObjectLog = SpiceObject.logger(["GPSSeconds", "J2000Current", "julianDateCurrent", "GPSWeek"])
-    TotalSim.AddModelToTask(unitTaskName, spiceObjectLog)
+    total_sim.ConfigureStopTime(int(60.0 * 1E9))
+    total_sim.InitializeSimulation()
+    total_sim.ExecuteSimulation()
 
-    # Configure simulation
-    TotalSim.ConfigureStopTime(int(60.0 * 1E9))
+    data_gps_sec = unitTestSupport.addTimeColumn(spice_object_log.times(), spice_object_log.GPSSeconds)
+    data_jd = unitTestSupport.addTimeColumn(spice_object_log.times(), spice_object_log.julianDateCurrent)
 
-    # Execute simulation
-    TotalSim.InitializeSimulation()
-    TotalSim.ExecuteSimulation()
+    year = "".join(("20", date_plot[6:8]))
+    date = datetime.datetime(int(year), int(date_plot[0:2]), int(date_plot[3:5]))
+    test_plotting_fixture.date = date_plot[0:8]
 
-    # Get the logged variables (GPS seconds, Julian Date)
-    DataGPSSec = unitTestSupport.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.GPSSeconds)
-    DataJD = unitTestSupport.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.julianDateCurrent)
+    # Reference epoch for GPS time
+    gps_epoch = datetime.datetime(1980, 1, 6)
+    time_diff = date - gps_epoch
+    gps_time_seconds = time_diff.days * 86400
 
-    # Get parametrized date from DatePlot
-    year = "".join(("20", DatePlot[6:8]))
-    date = datetime.datetime( int(year), int(DatePlot[0:2]), int(DatePlot[3:5]))
+    julian_start_date = date.toordinal() + 1721424.5
 
-    testPlottingFixture.Date = DatePlot[0:8]
-
-    # Get the GPS time
-    date2 = datetime.datetime(1980, 0o1, 6)  # Start of GPS time
-    timeDiff = date-date2  # Time in days since GPS time
-    GPSTimeSeconds = timeDiff.days*86400
-
-    # Get the Julian day
-    JulianStartDate = date.toordinal()+1721424.5
-
-    #
-    # Begin testing module results to truth values
-    #
-
-    # Truth values
-    # For Time delta check
-    GPSRow = DataGPSSec[0, :]
-    InitDiff = GPSRow[1] - GPSRow[0] * 1.0E-9
+    # Time delta check: difference between GPS seconds and J2000 seconds should stay constant.
+    gps_row = data_gps_sec[0, :]
+    init_diff = gps_row[1] - gps_row[0] * 1.0E-9
     i = 1
-
-    # Compare the GPS seconds values
-    AllowTolerance = 1E-6
-    while i < DataGPSSec.shape[0]:
-        if date.isoweekday() == 7:  # Skip test on Sundays, because it's the end of a GPS week (seconds go to zero)
+    allow_tolerance = 1E-6
+    while i < data_gps_sec.shape[0]:
+        if date.isoweekday() == 7:  # Sundays end a GPS week, GPS seconds wrap to 0
             i += 1
         else:
-            GPSRow = DataGPSSec[i, :]
-            CurrDiff = GPSRow[1] - GPSRow[0] * 1.0E-9
-            if abs(CurrDiff - InitDiff) > AllowTolerance:
-                testFailCount += 1
-                testMessages.append("FAILED: Time delta check failed with difference of: %(DiffVal)f \n"% \
-                                {"DiffVal": CurrDiff - InitDiff})
+            gps_row = data_gps_sec[i, :]
+            curr_diff = gps_row[1] - gps_row[0] * 1.0E-9
+            if abs(curr_diff - init_diff) > allow_tolerance:
+                test_fail_count += 1
+                test_messages.append(f"FAILED: Time delta check failed with difference of: {curr_diff - init_diff:f} \n")
             i += 1
 
-    # Truth values
-    # For absolute GPS time check
-    if date > datetime.datetime(2015, 0o6, 30):  # Taking into account the extra leap second added on 6/30/2015
-        GPSEndTime = GPSTimeSeconds + 17 + 60.0 - 68.184  # 17 GPS skip seconds passed that date
+    # Absolute GPS time check (account for the leap second introduced 2015-06-30).
+    if date > datetime.datetime(2015, 6, 30):
+        gps_end_time = gps_time_seconds + 17 + 60.0 - 68.184  # 17 GPS skip seconds after 2015-06-30
     else:
-        GPSEndTime = GPSTimeSeconds + 16 + 60.0 - 67.184  # 16 GPS skip seconds before
+        gps_end_time = gps_time_seconds + 16 + 60.0 - 67.184
 
-    GPSWeek = int(GPSEndTime / (86400 * 7))
-    GPSSecondAssumed = GPSEndTime - GPSWeek * 86400 * 7
-    GPSSecDiff = abs(GPSRow[1] - GPSSecondAssumed)
+    gps_week = int(gps_end_time / (86400 * 7))
+    gps_second_assumed = gps_end_time - gps_week * 86400 * 7
+    gps_sec_diff = abs(gps_row[1] - gps_second_assumed)
 
-    # TestResults['GPSAbsTimeCheck'] = True
-    AllowTolerance = 1E-4
-    if useMsg:
-        AllowTolerance = 2E-2
-    # Skip test days that are Sunday because of the end of a GPS week
-    if date.isoweekday() != 7 and GPSSecDiff > AllowTolerance:
-        testFailCount += 1
-        testMessages.append("FAILED: Absolute GPS time check failed with difference of: %(DiffVal)f \n" % \
-                            {"DiffVal": GPSSecDiff})
+    allow_tolerance = 1E-4
+    if use_msg:
+        allow_tolerance = 2E-2
+    if date.isoweekday() != 7 and gps_sec_diff > allow_tolerance:
+        test_fail_count += 1
+        test_messages.append(f"FAILED: Absolute GPS time check failed with difference of: {gps_sec_diff:f} \n")
 
-    # Truth values
-    # For absolute Julian date time check
-    if date>datetime.datetime(2015, 0o6, 30):  # Taking into account the extra leap second added on 6/30/2015
-        JDEndTime = JulianStartDate + 0.0006944440 - 68.184 / 86400
+    # Absolute Julian date check (same leap-second adjustment as above).
+    if date > datetime.datetime(2015, 6, 30):
+        jd_end_time = julian_start_date + 0.0006944440 - 68.184 / 86400
     else:
-        JDEndTime = JulianStartDate + 0.0006944440 - 67.184 / 86400
+        jd_end_time = julian_start_date + 0.0006944440 - 67.184 / 86400
 
-    # Simulated values
-    JDEndSim = DataJD[i - 1, 1]
-    JDTimeErrorAllow = 0.1 / (24.0 * 3600.0)
-    if abs(JDEndSim - JDEndTime) > JDTimeErrorAllow:
-        testFailCount += 1
-        testMessages.append("FAILED: Absolute Julian Date time check failed with difference of: %(DiffVal)f \n" % \
-                            {"DiffVal": abs(JDEndSim - JDEndTime)})
+    jd_end_sim = data_jd[i - 1, 1]
+    jd_time_error_allow = 0.1 / (24.0 * 3600.0)
+    if abs(jd_end_sim - jd_end_time) > jd_time_error_allow:
+        test_fail_count += 1
+        test_messages.append(f"FAILED: Absolute Julian Date time check failed with difference of: {abs(jd_end_sim - jd_end_time):f} \n")
 
-    # Truth values
-    # For Mars position check
-    MarsPosEnd = numpy.array(MarsTruthPos)
-    MarsPosEnd = MarsPosEnd * 1000.0
+    pos_err_tolerance = 1000 if use_msg else 250
 
-    # Get Simulated values
-    MarsPosVec = SpiceObject.planetStateOutMsgs[1].read().PositionVector
+    # Mars position
+    mars_pos_truth = numpy.array(mars_truth_pos) * 1000.0
+    mars_pos_vec = spice_object.planetStateOutMsgs[1].read().PositionVector
+    mars_pos_diff = numpy.array(mars_pos_vec) - mars_pos_truth
+    mars_err = numpy.linalg.norm(mars_pos_diff)
+    test_plotting_fixture.mars_pos_err = mars_err
+    if mars_err > pos_err_tolerance:
+        test_fail_count += 1
+        test_messages.append(f"FAILED: Mars position check failed with difference of: {mars_err:f} \n")
 
-    # Compare Mars position values
-    MarsPosArray = numpy.array([MarsPosVec[0], MarsPosVec[1], MarsPosVec[2]])
-    MarsPosDiff = MarsPosArray - MarsPosEnd
-    PosDiffNorm = numpy.linalg.norm(MarsPosDiff)
+    # Earth position
+    earth_pos_truth = numpy.array(earth_truth_pos) * 1000.0
+    earth_pos_vec = spice_object.planetStateOutMsgs[0].read().PositionVector
+    earth_pos_diff = numpy.array(earth_pos_vec) - earth_pos_truth
+    earth_err = numpy.linalg.norm(earth_pos_diff)
+    test_plotting_fixture.earth_pos_err = earth_err
+    if earth_err > pos_err_tolerance:
+        test_fail_count += 1
+        test_messages.append(f"FAILED: Earth position check failed with difference of: {earth_err:f} \n")
 
-    # Plot Mars position values
-    testPlottingFixture.MarsPosErr = PosDiffNorm
+    # Sun position
+    sun_pos_truth = numpy.array(sun_truth_pos) * 1000.0
+    sun_pos_vec = spice_object.planetStateOutMsgs[2].read().PositionVector
+    sun_pos_diff = numpy.array(sun_pos_vec) - sun_pos_truth
+    sun_err = numpy.linalg.norm(sun_pos_diff)
+    test_plotting_fixture.sun_pos_err = sun_err
+    if sun_err > pos_err_tolerance:
+        test_fail_count += 1
+        test_messages.append(f"FAILED: Sun position check failed with difference of: {sun_err:f} \n")
 
-    # Test Mars position values
-    PosErrTolerance = 250
-    if useMsg:
-        PosErrTolerance = 1000
-    if (PosDiffNorm > PosErrTolerance):
-        testFailCount += 1
-        testMessages.append("FAILED: Mars position check failed with difference of: %(DiffVal)f \n" % \
-                            {"DiffVal": PosDiffNorm})
-
-    # Truth values
-    # For Earth position check
-    EarthPosEnd = numpy.array(EarthTruthPos)
-    EarthPosEnd = EarthPosEnd * 1000.0
-
-    # Simulated Earth position values
-    EarthPosVec = SpiceObject.planetStateOutMsgs[0].read().PositionVector
-
-    # Compare Earth position values
-    EarthPosArray = numpy.array([EarthPosVec[0], EarthPosVec[1], EarthPosVec[2]])
-    EarthPosDiff = EarthPosArray - EarthPosEnd
-    PosDiffNorm = numpy.linalg.norm(EarthPosDiff)
-
-    # Plot Earth position values
-    testPlottingFixture.EarthPosErr = PosDiffNorm
-
-    # TestResults['EarthPosCheck'] = True
-    if (PosDiffNorm > PosErrTolerance):
-        testFailCount += 1
-        testMessages.append("FAILED: Earth position check failed with difference of: %(DiffVal)f \n" % \
-                            {"DiffVal": PosDiffNorm})
-
-    # Truth Sun position values
-    SunPosEnd = numpy.array(SunTruthPos)
-    SunPosEnd = SunPosEnd * 1000.0
-
-    #Simulated Sun position values
-    SunPosVec = SpiceObject.planetStateOutMsgs[2].read().PositionVector
-
-    # Compare Sun position values
-    SunPosArray = numpy.array([SunPosVec[0], SunPosVec[1], SunPosVec[2]])
-    SunPosDiff = SunPosArray - SunPosEnd
-    PosDiffNorm = numpy.linalg.norm(SunPosDiff)
-
-    # plot Sun position values
-    testPlottingFixture.SunPosErr = PosDiffNorm
-
-    # Test Sun position values
-    if (PosDiffNorm > PosErrTolerance):
-        testFailCount += 1
-        testMessages.append("FAILED: Sun position check failed with difference of: %(DiffVal)f \n" % \
-                            {"DiffVal": PosDiffNorm})
-
-    if date == datetime.datetime(2016,12,20): # Only test the false files on the last test
-
-        # Test non existing directory
-        SpiceObject.SPICEDataPath = "ADirectoryThatDoesntreallyexist"
-        SpiceObject.SPICELoaded = False
-
-        # TotalSim.ConfigureStopTime(int(1E9)) #Uncomment these 3 lines to test false directory
-        # TotalSim.InitializeSimulation()
-        # TotalSim.ExecuteSimulation()
-
-        # Test overly long planet name
-        SpiceObject.SPICEDataPath = ""
-        SpiceObject.SPICELoaded = False
-        # Uncomment these 4 lines to test false planet names
-        # SpiceObject.addPlanetNames(spiceInterface.StringVector(["earth", "mars", "sun",
-        #                                                     "thisisaplanetthatisntreallyanythingbutIneedthenametobesolongthatIhitaninvalidconditioninmycode"]))
-        # TotalSim.ConfigureStopTime(int(1E9))
-        # TotalSim.InitializeSimulation()
-        # TotalSim.ExecuteSimulation()
-
-    # print out success message if no error were found
-    if testFailCount == 0:
+    if test_fail_count == 0:
         print(" \n PASSED ")
 
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
-    return [testFailCount, ''.join(testMessages)]
+    return [test_fail_count, "".join(test_messages)]
 
 
-# This statement below ensures that the unit test scrip can be run as a
-# stand-along python script
-#
 if __name__ == "__main__":
     test_unitSpice(
-                   testPlottingFixture,
-                   True,  # show_plots
-                   "2015 February 10, 00:00:00.00 TDB",
-                   "02/10/15",
-                   [2.049283795042291E+08, 4.654550957513031E+07, 1.580778617009296E+07],
-                   [-1.137790671899544E+08, 8.569008401822130E+07, 3.712507705247846E+07],
-                   [4.480338216752146E+05, -7.947764237588293E+04, -5.745748832696378E+04],
-                   True   # useMsg
-                   )
+        None,  # test_plotting_fixture
+        True,  # show_plots
+        "2015 February 10, 00:00:00.00 TDB",
+        "02/10/15",
+        [2.049283795042291E+08, 4.654550957513031E+07, 1.580778617009296E+07],
+        [-1.137790671899544E+08, 8.569008401822130E+07, 3.712507705247846E+07],
+        [4.480338216752146E+05, -7.947764237588293E+04, -5.745748832696378E+04],
+        True,  # use_msg
+    )

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpicePlanetOffset.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpicePlanetOffset.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: ISC
+# Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+#
+
+import inspect
+import os
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+# Exercises the SecondaryBody capability of SpiceInterface:
+#   - the secondary state output message equals the primary's state plus
+#     the configured offset, and the body is renamed
+#   - the primary planet message itself is untouched
+#   - when an orbital period is set, the secondary traces a circle of radius |offset|
+#     centered on the primary, in the equator-tilted plane normal to
+#     offset x (offset x J2000 Z)
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+from xmera import __path__
+bsk_path = __path__[0]
+
+from xmera.utilities import SimulationBaseClass
+from xmera.simulation import spiceInterface
+from xmera.utilities import macros
+from xmera.architecture import messaging  # noqa: F401  registers Message<X> Python wrappers
+
+
+planet_names = ["earth", "moon"]
+primary_name = "moon"
+primary_index = 1
+secondary_name = "binaryAsteroid"
+default_offset = np.array([1000.0, 2000.0, -3000.0])  # m
+date_spice = "2015 February 10, 00:00:00.0 TDB"
+# Position-difference tolerance: secondary - primary involves subtracting two
+# SPICE-derived positions of order 1e8 m, so the float-precision floor is ~1e-8 m.
+# 1e-3 m (1 mm) is well below any physically meaningful threshold.
+position_atol = 1e-3  # m
+
+
+def build_sim(orbital_period, stop_time_sec, time_step_sec=0.1, attach_secondary=True,
+              offset=default_offset):
+    """Configure a SpiceInterface, attach recorders, run the sim, and return
+    (spice, secondary_rec, primary_rec)."""
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("TestProcess")
+    proc.addTask(sim.CreateNewTask("unitTask", macros.sec2nano(time_step_sec)))
+
+    spice = spiceInterface.SpiceInterface()
+    spice.modelTag = "SpiceInterface"
+    spice.SPICEDataPath = bsk_path + "/supportData/EphemerisData/"
+    spice.addPlanetNames(planet_names)
+    spice.UTCCalInit = date_spice
+
+    if attach_secondary:
+        secondary = spiceInterface.SecondaryBody()
+        secondary.secondaryName = secondary_name
+        secondary.positionOffset = np.asarray(offset, dtype=float)
+        secondary.orbitalPeriod = orbital_period
+        spice.setOffsetBody(primary_name, secondary)
+
+    secondary_rec = spice.secondaryStateOutMsg.recorder()
+    primary_rec = spice.planetStateOutMsgs[primary_index].recorder()
+
+    sim.AddModelToTask("unitTask", spice)
+    sim.AddModelToTask("unitTask", secondary_rec)
+    sim.AddModelToTask("unitTask", primary_rec)
+    sim.ConfigureStopTime(macros.sec2nano(stop_time_sec))
+    sim.InitializeSimulation()
+    sim.ExecuteSimulation()
+
+    return spice, secondary_rec, primary_rec
+
+
+def test_secondary_body_static_offset(show_plots):
+    """Period=0: secondary position = primary position + constant offset; name is renamed."""
+    spice, secondary_rec, primary_rec = build_sim(orbital_period=0.0, stop_time_sec=0.5)
+
+    delta = np.array(secondary_rec.PositionVector) - np.array(primary_rec.PositionVector)
+    npt.assert_allclose(delta, np.broadcast_to(default_offset, delta.shape), atol=position_atol,
+                        err_msg="static offset mismatch in secondary message")
+
+    name = spice.secondaryStateOutMsg.read().PlanetName
+    npt.assert_equal(name, secondary_name)
+
+
+def test_primary_body_unchanged(show_plots):
+    """Attaching a SecondaryBody must not perturb the primary's planet message."""
+    _, _, primary_with_rec = build_sim(orbital_period=0.0, stop_time_sec=0.5,
+                                       attach_secondary=True)
+    _, _, primary_ref_rec = build_sim(orbital_period=0.0, stop_time_sec=0.5,
+                                      attach_secondary=False)
+
+    npt.assert_allclose(np.array(primary_with_rec.PositionVector),
+                        np.array(primary_ref_rec.PositionVector),
+                        atol=position_atol,
+                        err_msg="primary planet message changed when SecondaryBody attached")
+
+
+def _expected_orbit_basis(offset):
+    """Replicates the C++ orbit-plane construction: plane_normal = offset x (offset x up),
+    which tilts the orbit toward the equator rather than through the poles. Falls back
+    to the J2000 X axis when offset is parallel to up."""
+    parallel_tol = 8.0 * np.finfo(np.float64).eps
+    up = np.array([0.0, 0.0, 1.0])
+    intermediate = np.cross(offset, up)
+    if np.linalg.norm(intermediate) < parallel_tol * np.linalg.norm(offset):
+        intermediate = np.cross(offset, np.array([1.0, 0.0, 0.0]))
+    plane_normal = np.cross(offset, intermediate)
+    plane_normal /= np.linalg.norm(plane_normal)
+    return plane_normal, np.cross(plane_normal, offset)
+
+
+# Offsets cover: generic 3-component, pure +X, pure +Y, asymmetric in-plane,
+# and the parallel-to-up degenerate case (forces the X-axis fallback in the
+# C++ basis construction).
+orbit_offsets = [
+    pytest.param(np.array([1000.0, 2000.0, -3000.0]), id="mixed"),
+    pytest.param(np.array([5000.0, 0.0, 0.0]),        id="pure_x"),
+    pytest.param(np.array([0.0, 4000.0, 0.0]),        id="pure_y"),
+    pytest.param(np.array([-500.0, 1500.0, 0.0]),     id="asymmetric_xy"),
+    pytest.param(np.array([0.0, 0.0, 2500.0]),        id="parallel_to_up"),
+]
+
+
+@pytest.mark.parametrize("offset", orbit_offsets)
+def test_secondary_body_circular_orbit(show_plots, offset):
+    """Period=T: secondary orbits the primary in the equator-tilted plane normal to
+    offset x (offset x J2000 Z) (or offset x (offset x X) when offset is parallel to Z),
+    and returns to start at t=T."""
+    period = 10.0  # s
+    time_step = period / 20.0
+    _, secondary_rec, primary_rec = build_sim(
+        orbital_period=period, stop_time_sec=period, time_step_sec=time_step,
+        offset=offset,
+    )
+
+    times = np.array(secondary_rec.times()) * macros.NANO2SEC
+    delta = np.array(secondary_rec.PositionVector) - np.array(primary_rec.PositionVector)
+
+    angles = 2.0 * np.pi * times / period
+    plane_normal, perp = _expected_orbit_basis(offset)
+    expected = (np.outer(np.cos(angles), offset)
+                + np.outer(np.sin(angles), perp))
+    npt.assert_allclose(delta, expected, atol=position_atol,
+                        err_msg="circular-orbit rotation mismatch")
+
+    # Radius is conserved.
+    r_3d = np.linalg.norm(delta, axis=1)
+    npt.assert_allclose(r_3d, np.linalg.norm(offset), atol=position_atol,
+                        err_msg="orbital radius drifted")
+
+    # Trajectory stays in the plane (projection onto the plane normal is zero).
+    out_of_plane = delta @ plane_normal
+    npt.assert_allclose(out_of_plane, 0.0, atol=position_atol,
+                        err_msg="secondary drifted out of orbital plane")
+
+    # Closes the loop: t=0 and t=T positions match.
+    npt.assert_allclose(delta[-1], delta[0], atol=position_atol,
+                        err_msg="orbit did not close after one period")
+
+    if show_plots:
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+        fig = plt.figure(figsize=(7, 6))
+        ax = fig.add_subplot(111, projection="3d")
+        ax.plot(delta[:, 0], delta[:, 1], delta[:, 2], "o-",
+                label="secondary - primary")
+        ax.scatter([offset[0]], [offset[1]], [offset[2]],
+                   color="r", s=80, label="initial offset")
+        ax.scatter([0], [0], [0], color="k", s=40, label="primary")
+        ax.set_xlabel("X offset [m]")
+        ax.set_ylabel("Y offset [m]")
+        ax.set_zlabel("Z offset [m]")
+        ax.set_title(f"Secondary body trajectory (T={period}s, offset={offset.tolist()})")
+        ax.legend()
+        plt.show()
+
+
+if __name__ == "__main__":
+    test_secondary_body_static_offset(True)
+    test_primary_body_unchanged(True)
+    for params in orbit_offsets:
+        test_secondary_body_circular_orbit(True, params.values[0])
+    print(" \n PASSED ")

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpiceSpacecraft.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpiceSpacecraft.py
@@ -8,147 +8,108 @@ import os
 
 import numpy as np
 
-#
-# Spice Unit Test
-#
-# Purpose:  Test the proper function of the Spice Ephemeris module for spacecraft information.
-#           Proper function is tested by comparing Spice Ephemeris to
-#           JPL Horizons Database for different planets and times of year
-# Author:   Hanspeter Schaub
-# Creation Date:  Dec. 17, 2021
-#
+# Spice Spacecraft Unit Test
+# Purpose:  Verify that SpiceInterface produces correct spacecraft state, attitude
+#           reference, and translational reference messages for a SPICE-tracked
+#           spacecraft (HST), benchmarked against JPL Horizons.
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 from xmera import __path__
-bskPath = __path__[0]
+bsk_path = __path__[0]
 
-import xmera.architecture.messaging
+import xmera.architecture.messaging  # noqa: F401
 from xmera.utilities import unitTestSupport
 from xmera.utilities import SimulationBaseClass
 from xmera.simulation import spiceInterface
 from xmera.utilities import macros
 
-# provide a unique test method name, starting with test_
+
 def test_unitSpiceSc(show_plots):
     """Module Unit Test"""
-    # each test method requires a single assert method to be called
-    [testResults, testMessage] = unitSpiceSc(show_plots)
-    assert testResults < 1, testMessage
+    [test_fail_count, test_message] = unit_spice_sc(show_plots)
+    assert test_fail_count < 1, test_message
 
 
-# Run unit test
-def unitSpiceSc(show_plots):
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty array to store test log messages
+def unit_spice_sc(show_plots):
+    test_fail_count = 0
+    test_messages = []
 
-    # Create a sim module as an empty container
-    unitTaskName = "unitTask"  # arbitrary name (don't change)
-    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
 
-    # Create a sim module as an empty container
-    TotalSim = SimulationBaseClass.SimBaseClass()
+    total_sim = SimulationBaseClass.SimBaseClass()
+    dyn_unit_test_proc = total_sim.CreateNewProcess(unit_process_name)
+    dyn_unit_test_proc.addTask(total_sim.CreateNewTask(unit_task_name, macros.sec2nano(0.1)))
+    date_spice = "2015 February 10, 00:00:00.0 TDB"
 
-    DynUnitTestProc = TotalSim.CreateNewProcess(unitProcessName)
-    # create the dynamics task and specify the integration update time
-    DynUnitTestProc.addTask(TotalSim.CreateNewTask(unitTaskName, macros.sec2nano(0.1)))
-    dateSpice = "2015 February 10, 00:00:00.0 TDB"
+    spice_object = spiceInterface.SpiceInterface()
+    spice_object.modelTag = "SpiceInterfaceData"
+    spice_object.SPICEDataPath = bsk_path + "/supportData/EphemerisData/"
+    sc_names = ["HUBBLE SPACE TELESCOPE"]
+    spice_object.addSpacecraftNames(sc_names)
+    spice_object.UTCCalInit = date_spice
+    spice_object.zeroBase = "earth"
+    spice_object.loadSpiceKernel("hst_edited.bsp", bsk_path + "/supportData/EphemerisData/")
 
-    # Initialize the spice modules that we are using.
-    spiceObject = spiceInterface.SpiceInterface()
-    spiceObject.modelTag = "SpiceInterfaceData"
-    spiceObject.SPICEDataPath = bskPath + '/supportData/EphemerisData/'
-    scNames = ["HUBBLE SPACE TELESCOPE"]
-    spiceObject.addSpacecraftNames(scNames)
-    spiceObject.UTCCalInit = dateSpice
-    spiceObject.zeroBase = "earth"
-    spiceObject.loadSpiceKernel("hst_edited.bsp", bskPath + '/supportData/EphemerisData/')
+    total_sim.AddModelToTask(unit_task_name, spice_object)
 
-    TotalSim.AddModelToTask(unitTaskName, spiceObject)
+    total_sim.ConfigureStopTime(macros.sec2nano(0.1))
+    total_sim.InitializeSimulation()
+    total_sim.ExecuteSimulation()
 
-    # Configure simulation
-    TotalSim.ConfigureStopTime(macros.sec2nano(0.1))
+    spice_object.unloadSpiceKernel("hst_edited.bsp", bsk_path + "/supportData/EphemerisData/")
 
-    # Execute simulation
-    TotalSim.InitializeSimulation()
-    TotalSim.ExecuteSimulation()
-
-    # unload spice kernel
-    spiceObject.unloadSpiceKernel("hst_edited.bsp", bskPath + '/supportData/EphemerisData/')
-
-    # set truth
-    truthPosition = np.array([-5855529.540348052, 1986110.860522791, -3116764.7117067943])
-    truthVelocity = np.array([-1848.9038338503085, -7268.515626753905, -1155.3578832725618])
-    truthAtt = np.array([0., 0., 0.])
-    truthZero = np.array([0., 0., 0.])
-
-    scStateMsg = spiceObject.scStateOutMsgs[0].read()
-    # print(scStateMsg.r_BN_N)
-    # print(scStateMsg.v_BN_N)
-    # print(scStateMsg.sigma_BN)
+    truth_position = np.array([-5855529.540348052, 1986110.860522791, -3116764.7117067943])
+    truth_velocity = np.array([-1848.9038338503085, -7268.515626753905, -1155.3578832725618])
+    truth_att = np.array([0., 0., 0.])
+    truth_zero = np.array([0., 0., 0.])
     accuracy = 0.01
-    testFailCount, testMessages = unitTestSupport.compareVector(truthPosition,
-                                                                scStateMsg.r_BN_N,
-                                                                accuracy, "scState-r_BN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthPosition,
-                                                                scStateMsg.r_CN_N,
-                                                                accuracy, "scState-r_CN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthVelocity,
-                                                                scStateMsg.v_BN_N,
-                                                                accuracy, "scState-v_BN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthVelocity,
-                                                                scStateMsg.v_CN_N,
-                                                                accuracy, "scState-v_CN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthAtt,
-                                                                scStateMsg.sigma_BN,
-                                                                accuracy, "scState-sigma_BN",
-                                                                testFailCount, testMessages)
-    attStateMsg = spiceObject.attRefStateOutMsgs[0].read()
-    testFailCount, testMessages = unitTestSupport.compareVector(truthAtt,
-                                                                attStateMsg.sigma_RN,
-                                                                accuracy, "scState-sigma_RN",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthZero,
-                                                                attStateMsg.omega_RN_N,
-                                                                accuracy, "scState-omega_RN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthZero,
-                                                                attStateMsg.domega_RN_N,
-                                                                accuracy, "scState-domega_RN_N",
-                                                                testFailCount, testMessages)
 
-    transStateMsg = spiceObject.transRefStateOutMsgs[0].read()
-    testFailCount, testMessages = unitTestSupport.compareVector(truthPosition,
-                                                                transStateMsg.r_RN_N,
-                                                                accuracy, "scState-r_RN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthVelocity,
-                                                                transStateMsg.v_RN_N,
-                                                                accuracy, "scState-v_RN_N",
-                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareVector(truthZero,
-                                                                transStateMsg.a_RN_N,
-                                                                accuracy, "scState-a_RN_N",
-                                                                testFailCount, testMessages)
+    sc_state_msg = spice_object.scStateOutMsgs[0].read()
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_position, sc_state_msg.r_BN_N,
+                                                                   accuracy, "scState-r_BN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_position, sc_state_msg.r_CN_N,
+                                                                   accuracy, "scState-r_CN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_velocity, sc_state_msg.v_BN_N,
+                                                                   accuracy, "scState-v_BN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_velocity, sc_state_msg.v_CN_N,
+                                                                   accuracy, "scState-v_CN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_att, sc_state_msg.sigma_BN,
+                                                                   accuracy, "scState-sigma_BN",
+                                                                   test_fail_count, test_messages)
 
+    att_state_msg = spice_object.attRefStateOutMsgs[0].read()
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_att, att_state_msg.sigma_RN,
+                                                                   accuracy, "scState-sigma_RN",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_zero, att_state_msg.omega_RN_N,
+                                                                   accuracy, "scState-omega_RN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_zero, att_state_msg.domega_RN_N,
+                                                                   accuracy, "scState-domega_RN_N",
+                                                                   test_fail_count, test_messages)
 
-    # print out success message if no error were found
-    if testFailCount == 0:
+    trans_state_msg = spice_object.transRefStateOutMsgs[0].read()
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_position, trans_state_msg.r_RN_N,
+                                                                   accuracy, "scState-r_RN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_velocity, trans_state_msg.v_RN_N,
+                                                                   accuracy, "scState-v_RN_N",
+                                                                   test_fail_count, test_messages)
+    test_fail_count, test_messages = unitTestSupport.compareVector(truth_zero, trans_state_msg.a_RN_N,
+                                                                   accuracy, "scState-a_RN_N",
+                                                                   test_fail_count, test_messages)
+
+    if test_fail_count == 0:
         print(" \n PASSED ")
 
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
-    return [testFailCount, ''.join(testMessages)]
+    return [test_fail_count, "".join(test_messages)]
 
 
-# This statement below ensures that the unit test scrip can be run as a
-# stand-along python script
-#
 if __name__ == "__main__":
-    test_unitSpiceSc(
-                     False  # show_plots
-                     )
+    test_unitSpiceSc(False)

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -7,8 +7,47 @@
 #include <architecture/utilities/rigidBodyKinematics.h>
 #include <architecture/utilities/simDefinitions.h>
 #include <SpiceUsr.h>
+#include <cmath>
+#include <limits>
 #include <string.h>
 #include <sstream>
+
+void SecondaryBody::setPositionOffset(const Eigen::Vector3d& offset) { this->offset = offset; }
+
+Eigen::Vector3d SecondaryBody::getPositionOffset() const { return this->offset; }
+
+Eigen::Vector3d SecondaryBody::getPositionOffsetAt(double elapsedSeconds) const {
+    if (this->orbitalPeriod <= 0.0) {
+        return this->offset;
+    }
+    // The orbit is a circle of radius |offset| centered on the primary. The plane
+    // normal is offset x (offset x up): this lies in the offset-up plane, so the
+    // orbit plane itself tilts toward the equator (perpendicular to up) rather
+    // than running through the poles. When offset is parallel to up the cross
+    // product degenerates; fall back to the J2000 X axis.
+    // |offset x up| / |offset| = sin(angle); when offset is parallel to up this
+    // collapses to float roundoff, so detect it with a small multiple of machine eps.
+    constexpr double parallelTol = 8.0 * std::numeric_limits<double>::epsilon();
+    const Eigen::Vector3d up(0.0, 0.0, 1.0);
+    Eigen::Vector3d intermediate = this->offset.cross(up);
+    if (intermediate.norm() < parallelTol * this->offset.norm()) {
+        intermediate = this->offset.cross(Eigen::Vector3d(1.0, 0.0, 0.0));
+    }
+    Eigen::Vector3d planeNormal = this->offset.cross(intermediate);
+    planeNormal.normalize();
+
+    const Eigen::Vector3d perp = planeNormal.cross(this->offset);
+    const double angle = 2.0 * M_PI * elapsedSeconds / this->orbitalPeriod;
+    return std::cos(angle) * this->offset + std::sin(angle) * perp;
+}
+
+void SecondaryBody::setSecondaryName(const std::string& name) { this->secondaryName = name; }
+
+std::string SecondaryBody::getSecondaryName() const { return this->secondaryName; }
+
+void SecondaryBody::setOrbitalPeriod(double period) { this->orbitalPeriod = period; }
+
+double SecondaryBody::getOrbitalPeriod() const { return this->orbitalPeriod; }
 
 /*! This constructor initializes the variables that spice uses.  Most of them are
  not intended to be changed, but a couple are user configurable.
@@ -46,6 +85,8 @@ SpiceInterface::SpiceInterface() {
              EPOCH_MIN,
              EPOCH_SEC);
     this->UTCCalInit = string;
+    planetWithSecondary = "";
+    secondaryBody = SecondaryBody();
 
     return;
 }
@@ -197,6 +238,19 @@ void SpiceInterface::computeGPSData() {
     this->GPSWeek = (uint16_t)(this->GPSWeek - this->GPSRollovers * 1024);
 }
 
+SpicePlanetStateMsgPayload SpiceInterface::populateSecondaryBodyMsg(
+    const SpicePlanetStateMsgPayload& primaryBody) const {
+    SpicePlanetStateMsgPayload message = primaryBody;
+    const double elapsedSeconds = this->J2000Current - this->J2000ETInit;
+    const auto pos = this->secondaryBody.getPositionOffsetAt(elapsedSeconds);
+    message.PositionVector[0] += pos[0];
+    message.PositionVector[1] += pos[1];
+    message.PositionVector[2] += pos[2];
+
+    strcpy(message.PlanetName, this->secondaryBody.getSecondaryName().c_str());
+    return message;
+}
+
 /*! This method takes the values computed in the model and outputs them.
  It packages up the internal variables into the output structure definitions
  and puts them out on the messaging system
@@ -217,6 +271,10 @@ void SpiceInterface::writeOutputMessages(uint64_t CurrentClock) {
     //! - Iterate through all of the planets that are on and write their outputs
     for (long unsigned int c = 0; c < this->planetStateOutMsgs.size(); c++) {
         this->planetStateOutMsgs[c]->write(&this->planetData[c], this->moduleID, CurrentClock);
+        if (this->planetWithSecondary == this->planetNames[c]) {
+            auto message = this->populateSecondaryBodyMsg(this->planetData[c]);
+            this->secondaryStateOutMsg.write(&message, this->moduleID, CurrentClock);
+        }
     }
 
     //! - Iterate through all of the spacecraft that are on and write their outputs
@@ -265,7 +323,7 @@ void SpiceInterface::updateState(uint64_t currentSimNanos) {
     planet state output messages and the vector of planet state message payloads */
 void SpiceInterface::addPlanetNames(std::vector<std::string> planetNames) {
     std::vector<std::string>::iterator it;
-
+    this->planetNames = planetNames;
     /* clear the planet state message and payload vectors */
     for (long unsigned int c = 0; c < this->planetStateOutMsgs.size(); c++) {
         delete this->planetStateOutMsgs.at(c);
@@ -350,6 +408,22 @@ void SpiceInterface::addSpacecraftNames(std::vector<std::string> spacecraftNames
 
     return;
 }
+
+/*! Attach a secondary body to a primary celestial body in the planet list.
+ The secondary's state is published to secondaryStateOutMsg as the primary's
+ SPICE-derived state plus the secondary's (optionally time-varying) offset.
+@param name Name of the primary celestial body in the planet list
+@param offsetBody The SecondaryBody to attach
+ */
+void SpiceInterface::setOffsetBody(const std::string& name, const SecondaryBody& offsetBody) {
+    this->planetWithSecondary = name;
+    this->secondaryBody = offsetBody;
+}
+
+/*! Stop publishing the secondary state output message. The stored SecondaryBody
+ configuration is preserved, so a subsequent setOffsetBody() call re-activates it.
+ */
+void SpiceInterface::passivateSecondary() { this->planetWithSecondary = ""; }
 
 /*! This method gets the state of each spice item that has been added to the module
  and saves the information off into the array.

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -87,8 +87,6 @@ SpiceInterface::SpiceInterface() {
     this->UTCCalInit = string;
     planetWithSecondary = "";
     secondaryBody = SecondaryBody();
-
-    return;
 }
 
 /*! The only needed activity in the destructor is to delete the spice I/O buffer
@@ -107,18 +105,11 @@ SpiceInterface::~SpiceInterface() {
         delete this->transRefStateOutMsgs.at(c);
     }
     delete[] this->spiceBuffer;
-    //    if(this->SPICELoaded)
-    //    {
-    //        this->clearKeeper();
-    //    }
-    return;
 }
 
 void SpiceInterface::clearKeeper() { kclear_c(); }
 
-/*! Reset the module to origina configuration values.
- @return void
- */
+/*! Reset the module to original configuration values. */
 void SpiceInterface::reset(uint64_t CurrenSimNanos) {
     //! - Bail if the SPICEDataPath is not present
     if (this->SPICEDataPath == "") {
@@ -472,16 +463,10 @@ void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload>* spic
         }
 
         if (planit->computeOrient) {
-            // pxform_c ( referenceBase.c_str(), planetFrame.c_str(), J2000Current,
-            //     planit->second.J20002Pfix);
-
             double aux[6][6];
 
-            sxform_c(
-                this->referenceBase.c_str(),
-                planetFrame.c_str(),
-                this->J2000Current,
-                aux);  // returns attitude of planet (i.e. IAU_EARTH) wrt "j2000". note j2000 is actually ICRF in Spice.
+            // returns attitude of planet (e.g. IAU_EARTH) wrt "j2000" (which is ICRF in Spice)
+            sxform_c(this->referenceBase.c_str(), planetFrame.c_str(), this->J2000Current, aux);
 
             m66Get33Matrix(0, 0, aux, planit->J20002Pfix);
 

--- a/src/simulation/environment/spiceInterface/spiceInterface.h
+++ b/src/simulation/environment/spiceInterface/spiceInterface.h
@@ -20,6 +20,25 @@
 #include <architecture/msgPayloadDef/SpiceTimeMsgPayload.h>
 #include <architecture/msgPayloadDef/TransRefMsgPayload.h>
 
+class SecondaryBody {
+   public:
+    SecondaryBody() = default;
+    ~SecondaryBody() = default;
+
+    void setPositionOffset(const Eigen::Vector3d& offset);
+    Eigen::Vector3d getPositionOffset() const;
+    Eigen::Vector3d getPositionOffsetAt(double elapsedSeconds) const;
+    void setSecondaryName(const std::string& name);
+    std::string getSecondaryName() const;
+    void setOrbitalPeriod(double period);
+    double getOrbitalPeriod() const;
+
+   private:
+    std::string secondaryName{};
+    Eigen::Vector3d offset{Eigen::Vector3d::Zero()};
+    double orbitalPeriod{0.0};  //!< s circular-orbit period; 0 disables motion
+};
+
 /*! @brief spice interface class */
 class SpiceInterface : public SysModel {
    public:
@@ -38,11 +57,15 @@ class SpiceInterface : public SysModel {
     void clearKeeper();  //!< class method
     void addPlanetNames(std::vector<std::string> planetNames);
     void addSpacecraftNames(std::vector<std::string> spacecraftNames);
+    SpicePlanetStateMsgPayload populateSecondaryBodyMsg(const SpicePlanetStateMsgPayload& primaryBody) const;
+    void setOffsetBody(const std::string& planetName, const SecondaryBody& offsetBody);
+    void passivateSecondary();
 
    public:
     Message<SpiceTimeMsgPayload> spiceTimeOutMsg;                          //!< spice time sampling output message
     ReadFunctor<EpochMsgPayload> epochInMsg;                               //!< (optional) input epoch message
     std::vector<Message<SpicePlanetStateMsgPayload>*> planetStateOutMsgs;  //!< vector of planet state output messages
+    Message<SpicePlanetStateMsgPayload> secondaryStateOutMsg;  //!< State output message for a secondary body
     std::vector<Message<SCStatesMsgPayload>*> scStateOutMsgs;  //!< vector of spacecraft state output messages
     std::vector<Message<AttRefMsgPayload>*>
         attRefStateOutMsgs;  //!< vector of spacecraft attitude reference state output messages
@@ -58,16 +81,18 @@ class SpiceInterface : public SysModel {
     uint8_t* spiceBuffer;        //!< -- General buffer to pass down to spice
     std::string UTCCalInit;      //!< -- UTC time string for init time
 
+    std::vector<std::string> planetNames{};  //!< -- Vector of the input planet names
     std::vector<std::string>
         planetFrames;  //!< -- Optional vector of planet frame names.  Default values are IAU_ + planet name
-
-    bool timeDataInit;         //!< -- Flag indicating whether time has been init
-    double J2000ETInit;        //!< s Seconds elapsed since J2000 at init
-    double J2000Current;       //!< s Current J2000 elapsed time
-    double julianDateCurrent;  //!< s Current JulianDate
-    double GPSSeconds;         //!< s Current GPS seconds
-    uint16_t GPSWeek;          //!< -- Current GPS week value
-    uint64_t GPSRollovers;     //!< -- Count on the number of GPS rollovers
+    std::string planetWithSecondary{};  //!< -- Optional : planet in the list which will have a secondary body attached
+    SecondaryBody secondaryBody{};      //!< -- Optional : the secondary body
+    bool timeDataInit;                  //!< -- Flag indicating whether time has been init
+    double J2000ETInit;                 //!< s Seconds elapsed since J2000 at init
+    double J2000Current;                //!< s Current J2000 elapsed time
+    double julianDateCurrent;           //!< s Current JulianDate
+    double GPSSeconds;                  //!< s Current GPS seconds
+    uint16_t GPSWeek;                   //!< -- Current GPS week value
+    uint64_t GPSRollovers;              //!< -- Count on the number of GPS rollovers
 
     BSKLogger bskLogger;  //!< -- BSK Logging
 

--- a/src/simulation/environment/spiceInterface/spiceInterface.i
+++ b/src/simulation/environment/spiceInterface/spiceInterface.i
@@ -7,7 +7,13 @@
    #include "spiceInterface.h"
 %}
 
+%include <attribute.i>
+%attributestring(SecondaryBody, std::string, secondaryName, getSecondaryName, setSecondaryName)
+%attribute(SecondaryBody, Eigen::Vector3d, positionOffset, getPositionOffset, setPositionOffset)
+%attribute(SecondaryBody, double, orbitalPeriod, getOrbitalPeriod, setOrbitalPeriod)
+
 %include <architecture/_GeneralModuleFiles/swig_conly_data.i>
+%include <architecture/_GeneralModuleFiles/swig_eigen.i>
 %include <std_string.i>
 %include <std_vector.i>
 

--- a/src/simulation/environment/spiceInterface/spiceInterface.rst
+++ b/src/simulation/environment/spiceInterface/spiceInterface.rst
@@ -33,6 +33,10 @@ provides information on what this message is used for.
     * - planetStateOutMsgs
       - :ref:`SpicePlanetStateMsgPayload`
       - vector of planet state output messages
+    * - secondaryStateOutMsg
+      - :ref:`SpicePlanetStateMsgPayload`
+      - (optional) state output message for a secondary body attached to one of the
+        planets in ``planetStateOutMsgs``
     * - scStateOutMsgs
       - :ref:`SCStatesMsgPayload`
       - vector of spacecraft state messages
@@ -63,3 +67,60 @@ messages in three different formats.
   only prescribe the spacecraft attitude motion.
 - ``transRefStateOutMsgs[]``: these are the translational reference message :ref:`TransRefMsgPayload`.  These are useful to only
   prescribe the translational motion and leave the attitude motion free.
+
+Secondary Body
+^^^^^^^^^^^^^^
+A ``SecondaryBody`` can be attached to one of the celestial bodies in ``planetStateOutMsgs`` to model
+a small companion (for example, the secondary of a binary asteroid).  Each module update writes a
+:ref:`SpicePlanetStateMsgPayload` on ``secondaryStateOutMsg`` whose ``PositionVector`` is the primary's
+SPICE-derived position plus a configurable offset, and whose ``PlanetName`` is set to the secondary's
+name (the primary's planet message is not modified).
+
+Configure a secondary body in python::
+
+    secondary = spiceInterface.SecondaryBody()
+    secondary.secondaryName = "companion"
+    secondary.positionOffset = [1000.0, 2000.0, -3000.0]  # m, in the inertial frame
+    secondary.orbitalPeriod = 11.92 * 3600.0              # s; 0 (default) keeps the offset static
+    spice.setOffsetBody("primaryName", secondary)
+
+When a non-zero ``orbitalPeriod`` ``T`` is set, the secondary moves on a circle of radius
+:math:`|\boldsymbol{r}_{\text{offset}}|` centered on the primary, at angular rate
+:math:`\omega = 2\pi/T`.  The orbit plane has normal
+:math:`\boldsymbol{r}_{\text{offset}} \times (\boldsymbol{r}_{\text{offset}} \times \hat{Z})`,
+which keeps the plane tilted toward the equator (perpendicular to ``Z``) rather than running
+through the poles.  The secondary starts at ``positionOffset`` at :math:`t = 0` and a quarter
+period later passes through a vector that lies in the equatorial (``XY``) plane.  When the
+offset is parallel to ``Z`` the construction degenerates and the orbit plane normal is
+instead :math:`\boldsymbol{r}_{\text{offset}} \times (\boldsymbol{r}_{\text{offset}} \times \hat{X})`.
+With ``orbitalPeriod = 0`` the offset is held constant.
+
+To stop publishing ``secondaryStateOutMsg`` without discarding the configuration, call
+``spice.passivateSecondary()``.  The stored ``SecondaryBody`` is preserved, and a subsequent
+``setOffsetBody()`` call re-activates the output.
+
+Limitations
+"""""""""""
+The secondary body model is a simple kinematic prescription, not a dynamics integration.
+Specifically:
+
+- **Circular orbit only.**  The offset is rotated at a constant angular rate
+  :math:`2\pi/T` about the primary.  There is no eccentricity, perturbation, or
+  two-body integration; supplying an ``orbitalPeriod`` does not solve any
+  equations of motion.
+- **Orbit plane derived from the offset and J2000 Z.**  The plane normal is
+  :math:`\boldsymbol{r}_{\text{offset}} \times (\boldsymbol{r}_{\text{offset}} \times \hat{Z})`
+  (or substitute :math:`\hat{X}` for :math:`\hat{Z}` when offset is parallel to
+  ``Z``); arbitrary user-specified orbital planes are not supported.
+- **Single secondary per ``SpiceInterface`` instance.**  Only one body in
+  ``planetStateOutMsgs`` can have a secondary attached at a time.  A second
+  binary system requires a second ``SpiceInterface`` instance.
+- **Velocity is inherited, not orbital.**  ``secondaryStateOutMsg.VelocityVector``
+  is copied from the primary; it does not include the secondary's
+  :math:`\boldsymbol{\omega}\times\boldsymbol{r}` contribution.  Consumers that
+  need a kinematically consistent velocity must compute it themselves.
+- **Initial phase set by the offset vector.**  At :math:`t = 0` the secondary is
+  located at the configured ``positionOffset``.  To start at a different phase,
+  rotate the offset vector before calling ``setPositionOffset``.
+- **Attitude (J20002Pfix) inherited from the primary.**  No body-frame
+  orientation of the secondary is computed.


### PR DESCRIPTION
* **Tickets addressed:** xmera-1540
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
Add the capability to add a second body to an existing spice body. This is done by defining a secondary body with some simple orbital characteristics and attaching it to a body.

## Verification
Unit tests were added

## Documentation
Updated

## Future work
This change can only add one secondary body to a spice body, it also assumes a perfectly circular orbit with no dynamics (knowledge of the central body mu). It may be desirable to overhaul this capability in the future for more functionality
