### PR TITLE
Fix pytest collection errors

### DIFF
--- a/examples/scenarioIntegrators.py
+++ b/examples/scenarioIntegrators.py
@@ -313,12 +313,11 @@ def run(show_plots, integratorCase):
     #   plot the results
     #
     np.set_printoptions(precision=16)
-    if integratorCase == "rk4":
-        plt.close("all")  # clears out plots from earlier test runs
 
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
+    plt.close(1)
     plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -33,6 +33,23 @@ def pytest_addoption(parser):
                      help="test(s) shall display plots")
     parser.addoption("--report", action="store_true",  # --report is easier, more controlled than --html=<pathToReport>
                          help="whether or not to gen a pytest-html report. The report is saved in ./tests/report")
+    parser.addoption("--log-worker-tests", action="store",
+                     default=None,
+                     help="Directory to write per-xdist-worker test execution logs (one file per worker). "
+                          "Each line is the test nodeid as it begins. Use to identify which test ran "
+                          "just before a worker crash.")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    log_dir = item.config.getoption("--log-worker-tests")
+    if not log_dir:
+        return
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    os.makedirs(log_dir, exist_ok=True)
+    with open(os.path.join(log_dir, f"worker-{worker}.log"), "a") as f:
+        f.write(item.nodeid + "\n")
+        f.flush()
 
 
 @pytest.fixture(scope="module")

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -11,6 +11,13 @@ import sys
 
 import pytest
 
+
+def pytest_collectstart(collector):
+    if isinstance(collector, pytest.Module):
+        directory = str(collector.path.parent)
+        if directory not in sys.path:
+            sys.path.insert(0, directory)
+
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 print(path)

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/test_thrForceMapping.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/test_thrForceMapping.py
@@ -8,7 +8,7 @@ import pytest
 from xmera.architecture import messaging
 from xmera.fswAlgorithms import thrForceMapping
 from xmera.utilities import (macros, fswSetupThrusters, SimulationBaseClass)
-from .Support.thruster_force_mapping_test_oracle import ThrForceMappingTestOracle
+from Support.thruster_force_mapping_test_oracle import ThrForceMappingTestOracle
 
 
 @pytest.mark.parametrize("useDVThruster", [True, False])

--- a/src/fswAlgorithms/orbitControl/lambertSolver/_UnitTest/test_lambertSolver.py
+++ b/src/fswAlgorithms/orbitControl/lambertSolver/_UnitTest/test_lambertSolver.py
@@ -12,7 +12,7 @@ from xmera.utilities import SimulationBaseClass
 from xmera.utilities import macros
 from xmera.utilities import orbitalMotion
 
-from fswAlgorithms.orbitControl.lambertSolver._UnitTest.Support.IzzoLambert import *
+from Support.IzzoLambert import *
 
 # parameters
 solver = ["Gooding", "Izzo"]

--- a/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/_UnitTest/test_lambertSurfaceRelativeVelocity.py
+++ b/src/fswAlgorithms/orbitControl/lambertSurfaceRelativeVelocity/_UnitTest/test_lambertSurfaceRelativeVelocity.py
@@ -18,7 +18,7 @@ relativeVelocities = np.array([[0., 0., 0.], [100., -300., 200.]])
 time_maneuver = [1.e3, 2.e3]
 trueAnomalies = [0., 70.]
 rotAngles = [0., 230.]
-angularVelocities = np.array([[0., 0., 0.], [1., -3., 2.]])
+angularVelocities = np.array([[1., -3., 2.]])
 
 paramArray = [relativeVelocities, time_maneuver, trueAnomalies, rotAngles, angularVelocities]
 # create list with all combinations of parameters

--- a/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/_UnitTest/test_cameraTriangulation.py
+++ b/src/fswAlgorithms/pointCloudProcessing/cameraTriangulation/_UnitTest/test_cameraTriangulation.py
@@ -257,9 +257,11 @@ def computeTriangulationCovariance(pointCloud, imagePoints, cameraCalibrationMat
         dij = pj - pi
         ai = dcm_FC.dot(Kinv).dot(uiBar)
         aj = dcm_FCj.dot(Kinv).dot(ujBar)
-        gamma = np.linalg.norm(np.cross(dij, aj))/np.linalg.norm(np.cross(ai, aj))
-        if np.linalg.norm(np.cross(ai, aj)) < 1e-10:
+        normCrossAiAj = np.linalg.norm(np.cross(ai, aj))
+        if normCrossAiAj < 1e-10:
             gamma = 0
+        else:
+            gamma = np.linalg.norm(np.cross(dij, aj))/normCrossAiAj
         Re = -gamma**2 * xiBarTilde.dot(Rx).dot(xiBarTilde)
         covarianceSumTerm += dcm_FC.dot(xiBarTilde).dot(Re).dot(xiBarTilde).dot(dcm_CF)
 

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
@@ -115,8 +115,7 @@ def smallBodyNavEKFTestFunction(show_plots):
         true_x_hat, np.array([x_hat[-1,:]]), 0.1, "x_hat",
         testFailCount, testMessages)
 
