### PR TITLE
Make message payload const correct

### DIFF
--- a/docs/source/learn/making-modules/cppModules/module-definition.rst
+++ b/docs/source/learn/making-modules/cppModules/module-definition.rst
@@ -63,7 +63,7 @@ The ``updateState()`` is the method that is called each time the Xmera simulatio
         v3Copy(inMsgBuffer.dataVector, outMsgBuffer.dataVector);
 
         /*! - write the module output message */
-        this->dataOutMsg.write(&outMsgBuffer, this->moduleID, currentSimNanos);
+        this->dataOutMsg.write(outMsgBuffer, this->moduleID, currentSimNanos);
     }
 
 .. warning::

--- a/docs/source/learn/making-modules/messaging/message-objects.rst
+++ b/docs/source/learn/making-modules/messaging/message-objects.rst
@@ -81,13 +81,19 @@ Fill a zero-initialised local buffer and call ``write()``:
 
     SomeMsgPayload buf{};
     buf.dataVector[0] = 1.0;
-    this->someOutMsg.write(&buf, this->moduleID, currentSimNanos);
+    this->someOutMsg.write(buf, this->moduleID, currentSimNanos);
 
 .. note::
 
     Always zero-initialise the output buffer with ``{}`` to avoid writing
     uninitialised values.  A compile-time error is raised if the buffer type
     does not match the message type.
+
+.. note::
+
+    The pointer form ``write(&buf, ...)`` is deprecated and emits a
+    compile-time warning.  Existing module code that uses it still works,
+    but new code should pass the payload by reference as shown above.
 
 Helper Methods
 ^^^^^^^^^^^^^^

--- a/docs/source/learn/making-modules/messaging/overview.rst
+++ b/docs/source/learn/making-modules/messaging/overview.rst
@@ -54,7 +54,7 @@ Message Lifecycle
 
        SomeMsgPayload buf{};
        buf.value = 42.0;
-       this->someOutMsg.write(&buf, this->moduleID, currentSimNanos);
+       this->someOutMsg.write(buf, this->moduleID, currentSimNanos);
 
 4. **Read** -- The consuming module reads the input message by calling the read
    functor:
@@ -96,7 +96,7 @@ Quick Example
 
         ControlCmdPayload cmd{};
         cmd.torque = computeControl(state);
-        this->controlOutMsg.write(&cmd, this->moduleID, currentSimNanos);
+        this->controlOutMsg.write(cmd, this->moduleID, currentSimNanos);
     }
 
 Next Steps

--- a/docs/source/learn/making-modules/modules.rst
+++ b/docs/source/learn/making-modules/modules.rst
@@ -64,5 +64,5 @@ Modules typically use the Xmera messaging system to receive inputs and publish o
         ExampleOutputMsgPayload output = {};
 
         // Compute results using `input`
-        this->outputMsg.write(&output, currentSimNanos);
+        this->outputMsg.write(output, this->moduleID, currentSimNanos);
     }

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -125,12 +125,18 @@ class WriteFunctor {
     WriteFunctor(messageType* payloadPointer, MsgHeader* headerPointer)
         : payloadPointer(payloadPointer), headerPointer(headerPointer) {};
     //! write functor constructor
-    void operator()(messageType* payload, int64_t moduleID, uint64_t callTime) {
-        *this->payloadPointer = *payload;
+    void operator()(const messageType& payload, int64_t moduleID, uint64_t callTime) {
+        *this->payloadPointer = payload;
         this->headerPointer->isWritten = 1;
         this->headerPointer->timeWritten = callTime;
         this->headerPointer->moduleID = moduleID;
     }
+#ifndef SWIG
+    [[deprecated("pass the payload by reference: outMsg.write(payload, moduleID, callTime)")]]
+    void operator()(const messageType* payload, int64_t moduleID, uint64_t callTime) {
+        (*this)(*payload, moduleID, callTime);
+    }
+#endif
 };
 
 /*!


### PR DESCRIPTION
* **Tickets addressed:** #600 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR adds a second C++ `write()` method to message which takes a const reference payload rather than a non const payload pointer. The second commit contains relevant documentation changes.

## Verification
CI runs. Deprecation warning shows.

## Documentation
Documentation is updated to reflect the usage and deprecation.

## Future work
None
