### PR TITLE
Feature/2154 stepper motor update

### DIFF
--- a/src/architecture/msgPayloadDef/MotorStepCommandMsgPayload.h
+++ b/src/architecture/msgPayloadDef/MotorStepCommandMsgPayload.h
@@ -5,9 +5,10 @@
 #ifndef motorStepCommandSimMsg_h
 #define motorStepCommandSimMsg_h
 
-/*! @brief Structure containing number of commanded stepper motor steps */
+/*! @brief Structure containing the stepper motor step command */
 typedef struct {
-    int stepsCommanded;  //!< Number of commanded stepper motor steps
+    int stepsCommanded;     //!< Number of commanded stepper motor steps (ignored when stopMotorCommand is true)
+    bool stopMotorCommand;  //!< If true, request the motor to halt after completing the current step
 } MotorStepCommandMsgPayload;
 
 #endif /* motorStepCommandSimMsg_h */

--- a/src/architecture/msgPayloadDef/StepperMotorMsgPayload.h
+++ b/src/architecture/msgPayloadDef/StepperMotorMsgPayload.h
@@ -11,7 +11,8 @@ typedef struct {
     double thetaDot;     //!< [rad/s] Current motor angle rate
     double thetaDDot;    //!< [rad/s^2] Current motor angular acceleration
     int stepsCommanded;  //!< Current number of commanded motor steps
-    int stepCount;       //!< Current motor step count (number of steps taken)
+    int stepCount;       //!< Current motor step count within the active command (resets to 0 at each new command)
+    int motorPosition;   //!< [steps] Absolute motor position; cumulative net signed step count, never reset
     bool isMotorMoving;  //!< indicator whether the motor is moving
 } StepperMotorMsgPayload;
 

