### PR TITLE
Deallocate new-allocated objects with delete, not free

### DIFF
--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -24,7 +24,7 @@ ThrusterDynamicEffector::ThrusterDynamicEffector()
 /*! The destructor. */
 ThrusterDynamicEffector::~ThrusterDynamicEffector() {
     for (long unsigned int c = 0; c < this->thrusterOutMsgs.size(); c++) {
-        free(this->thrusterOutMsgs.at(c));
+        delete this->thrusterOutMsgs.at(c);
     }
     return;
 }


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
I noticed that `ThrusterDynamicEffector` was allocating its messages with `new`, but then deallocating them with `free`. This is [undefined behavior](https://en.cppreference.com/cpp/memory/c/free), and regardless, there is no guarantee that the `new` and `delete` operators act on the same heap that `malloc` and `free` do.

This PR makes sure that the messages in `ThrusterDynamicEffector` allocated by `new` are properly deallocated by `delete`, not by `free`.

## Verification
By the CI test suite.

## Documentation
N/A

## Future work
N/A
