### PR TITLE
Close matplotlib figures after each test to avoid figure-reuse warnings

### DIFF
--- a/examples/scenarioIntegrators.py
+++ b/examples/scenarioIntegrators.py
@@ -319,7 +319,12 @@ def run(show_plots, integratorCase):
     # draw orbit in perifocal frame
     b = oe.a * np.sqrt(1 - oe.e * oe.e)
     p = oe.a * (1 - oe.e * oe.e)
-    plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
+    # Each integrator case overlays onto the same figure 1; size it only on creation so
+    # later cases don't re-pass figsize (which matplotlib ignores with a warning).
+    if not plt.fignum_exists(1):
+        plt.figure(1, figsize=tuple(np.array((1.0, b / oe.a)) * 4.75), dpi=100)
+    else:
+        plt.figure(1)
     plt.axis(np.array([-oe.rApoap, oe.rPeriap, -b, b]) / 1000 * 1.25)
     # draw the planet
     fig = plt.gcf()

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -33,6 +33,22 @@ def show_plots(request):
     return request.config.getoption("--show_plots")
 
 
+@pytest.fixture(autouse=True)
+def _close_matplotlib_figures():
+    """Close matplotlib figures left open by a test.
+
+    Tests open figures with hard-coded numbers (``plt.figure(1, figsize=...)``).
+    When a figure with that number survives into a later test, matplotlib ignores
+    the size/dpi arguments and warns ("figure with num: N already exists"). Closing
+    after each test keeps figure numbers from leaking across tests. Only acts when
+    pyplot was actually imported, so non-plotting tests incur no cost.
+    """
+    yield
+    plt = sys.modules.get("matplotlib.pyplot")
+    if plt is not None:
+        plt.close("all")
+
+
 def pytest_make_parametrize_id(config, val, argname):
     return f"{argname}={val}"
 

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
@@ -115,8 +115,6 @@ def smallBodyNavEKFTestFunction(show_plots):
         true_x_hat, np.array([x_hat[-1,:]]), 0.1, "x_hat",
         testFailCount, testMessages)
 
-    plt.figure(1)
-    plt.clf()
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.ticklabel_format(useOffset=False)
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,0], label='x-pos')
@@ -127,8 +125,6 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('r_BO_O (m)')
     plt.title('Estimated Relative Spacecraft Position')
 
-    plt.figure(2)
-    plt.clf()
     plt.figure(2, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,3], label='x-vel')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,4], label='y-vel')
@@ -138,8 +134,6 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('v_BO_O (m/s)')
     plt.title('Estimated Spacecraft Velocity')
 
-    plt.figure(5)
-    plt.clf()
     plt.figure(5, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,6], label='s1')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,7], label='s2')
@@ -149,8 +143,6 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('sigma_AN (rad)')
     plt.title('Estimated Asteroid Attitude')
 
-    plt.figure(6)
-    plt.clf()
     plt.figure(6, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,9], label='omega1')
     plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,10], label='omega2')

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/_UnitTest/test_smallBodyNavUKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/_UnitTest/test_smallBodyNavUKF.py
@@ -113,8 +113,6 @@ def smallBodyNavUKFTestFunction(show_plots):
         [true_x_hat], np.array([x_hat[-1,:]]), 0.01, "x_hat",
         testFailCount, testMessages)
 
-    plt.figure(1)
-    plt.clf()
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.ticklabel_format(useOffset=False)
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,0] / 1000, label='x-pos')
@@ -125,8 +123,6 @@ def smallBodyNavUKFTestFunction(show_plots):
     plt.ylabel('${}^{A}r_{BA}$ (km)')
     plt.title('Estimated Relative Spacecraft Position')
 
-    plt.figure(2)
-    plt.clf()
     plt.figure(2, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,3], label='x-vel')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,4], label='y-vel')
@@ -136,8 +132,6 @@ def smallBodyNavUKFTestFunction(show_plots):
     plt.ylabel('${}^{A}v_{BA}$ (m/s)')
     plt.title('Estimated Spacecraft Velocity')
 
-    plt.figure(3)
-    plt.clf()
     plt.figure(3, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,6], label='x-acc')
     plt.plot(smallBodyNavUKFOutMsgRec.times() * 1.0E-9 / 60, x_hat[:,7], label='y-acc')

--- a/src/simulation/navigation/planetNav/_UnitTest/test_planetNav.py
+++ b/src/simulation/navigation/planetNav/_UnitTest/test_planetNav.py
@@ -185,8 +185,6 @@ def planetNavTestFunction(show_plots):
             testFailCount += 1
             testMessages.append("FAILED: Too few error counts - " + str(count))
 
-    plt.figure(1)
-    plt.clf()
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, r_BN_N[:,0], label='x-position')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, r_BN_N[:,1], label='y-position')
@@ -196,8 +194,6 @@ def planetNavTestFunction(show_plots):
     plt.xlabel('Time (s)')
     plt.ylabel('Position (m)')
 
-    plt.figure(2)
-    plt.clf()
     plt.figure(2, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, v_BN_N[:,0], label='x-velocity')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, v_BN_N[:,1], label='y-velocity')
@@ -207,8 +203,6 @@ def planetNavTestFunction(show_plots):
     plt.xlabel('Time (s)')
     plt.ylabel('Velocity (m/s)')
 
-    plt.figure(3)
-    plt.clf()
     plt.figure(3, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, sigma_BN[:, 0], label='x-rotation')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, sigma_BN[:, 1], label='y-rotation')
@@ -218,8 +212,6 @@ def planetNavTestFunction(show_plots):
     plt.xlabel('Time (s)')
     plt.ylabel('Attitude (rad)')
 
-    plt.figure(4)
-    plt.clf()
     plt.figure(4, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, omega_BN_B[:, 0], label='x-angular vel.')
     plt.plot(ephemerisOutMsgRec.times() * 1.0E-9, omega_BN_B[:, 1], label='y-angular vel.')

--- a/src/simulation/sensors/simpleVoltEstimator/_UnitTest/test_simpleVoltEstimator.py
+++ b/src/simulation/sensors/simpleVoltEstimator/_UnitTest/test_simpleVoltEstimator.py
@@ -109,8 +109,6 @@ def unitSimpleVoltEstimator(show_plots):
             testFailCount += 1
             testMessages.append("FAILED: Too few error counts - " + str(count))
 
-    plt.figure(1)
-    plt.clf()
     plt.figure(1, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
     plt.plot(dataVoltLog.times() * 1.0E-9, volt[:])
 


### PR DESCRIPTION
* **Tickets addressed:** xmera-#615
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR ensures that the python tests automatically close any plots a test opens once the test finishes. This prevents leftover plots from one test confusing the figure numbering for the next one.

## Verification
The tests are run and the figure number warnings no longer appear.

## Documentation
None invalidated. None added.

## Future work
None