--- a/src/architecture/msgPayloadDef/StepperMotorMsgPayload.h
+++ b/src/architecture/msgPayloadDef/StepperMotorMsgPayload.h
@@ -12,6 +12,7 @@ typedef struct {
     double thetaDDot;    //!< [rad/s^2] Current motor angular acceleration
     int stepsCommanded;  //!< Current number of commanded motor steps
     int stepCount;       //!< Current motor step count (number of steps taken)
+    bool isMotorMoving;  //!< indicator whether the motor is moving
 } StepperMotorMsgPayload;
 
 #endif /* stepperMotorSimMsg_h */

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
@@ -63,12 +63,14 @@ void StepperMotor::updateState(uint64_t callTime) {
 
     // Actuate the motor only if a current actuation segment is not complete
     double t = callTime * NANO2SEC;
+    bool isMotorMoving = false;
     if (!(this->actuationComplete)) {
         // Reset the motor immediately after a new non-interrupting request is received
         if ((this->newMsg && !this->interruptMsg) || (this->interruptMsg && this->stepComplete)) {
             this->resetMotor();
         }
         this->actuateMotor(t);
+        isMotorMoving = true;
     } else {
         this->tInit = t;
         this->thetaDDot = 0.0;
@@ -81,6 +83,7 @@ void StepperMotor::updateState(uint64_t callTime) {
     stepperMotorOut.thetaDDot = this->thetaDDot;
     stepperMotorOut.stepsCommanded = this->stepsCommanded;
     stepperMotorOut.stepCount = this->stepCount;
+    stepperMotorOut.isMotorMoving = isMotorMoving;
     this->stepperMotorOutMsg.write(&stepperMotorOut, moduleID, callTime);
 }
 

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
@@ -184,7 +184,10 @@ void StepperMotor::computeStepComplete(double t) {
     this->stepComplete = true;
     this->thetaDot = 0.0;
     this->theta = this->intermediateThetaRef;
-    this->tInit = t;
+    // Anchor to tf rather than t so the (t - tf) residual carries into the next step;
+    // otherwise, when the dynamics tick doesn't divide stepTime, that residual is lost
+    // each step and the long-run motor rate falls below 1/stepTime.
+    this->tInit = this->tf;
 
     // Update the motor step count
     if (this->intermediateThetaRef > this->intermediateThetaInit) {

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
@@ -19,6 +19,8 @@ void StepperMotor::reset(uint64_t callTime) {
     this->thetaDDot = 0.0;
     this->tInit = 0.0;
     this->stepCount = 0;
+    // Absolute motor position from theta=0 (so motorPosition * stepAngle ≈ theta).
+    this->motorPosition = static_cast<int>(std::round(this->thetaInit / this->stepAngle));
     this->previousWrittenTime = -1;
     this->actuationComplete = true;
     this->stepComplete = true;
@@ -83,6 +85,7 @@ void StepperMotor::updateState(uint64_t callTime) {
     stepperMotorOut.thetaDDot = this->thetaDDot;
     stepperMotorOut.stepsCommanded = this->stepsCommanded;
     stepperMotorOut.stepCount = this->stepCount;
+    stepperMotorOut.motorPosition = this->motorPosition;
     stepperMotorOut.isMotorMoving = isMotorMoving;
     this->stepperMotorOutMsg.write(&stepperMotorOut, moduleID, callTime);
 }
@@ -195,8 +198,10 @@ void StepperMotor::computeStepComplete(double t) {
     // Update the motor step count
     if (this->intermediateThetaRef > this->intermediateThetaInit) {
         this->stepCount++;
+        this->motorPosition++;
     } else {
         this->stepCount--;
+        this->motorPosition--;
     }
 
     // Update the actuationComplete boolean variable only when motor actuation is complete

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.cpp
@@ -26,6 +26,7 @@ void StepperMotor::reset(uint64_t callTime) {
     this->stepComplete = true;
     this->newMsg = false;
     this->interruptMsg = false;
+    this->pendingStop = false;
 
     // Set motor maximum angular acceleration
     this->thetaDDotMax = this->stepAngle / (0.25 * this->stepTime * this->stepTime);  // [rad/s^2]
@@ -42,23 +43,33 @@ void StepperMotor::updateState(uint64_t callTime) {
     // Read the input message
     if (this->motorStepCommandInMsg.isWritten()) {
         motorStepCommandIn = this->motorStepCommandInMsg();
-        // Store the number of commanded motor steps when a new message is written
+        // Process a new command message
         if (this->previousWrittenTime < this->motorStepCommandInMsg.timeWritten()) {
-            this->stepsCommanded = motorStepCommandIn.stepsCommanded;
             this->previousWrittenTime = this->motorStepCommandInMsg.timeWritten();
 
-            // Update booleans
-            this->newMsg = true;
-            if (this->actuationComplete) {
-                this->interruptMsg = false;
+            if (motorStepCommandIn.stopMotorCommand) {
+                // Honor the stop only if the motor is currently actuating; the current step is
+                // allowed to finish before halting (motor cannot physically stop mid-step).
+                if (!this->actuationComplete) {
+                    this->pendingStop = true;
+                }
             } else {
-                this->interruptMsg = true;
-            }
-            if (this->stepsCommanded == 0) {
-                this->actuationComplete = true;
-                this->stepCount = 0;
-            } else {
-                this->actuationComplete = false;
+                this->stepsCommanded = motorStepCommandIn.stepsCommanded;
+                this->pendingStop = false;
+
+                // Update booleans
+                this->newMsg = true;
+                if (this->actuationComplete) {
+                    this->interruptMsg = false;
+                } else {
+                    this->interruptMsg = true;
+                }
+                if (this->stepsCommanded == 0) {
+                    this->actuationComplete = true;
+                    this->stepCount = 0;
+                } else {
+                    this->actuationComplete = false;
+                }
             }
         }
     }
@@ -97,6 +108,15 @@ void StepperMotor::updateState(uint64_t callTime) {
 void StepperMotor::actuateMotor(double t) {
     // Update the motor step parameters when a step is completed
     if (this->stepComplete) {
+        // If a stop was requested, halt at the step boundary instead of starting a new step.
+        if (this->pendingStop) {
+            this->actuationComplete = true;
+            this->pendingStop = false;
+            this->stepsCommanded = this->stepCount;
+            this->thetaDot = 0.0;
+            this->thetaDDot = 0.0;
+            return;
+        }
         this->updateStepParameters();
     }
 

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.h
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.h
@@ -47,7 +47,8 @@ class StepperMotor : public SysModel {
     double stepAngle;    //!< [rad] Angle the stepper motor moves through for a single step (constant)
     double stepTime;     //!< [s] Time required for a single motor step (constant)
     int stepsCommanded;  //!< [steps] Number of commanded steps
-    int stepCount;       //!< [steps] Current motor step count (number of steps taken)
+    int stepCount;  //!< [steps] Current motor step count within the active command (resets to 0 at each new command)
+    int motorPosition;  //!< [steps] Absolute motor position; cumulative net signed step count, never reset
 
     /* Motor angle parameters */
     double thetaInit;              //!< [rad] Initial motor angle

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.h
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.h
@@ -70,6 +70,7 @@ class StepperMotor : public SysModel {
     bool stepComplete;       //!< Boolean designating the completion of a step
     bool newMsg;             //!< Boolean designating a new command message is written
     bool interruptMsg;       //!< Boolean designating the new command message is interrupting motor actuation
+    bool pendingStop;        //!< Boolean designating a stop command was received; halt after the current step completes
 
     /* Constant parameters */
     double a;  //!< Parabolic constant for the first half of a step

--- a/src/simulation/dynamics/stepperMotor/stepperMotor.rst
+++ b/src/simulation/dynamics/stepperMotor/stepperMotor.rst
@@ -2,35 +2,25 @@
 Stepper Motor
 =============
 
-.. list-table::
-   :widths: 5 40 10 10
-   :header-rows: 0
-
-   * - **Rev**
-     - **Change Description**
-     - **By**
-     - **Date**
-   * - 1.0
-     - Initial Draft
-     - L. Kiner
-     - 20250820
-
-
-==================
-Module Description
-==================
-
 Introduction
 ------------
 The stepper motor module simulates the actuation of a stepper motor. Given the initial motor angle :math:`\theta_0`, a
 fixed motor step angle :math:`\Delta\theta`, a fixed motor step time :math:`\Delta t`, and an input message containing
 an integer number of steps commanded, the motor states are computed at each time step and output from the module.
 The motor states include the scalar motor angle :math:`\theta`, scalar angle rate :math:`\dot{\theta}`, scalar angular
-acceleration :math:`\ddot{\theta}`, the current motor step count :math:`c_s`, and the number of steps commanded to the
-motor :math:`n_s`. The motor actuation through each step of the command sequence is profiled using a bang-bang
-acceleration profile. This module also includes logic for handling incoming reference commands that interrupt an
-unfinished motor actuation sequence. Because the stepper motor is unable to stop actuating during a step, it must
-finish actuating through the current step before it can begin following a new reference command.
+acceleration :math:`\ddot{\theta}`, the current motor step count :math:`c_s` (within the active command, reset on each
+new non-interrupting command), the absolute motor position :math:`p_s` in steps (cumulative net signed step count,
+never reset; ``motorPosition`` in the output payload, with ``motorPosition * stepAngle`` ≈ :math:`\theta`), the number
+of steps commanded to the motor :math:`n_s`, and a boolean ``isMotorMoving`` flag that is true while the motor is
+actively actuating through a command and false when no actuation is in progress. The motor actuation through each
+step of the command sequence is profiled using a bang-bang acceleration profile.
+
+The module supports two types of incoming commands. A standard step command (``stopMotorCommand = false``) sets the
+number of steps to actuate; if the motor is already moving, the new command interrupts the current actuation and the
+motor finishes the current step before beginning to follow the new command. A stop command (``stopMotorCommand =
+true``) halts the motor after the current step completes; because a stepper motor cannot stop actuating mid-step, the
+motor reports ``isMotorMoving = true`` until the in-progress step finishes, then transitions to ``isMotorMoving =
+false`` at a step-aligned angle.
 
 Module Input/Output Messages
 ============================
@@ -45,7 +35,8 @@ The following table lists the module input and output messages.
       - Description
     * - motorStepCommandInMsg
       - :ref:`MotorStepCommandMsgPayload`
-      - Input message containing the number of commanded motor steps
+      - Input message containing the number of commanded motor steps (``stepsCommanded``) and a stop-request flag
+        (``stopMotorCommand``). When ``stopMotorCommand`` is true the motor halts after completing its current step.
     * - stepperMotorOutMsg
       - :ref:`StepperMotorMsgPayload`
       - Output message containing the stepper motor states
@@ -123,7 +114,11 @@ profile. The equations used to profile each motor step are
     \end{cases}
 
 Note that the parameters :math:`t_0, t_s` and :math:`t_f` must be continually updated after each step is complete to
-reflect the advancement of time. Doing so enables use of the above equations for each motor step.
+reflect the advancement of time. Doing so enables use of the above equations for each motor step. Specifically,
+:math:`t_0` for the next step is anchored to the previous step's :math:`t_f` (rather than to the current sample time at
+which the step-complete event is detected). This preserves the long-run motor rate of :math:`1 / \Delta t` when the
+module update period does not divide :math:`\Delta t` evenly; otherwise the residual :math:`(t - t_f)` would be lost at
+each step boundary and the effective step rate would drop below :math:`1 / \Delta t`.
 
 .. important::
     If the motor actuation is interrupted by a new reference message while actuating through a step,
@@ -131,59 +126,88 @@ reflect the advancement of time. Doing so enables use of the above equations for
     If the interrupting message is written when the motor is not in the midst of a step, the module resets the motor
     step count and immediately begins actuating to follow the new reference command.
 
+Stop Command Handling
+=====================
+When an input message arrives with ``stopMotorCommand = true``, the module sets an internal ``pendingStop`` flag
+instead of immediately resetting the actuation. The stop is then honored at the next step-boundary:
+
+    - If the motor is **mid-step** when the stop arrives, the in-progress step runs to completion through the normal
+      bang-bang profile. At the step boundary the module sets ``actuationComplete = true``, zeroes :math:`\dot\theta`
+      and :math:`\ddot\theta`, and reports ``isMotorMoving = false`` on the next tick.
+    - If the motor is **between steps** (``stepComplete = true``) when the stop is honored, the module halts before
+      starting the next step.
+    - If the motor is **already idle** (``actuationComplete = true``) when the stop arrives, the stop is a no-op —
+      ``pendingStop`` is not set.
+    - If a fresh non-stop command arrives before a pending stop is honored, ``pendingStop`` is cleared and the new
+      command is processed normally (interrupting the current actuation if applicable).
+
+Because the stop halts at a step boundary, :math:`\theta` lands on an integer multiple of :math:`\Delta\theta` from the
+origin, ``motorPosition`` remains consistent with :math:`\theta` (``motorPosition * stepAngle`` ≈ :math:`\theta`), and
+the algorithm consuming ``isMotorMoving`` sees the motor as settled only when it is physically at rest.
+
 Module Functions
 ================
 Below is a list of functions that this simulation module performs
 
-    - Reads the incoming motor step command message
-    - Computes the motor states as a function of time
+    - Reads the incoming motor step command message (``stepsCommanded`` and ``stopMotorCommand``)
+    - Computes the motor states as a function of time using a bang-bang acceleration profile
+    - Tracks the absolute motor position (``motorPosition``) across commands
     - Writes the motor states to the module output message
     - Handles interruptions to motor actuation by resetting the motor actuation after the current step is complete
+    - Honors stop commands by halting after the current step completes, preserving step-aligned :math:`\theta` and
+      consistent ``motorPosition``
 
 Module Assumptions and Limitations
 ==================================
     - The motor step angle and step time are fixed parameters (Cannot be negative)
     - The motor cannot stop actuating in the middle of a step
     - When the motor actuation is interrupted by a new reference command, the motor must complete its actuation through the current step before following the new command
+    - Stop commands are likewise honored only at the next step boundary
     - The module update rate must be faster than or equal to the provided motor step time :math:`\Delta t`
     - The module update rate cannot be slower than the motor step rate, or the motor actuation cannot be resolved
 
 Test Description and Success Criteria
 =====================================
-There are two tests for this module. The tests are located in ``simulation/dynamics/stepperMotor/_UnitTest/test_stepperMotor.py``
-The first test is a nominal test named ``test_stepper_motor_nominal``. The second test named
-``test_stepper_motor_interrupt`` tests the module logic for commands interrupting the motor actuation. Both tests
-configure two actuation commands. The nominal test separates the actuation commands by a rest period of 5 seconds. The
-interruption test interrupts the first command sequence after half of the commanded motor steps are completed. The
-time the second command message is written is determined using an interruption factor to specify what fraction of the
-next step is completed before the second command message is written. Both tests add 5 seconds to the end of each
-simulation for clarity when viewing the generated plots.
-
-The success criteria for all tests is that the motor states converge to the computed reference values in the test at
-the end of each actuation sequence. Specifically, the motor angle, rate, acceleration, and step count are checked to
-converge to the reference values at the end of each simulation chunk. The motor rate and acceleration are checked to
-be zero at the end of each actuation sequence. Note that the motor acceleration is checked at one time step after the
-other motor states are checked because the motor acceleration is nonzero at the completion of each motor step. The motor
-acceleration is not zero until after the motor step is complete. This differs from the motor rate profile, which
-is zero at the completion of each motor step.
+The unit tests for this module live in ``simulation/dynamics/stepperMotor/_UnitTest/test_stepperMotor.py``. The common
+success criterion across all tests is that the motor states converge to independently computed reference values at
+the end of each actuation sequence. Specifically, the motor angle, rate, acceleration, and step count are checked
+to converge to the reference values at the end of each simulation chunk. The motor rate is zero at the completion of
+each motor step, while the motor acceleration is nonzero at the instant of step completion and is therefore checked
+one time step later, after the acceleration has been cleared.
 
 Nominal Test
 ------------
-The nominal unit test configures two actuation command segments with a rest period of 5 seconds between the commands.
-A rest period of 5 seconds is also added to the end of the simulation for clarity when viewing the generated plots.
-The initial motor angle, motor step angle, step time, and steps commanded for each actuation sequence are varied so
-that the motor actuates both forwards and backwards during the test. Zero steps commanded are also included in the
-test to check that the module correctly updates the motor states for a zero command message. The motor angle, rate,
-acceleration, and step count are checked to converge to the reference values at the end of each simulation chunk.
+``test_stepper_motor_nominal`` configures two actuation command segments separated by a 5-second rest period, with a
+trailing 5-second rest for plot clarity. The initial motor angle, motor step angle, step time, and steps commanded
+for each actuation sequence are varied so that the motor actuates both forwards and backwards. A zero-step command
+is also exercised to verify the module correctly handles a no-op command.
 
 Interruption Test
 -----------------
-The interruption unit test ensures that the module correctly handles reference messages that interrupt an unfinished
-motor actuation sequence. The initial motor angle, motor step angle, and step time are not varied in the interruption
-test because these parameters were already varied in the nominal test. The interruption test interrupts the first
-command sequence after half of the commanded motor steps are completed. The time the second command message is
-written is determined using an interruption factor to specify what fraction of the next step is completed before the
-second command message is written. Interruption factors of 0 and 1 are also included to ensure the module correctly
-resets the motor states when the interruption falls precisely when a step is completed. A rest period of 5 seconds is
-added to the end of the simulation for clarity when viewing the generated plots. The motor angle, rate,
-acceleration, and step count are checked to converge to the reference values at the end of each simulation chunk.
+``test_stepper_motor_interrupt`` verifies that the module correctly handles reference messages that interrupt an
+unfinished motor actuation sequence. The first command is interrupted after half of its commanded steps have been
+completed. The time the second command message is written is parameterized by an interruption factor specifying what
+fraction of the next step has completed before the interrupt arrives. Interruption factors of 0 and 1 are included
+to ensure the module correctly resets when the interrupt falls precisely on a step boundary. A 5-second trailing
+rest is added for plot clarity.
+
+Timestep Overshoot Test
+-----------------------
+``test_stepper_motor_timestep_overshoot`` verifies the motor correctly completes actuation when the simulation
+timestep does not divide evenly into the motor step time. In this scenario the simulation time overshoots the step
+completion time :math:`t_f`. The test guards against a regression in which the leftover :math:`(t - t_f)` residual
+was dropped at each step boundary, causing the motor to either never reach step-complete or to fall behind the
+expected step rate of :math:`1 / \Delta t`.
+
+Single-Step Edge Case Test
+--------------------------
+``test_stepper_motor_single_step`` verifies the motor correctly actuates for a single-step command in both forward
+(``stepsCommanded = +1``) and backward (``stepsCommanded = -1``) directions — an edge case where the motor must
+complete exactly one step and immediately come to rest.
+
+Rapid Command Interruption Test
+-------------------------------
+``test_stepper_motor_rapid_commands`` verifies the module's behavior under multiple back-to-back command interrupts.
+Three commands are sent in rapid succession, each interrupting the previous after only 2 steps have completed. The
+test checks that the motor angle, rate, and step count converge to the expected values after the final command
+completes.


### PR DESCRIPTION
* **Tickets addressed:** xmera-2154
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
Updates `stepperMotor` so it stays consistent with `stepperMotorController` under
  interrupts and stop commands, and exposes absolute position + motion status on its
  output.

  Five commits, intended to be reviewed in order:
  
  1. Anchor each step's `tInit` to the previous step's `tf` so the motor rate doesn't
     drift when the update period doesn't divide `stepTime` evenly.
  2. Add `isMotorMoving` to the output message.
  3. Add `motorPosition` (cumulative net signed step count, never reset) to the output
     message.
  4. Add `stopMotorCommand` to `MotorStepCommandMsgPayload`; when set, halt at the next
     step boundary via a `pendingStop` flag.
  5. Refresh `stepperMotor.rst`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->
All tests still pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->
Documentation updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None