-    plt.figure(1)
-    plt.clf()
+    plt.close(1)
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.ticklabel_format(useOffset=False)
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,0], label='x-pos')
@@ -127,8 +126,7 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('r_BO_O (m)')
     plt.title('Estimated Relative Spacecraft Position')
 
-    plt.figure(2)
-    plt.clf()
+    plt.close(2)
     plt.figure(2, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,3], label='x-vel')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,4], label='y-vel')
@@ -138,8 +136,7 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('v_BO_O (m/s)')
     plt.title('Estimated Spacecraft Velocity')
 
-    plt.figure(5)
-    plt.clf()
+    plt.close(5)
     plt.figure(5, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,6], label='s1')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,7], label='s2')
@@ -149,8 +146,7 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('sigma_AN (rad)')
     plt.title('Estimated Asteroid Attitude')
 
-    plt.figure(6)
-    plt.clf()
+    plt.close(6)
     plt.figure(6, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,9], label='omega1')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,10], label='omega2')

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/_UnitTest/test_smallBodyNavUKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/_UnitTest/test_smallBodyNavUKF.py
@@ -113,8 +113,7 @@ def smallBodyNavUKFTestFunction(show_plots):
         [true_x_hat], np.array([x_hat[-1,:]]), 0.01, "x_hat",
         testFailCount, testMessages)
 
-    plt.figure(1)
-    plt.clf()
+    plt.close(1)
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.ticklabel_format(useOffset=False)
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,0] / 1000, label='x-pos')
@@ -125,8 +124,7 @@ def smallBodyNavUKFTestFunction(show_plots):
     plt.ylabel('${}^{A}r_{BA}$ (km)')
     plt.title('Estimated Relative Spacecraft Position')
 
-    plt.figure(2)
-    plt.clf()
+    plt.close(2)
     plt.figure(2, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,3], label='x-vel')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,4], label='y-vel')
@@ -136,8 +134,7 @@ def smallBodyNavUKFTestFunction(show_plots):
     plt.ylabel('${}^{A}v_{BA}$ (m/s)')
     plt.title('Estimated Spacecraft Velocity')
 
-    plt.figure(3)
-    plt.clf()
+    plt.close(3)
     plt.figure(3, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,6], label='x-acc')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,7], label='y-acc')

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,5 +1,6 @@
 # content of pytest.ini
 [pytest]
+addopts = --import-mode=importlib
 markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -3,3 +3,5 @@
 markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.
+filterwarnings =
+    ignore::FutureWarning:dask.dataframe

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/_UnitTest/test_orb_elem_convert.py
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/_UnitTest/test_orb_elem_convert.py
@@ -490,8 +490,8 @@ def orbElem(a, e, i, AN, AP, f, mu, name, DispPlot):
     # txt = 'e = ' + str(e) + ' and a = ' + str(a) + 'km'
     fact = (len(str(abs(a)))-3.0)
 
+    plt.close(1)
     plt.figure(1,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.clf()
     # fig1.text(.5, .05, txt, ha='center')
     ax1 = plt.subplot(211)
     ax1.cla()

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
@@ -190,12 +190,11 @@ def run(doUnitTests, show_plots, integratorCase):
     #
     np.set_printoptions(precision=16)
     fileNameString = filename[len(path) + 6:-3]
-    if integratorCase == "rk4":
-        plt.close("all")  # clears out plots from earlier test runs
 
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
+    plt.close(1)
     plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet

--- a/src/simulation/navigation/planetNav/_UnitTest/test_planetNav.py
+++ b/src/simulation/navigation/planetNav/_UnitTest/test_planetNav.py
@@ -185,8 +185,7 @@ def planetNavTestFunction(show_plots):
             testFailCount += 1
             testMessages.append("FAILED: Too few error counts - " + str(count))
 
-    plt.figure(1)
-    plt.clf()
+    plt.close(1)
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, r_BN_N[:,0], label='x-position')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, r_BN_N[:,1], label='y-position')
@@ -196,8 +195,7 @@ def planetNavTestFunction(show_plots):
     plt.xlabel('Time (s)')
     plt.ylabel('Position (m)')
 
-    plt.figure(2)
-    plt.clf()
+    plt.close(2)
     plt.figure(2, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, v_BN_N[:,0], label='x-velocity')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, v_BN_N[:,1], label='y-velocity')
@@ -207,8 +205,7 @@ def planetNavTestFunction(show_plots):
     plt.xlabel('Time (s)')
     plt.ylabel('Velocity (m/s)')
 
-    plt.figure(3)
-    plt.clf()
+    plt.close(3)
     plt.figure(3, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, sigma_BN[:, 0], label='x-rotation')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, sigma_BN[:, 1], label='y-rotation')
