### PR TITLE
Add tie break to region of interest Prune

### DIFF
--- a/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPruneAlgorithm.cpp
+++ b/src/fswAlgorithms/imageProcessing/regionsOfInterestPrune/regionsOfInterestPruneAlgorithm.cpp
@@ -95,13 +95,17 @@ std::vector<RoiCandidateEntry> RegionsOfInterestPruneAlgorithm::buildCandidates(
     return candidates;
 }
 
-/*! Sorts candidates by estimated pixel count (descending), truncates to ROI_CANDIDATES_MAX,
+/*! Sorts candidates by estimated pixel count (descending), use window area for tie break, truncates to
+ ROI_CANDIDATES_MAX,
  *  and packs the result into a RoiCandidates ready for publication.
  @return RoiCandidates with numCandidates set and candidates[0] = rank-1.
  @param candidates  Unsorted candidate list (taken by value; sorted in-place).
 */
 RoiCandidates RegionsOfInterestPruneAlgorithm::packOutput(std::vector<RoiCandidateEntry> candidates) {
-    std::ranges::sort(candidates, std::greater{}, &RoiCandidateEntry::count);
+    std::ranges::sort(candidates, [](const RoiCandidateEntry& a, const RoiCandidateEntry& b) {
+        if (a.count != b.count) return a.count > b.count;
+        return a.height * a.width < b.height * b.width;
+    });
     if (candidates.size() > ROI_CANDIDATES_MAX) candidates.resize(ROI_CANDIDATES_MAX);
 
     RoiCandidates outRoi{};


### PR DESCRIPTION
* **Tickets addressed:** xmera-2249
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
Add tie break to region of interest prune module. If two regions have the same bright pixel counts, use the window area of each region for tie break. The smaller the window area, the more priority of this region. This tie break preserves the correctness of the rank-1 region, and is mainly used to identify the rank-2 region.

## Verification
Pass unit test and the behavior of the ema-gnc scenario_talons_flyby is as expected.

## Documentation
N/A

## Future work
N/A