@@ -218,8 +215,7 @@ def planetNavTestFunction(show_plots):
     plt.xlabel('Time (s)')
     plt.ylabel('Attitude (rad)')
 
-    plt.figure(4)
-    plt.clf()
+    plt.close(4)
     plt.figure(4, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, omega_BN_B[:, 0], label='x-angular vel.')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, omega_BN_B[:, 1], label='y-angular vel.')

--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
@@ -248,8 +248,8 @@ def run(show_plots, useConstellation, visibilityFactor, fov, kelly, scaleFactor,
         constellationP1data = dataLogP1.CosValue
         constellationP2data = dataLogP2.CosValue
 
+        plt.close(1)
         plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-        plt.clf()
         plt.subplot(2, 1, 1)
         for i in range(4):
             sensorlabel = "cssP1" + str(i + 1)
@@ -279,6 +279,7 @@ def run(show_plots, useConstellation, visibilityFactor, fov, kelly, scaleFactor,
     else:
         justTheNoise = cssOutput - truthVector  # subtract curve from noisy curve
         outputStd = np.std(justTheNoise)
+        plt.close(3)
         plt.figure(3, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
         plt.plot(dataLogSingle.times() * macros.NANO2MIN, cssOutput, label=name, zorder=zLevel, linewidth=lineWide)
         plt.legend()

--- a/src/simulation/sensors/imuSensor/_UnitTest/test_imu_sensor.py
+++ b/src/simulation/sensors/imuSensor/_UnitTest/test_imu_sensor.py
@@ -328,8 +328,8 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
 
     # truth/output comparison plots and AutoTex output
     time = dataLog.times()/1e9
+    plt.close(1)
     plt.figure(1,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.clf()
     plt.plot(time, DRout[0:,0], linewidth = 6, color = 'black', label = "output1")
     plt.plot(time, stepPRV_PN[:,0], linestyle = '--', color = 'cyan', label = "truth1")
     plt.plot(time, DRout[0:,1], linewidth = 4, color = 'black', label = "output2")
@@ -344,8 +344,8 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     unitTestSupport.writeFigureLaTeX(testCase + "PRVcomparison",
                                      'Plot Comparing Time Step PRV Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the principal rotation vector.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
+    plt.close(4)
     plt.figure(4,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.clf()
     plt.plot(time, omegaOut[:,0], linewidth = 6, color = 'black', label = "output1")
     plt.plot(time, omega_PN_P[:,0], linestyle = '--', color = 'cyan', label = "truth1")
     plt.plot(time, omegaOut[:,1], linewidth = 4, color = 'black', label = "output2")
@@ -360,8 +360,8 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     unitTestSupport.writeFigureLaTeX(testCase + "omegaComparison",
                                      'Plot Comparing Angular Rate Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the angular rate.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
+    plt.close(7)
     plt.figure(7,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.clf()
     plt.plot(time, rDotDotOut[:,0], linewidth = 6, color = 'black', label = "output1")
     plt.plot(time, rDotDot_SN_P[:,0], linestyle = '--', color = 'cyan', label = "truth1")
     plt.plot(time, rDotDotOut[:,1], linewidth = 4, color = 'black', label = "output2")
@@ -377,8 +377,8 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
                                      'Plot Comparing Sensor Linear Accelertaion Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the acceleration.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
 
+    plt.close(10)
     plt.figure(10,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.clf()
     plt.plot(time, DVout[:,0], linewidth = 6, color = 'black', label = "output1")
     plt.plot(time, DVAccum_SN_P[:,0], linestyle = '--', color = 'cyan', label = "truth1")
     plt.plot(time, DVout[:,1], linewidth = 4, color = 'black', label = "output2")

--- a/src/simulation/sensors/simpleVoltEstimator/_UnitTest/test_simpleVoltEstimator.py
+++ b/src/simulation/sensors/simpleVoltEstimator/_UnitTest/test_simpleVoltEstimator.py
@@ -109,8 +109,7 @@ def unitSimpleVoltEstimator(show_plots):
             testFailCount += 1
             testMessages.append("FAILED: Too few error counts - " + str(count))
 
-    plt.figure(1)
-    plt.clf()
+    plt.close(1)
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(dataVoltLog.times() * 1.0E-9, volt[:])
 


### PR DESCRIPTION
* **Tickets addressed:** #602 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Switch pytest to `--import-mode=importlib` so test modules no longer require package-style `__init__.py` files.

This PR also resolves a range of pytest warnings summary from the test suite;
- `simpleVoltEstimator`, `coarseSunSensor`, `imuSensor`, `orbElemConvert`, `Integrators`, `scenarioIntegrators`.
- Import mode: added `pytest_collectstart` hook that puts each test module's directory on sys.path; converted `test_thrForceMapping.py` and `test_lambertSolver.py` to Support.X imports; adjusted pytest.ini to `--import-mode=importlib`.

## Verification
Successful CI and absence of pytest warnings.

## Documentation
NA

## Future work
None
